### PR TITLE
Fix firm CAPEX loans not creating deposits

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -290,6 +290,7 @@ object Sfc:
           flows.jstDepositChange +
           flows.dividendIncome - flows.foreignDividendOutflow - flows.remittanceOutflow + flows.diasporaInflow +
           flows.tourismExport - flows.tourismImport - flows.bailInLoss +
+          flows.newLoans +
           flows.consumerOrigination + flows.insNetDepositChange + flows.nbfiDepositDrain,
         actual = curr.bankDeposits - prev.bankDeposits,
         tolerance,

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -602,7 +602,7 @@ object Firm:
         val f    = firm.copy(
           tech = newTech,
           debt = firm.debt + loan,
-          cash = firm.cash + pnl.netAfterTax - downPayment,
+          cash = firm.cash + pnl.netAfterTax + loan - downPayment,
         )
         buildResult(
           drUpdate.fold(f)(dr => f.copy(digitalReadiness = dr)),
@@ -616,7 +616,7 @@ object Firm:
         val tImp = capex * p.forex.techImportShare
         buildResult(
           firm.copy(
-            cash = firm.cash + pnl.netAfterTax - down,
+            cash = firm.cash + pnl.netAfterTax + loan - down,
             debt = firm.debt + loan,
             tech = TechState.Bankrupt(reason),
           ),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -292,6 +292,7 @@ object BankUpdateStep:
         + jstDepositChange
         + in.s7.netDomesticDividends - in.s7.foreignDividendOutflow - in.s6.remittanceOutflow + in.s6.diasporaInflow
         + in.s6.tourismExport - in.s6.tourismImport
+        + in.s5.sumNewLoans
         + in.s6.consumerOrigination + in.s8.nonBank.insNetDepositChange + in.s8.nonBank.nbfiDepositDrain,
       consumerLoans = (in.w.bank.consumerLoans + in.s6.consumerOrigination - in.s6.consumerPrincipal - in.s6.consumerDefaultAmt).max(PLN.Zero),
       consumerNpl = (in.w.bank.consumerNpl + in.s6.consumerDefaultAmt - in.w.bank.consumerNpl * NplMonthlyWriteOff).max(PLN.Zero),
@@ -406,13 +407,14 @@ object BankUpdateStep:
     val bankSfInc     = perBankStandingFac.perBank(bId)
     val bankIbInt     = perBankInterbankInt.perBank(bId)
     val newLoansTotal =
-      (b.loans + PLN(in.s5.perBankNewLoans(bId)) - bankNplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero)
+      (b.loans + in.s5.perBankNewLoans(bId) - bankNplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero)
 
     val newDep = b.deposits + (hhFlows.incomeShare - hhFlows.consShare) +
       investNetDepositFlow * ws + jstDepositChange * ws +
       in.s7.netDomesticDividends * ws - in.s7.foreignDividendOutflow * ws -
       in.s6.remittanceOutflow * ws + in.s6.diasporaInflow * ws +
       in.s6.tourismExport * ws - in.s6.tourismImport * ws +
+      in.s5.perBankNewLoans(bId) +
       hhFlows.ccOrigination +
       in.s8.nonBank.insNetDepositChange * ws + in.s8.nonBank.nbfiDepositDrain * ws
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
@@ -115,7 +115,7 @@ object FirmProcessingStep:
       corpBondAbsorption: Ratio,           // Catalyst absorption ratio (0-1)
       actualBondIssuance: PLN,             // bond issuance after absorption constraint
       netMigration: Int,                   // net immigration (inflow - outflow)
-      perBankNewLoans: Vector[Double],     // new loans by bank index (mutable accumulator)
+      perBankNewLoans: Vector[PLN],        // new loans by bank index
       perBankNplDebt: Vector[Double],      // NPL debt by bank index
       perBankIntIncome: Vector[Double],    // interest income by bank index
       perBankWorkers: Vector[Int],         // worker count by bank index
@@ -296,7 +296,7 @@ object FirmProcessingStep:
       corpBondAbsorption = Ratio(corpBondAbsorption),
       actualBondIssuance = actualBondIssuance,
       netMigration = netMigration,
-      perBankNewLoans = perBankNewLoans.toVector,
+      perBankNewLoans = perBankNewLoans.toVector.map(PLN(_)),
       perBankNplDebt = perBankNplDebt.toVector,
       perBankIntIncome = perBankIntIncome.toVector,
       perBankWorkers = perBankWorkers.toVector,

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -519,6 +519,7 @@ object Generators:
         flows.jstDepositChange +
         flows.dividendIncome - flows.foreignDividendOutflow - flows.remittanceOutflow + flows.diasporaInflow +
         flows.tourismExport - flows.tourismImport - flows.bailInLoss +
+        flows.newLoans +
         flows.consumerOrigination + flows.insNetDepositChange + flows.nbfiDepositDrain
       val expectedGovDebtChange  = flows.govSpending - flows.govRevenue
       val expectedNfaChange      = flows.currentAccount + flows.valuationEffect


### PR DESCRIPTION
## Summary
- Firm bank loans now correctly create deposits at origination (post-Keynesian "loans create deposits")
- `perBankNewLoans` type strengthened from `Vector[Double]` to `Vector[PLN]`
- SFC Identity 2 updated to include `flows.newLoans`
- Test generator aligned with new deposit formula

## Changed files
- `Firm.scala` — credit loan proceeds to firm.cash
- `BankUpdateStep.scala` — add newLoans to aggregate + per-bank deposits
- `Sfc.scala` — Identity 2 expected formula
- `FirmProcessingStep.scala` — `perBankNewLoans: Vector[PLN]`
- `Generators.scala` — test fixture consistency

## Test plan
- [x] 1244 tests pass (0 failures)
- [x] SFC Identity 2 (bank deposits) now includes firm loan origination
- [x] Property-based SFC tests updated and passing