### PR TITLE
Decompose FirmProcessingStep into pure phases, remove mutability

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
@@ -9,21 +9,11 @@ import com.boombustgroup.amorfati.util.KahanSum.*
 
 import scala.util.Random
 
-/** Monthly firm processing pipeline: production decisions, financing (bank
-  * loans, equity issuance, corporate bonds), intermediate-goods trade via the
-  * I-O market, labor market matching (separations, job search, wage updates),
-  * and immigration flows.
-  *
-  * Decomposed into six pure phases:
-  *   1. `buildContext` — rates, lending functions, world snapshot for firms
-  *   2. `processFirms` — per-firm decisions, financing splits, flow
-  *      accumulation
-  *   3. `applyBondAbsorption` — Catalyst demand constraint, unsold bonds → bank
-  *      loans
-  *   4. `applyIntermediateMarket` — I-O intermediate goods trade
-  *   5. `processLaborMarket` — separations, job search, wages, immigration
-  *   6. `computeNplAndInterest` — dead firm detection, per-bank NPL and
-  *      interest
+/** Monthly firm sector cycle: each firm decides on investment and automation,
+  * finances CAPEX through bank credit / equity / corporate bonds, trades
+  * intermediate goods across sectors, and the labor market clears — displaced
+  * workers search for jobs, wages adjust, immigrants arrive. Bankrupt firms
+  * generate credit losses allocated to their relationship bank.
   */
 object FirmProcessingStep:
 
@@ -53,38 +43,38 @@ object FirmProcessingStep:
       principalRepaid: PLN, // firm loan principal repaid
   ):
     def +(o: FirmFlows): FirmFlows = FirmFlows(
-      tax = tax + o.tax,
-      capex = capex + o.capex,
-      techImp = techImp + o.techImp,
-      newLoans = newLoans + o.newLoans,
-      equityIssuance = equityIssuance + o.equityIssuance,
-      grossInvestment = grossInvestment + o.grossInvestment,
-      bondIssuance = bondIssuance + o.bondIssuance,
-      profitShifting = profitShifting + o.profitShifting,
-      fdiRepatriation = fdiRepatriation + o.fdiRepatriation,
-      inventoryChange = inventoryChange + o.inventoryChange,
-      citEvasion = citEvasion + o.citEvasion,
-      energyCost = energyCost + o.energyCost,
-      greenInvestment = greenInvestment + o.greenInvestment,
-      principalRepaid = principalRepaid + o.principalRepaid,
+      tax + o.tax,
+      capex + o.capex,
+      techImp + o.techImp,
+      newLoans + o.newLoans,
+      equityIssuance + o.equityIssuance,
+      grossInvestment + o.grossInvestment,
+      bondIssuance + o.bondIssuance,
+      profitShifting + o.profitShifting,
+      fdiRepatriation + o.fdiRepatriation,
+      inventoryChange + o.inventoryChange,
+      citEvasion + o.citEvasion,
+      energyCost + o.energyCost,
+      greenInvestment + o.greenInvestment,
+      principalRepaid + o.principalRepaid,
     )
 
   private object FirmFlows:
     val zero: FirmFlows = FirmFlows(
-      tax = PLN.Zero,
-      capex = PLN.Zero,
-      techImp = PLN.Zero,
-      newLoans = PLN.Zero,
-      equityIssuance = PLN.Zero,
-      grossInvestment = PLN.Zero,
-      bondIssuance = PLN.Zero,
-      profitShifting = PLN.Zero,
-      fdiRepatriation = PLN.Zero,
-      inventoryChange = PLN.Zero,
-      citEvasion = PLN.Zero,
-      energyCost = PLN.Zero,
-      greenInvestment = PLN.Zero,
-      principalRepaid = PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
     )
 
   // ---- Public I/O types ----
@@ -136,43 +126,57 @@ object FirmProcessingStep:
 
   // ---- Internal phase result types ----
 
