### PR TITLE
Add NBP-compatible monetary aggregates M0/M1/M2/M3

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -101,18 +101,31 @@ object Banking:
   // Monetary aggregates (diagnostic, not SFC-relevant)
   // ---------------------------------------------------------------------------
 
-  /** Monetary aggregates — diagnostic, not SFC-relevant. */
+  /** Monetary aggregates — diagnostic, NBP-compatible definitions. M0 =
+    * reserves at NBP (monetary base, excl. currency in circulation — model is
+    * cashless) M1 = demand deposits only (overnight, NBP definition) M2 = M1 +
+    * term deposits (deposits with agreed maturity) M3 = M2 + TFI AUM +
+    * short-term corporate bonds (money market instruments)
+    */
   case class MonetaryAggregates(
-      m1: PLN,                 // Bank deposits (≈ narrow money)
-      monetaryBase: PLN,       // Reserves at NBP
-      creditMultiplier: Double, // m1 / monetaryBase
+      m0: PLN,                 // monetary base: reserves at NBP
+      m1: PLN,                 // narrow money: demand deposits
+      m2: PLN,                 // intermediate: M1 + term deposits
+      m3: PLN,                 // broad money: M2 + TFI AUM + corp bonds
+      creditMultiplier: Double, // m2 / m0 (broad deposit multiplier)
   )
   object MonetaryAggregates:
-    val zero: MonetaryAggregates = MonetaryAggregates(PLN.Zero, PLN.Zero, 0)
+    val zero: MonetaryAggregates = MonetaryAggregates(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0)
 
-    def compute(deposits: PLN, reserves: PLN): MonetaryAggregates =
-      val base = Math.max(1.0, reserves.toDouble)
-      MonetaryAggregates(deposits, reserves, deposits.toDouble / base)
+    def compute(banks: Vector[BankState], tfiAum: PLN, corpBondOutstanding: PLN): MonetaryAggregates =
+      val alive  = banks.filterNot(_.failed)
+      val m0     = PLN(alive.kahanSumBy(_.reservesAtNbp.toDouble))
+      val demand = PLN(alive.kahanSumBy(_.demandDeposits.toDouble))
+      val term   = PLN(alive.kahanSumBy(_.termDeposits.toDouble))
+      val m1     = demand
+      val m2     = demand + term
+      val m3     = m2 + tfiAum + corpBondOutstanding
+      MonetaryAggregates(m0, m1, m2, m3, m2 / m0.max(PLN(1.0)))
 
   // ---------------------------------------------------------------------------
   // Named result types

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -130,7 +130,7 @@ object BankUpdateStep:
       housing.mortgageFlows,
       bonds,
     )
-    val monAgg               = computeMonetaryAggregates(multi.finalBankingSector, multi.resolvedBank)
+    val monAgg               = computeMonetaryAggregates(multi.finalBankingSector, in)
 
     Output(
       resolvedBank = multi.resolvedBank,
@@ -573,12 +573,17 @@ object BankUpdateStep:
       resolvedBank = finalBankingSector.aggregate,
     )
 
-  /** Monetary aggregates (M1/M2/M3) when credit diagnostics enabled. */
+  /** Monetary aggregates (M0/M1/M2/M3) when credit diagnostics enabled. */
   private def computeMonetaryAggregates(
       finalBankingSector: Banking.State,
-      resolvedBank: Banking.Aggregate,
+      in: Input,
   )(using p: SimParams): Option[Banking.MonetaryAggregates] =
     if p.flags.creditDiagnostics then
-      val totalReserves = PLN(finalBankingSector.banks.kahanSumBy(_.reservesAtNbp.toDouble))
-      Some(Banking.MonetaryAggregates.compute(resolvedBank.deposits, totalReserves))
+      Some(
+        Banking.MonetaryAggregates.compute(
+          finalBankingSector.banks,
+          in.w.financial.nbfi.tfiAum,
+          in.w.financial.corporateBonds.outstanding,
+        ),
+      )
     else None

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -182,9 +182,11 @@ object SimOutput:
     ColumnDef("StandingFacilityNet", ctx => ctx.world.plumbing.standingFacilityNet.toDouble),
     ColumnDef("DepositFacilityUsage", ctx => ctx.world.plumbing.depositFacilityUsage.toDouble),
     ColumnDef("InterbankInterestNet", ctx => ctx.world.plumbing.interbankInterestNet.toDouble),
-    // Credit diagnostics
+    // Credit diagnostics — NBP-compatible monetary aggregates
+    ColumnDef("M0", ctx => ctx.world.monetaryAgg.map(_.m0.toDouble).getOrElse(0.0)),
     ColumnDef("M1", ctx => ctx.world.monetaryAgg.map(_.m1.toDouble).getOrElse(ctx.world.bank.deposits.toDouble)),
