### PR TITLE
Add CIT loss carryforward (Art. 7 ustawy o CIT)

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -136,6 +136,7 @@ object Firm:
       foreignOwned: Boolean,        // FDI: subject to profit shifting & repatriation
       inventory: PLN,               // Inventory stock (PLN)
       greenCapital: PLN,            // Green capital stock (PLN)
+      accumulatedLoss: PLN,         // CIT loss carryforward stock (Art. 7 ustawy o CIT)
   )
 
   /** Output of `process` for one firm in one month — updated state + flow
@@ -165,15 +166,16 @@ object Firm:
 
   /** Monthly profit-and-loss breakdown, computed by `computePnL`. */
   case class PnL(
-      revenue: PLN,         // Gross revenue (capacity × demand × price)
-      costs: PLN,           // Total costs including profit shifting
-      tax: PLN,             // CIT on positive profit
-      netAfterTax: PLN,     // Profit minus tax (can be negative)
-      profitShiftCost: PLN, // FDI profit shifting cost (zero if not foreign-owned)
-      energyCost: PLN,      // Energy + ETS carbon surcharge
+      revenue: PLN,           // Gross revenue (capacity × demand × price)
+      costs: PLN,             // Total costs including profit shifting
+      tax: PLN,               // CIT after loss carryforward offset
+      netAfterTax: PLN,       // Profit minus tax (can be negative)
+      profitShiftCost: PLN,   // FDI profit shifting cost (zero if not foreign-owned)
+      energyCost: PLN,        // Energy + ETS carbon surcharge
+      newAccumulatedLoss: PLN, // Updated loss carryforward stock for next month
   )
   object PnL:
