### PR TITLE
Make standing facilities always-on, deduct ZUS from PIT base

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -597,20 +597,18 @@ object Banking:
     PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))
 
   /** Standing facility flows (monthly): deposit rate for excess reserves,
-    * lombard rate for borrowers. No-op when flags.nbpStandingFacilities is
-    * false.
+    * lombard rate for borrowers. Always-on — the NBP corridor (ref ± 100 bps)
+    * is structural, not optional.
     */
   def computeStandingFacilities(banks: Vector[BankState], refRate: Rate)(using p: SimParams): PerBankAmounts =
-    if !p.flags.nbpStandingFacilities then PerBankAmounts(banks.map(_ => PLN.Zero), PLN.Zero)
-    else
-      val depositRate = Math.max(0.0, (refRate - p.monetary.depositFacilitySpread).toDouble)
-      val lombardRate = refRate + p.monetary.lombardSpread
-      val perBank     = banks.map: b =>
-        if b.failed then PLN.Zero
-        else if b.reservesAtNbp > PLN.Zero then b.reservesAtNbp * depositRate / 12.0
-        else if b.interbankNet < PLN.Zero then -(b.interbankNet.abs * lombardRate.monthly)
-        else PLN.Zero
-      PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))
+    val depositRate = Math.max(0.0, (refRate - p.monetary.depositFacilitySpread).toDouble)
+    val lombardRate = refRate + p.monetary.lombardSpread
+    val perBank     = banks.map: b =>
+      if b.failed then PLN.Zero
+      else if b.reservesAtNbp > PLN.Zero then b.reservesAtNbp * depositRate / 12.0
+      else if b.interbankNet < PLN.Zero then -(b.interbankNet.abs * lombardRate.monthly)
+      else PLN.Zero
+    PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))
 
   /** Interbank interest flows (monthly). Net zero in aggregate (closed system).
     */

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -327,11 +327,14 @@ object Household:
 
   // ---- Logic ----
 
-  /** Monthly PIT: progressive Polish brackets (12%/32%), minus kwota wolna. */
+  /** Monthly PIT: progressive Polish brackets (12%/32%), minus kwota wolna. PIT
+    * base = gross income − ZUS employee contribution (Art. 26 ustawy o PIT).
+    */
   def computeMonthlyPit(monthlyIncome: PLN)(using p: SimParams): PLN =
     if !p.flags.pit || monthlyIncome <= PLN.Zero then PLN.Zero
     else
-      val annualized = monthlyIncome * 12.0
+      val afterZus   = monthlyIncome * (1.0 - p.social.zusEmployeeRate.toDouble)
+      val annualized = afterZus * 12.0
       val grossTax   =
         if annualized <= p.fiscal.pitBracket1Annual then annualized * p.fiscal.pitRate1.toDouble
         else

--- a/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
@@ -15,8 +15,8 @@ package com.boombustgroup.amorfati.config
   * '''Government:''' `govInvest`, `euFunds`, `minWage`, `govBondMarket`,
   * `govUnempBenefit`, `pit`, `social800`, `social800ImmigEligible`
   *
-  * '''Central bank (NBP):''' `nbpSymmetric`, `nbpStandingFacilities`,
-  * `nbpForwardGuidance`, `nbpQe`, `nbpFxIntervention`
+  * '''Central bank (NBP):''' `nbpSymmetric`, `nbpForwardGuidance`, `nbpQe`,
+  * `nbpFxIntervention`
   *
   * '''Banking:''' `bankFailure`, `bankLcr`, `interbankTermStructure`,
   * `creditDiagnostics`, `bailIn`, `macropru`, `jst`
@@ -52,7 +52,6 @@ case class FeatureFlags(
     social800ImmigEligible: Boolean = true,
     // Central bank (NBP)
     nbpSymmetric: Boolean = true,
-    nbpStandingFacilities: Boolean = false,
     nbpForwardGuidance: Boolean = false,
     nbpQe: Boolean = true,
     nbpFxIntervention: Boolean = false,

--- a/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
@@ -51,6 +51,7 @@ import com.boombustgroup.amorfati.types.*
 case class SocialConfig(
     // ZUS (Ustawa o systemie ubezpieczen spolecznych)
     zusContribRate: Rate = Rate(0.1952),
+    zusEmployeeRate: Rate = Rate(0.1371), // employee portion deducted from PIT base (emerytura 9.76% + rentowe 1.5% + chorobowe 2.45%)
     zusBasePension: PLN = PLN(3500.0),
     zusScale: Double = 1.0,
     // PPK (Ustawa o PPK)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -166,15 +166,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
   // Standing Facilities
   // =========================================================================
 
-  "Banking.computeStandingFacilities" should "return zeros when disabled" in {
-    // Standing facilities are OFF by default (p.flags.nbpStandingFacilities = false)
-    val banks  = Vector(mkBank(0, reservesAtNbp = PLN(1e8)), mkBank(1, reservesAtNbp = PLN(5e7)))
-    val result = Banking.computeStandingFacilities(banks, Rate(0.06))
-    result.perBank.foreach(_ shouldBe PLN.Zero)
-    result.total shouldBe PLN.Zero
-  }
-
-  it should "compute deposit facility income for banks with excess reserves" in {
+  "Banking.computeStandingFacilities" should "compute deposit facility income for banks with excess reserves" in {
     // When standing facilities enabled, banks with reservesAtNbp > 0 earn deposit rate
     // We can't easily set Config at runtime, so test the formula directly
     val bank            = mkBank(0, reservesAtNbp = PLN(1e8))


### PR DESCRIPTION
## Summary
Two quick wins:

**Standing facilities corridor (#8):**
- Remove `nbpStandingFacilities` toggle from FeatureFlags
- NBP corridor (ref ± 100 bps) is structural, always active
- Deposit/lombard facility flows from month 1

**ZUS-PIT deduction (#18):**
- PIT base = gross income − ZUS employee contribution (13.71%)
- Per Art. 26 ustawy o PIT
- Fixes ~15-20% PIT revenue overstatement
- New `zusEmployeeRate` in SocialConfig

## Test plan
- [x] 1243 tests pass (1 removed: "return zeros when disabled")
- [x] Formatter clean

Fixes #8
Fixes #18