-    ColumnDef("MonetaryBase", ctx => ctx.world.monetaryAgg.map(_.monetaryBase.toDouble).getOrElse(0.0)),
+    ColumnDef("M2", ctx => ctx.world.monetaryAgg.map(_.m2.toDouble).getOrElse(ctx.world.bank.deposits.toDouble)),
+    ColumnDef("M3", ctx => ctx.world.monetaryAgg.map(_.m3.toDouble).getOrElse(ctx.world.bank.deposits.toDouble)),
     ColumnDef("CreditMultiplier", ctx => ctx.world.monetaryAgg.map(_.creditMultiplier).getOrElse(0.0)),
     // JST
     ColumnDef("JstRevenue", ctx => ctx.world.social.jst.revenue.toDouble),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -314,25 +314,45 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
   // Credit Diagnostics (M1/M2)
   // =========================================================================
 
-  "MonetaryAggregates.compute" should "compute M1 as deposits" in {
-    val agg = Banking.MonetaryAggregates.compute(PLN(1e9), PLN(1e8))
-    agg.m1 shouldBe PLN(1e9)
-    agg.monetaryBase shouldBe PLN(1e8)
+  "MonetaryAggregates.compute" should "compute M0/M1/M2/M3 from bank vector" in {
+    val b0  = mkBank(0, deposits = PLN(6e8), reservesAtNbp = PLN(5e7)).copy(
+      demandDeposits = PLN(3.6e8),
+      termDeposits = PLN(2.4e8),
+    )
+    val b1  = mkBank(1, deposits = PLN(4e8), reservesAtNbp = PLN(5e7)).copy(
+      demandDeposits = PLN(2.4e8),
+      termDeposits = PLN(1.6e8),
+    )
+    val agg = Banking.MonetaryAggregates.compute(Vector(b0, b1), PLN(1e8), PLN(5e7))
+    agg.m0 shouldBe PLN(1e8)                          // sum of reserves
+    agg.m1 shouldBe PLN(6e8)                          // sum of demand deposits
+    agg.m2 shouldBe PLN(1e9)                          // demand + term
+    agg.m3.toDouble shouldBe (1e9 + 1e8 + 5e7 +- 1.0) // M2 + tfiAum + corpBonds
   }
 
-  it should "compute credit multiplier as M1/base" in {
-    val agg = Banking.MonetaryAggregates.compute(PLN(4.5e9), PLN(1e9))
+  it should "compute credit multiplier as M2/M0" in {
+    val b   = mkBank(0, deposits = PLN(4.5e9), reservesAtNbp = PLN(1e9)).copy(
+      demandDeposits = PLN(2.7e9),
+      termDeposits = PLN(1.8e9),
+    )
+    val agg = Banking.MonetaryAggregates.compute(Vector(b), PLN.Zero, PLN.Zero)
     agg.creditMultiplier shouldBe (4.5 +- 0.01)
   }
 
   it should "handle zero reserves with floor" in {
-    val agg = Banking.MonetaryAggregates.compute(PLN(1e9), PLN.Zero)
-    agg.creditMultiplier shouldBe (1e9 +- 1.0) // m1 / max(1.0, 0.0)
+    val b   = mkBank(0, deposits = PLN(1e9), reservesAtNbp = PLN.Zero).copy(
+      demandDeposits = PLN(6e8),
+      termDeposits = PLN(4e8),
+    )
+    val agg = Banking.MonetaryAggregates.compute(Vector(b), PLN.Zero, PLN.Zero)
+    agg.creditMultiplier shouldBe (1e9 +- 1.0) // m2 / max(PLN(1.0), PLN.Zero)
   }
 
   "MonetaryAggregates.zero" should "have all zero values" in {
+    Banking.MonetaryAggregates.zero.m0 shouldBe PLN.Zero
     Banking.MonetaryAggregates.zero.m1 shouldBe PLN.Zero
-    Banking.MonetaryAggregates.zero.monetaryBase shouldBe PLN.Zero
+    Banking.MonetaryAggregates.zero.m2 shouldBe PLN.Zero
+    Banking.MonetaryAggregates.zero.m3 shouldBe PLN.Zero
     Banking.MonetaryAggregates.zero.creditMultiplier shouldBe 0.0
   }
 


### PR DESCRIPTION
## Summary
- M0 = reserves at NBP (monetary base)
- M1 = demand deposits (narrow money, NBP definition)
- M2 = M1 + term deposits
- M3 = M2 + TFI AUM + corporate bonds outstanding
- Credit multiplier = M2 / M0 (broad deposit multiplier)
- 2 net new output columns (M0, M2); M3 replaces MonetaryBase
- `compute` now takes `Vector[BankState]` for per-bank demand/term split
- Enables direct validation against NBP monthly monetary statistics

## Test plan
- [x] 1243 tests pass
- [x] MonetaryPlumbingSpec updated for new API

Fixes #38