-  /** Context shared across phases — rates, lending functions, world snapshot.
-    */
-  private case class FirmContext(
+  /** Per-bank lending rates and credit approval, shared across phases. */
+  private case class LendingConditions(
       macro4firms: World,                 // world with updated demand mults + wages
       rates: Vector[Rate],                // per-bank lending rates
       lendingRates: Vector[Double],       // rates as Double (for Output)
-      bankCanLend: (Int, PLN) => Boolean, // credit approval function
-      nBanks: Int,                        // number of banks
-      currentCcyb: Rate,                  // current countercyclical buffer
+      bankCanLend: (Int, PLN) => Boolean, // credit approval: (bankId, amount) => approved?
+      nBanks: Int,                        // number of banks in multi-bank system
+  )
+
+  /** Per-firm processing outcome — immutable, one per firm. */
+  private case class FirmOutcome(
+      firm: Firm.State,    // updated firm state after decision + financing
+      flows: FirmFlows,    // monetary flows from this firm
+      bankId: BankId,      // relationship bank (for per-bank aggregation)
+      finalLoan: PLN,      // bank loan after equity/bond splits
+      bondAmt: PLN,        // corporate bond issuance (pre-absorption)
+      principalRepaid: PLN, // scheduled loan principal repaid this month
   )
 
   /** Result of per-firm processing (phase 2). */
   private case class FirmProcessingResult(
-      firms: Vector[Firm.State],                                       // firms after decisions + financing
-      flows: FirmFlows,                                                // aggregate monetary flows
-      firmBondAmounts: scala.collection.immutable.Map[FirmId, Double], // per-firm bond issuance
-      perBankNewLoans: Array[Double],                                  // mutable accumulator (tight loop)
-      perBankFirmPrincipal: Array[Double],                             // mutable accumulator (tight loop)
+      outcomes: Vector[FirmOutcome],       // per-firm immutable outcomes
+      flows: FirmFlows,                    // aggregate flows (monoid sum)
+      firmBondAmounts: Map[FirmId, Double], // per-firm bond issuance for reversion
   )
 
   /** Result of bond absorption (phase 3). */
   private case class BondAbsorptionResult(
-      firms: Vector[Firm.State],     // firms after reversion
-      sumNewLoans: PLN,              // total new loans incl. reversion
-      corpBondAbsorption: Ratio,     // absorption ratio (0-1)
-      actualBondIssuance: PLN,       // issued after absorption constraint
-      perBankNewLoans: Array[Double], // updated with reversion
+      firms: Vector[Firm.State], // firms after bond reversion (unsold → bank loans)
+      sumNewLoans: PLN,          // total new bank loans incl. reversion
+      corpBondAbsorption: Ratio, // Catalyst absorption ratio (0-1)
+      actualBondIssuance: PLN,   // bonds issued after absorption constraint
+  )
+
+  /** Financing split: how a firm's CAPEX loan is divided across three channels.
+    */
+  private case class FinancingSplit(
+      bankLoan: PLN,   // remainder after equity and bond channels
+      equity: PLN,     // GPW equity issuance (large firms only)
+      bonds: PLN,      // Catalyst corporate bonds (medium+ firms only)
+      firm: Firm.State, // firm with updated debt/equity/bondDebt
   )
 
   /** Result of NPL and interest computation (phase 6). */
   private case class NplResult(
-      nplNew: PLN,                      // new NPL volume
+      nplNew: PLN,                      // new NPL volume from bankruptcies
       nplLoss: PLN,                     // NPL loss net of recovery
       totalBondDefault: PLN,            // bond default from bankrupt firms
       firmDeaths: Int,                  // count of newly bankrupt firms
       intIncome: PLN,                   // aggregate bank interest income
-      perBankNplDebt: Vector[Double],   // NPL by bank index
+      perBankNplDebt: Vector[Double],   // NPL debt by bank index
       perBankIntIncome: Vector[Double], // interest income by bank index
       perBankWorkers: Vector[Int],      // worker count by bank index
   )
@@ -180,77 +184,81 @@ object FirmProcessingStep:
   // ---- Entry point ----
 
   def run(in: Input, rng: Random)(using p: SimParams): Output =
-    val ctx                                 = buildContext(in, rng)
-    val fp                                  = processFirms(in.firms, ctx, rng)
+    val lending                             = prepareLending(in, rng)
+    val fp                                  = processFirms(in.firms, lending, rng)
     val bonded                              = applyBondAbsorption(fp, in.w)
     val (ioFirms, totalIoPaid)              = applyIntermediateMarket(bonded.firms, in)
     val (finalHouseholds, crossSectorHires) = processLaborMarket(ioFirms, in, rng)
-    val npl                                 = computeNplAndInterest(in.firms, ioFirms, ctx)
-    assembleOutput(fp, bonded, ioFirms, totalIoPaid, finalHouseholds, crossSectorHires, npl, in, ctx)
+    val npl                                 = computeNplAndInterest(in.firms, ioFirms, lending)
+    assembleOutput(fp, bonded, ioFirms, totalIoPaid, finalHouseholds, crossSectorHires, npl, in, lending)
 
-  // ---- Phase 1: Build context ----
+  // ---- Phase 1: Lending conditions ----
 
-  /** Prepare shared context: per-bank rates, lending functions, world snapshot
-    * with updated demand multipliers and wages for firm decision-making.
+  /** Prepare per-bank rates, lending functions, and world snapshot with updated
+    * demand multipliers and wages for firm decision-making.
     */
-  private def buildContext(in: Input, rng: Random)(using p: SimParams): FirmContext =
-    val bsec        = in.w.bankingSector
-    val nBanks      = bsec.banks.length
-    val ccyb        = in.w.mechanisms.macropru.ccyb
-    val rates       = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate))
-    val canLend     = (bankId: Int, amt: PLN) => Banking.canLend(bsec.banks(bankId), amt, rng, ccyb)
-    val macro4firms = in.w.copy(
+  private def prepareLending(in: Input, rng: Random)(using p: SimParams): LendingConditions =
+    val bsec    = in.w.bankingSector
+    val nBanks  = bsec.banks.length
+    val ccyb    = in.w.mechanisms.macropru.ccyb
+    val rates   = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate))
+    val canLend = (bankId: Int, amt: PLN) => Banking.canLend(bsec.banks(bankId), amt, rng, ccyb)
+    val world   = in.w.copy(
       month = in.s1.m,
       flows = in.w.flows.copy(sectorDemandMult = in.s4.sectorMults),
       hhAgg = in.w.hhAgg.copy(marketWage = in.s2.newWage, reservationWage = in.s1.resWage),
     )
