### PR TITLE
Add scheduled firm loan amortization

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -138,6 +138,7 @@ object Sfc:
       bailInLoss: PLN,              // bail-in deposit destruction
       bankCapitalDestruction: PLN,  // Capital wiped when bank fails (shareholders wiped)
       investNetDepositFlow: PLN,    // Investment demand net flow: lagged revenue - current spending
+      firmPrincipalRepaid: PLN,     // firm loan principal repaid (deposit destruction)
   )
 
   /** Enumeration of the 13 balance-sheet identities checked each month. Used as
@@ -290,7 +291,7 @@ object Sfc:
           flows.jstDepositChange +
           flows.dividendIncome - flows.foreignDividendOutflow - flows.remittanceOutflow + flows.diasporaInflow +
           flows.tourismExport - flows.tourismImport - flows.bailInLoss +
-          flows.newLoans +
+          flows.newLoans - flows.firmPrincipalRepaid +
           flows.consumerOrigination + flows.insNetDepositChange + flows.nbfiDepositDrain,
         actual = curr.bankDeposits - prev.bankDeposits,
         tolerance,

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -156,11 +156,12 @@ object Firm:
       citEvasion: PLN,      // CIT evaded via informal economy
       energyCost: PLN,      // Total energy + ETS cost this month
       greenInvestment: PLN, // Green capital investment this month
+      principalRepaid: PLN, // Monthly firm loan principal repayment
   )
   object Result:
     /** Convenience factory for tests — all flow fields set to `PLN.Zero`. */
     def zero(firm: State): Result =
-      Result(firm, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+      Result(firm, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
 
   /** Monthly profit-and-loss breakdown, computed by `computePnL`. */
   case class PnL(
@@ -292,7 +293,8 @@ object Firm:
   )(using p: SimParams): Result =
     val decision = decide(firm, w, lendRate, bankCanLend, allFirms, rng)
     val r0       = execute(firm, decision)
-    val r1       = applyGreenInvestment(r0)
+    val r0a      = applyLoanAmortization(r0)
+    val r1       = applyGreenInvestment(r0a)
     val r2       = applyInvestment(r1)
     val r3       = applyDigitalDrift(r2)
     val r4       = applyInventory(r3, sectorDemandMult = w.flows.sectorDemandMult(firm.sector.toInt))
@@ -660,9 +662,24 @@ object Firm:
       citEvasion = PLN.Zero,
       energyCost = pnl.energyCost,
       greenInvestment = PLN.Zero,
+      principalRepaid = PLN.Zero,
     )
 
   // ---- Post-processing pipeline ----
+
+  /** Scheduled loan principal repayment: debt × amortRate per month. Reduces
+    * firm.debt and firm.cash; reports flow for SFC accounting. Bankrupt firms
+    * and firms with zero debt skip.
+    */
+  private def applyLoanAmortization(r: Result)(using p: SimParams): Result =
+    val f         = r.firm
+    if !isAlive(f) || f.debt <= PLN.Zero then return r
+    val principal = f.debt * p.banking.firmLoanAmortRate
+    val paid      = principal.min(f.cash.max(PLN.Zero))
+    r.copy(
+      firm = f.copy(debt = f.debt - paid, cash = f.cash - paid),
+      principalRepaid = paid,
+    )
 
   /** Apply natural digital drift to all living firms (always-on). */
   private def applyDigitalDrift(r: Result)(using p: SimParams): Result =

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -82,6 +82,7 @@ case class BankingConfig(
     nplSpreadFactor: Double = 5.0,
     minCar: Ratio = Ratio(0.08),
     loanRecovery: Ratio = Ratio(0.30),
+    firmLoanAmortRate: Rate = Rate(1.0 / 60), // monthly: 1/60 ≈ 5-year avg maturity (NBP 2024)
     profitRetention: Ratio = Ratio(0.30),
     reserveReq: Rate = Rate(0.035),
     stressThreshold: Ratio = Ratio(0.05),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -285,14 +285,14 @@ object BankUpdateStep:
       ),
     )
     in.w.bank.copy(
-      totalLoans = (in.w.bank.totalLoans + in.s5.sumNewLoans - in.s5.nplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero),
+      totalLoans = (in.w.bank.totalLoans + in.s5.sumNewLoans - in.s5.sumFirmPrincipal - in.s5.nplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero),
       nplAmount = (in.w.bank.nplAmount + in.s5.nplNew - in.w.bank.nplAmount * NplMonthlyWriteOff).max(PLN.Zero),
       capital = aggCapitalPnl.newCapital,
       deposits = in.w.bank.deposits + (in.s3.totalIncome - in.s3.consumption) + investNetDepositFlow
         + jstDepositChange
         + in.s7.netDomesticDividends - in.s7.foreignDividendOutflow - in.s6.remittanceOutflow + in.s6.diasporaInflow
         + in.s6.tourismExport - in.s6.tourismImport
-        + in.s5.sumNewLoans
+        + in.s5.sumNewLoans - in.s5.sumFirmPrincipal
         + in.s6.consumerOrigination + in.s8.nonBank.insNetDepositChange + in.s8.nonBank.nbfiDepositDrain,
       consumerLoans = (in.w.bank.consumerLoans + in.s6.consumerOrigination - in.s6.consumerPrincipal - in.s6.consumerDefaultAmt).max(PLN.Zero),
       consumerNpl = (in.w.bank.consumerNpl + in.s6.consumerDefaultAmt - in.w.bank.consumerNpl * NplMonthlyWriteOff).max(PLN.Zero),
@@ -407,14 +407,14 @@ object BankUpdateStep:
     val bankSfInc     = perBankStandingFac.perBank(bId)
     val bankIbInt     = perBankInterbankInt.perBank(bId)
     val newLoansTotal =
-      (b.loans + in.s5.perBankNewLoans(bId) - bankNplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero)
+      (b.loans + in.s5.perBankNewLoans(bId) - in.s5.perBankFirmPrincipal(bId) - bankNplNew * p.banking.loanRecovery.toDouble).max(PLN.Zero)
 
     val newDep = b.deposits + (hhFlows.incomeShare - hhFlows.consShare) +
       investNetDepositFlow * ws + jstDepositChange * ws +
       in.s7.netDomesticDividends * ws - in.s7.foreignDividendOutflow * ws -
       in.s6.remittanceOutflow * ws + in.s6.diasporaInflow * ws +
       in.s6.tourismExport * ws - in.s6.tourismImport * ws +
-      in.s5.perBankNewLoans(bId) +
+      in.s5.perBankNewLoans(bId) - in.s5.perBankFirmPrincipal(bId) +
       hhFlows.ccOrigination +
       in.s8.nonBank.insNetDepositChange * ws + in.s8.nonBank.nbfiDepositDrain * ws
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
@@ -46,6 +46,7 @@ object FirmProcessingStep:
       citEvasion: PLN,      // CIT evaded via informal economy
       energyCost: PLN,      // total energy + ETS cost
       greenInvestment: PLN, // green capital investment
+      principalRepaid: PLN, // firm loan principal repaid
   ):
     def +(o: FirmFlows): FirmFlows = FirmFlows(
       tax = tax + o.tax,
@@ -61,6 +62,7 @@ object FirmProcessingStep:
       citEvasion = citEvasion + o.citEvasion,
       energyCost = energyCost + o.energyCost,
       greenInvestment = greenInvestment + o.greenInvestment,
+      principalRepaid = principalRepaid + o.principalRepaid,
     )
 
   private object FirmFlows:
