### PR TITLE
Connect housing wealth effect to household consumption

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -520,13 +520,14 @@ object Household:
     val consumptionAdj   =
       if neighborDistress > NeighborDistressThreshold then consumption * NeighborDistressConsAdj else consumption
 
-    // GPW equity wealth effect
+    // Wealth effects: equity (GPW) + housing (Meen HPI)
     val newEquityWealth       = (hh.equityWealth * (1.0 + equityIndexReturn)).max(PLN.Zero)
     val equityGain            = newEquityWealth - hh.equityWealth
-    val wealthEffectBoost     =
+    val equityBoost           =
       if p.flags.gpwHhEquity && equityGain > PLN.Zero then equityGain * p.equity.wealthEffectMpc
       else PLN.Zero
-    val consumptionWithWealth = consumptionAdj + wealthEffectBoost
+    val housingBoost          = world.real.housing.lastWealthEffect / world.totalPopulation.toDouble
+    val consumptionWithWealth = consumptionAdj + equityBoost + housingBoost
 
     MonthlyFlows(
       hh = hh,


### PR DESCRIPTION
## Summary
- `HousingMarket.lastWealthEffect` was already computed (Meen HPI × wealthMpc) but never consumed by HH
- Now distributed per capita into HH consumption alongside equity wealth effect
- Housing = 60%+ of Polish HH wealth — was the missing dominant wealth channel

## Change
`Household.scala:523-529` — add `housingBoost = world.real.housing.lastWealthEffect / totalPopulation` to `consumptionWithWealth`.

## Test plan
- [x] 1243 tests pass
- [x] Formatter clean

Fixes #26