-    FirmContext(macro4firms, rates, rates.map(_.toDouble), canLend, nBanks, ccyb)
+    LendingConditions(world, rates, rates.map(_.toDouble), canLend, nBanks)
 
   // ---- Phase 2: Per-firm processing ----
 
   /** Process each firm: technology decisions, financing splits (equity → bonds
-    * → bank loans), and per-bank accumulation. Mutable arrays used for per-bank
-    * accumulators (tight 10K-firm loop with clear boundary).
+    * → bank loans). Returns immutable per-firm outcomes and aggregate flows.
     */
-  private def processFirms(firms: Vector[Firm.State], ctx: FirmContext, rng: Random)(using p: SimParams): FirmProcessingResult =
-    val perBankNewLoans      = new Array[Double](ctx.nBanks)
-    val perBankFirmPrincipal = new Array[Double](ctx.nBanks)
-    val firmBondAmounts      = scala.collection.mutable.HashMap.empty[FirmId, Double]
+  private def processFirms(
+      firms: Vector[Firm.State],
+      lending: LendingConditions,
+      rng: Random,
+  )(using p: SimParams): FirmProcessingResult =
+    val outcomes = firms.map: f =>
+      val rate    = lending.rates(f.bankId.toInt)
+      val canLend = (amt: PLN) => lending.bankCanLend(f.bankId.toInt, amt)
+      val r       = Firm.process(f, lending.macro4firms, rate, canLend, firms, rng)
+      val fin     = splitFinancing(r)
 