@@ -78,6 +80,7 @@ object FirmProcessingStep:
       citEvasion = PLN.Zero,
       energyCost = PLN.Zero,
       greenInvestment = PLN.Zero,
+      principalRepaid = PLN.Zero,
     )
 
   case class Input(
@@ -116,6 +119,8 @@ object FirmProcessingStep:
       actualBondIssuance: PLN,             // bond issuance after absorption constraint
       netMigration: Int,                   // net immigration (inflow - outflow)
       perBankNewLoans: Vector[PLN],        // new loans by bank index
+      sumFirmPrincipal: PLN,               // aggregate firm loan principal repaid
+      perBankFirmPrincipal: Vector[PLN],   // firm principal repaid by bank index
       perBankNplDebt: Vector[Double],      // NPL debt by bank index
       perBankIntIncome: Vector[Double],    // interest income by bank index
       perBankWorkers: Vector[Int],         // worker count by bank index
@@ -124,12 +129,13 @@ object FirmProcessingStep:
   )
 
   def run(in: Input, rng: Random)(using p: SimParams): Output =
-    val bsec             = in.w.bankingSector
-    val nBanks           = bsec.banks.length
-    val perBankNewLoans  = new Array[Double](nBanks)
-    val perBankNplDebt   = new Array[Double](nBanks)
-    val perBankIntIncome = new Array[Double](nBanks)
-    val perBankWorkers   = new Array[Int](nBanks)
+    val bsec                 = in.w.bankingSector
+    val nBanks               = bsec.banks.length
+    val perBankNewLoans      = new Array[Double](nBanks)
+    val perBankFirmPrincipal = new Array[Double](nBanks)
+    val perBankNplDebt       = new Array[Double](nBanks)
+    val perBankIntIncome     = new Array[Double](nBanks)
+    val perBankWorkers       = new Array[Int](nBanks)
 
     val currentCcyb                          = in.w.mechanisms.macropru.ccyb
     val rates                                = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate))
