### PR TITLE
FX intervention injects/drains PLN reserves at banks

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
@@ -49,7 +49,8 @@ object Nbp:
   case class FxInterventionResult(
       erEffect: Double, // dimensionless ER change added to erChange in OpenEconomy
       eurTraded: PLN,   // positive = bought EUR (weakened PLN), negative = sold EUR
-      newReserves: PLN, // updated reserve level
+      newReserves: PLN, // updated NBP FX reserve level (EUR)
+      plnInjection: PLN, // PLN injected (+) or drained (−) from banking system reserves
   )
 
   // ---------------------------------------------------------------------------
@@ -159,9 +160,10 @@ object Nbp:
   // FX intervention
   // ---------------------------------------------------------------------------
 
-  /** Sterilized FX intervention. NBP buys/sells EUR to dampen ER deviations
-    * beyond the tolerance band. Sterilized: affects only ER, not bank
-    * deposits/capital.
+  /** FX intervention. NBP buys/sells EUR to dampen ER deviations beyond the
+    * tolerance band. EUR purchase injects PLN into banking system reserves; EUR
+    * sale drains PLN. The PLN injection feeds into the liquidity-aware
+    * interbank rate (#9) via bank reservesAtNbp.
     */
   def fxIntervention(
       prevER: Double,
@@ -169,10 +171,10 @@ object Nbp:
       gdp: Double,
       enabled: Boolean,
   )(using p: SimParams): FxInterventionResult =
-    if !enabled then FxInterventionResult(0.0, PLN.Zero, PLN(reserves))
+    if !enabled then FxInterventionResult(0.0, PLN.Zero, PLN(reserves), PLN.Zero)
     else
       val erDev = (prevER - p.forex.baseExRate) / p.forex.baseExRate
-      if Math.abs(erDev) <= p.monetary.fxBand.toDouble then FxInterventionResult(0.0, PLN.Zero, PLN(reserves))
+      if Math.abs(erDev) <= p.monetary.fxBand.toDouble then FxInterventionResult(0.0, PLN.Zero, PLN(reserves), PLN.Zero)
       else
         val direction     = -Math.signum(erDev)
         val maxByReserves = reserves * p.monetary.fxMaxMonthly.toDouble
@@ -183,4 +185,6 @@ object Nbp:
         val newReserves   = reserves + eurTraded
         val gdpEffect     = if gdp > 0 then Math.abs(eurTraded) * p.forex.baseExRate / gdp else 0.0
         val erEffect      = direction * gdpEffect * p.monetary.fxStrength.toDouble
-        FxInterventionResult(erEffect, PLN(eurTraded), PLN(newReserves).max(PLN.Zero))
+        // PLN injection: EUR purchase → NBP pays PLN to banks (+), EUR sale → banks pay PLN to NBP (−)
+        val plnInjection  = PLN(eurTraded * p.forex.baseExRate)
+        FxInterventionResult(erEffect, PLN(eurTraded), PLN(newReserves).max(PLN.Zero), plnInjection)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -129,7 +129,7 @@ object OpenEconomy:
       importedIntermediates: Vector[PLN], // per-sector imported intermediate goods
       valuationEffect: PLN,               // NFA valuation change from ER movement
       fxIntervention: Nbp.FxInterventionResult // NBP FX intervention result (reserves, EUR traded)
-      = Nbp.FxInterventionResult(0.0, PLN.Zero, PLN.Zero),
+      = Nbp.FxInterventionResult(0.0, PLN.Zero, PLN.Zero, PLN.Zero),
   )
 
   case class StepInput(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -517,9 +517,10 @@ object BankUpdateStep:
   )(using p: SimParams): MultiBankResult =
     val ibRate               = Banking.interbankRate(updatedBanks, in.w.nbp.referenceRate)
     val afterInterbank       = Banking.clearInterbank(updatedBanks, bs.configs)
+    val afterFxInjection     = distributeFxInjection(afterInterbank, in.s8.monetary.fxPlnInjection)
     val afterBonds           =
-      if p.flags.govBondMarket then Banking.allocateBonds(afterInterbank, bonds.actualBondChange)
-      else afterInterbank
+      if p.flags.govBondMarket then Banking.allocateBonds(afterFxInjection, bonds.actualBondChange)
+      else afterFxInjection
     val afterQe              = Banking.allocateQePurchases(afterBonds, in.s8.monetary.qePurchaseAmount)
     val afterPpk             = Banking.allocateQePurchases(afterQe, bonds.ppkBondPurchase)
     val afterIns             = Banking.allocateQePurchases(afterPpk, bonds.insBondPurchase)