-    val pairs = firms.map: f =>
-      val r                                            = Firm.process(f, ctx.macro4firms, ctx.rates(f.bankId.toInt), amt => ctx.bankCanLend(f.bankId.toInt, amt), firms, rng)
-      val (finalLoan, equityAmt, bondAmt, updatedFirm) = splitFinancing(r)
-
-      if bondAmt > PLN.Zero then firmBondAmounts(f.id) = bondAmt.toDouble
-      perBankNewLoans(f.bankId.toInt) += finalLoan.toDouble
-      perBankFirmPrincipal(f.bankId.toInt) += r.principalRepaid.toDouble
-
-      val flows = FirmFlows(
-        tax = r.taxPaid,
-        capex = r.capexSpent,
-        techImp = r.techImports,
-        newLoans = finalLoan,
-        equityIssuance = equityAmt,
-        grossInvestment = r.grossInvestment,
-        bondIssuance = bondAmt,
-        profitShifting = r.profitShiftCost,
-        fdiRepatriation = r.fdiRepatriation,
-        inventoryChange = r.inventoryChange,
-        citEvasion = r.citEvasion,
-        energyCost = r.energyCost,
-        greenInvestment = r.greenInvestment,
+      FirmOutcome(
+        firm = fin.firm,
+        flows = FirmFlows(
+          tax = r.taxPaid,
+          capex = r.capexSpent,
+          techImp = r.techImports,
+          newLoans = fin.bankLoan,
+          equityIssuance = fin.equity,
+          grossInvestment = r.grossInvestment,
+          bondIssuance = fin.bonds,
+          profitShifting = r.profitShiftCost,
+          fdiRepatriation = r.fdiRepatriation,
+          inventoryChange = r.inventoryChange,
+          citEvasion = r.citEvasion,
+          energyCost = r.energyCost,
+          greenInvestment = r.greenInvestment,
+          principalRepaid = r.principalRepaid,
+        ),
+        bankId = f.bankId,
+        finalLoan = fin.bankLoan,
+        bondAmt = fin.bonds,
         principalRepaid = r.principalRepaid,
       )
-      (updatedFirm, flows)
 
-    val (newFirms, flowsPerFirm) = pairs.unzip
-    FirmProcessingResult(newFirms, flowsPerFirm.foldLeft(FirmFlows.zero)(_ + _), firmBondAmounts.toMap, perBankNewLoans, perBankFirmPrincipal)
+    val aggFlows = outcomes.foldLeft(FirmFlows.zero)((acc, o) => acc + o.flows)
+    val bondMap  = outcomes.collect { case o if o.bondAmt > PLN.Zero => o.firm.id -> o.bondAmt.toDouble }.toMap
+
+    FirmProcessingResult(outcomes, aggFlows, bondMap)
 
   /** Split a firm's new loan into three channels: GPW equity → Catalyst bonds →
-    * bank loan remainder. Returns (finalBankLoan, equityIssued, bondIssued,
-    * updatedFirm).
+    * bank loan remainder.
     */
-  private def splitFinancing(r: Firm.Result)(using p: SimParams): (PLN, PLN, PLN, Firm.State) =
+  private def splitFinancing(r: Firm.Result)(using p: SimParams): FinancingSplit =
     // Channel 1: GPW equity issuance (large firms only)
     val (afterEquityLoan, equityAmt, afterEquityFirm) =
       if p.flags.gpw && p.flags.gpwEquityIssuance && r.newLoan > PLN.Zero &&
@@ -271,49 +279,48 @@ object FirmProcessingStep:
         (adj, ba, f)
       else (afterEquityLoan, PLN.Zero, afterEquityFirm)
 
-    (finalLoan, equityAmt, bondAmt, finalFirm)
+    FinancingSplit(finalLoan, equityAmt, bondAmt, finalFirm)
 
   // ---- Phase 3: Bond absorption ----
 
   /** Apply Catalyst demand-side absorption constraint. Unsold bonds revert to
     * bank loans on the issuing firm's relationship bank.
     */
-  private def applyBondAbsorption(result: FirmProcessingResult, w: World)(using p: SimParams): BondAbsorptionResult =
+  private def applyBondAbsorption(
+      result: FirmProcessingResult,
+      w: World,
+  )(using p: SimParams): BondAbsorptionResult =
     val absorption         = CorporateBondMarket
       .computeAbsorption(w.financial.corporateBonds, result.flows.bondIssuance, w.bank.car, p.banking.minCar)
       .toDouble
     val actualBondIssuance = result.flows.bondIssuance * absorption
     val revertRatio        = 1.0 - absorption
 
-    val (adjustedFirms, bondRevertLoans) =
+    val adjustedFirms =
       if revertRatio > BondRevertThreshold then
-        val reverted = result.firms.map: f =>
-          val ba = result.firmBondAmounts.getOrElse(f.id, 0.0)
+        result.outcomes.map: o =>
+          val ba = result.firmBondAmounts.getOrElse(o.firm.id, 0.0)
           if ba > 0 then
             val revert = ba * revertRatio
-            f.copy(bondDebt = f.bondDebt - PLN(revert), debt = f.debt + PLN(revert))
-          else f
-        // Update per-bank loan accumulators with reverted amounts
-        for (fid, ba) <- result.firmBondAmounts do
-          val revert = ba * revertRatio
-          reverted.find(_.id == fid).foreach(af => result.perBankNewLoans(af.bankId.toInt) += revert)
-        (reverted, result.flows.bondIssuance * revertRatio)
-      else (result.firms, PLN.Zero)
+            o.firm.copy(bondDebt = o.firm.bondDebt - PLN(revert), debt = o.firm.debt + PLN(revert))
+          else o.firm
+      else result.outcomes.map(_.firm)
 
-    BondAbsorptionResult(
-      adjustedFirms,
-      result.flows.newLoans + bondRevertLoans,
-      Ratio(absorption),
-      actualBondIssuance,
-      result.perBankNewLoans,
-    )
+    val bondRevertLoans =
+      if revertRatio > BondRevertThreshold then result.flows.bondIssuance * revertRatio
+      else PLN.Zero
+
+    BondAbsorptionResult(adjustedFirms, result.flows.newLoans + bondRevertLoans, Ratio(absorption), actualBondIssuance)
 
   // ---- Phase 4: Intermediate market ----
 
   /** Run I-O intermediate goods market. Adjusts firm cash positions (zero-sum
     * transfers between sectors). Returns updated firms and total paid.
     */
-  private def applyIntermediateMarket(firms: Vector[Firm.State], in: Input)(using p: SimParams): (Vector[Firm.State], PLN) =
+  private def applyIntermediateMarket(
+      firms: Vector[Firm.State],
+      in: Input,
+  )(using p: SimParams): (Vector[Firm.State], PLN) =
     if p.flags.io then
       val r = IntermediateMarket.process(
         IntermediateMarket.Input(
@@ -360,7 +367,7 @@ object FirmProcessingStep:
   private def computeNplAndInterest(
       preFirms: Vector[Firm.State],
       postFirms: Vector[Firm.State],
-      ctx: FirmContext,
+      lending: LendingConditions,
   )(using p: SimParams): NplResult =
     val prevAlive        = preFirms.filter(Firm.isAlive).map(_.id).toSet
     val newlyDead        = postFirms.filter(f => !Firm.isAlive(f) && prevAlive.contains(f.id))
@@ -368,24 +375,25 @@ object FirmProcessingStep:
     val nplLoss          = nplNew * (1.0 - p.banking.loanRecovery.toDouble)
     val totalBondDefault = PLN(newlyDead.kahanSumBy(_.bondDebt.toDouble))
 
-    val perBankNplDebt   = new Array[Double](ctx.nBanks)
-    val perBankIntIncome = new Array[Double](ctx.nBanks)
-    val perBankWorkers   = new Array[Int](ctx.nBanks)
+    // Per-bank aggregation via groupMapReduce (pure, no mutable arrays)
+    val emptyDoubles = Vector.fill(lending.nBanks)(0.0)
+    val emptyInts    = Vector.fill(lending.nBanks)(0)
 
-    for f <- newlyDead do perBankNplDebt(f.bankId.toInt) += f.debt.toDouble
-    for f <- preFirms if Firm.isAlive(f) do perBankIntIncome(f.bankId.toInt) += f.debt.toDouble * ctx.rates(f.bankId.toInt).toDouble / MonthsPerYear
-    for f <- postFirms if Firm.isAlive(f) do perBankWorkers(f.bankId.toInt) += Firm.workerCount(f)
+    val perBankNplDebt = newlyDead.foldLeft(emptyDoubles): (acc, f) =>
+      acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + f.debt.toDouble)
 
-    NplResult(
-      nplNew,
-      nplLoss,
-      totalBondDefault,
-      newlyDead.length,
-      PLN(perBankIntIncome.kahanSum),
-      perBankNplDebt.toVector,
-      perBankIntIncome.toVector,
-      perBankWorkers.toVector,
-    )
+    val perBankIntIncome = preFirms
+      .filter(Firm.isAlive)
+      .foldLeft(emptyDoubles): (acc, f) =>
+        val interest = f.debt.toDouble * lending.rates(f.bankId.toInt).toDouble / MonthsPerYear
+        acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + interest)
+
+    val perBankWorkers = postFirms
+      .filter(Firm.isAlive)
+      .foldLeft(emptyInts): (acc, f) =>
+        acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + Firm.workerCount(f))
+
+    NplResult(nplNew, nplLoss, totalBondDefault, newlyDead.length, PLN(perBankIntIncome.sum), perBankNplDebt, perBankIntIncome, perBankWorkers)
 
   // ---- Output assembly ----
 