-    val zero: PnL = PnL(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+    val zero: PnL = PnL(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
 
   /** Intermediate ADT from `decide` → `execute`. Separates stochastic choices
     * from state mutation.
@@ -648,7 +650,7 @@ object Firm:
       newLoan: PLN = PLN.Zero,
   ): Result =
     Result(
-      firm = firm,
+      firm = firm.copy(accumulatedLoss = pnl.newAccumulatedLoss),
       taxPaid = pnl.tax,
       capexSpent = capex,
       techImports = techImports,
@@ -768,8 +770,21 @@ object Firm:
       else PLN.Zero
     val costs                = prePsCosts + profitShiftCost
     val profit               = revenue - costs
-    val tax: PLN             = profit.max(PLN.Zero) * p.fiscal.citRate
-    PnL(revenue, costs, tax, profit - tax, profitShiftCost, energyCost)
+
+    // CIT with loss carryforward (Art. 7 ustawy o CIT):
+    // - Losses accumulate when profit < 0
+    // - When profitable: offset up to 50% of profit from accumulated losses
+    // - Losses expire gradually (~5 year horizon via monthly decay)
+    val (tax, newAccLoss) =
+      if profit <= PLN.Zero then (PLN.Zero, firm.accumulatedLoss + profit.abs)
+      else
+        val maxOffset = profit * p.fiscal.citCarryforwardMaxShare.toDouble
+        val offset    = maxOffset.min(firm.accumulatedLoss)
+        val taxable   = profit - offset
+        val remaining = (firm.accumulatedLoss - offset) * (1.0 - p.fiscal.citCarryforwardDecay.toDouble)
+        (taxable * p.fiscal.citRate, remaining.max(PLN.Zero))
+
+    PnL(revenue, costs, tax, profit - tax, profitShiftCost, energyCost, newAccLoss)
 
   /** Apply green capital investment — separate cash pool. Firms earmark
     * GreenBudgetShare of cash for green investment; physical capital

--- a/src/main/scala/com/boombustgroup/amorfati/config/FiscalConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/FiscalConfig.scala
@@ -119,6 +119,8 @@ import com.boombustgroup.amorfati.types.*
 case class FiscalConfig(
     // Tax rates
     citRate: Rate = Rate(0.19),
+    citCarryforwardMaxShare: Ratio = Ratio(0.50), // max 50% of profit offset per year (Art. 7 ustawy o CIT)
+    citCarryforwardDecay: Rate = Rate(1.0 / 60),  // monthly decay ≈ 5-year expiry horizon
     vatRates: Vector[Rate] = Vector(Rate(0.23), Rate(0.19), Rate(0.12), Rate(0.06), Rate(0.10), Rate(0.07)),
     exciseRates: Vector[Rate] = Vector(Rate(0.01), Rate(0.04), Rate(0.03), Rate(0.005), Rate(0.002), Rate(0.02)),
     customsDutyRate: Rate = Rate(0.04),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/FirmEntry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/FirmEntry.scala
@@ -120,6 +120,7 @@ object FirmEntry:
       foreignOwned = p.flags.fdi && rng.nextDouble() < p.fdi.foreignShares.map(_.toDouble)(newSector),
       inventory = initInventory(firmSize, newSector),
       greenCapital = initGreenCapital(firmSize, newSector),
+      accumulatedLoss = PLN.Zero,
     )
 
   /** Select technology regime: AI-native entrants start as Hybrid with partial

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/PriceEquityStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/PriceEquityStep.scala
@@ -250,6 +250,7 @@ object PriceEquityStep:
           foreignOwned = false,
           inventory = PLN.Zero,
           greenCapital = PLN.Zero,
+          accumulatedLoss = PLN.Zero,
         )
       else
         // For surviving firms: only allocate a new neighbors array if the neighbor set actually changed

--- a/src/main/scala/com/boombustgroup/amorfati/init/FirmInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/FirmInit.scala
@@ -92,6 +92,7 @@ object FirmInit:
           foreignOwned = false,
           inventory = PLN.Zero,
           greenCapital = PLN.Zero,
+          accumulatedLoss = PLN.Zero,
         )
       .toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -125,6 +125,7 @@ object Generators:
     foreignOwned = false,
     inventory = PLN.Zero,
     greenCapital = PLN.Zero,
+    accumulatedLoss = PLN.Zero,
   )
 
   val genAliveFirm: Gen[Firm.State] = for
@@ -157,6 +158,7 @@ object Generators:
     foreignOwned = false,
     inventory = PLN.Zero,
     greenCapital = PLN.Zero,
+    accumulatedLoss = PLN.Zero,
   )
 
   // --- Balance sheet state generators ---

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -115,6 +115,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
@@ -157,6 +157,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     val newFirm  = Firm.State(
       FirmId(0),
@@ -176,6 +177,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
     val hhPrimary    = Household.State(
@@ -264,6 +266,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     val newFirm  = Firm.State(
       FirmId(0),
@@ -283,6 +286,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
     val hhLowSkill  = Household.State(
@@ -395,6 +399,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     val firms     = Vector(mkF(0, 0, 5), mkF(1, 2, 5))
     val socialNet = Array.fill(10)(Array.empty[Int])
@@ -426,6 +431,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       ),
     )
     val socialNet = Array.fill(10)(Array.empty[Int])

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmPropertySpec.scala
@@ -116,6 +116,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
       val f2    = Firm.State(
         FirmId(0),
@@ -135,6 +136,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
       val ratio = Firm.computeCapacity(f2) / Firm.computeCapacity(f1)
       ratio shouldBe (2.0 +- 0.01)
@@ -160,6 +162,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
       val f2    = Firm.State(
         FirmId(0),
@@ -179,6 +182,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
       val ratio = Firm.computeCapacity(f2) / Firm.computeCapacity(f1)
       ratio shouldBe (2.5 +- 0.01)
@@ -207,6 +211,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector
     for f <- firms do
@@ -234,6 +239,7 @@ class FirmPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     val firms = Vector(firm)
     Firm.computeLocalAutoRatio(firm, firms) shouldBe 0.0

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -175,6 +175,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkFirm(tech: TechState, sector: Int = 2): Firm.State =
@@ -196,6 +197,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkWorld(): World =

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -378,6 +378,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
@@ -34,6 +34,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkWorld(autoRatio: Double = 0.0, hybridRatio: Double = 0.0): World =

--- a/src/test/scala/com/boombustgroup/amorfati/config/FirmSizeDistributionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/FirmSizeDistributionSpec.scala
@@ -49,6 +49,7 @@ class FirmSizeDistributionSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   "Firm.skeletonCrew" should "return AutoSkeletonCrew for small firms" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
@@ -146,6 +146,7 @@ class EnergyClimateSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   "Firm" should "default greenCapital to 0.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
@@ -191,6 +191,7 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkWorld(): World =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
@@ -160,6 +160,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     entrant.debt shouldBe PLN.Zero
   }
@@ -189,6 +190,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     Firm.isAlive(entrant) shouldBe true
   }
@@ -299,6 +301,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       ),
     ) shouldBe 0
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
@@ -237,6 +237,7 @@ class FofSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkFirms(): Vector[Firm.State] =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -171,6 +171,7 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   "Firm.Result" should "have citEvasion defaulting to 0.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/IntermediateMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/IntermediateMarketPropertySpec.scala
@@ -42,6 +42,7 @@ class IntermediateMarketPropertySpec extends AnyFlatSpec with Matchers with Scal
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector
 
@@ -145,6 +146,7 @@ class IntermediateMarketPropertySpec extends AnyFlatSpec with Matchers with Scal
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     val f1                     = mkF(0, 0)
     val f2                     = mkF(1, 0)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/IntermediateMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/IntermediateMarketSpec.scala
@@ -50,6 +50,7 @@ class IntermediateMarketSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   @annotation.nowarn("msg=unused private member") // default used by callers

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
@@ -173,6 +173,7 @@ class InventorySpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   "Firm" should "have inventory defaulting to 0.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
@@ -188,6 +188,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       ) // sector 2 = Retail/Services
     }.toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/PhysicalCapitalSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/PhysicalCapitalSpec.scala
@@ -36,6 +36,7 @@ class PhysicalCapitalSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   // --- Config defaults ---
@@ -174,6 +175,7 @@ class PhysicalCapitalSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     Firm.computeCapacity(f) shouldBe PLN.Zero
   }
@@ -200,6 +202,7 @@ class PhysicalCapitalSpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
     val r = Firm.Result.zero(f)
     // When PhysCapEnabled, applyInvestment should zero K for bankrupt

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
@@ -78,6 +78,7 @@ class SectoralMobilityPropertySpec extends AnyFlatSpec with Matchers with ScalaC
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       ),
     )
     val hhs   = Vector.empty[Household.State]

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
@@ -180,6 +180,7 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
       foreignOwned = false,
       inventory = PLN.Zero,
       greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
     )
 
   private def mkHousehold(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/steps/DynamicNetworkSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/steps/DynamicNetworkSpec.scala
@@ -83,6 +83,7 @@ class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector
 
@@ -109,5 +110,6 @@ class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
         foreignOwned = false,
         inventory = PLN.Zero,
         greenCapital = PLN.Zero,
+        accumulatedLoss = PLN.Zero,
       )
     }.toVector


### PR DESCRIPTION
## Summary

Firms now accumulate losses and offset them against future profits per Art. 7 ustawy o CIT:

- **Loss accumulation:** negative profit adds to `accumulatedLoss` stock
- **Offset:** when profitable, up to 50% of profit offset from accumulated losses → reduced CIT
- **Decay:** losses expire gradually (monthly decay ≈ 5-year horizon)

**Macro effect:** after AI shock, firms accumulate large losses. During recovery, CIT revenue ramps slowly (carryforward absorbs profits) → government revenue recovery delayed → deficit persists longer than before.

## Changes
- `Firm.State`: new `accumulatedLoss: PLN` field
- `Firm.computePnL`: loss accumulation, offset, decay logic
- `FiscalConfig`: `citCarryforwardMaxShare` (50%), `citCarryforwardDecay` (1/60)
- `PnL`: `newAccumulatedLoss` propagated via `buildResult`
- 24 files updated for new `Firm.State` field

## Test plan
- [x] CI tests

Fixes #19