@@ -587,3 +588,17 @@ object BankUpdateStep:
         ),
       )
     else None
+
+  /** Distribute FX intervention PLN injection across banks proportional to
+    * deposit market share, adjusting reservesAtNbp. EUR purchase → PLN injected
+    * into banking system; EUR sale → PLN drained.
+    */
+  private def distributeFxInjection(banks: Vector[Banking.BankState], injection: PLN): Vector[Banking.BankState] =
+    if injection == PLN.Zero then banks
+    else
+      val totalDeposits = banks.kahanSumBy(_.deposits.toDouble)
+      if totalDeposits <= 0 then banks
+      else
+        banks.map: b =>
+          val share = b.deposits.toDouble / totalDeposits
+          b.copy(reservesAtNbp = (b.reservesAtNbp + injection * share).max(PLN.Zero))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
@@ -36,6 +36,7 @@ object OpenEconomyStep:
       newBondYield: Rate,
       qePurchaseAmount: PLN,
       postFxNbp: Nbp.State,
+      fxPlnInjection: PLN, // PLN injected (+) or drained (−) by FX intervention
   )
 
   case class BankingFlows(
@@ -112,6 +113,7 @@ object OpenEconomyStep:
         newBondYield = bondQe.newBondYield,
         qePurchaseAmount = bondQe.qePurchaseAmount,
         postFxNbp = bondQe.postFxNbp,
+        fxPlnInjection = external.fxIntervention.plnInjection,
       ),
       banking = BankingFlows(
         totalReserveInterest = interbank.reserveInterest,
@@ -233,7 +235,7 @@ object OpenEconomyStep:
         in.w.nbp.referenceRate,
         in.s7.gdp,
       )
-      ForexResult(fx, in.w.bop, PLN.Zero, Nbp.FxInterventionResult(0.0, PLN.Zero, in.w.nbp.fxReserves))
+      ForexResult(fx, in.w.bop, PLN.Zero, Nbp.FxInterventionResult(0.0, PLN.Zero, in.w.nbp.fxReserves, PLN.Zero))
 
   private def adjustBop(in: Input, bop0: OpenEconomy.BopState)(using p: SimParams): (OpenEconomy.BopState, PLN) =
     // Adjust BOP for foreign dividend outflow (primary income component)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FxInterventionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FxInterventionSpec.scala
@@ -108,10 +108,11 @@ class FxInterventionSpec extends AnyFlatSpec with Matchers:
   // --- FxInterventionResult ---
 
   "FxInterventionResult" should "be constructable with all fields" in {
-    val r = Nbp.FxInterventionResult(0.01, PLN(-5e8), PLN(9.5e9))
-    r.erEffect shouldBe 0.01
-    r.eurTraded shouldBe PLN(-5e8)
-    r.newReserves shouldBe PLN(9.5e9)
+    val r = Nbp.FxInterventionResult(0.01, PLN(-5e8), PLN(9.5e9), PLN(-5e8 * 4.33))
+    r.erEffect should be(0.01)
+    r.eurTraded should be(PLN(-5e8))
+    r.newReserves should be(PLN(9.5e9))
+    r.plnInjection should be(PLN(-5e8 * 4.33))
   }
 
   // --- NbpState FX fields ---


### PR DESCRIPTION
## Summary

NBP EUR purchase now injects PLN into banking system reserves (proportional to deposit market share). EUR sale drains PLN. Combined with #48 (liquidity-aware interbank rate), FX intervention now has a proper monetary transmission channel:

EUR purchase → bank reserves ↑ → liquidityRatio ↑ → interbank rate ↓

Previously FX intervention affected only the exchange rate — banking system liquidity was unchanged.

## Changes
- `Nbp.FxInterventionResult`: new `plnInjection` field (`eurTraded × baseExRate`)
- `OpenEconomyStep.MonetaryPolicy`: surface `fxPlnInjection`
- `BankUpdateStep.distributeFxInjection`: distribute across banks after interbank clearing

## Test plan
- [x] CI tests

Fixes #49