@@ -399,9 +407,29 @@ object FirmProcessingStep:
       crossSectorHires: Int,
       npl: NplResult,
       in: Input,
-      ctx: FirmContext,
+      lending: LendingConditions,
   ): Output =
     val flows = fp.flows
+
+    // Derive per-bank vectors from immutable outcomes
+    val emptyPln = Vector.fill(lending.nBanks)(PLN.Zero)
+
+    val perBankNewLoans = fp.outcomes.foldLeft(emptyPln): (acc, o) =>
+      acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + o.finalLoan)
+
+    // Add bond reversion amounts to per-bank loans
+    val perBankNewLoansWithRevert =
+      if bonded.corpBondAbsorption < Ratio.One then
+        val revertRatio = 1.0 - bonded.corpBondAbsorption.toDouble
+        fp.outcomes.foldLeft(perBankNewLoans): (acc, o) =>
+          val ba = fp.firmBondAmounts.getOrElse(o.firm.id, 0.0)
+          if ba > 0 then acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + PLN(ba * revertRatio))
+          else acc
+      else perBankNewLoans
+
+    val perBankFirmPrincipal = fp.outcomes.foldLeft(emptyPln): (acc, o) =>
+      acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + o.principalRepaid)
+
     Output(
       ioFirms = ioFirms,
       households = households,
@@ -427,12 +455,12 @@ object FirmProcessingStep:
       corpBondAbsorption = bonded.corpBondAbsorption,
       actualBondIssuance = bonded.actualBondIssuance,
       netMigration = in.s2.newImmig.monthlyInflow - in.s2.newImmig.monthlyOutflow,
-      perBankNewLoans = bonded.perBankNewLoans.toVector.map(PLN(_)),
+      perBankNewLoans = perBankNewLoansWithRevert,
       sumFirmPrincipal = flows.principalRepaid,
-      perBankFirmPrincipal = fp.perBankFirmPrincipal.toVector.map(PLN(_)),
+      perBankFirmPrincipal = perBankFirmPrincipal,
       perBankNplDebt = npl.perBankNplDebt,
       perBankIntIncome = npl.perBankIntIncome,
       perBankWorkers = npl.perBankWorkers,
-      lendingRates = ctx.lendingRates,
+      lendingRates = lending.lendingRates,
       postFirmCrossSectorHires = crossSectorHires,
     )


### PR DESCRIPTION
## Summary

Single 185-line `run` method decomposed into six pure functions. All mutable `Array` accumulators replaced with immutable `Vector` foldLeft.

**Phases:**
1. `prepareLending` — `LendingConditions`: per-bank rates, credit approval, world snapshot
2. `processFirms` — immutable `FirmOutcome` per firm, `FirmFlows` monoid fold
3. `applyBondAbsorption` — Catalyst demand constraint, unsold bonds → bank loans
4. `applyIntermediateMarket` — I-O intermediate goods trade
5. `processLaborMarket` — separations, job search, wages, immigration
6. `computeNplAndInterest` — per-bank NPL/interest via `foldLeft` on `Vector`

**Key changes:**
- `FirmOutcome` case class replaces per-firm side effects
- Per-bank vectors derived in `assembleOutput` from immutable outcomes
- `splitFinancing` extracted as pure function (equity → bonds → bank)
- Zero mutable state — all `Array` accumulators gone

## Test plan
- [x] CI tests (1243 expected)

Fixes #40