@@ -178,6 +184,7 @@ object FirmProcessingStep:
 
       if bondAmt > PLN.Zero then firmBondAmounts(f.id) = bondAmt.toDouble
       perBankNewLoans(f.bankId.toInt) += finalLoan.toDouble
+      perBankFirmPrincipal(f.bankId.toInt) += r.principalRepaid.toDouble
 
       val flows = FirmFlows(
         tax = r.taxPaid,
@@ -193,6 +200,7 @@ object FirmProcessingStep:
         citEvasion = r.citEvasion,
         energyCost = r.energyCost,
         greenInvestment = r.greenInvestment,
+        principalRepaid = r.principalRepaid,
       )
       (bondUpdatedFirm, flows)
 
@@ -297,6 +305,8 @@ object FirmProcessingStep:
       actualBondIssuance = actualBondIssuance,
       netMigration = netMigration,
       perBankNewLoans = perBankNewLoans.toVector.map(PLN(_)),
+      sumFirmPrincipal = ff.principalRepaid,
+      perBankFirmPrincipal = perBankFirmPrincipal.toVector.map(PLN(_)),
       perBankNplDebt = perBankNplDebt.toVector,
       perBankIntIncome = perBankIntIncome.toVector,
       perBankWorkers = perBankWorkers.toVector,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
@@ -321,6 +321,7 @@ object WorldAssemblyStep:
       bailInLoss = in.s9.bailInLoss,
       bankCapitalDestruction = in.s9.multiCapDestruction,
       investNetDepositFlow = in.s9.investNetDepositFlow,
+      firmPrincipalRepaid = in.s5.sumFirmPrincipal,
     )
 
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -501,6 +501,7 @@ object Generators:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   /** Generate (prev, curr, flows) where all 9 SFC identities hold exactly. */
@@ -519,7 +520,7 @@ object Generators:
         flows.jstDepositChange +
         flows.dividendIncome - flows.foreignDividendOutflow - flows.remittanceOutflow + flows.diasporaInflow +
         flows.tourismExport - flows.tourismImport - flows.bailInLoss +
-        flows.newLoans +
+        flows.newLoans - flows.firmPrincipalRepaid +
         flows.consumerOrigination + flows.insNetDepositChange + flows.nbfiDepositDrain
       val expectedGovDebtChange  = flows.govSpending - flows.govRevenue
       val expectedNfaChange      = flows.currentAccount + flows.valuationEffect

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
@@ -97,6 +97,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   private val baseSnap =

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
@@ -88,6 +88,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         bailInLoss = PLN.Zero,
         bankCapitalDestruction = PLN.Zero,
         investNetDepositFlow = PLN.Zero,
+        firmPrincipalRepaid = PLN.Zero,
       )
       val result    = Sfc.validate(snap, snap, zeroFlows)
       result shouldBe Right(())

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -226,6 +226,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   // ---- Snapshot tests ----

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -304,6 +304,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   "Sfc" should "pass consumer credit identity with zero flows" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
@@ -98,6 +98,7 @@ class FofSpec extends AnyFlatSpec with Matchers:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   "FofConsWeights" should "sum to 1.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -98,6 +98,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     bailInLoss = PLN.Zero,
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
+    firmPrincipalRepaid = PLN.Zero,
   )
 
   private def mkBank(


### PR DESCRIPTION
## Summary
- Firm bank loans now amortize at `firmLoanAmortRate` (default 1/60 = 5Y maturity)
- Principal repayment reduces firm.debt, firm.cash, bank.loans, and bank.deposits
- Cash-constrained: `paid = min(scheduled, available cash)`
- SFC Identity 2 updated: `- flows.firmPrincipalRepaid` (deposit destruction)

## Changed files (13)
- `BankingConfig.scala` — new `firmLoanAmortRate` parameter
- `Firm.scala` — `applyLoanAmortization` step, `principalRepaid` flow field
- `FirmProcessingStep.scala` — `FirmFlows.principalRepaid`, `sumFirmPrincipal`, `perBankFirmPrincipal`
- `BankUpdateStep.scala` — subtract principal from aggregate + per-bank loans and deposits
- `Sfc.scala` — `firmPrincipalRepaid` in MonthlyFlows, Identity 2
- `WorldAssemblyStep.scala` — wire flow
- 7 test files — add `firmPrincipalRepaid = PLN.Zero` to zeroFlows

## Test plan
- [x] 1244 tests pass (0 failures)
- [x] SFC Identity 2 includes firm principal repayment (deposit destruction)
- [x] Property-based SFC tests pass with new flow field

Fixes #2