### PR TITLE
Add mark-to-market interest rate risk on gov bond portfolio

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -139,6 +139,7 @@ object Sfc:
       bankCapitalDestruction: PLN,  // Capital wiped when bank fails (shareholders wiped)
       investNetDepositFlow: PLN,    // Investment demand net flow: lagged revenue - current spending
       firmPrincipalRepaid: PLN,     // firm loan principal repaid (deposit destruction)
+      unrealizedBondLoss: PLN,      // mark-to-market loss on gov bond portfolio (SVB channel)
   )
 
   /** Enumeration of the 13 balance-sheet identities checked each month. Used as
@@ -275,7 +276,7 @@ object Sfc:
         BankCapital,
         "bank capital change (profit retention + losses)",
         expected = -flows.nplLoss - flows.mortgageNplLoss - flows.consumerNplLoss
-          - flows.corpBondDefaultLoss - flows.bfgLevy - flows.bankCapitalDestruction +
+          - flows.corpBondDefaultLoss - flows.bfgLevy - flows.unrealizedBondLoss - flows.bankCapitalDestruction +
           (flows.interestIncome + flows.hhDebtService + flows.bankBondIncome
             + flows.mortgageInterestIncome + flows.consumerDebtService + flows.corpBondCouponIncome
             - flows.depositInterestPaid

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -219,7 +219,7 @@ object Banking:
     def hqla: PLN = reservesAtNbp + govBondHoldings
 
     /** Net cash outflows (30-day): demand deposits × runoff rate. */
-    def netCashOutflows(using p: SimParams): PLN = demandDeposits * p.banking.demandDepositRunoff.toDouble
+    def netCashOutflows(using p: SimParams): PLN = demandDeposits * p.banking.demandDepositRunoff
 
     /** Liquidity Coverage Ratio = HQLA / net cash outflows (Basel III). */
     def lcr(using p: SimParams): Ratio =
@@ -304,12 +304,12 @@ object Banking:
   def lendingRate(bank: BankState, cfg: Config, refRate: Rate)(using p: SimParams): Rate =
     if bank.failed then refRate + Rate(FailedBankSpread)
     else
-      val nplSpread  = Math.min(NplSpreadCap, (bank.nplRatio * p.banking.nplSpreadFactor).toDouble)
+      val nplSpread  = Rate((bank.nplRatio * p.banking.nplSpreadFactor).toDouble).min(Rate(NplSpreadCap))
+      val carThresh  = p.banking.minCar.toDouble * CarPenaltyThreshMult
       val carPenalty =
-        if bank.car.toDouble < p.banking.minCar.toDouble * CarPenaltyThreshMult then
-          Math.max(0.0, (p.banking.minCar.toDouble * CarPenaltyThreshMult - bank.car.toDouble) * CarPenaltyScale)
-        else 0.0
-      refRate + p.banking.baseSpread + cfg.lendingSpread + Rate(nplSpread + carPenalty)
+        if bank.car.toDouble < carThresh then Rate((carThresh - bank.car.toDouble) * CarPenaltyScale)
+        else Rate.Zero
+      refRate + p.banking.baseSpread + cfg.lendingSpread + nplSpread + carPenalty
 
   /** Interbank rate (WIBOR O/N proxy): blends credit stress (NPL) and liquidity
     * position (excess reserves). Under excess liquidity (post-QE, post-FX
@@ -439,7 +439,7 @@ object Banking:
   def computeBfgLevy(banks: Vector[BankState])(using p: SimParams): PerBankAmounts =
     val perBank = banks.map: b =>
       if b.failed then PLN.Zero
-      else b.deposits * p.banking.bfgLevyRate.toDouble / 12.0
+      else b.deposits * p.banking.bfgLevyRate.monthly
     PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))
 
   /** Bail-in: haircut uninsured deposits on failed banks. Deposits below
@@ -578,6 +578,7 @@ object Banking:
       consumerNplLoss: PLN,        // consumer credit NPL loss (after recovery)
       corpBondDefaultLoss: PLN,    // corporate bond default loss (bank share)
       bfgLevy: PLN,                // BFG resolution fund levy
+      unrealizedBondLoss: PLN,     // mark-to-market loss on gov bond portfolio (SVB channel)
       intIncome: PLN,              // interest income on corporate loans
       hhDebtService: PLN,          // household mortgage debt service
       bondIncome: PLN,             // government bond coupon income
@@ -601,13 +602,13 @@ object Banking:
     * `profitRetention` rate (SimParams).
     */
   def computeCapitalDelta(in: CapitalPnlInput)(using p: SimParams): CapitalPnlOutput =
-    val retain    = p.banking.profitRetention.toDouble
-    val losses    =
-      in.nplLoss.toDouble + in.mortgageNplLoss.toDouble + in.consumerNplLoss.toDouble + in.corpBondDefaultLoss.toDouble + in.bfgLevy.toDouble
-    val retIncome = (in.intIncome.toDouble + in.hhDebtService.toDouble + in.bondIncome.toDouble - in.depositInterest.toDouble
-      + in.reserveInterest.toDouble + in.standingFacilityIncome.toDouble + in.interbankInterest.toDouble
-      + in.mortgageInterestIncome.toDouble + in.consumerDebtService.toDouble + in.corpBondCoupon.toDouble) * retain
-    CapitalPnlOutput(newCapital = PLN(in.prevCapital.toDouble - losses + retIncome))
+    val losses         = in.nplLoss + in.mortgageNplLoss + in.consumerNplLoss +
+      in.corpBondDefaultLoss + in.bfgLevy + in.unrealizedBondLoss
+    val grossIncome    = in.intIncome + in.hhDebtService + in.bondIncome - in.depositInterest +
+      in.reserveInterest + in.standingFacilityIncome + in.interbankInterest +
+      in.mortgageInterestIncome + in.consumerDebtService + in.corpBondCoupon
+    val retainedIncome = grossIncome * p.banking.profitRetention
+    CapitalPnlOutput(newCapital = in.prevCapital - losses + retainedIncome)
 
   // ---------------------------------------------------------------------------
   // Monetary plumbing
@@ -617,7 +618,7 @@ object Banking:
     */
   def reserveInterest(bank: BankState, refRate: Rate)(using p: SimParams): PLN =
     if bank.failed || bank.reservesAtNbp <= PLN.Zero then PLN.Zero
-    else bank.reservesAtNbp * refRate.toDouble * p.monetary.reserveRateMult.toDouble / 12.0
+    else bank.reservesAtNbp * (refRate * p.monetary.reserveRateMult.toDouble).monthly
 
   /** Reserve interest for all banks → per-bank amounts + sector total. */
   def computeReserveInterest(banks: Vector[BankState], refRate: Rate)(using SimParams): PerBankAmounts =
@@ -629,11 +630,11 @@ object Banking:
     * is structural, not optional.
     */
   def computeStandingFacilities(banks: Vector[BankState], refRate: Rate)(using p: SimParams): PerBankAmounts =
-    val depositRate = Math.max(0.0, (refRate - p.monetary.depositFacilitySpread).toDouble)
+    val depositRate = (refRate - p.monetary.depositFacilitySpread).max(Rate.Zero)
     val lombardRate = refRate + p.monetary.lombardSpread
     val perBank     = banks.map: b =>
       if b.failed then PLN.Zero
-      else if b.reservesAtNbp > PLN.Zero then b.reservesAtNbp * depositRate / 12.0
+      else if b.reservesAtNbp > PLN.Zero then b.reservesAtNbp * depositRate.monthly
       else if b.interbankNet < PLN.Zero then -(b.interbankNet.abs * lombardRate.monthly)
       else PLN.Zero
     PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))
@@ -643,5 +644,5 @@ object Banking:
   def interbankInterestFlows(banks: Vector[BankState], rate: Rate): PerBankAmounts =
     val perBank = banks.map: b =>
       if b.failed then PLN.Zero
-      else b.interbankNet * rate.toDouble / 12.0
+      else b.interbankNet * rate.monthly
     PerBankAmounts(perBank, PLN(perBank.map(_.toDouble).kahanSum))

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -84,6 +84,7 @@ case class BankingConfig(
     loanRecovery: Ratio = Ratio(0.30),
     firmLoanAmortRate: Rate = Rate(1.0 / 60), // monthly: 1/60 ≈ 5-year avg maturity (NBP 2024)
     profitRetention: Ratio = Ratio(0.30),
+    govBondDuration: Double = 4.5,            // avg modified duration of Polish gov bond portfolio (years, MF 2024)
     reserveReq: Rate = Rate(0.035),
     stressThreshold: Ratio = Ratio(0.05),
     // LCR/NSFR (Basel III)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -23,50 +23,48 @@ object BankUpdateStep:
   private val LongLoanFrac       = 0.50 // fraction of loans in long-term maturity bucket
 
   case class Input(
-      w: World,
-      s1: FiscalConstraintStep.Output,
-      s2: LaborDemographicsStep.Output,
-      s3: HouseholdIncomeStep.Output,
-      s4: DemandStep.Output,
-      s5: FirmProcessingStep.Output,
-      s6: HouseholdFinancialStep.Output,
-      s7: PriceEquityStep.Output,
-      s8: OpenEconomyStep.Output,
+      w: World,                          // current world state (pre-step)
+      s1: FiscalConstraintStep.Output,   // fiscal constraint (month, lending base rate, res wage)
+      s2: LaborDemographicsStep.Output,  // labor/demographics (employment, wage, immigration)
+      s3: HouseholdIncomeStep.Output,    // household income (consumption, PIT, debt service)
+      s4: DemandStep.Output,             // demand (sector multipliers, gov purchases)
+      s5: FirmProcessingStep.Output,     // firm processing (loans, NPL, bonds, I-O firms)
+      s6: HouseholdFinancialStep.Output, // household financial (remittances, tourism, consumer credit)
+      s7: PriceEquityStep.Output,        // price/equity (inflation, GDP, equity state, macropru)
+      s8: OpenEconomyStep.Output,        // open economy (NBP rate, bond yield, QE, FX, BoP)
   )
 
   case class Output(
-      resolvedBank: Banking.Aggregate,
-      finalBankingSector: Banking.State,
-      reassignedFirms: Vector[Firm.State],
-      reassignedHouseholds: Vector[Household.State],
-      finalPpk: SocialSecurity.PpkState,
-      finalInsurance: Insurance.State,
-      finalNbfi: Nbfi.State,
-      newGovWithYield: FiscalBudget.GovState,
-      newJst: Jst.State,
-      housingAfterFlows: HousingMarket.State,
-      bfgLevy: PLN,
-      bailInLoss: PLN,
-      multiCapDestruction: PLN,
-      monAgg: Option[Banking.MonetaryAggregates],
-      finalHhAgg: Household.Aggregates,
-      // Tax intermediates (needed by SFC check)
-      vat: PLN,
-      vatAfterEvasion: PLN,
-      pitAfterEvasion: PLN,
-      exciseRevenue: PLN,
-      exciseAfterEvasion: PLN,
-      customsDutyRevenue: PLN,
-      effectiveShadowShare: Ratio,
-      // Housing flows (needed by SFC check)
-      mortgageInterestIncome: PLN,
-      mortgagePrincipal: PLN,
-      mortgageDefaultLoss: PLN,
-      mortgageDefaultAmount: PLN,
-      // Other intermediates (needed by SFC/World assembly)
-      jstDepositChange: PLN,
-      investNetDepositFlow: PLN,
-      actualBondChange: PLN,
+      resolvedBank: Banking.Aggregate,               // aggregate bank balance sheet after resolution
+      finalBankingSector: Banking.State,             // full banking sector state (per-bank + interbank)
+      reassignedFirms: Vector[Firm.State],           // firms with bankId reassigned after bank failure
+      reassignedHouseholds: Vector[Household.State], // HH with bankId reassigned after bank failure
+      finalPpk: SocialSecurity.PpkState,             // PPK state after bond purchases
+      finalInsurance: Insurance.State,               // insurance state after asset allocation
+      finalNbfi: Nbfi.State,                         // NBFI/TFI state after bond purchases
+      newGovWithYield: FiscalBudget.GovState,        // gov state with updated bond yield
+      newJst: Jst.State,                             // local government state
+      housingAfterFlows: HousingMarket.State,        // housing market after mortgage flows
+      bfgLevy: PLN,                                  // BFG resolution fund levy (aggregate)
+      bailInLoss: PLN,                               // bail-in deposit destruction (aggregate)
+      multiCapDestruction: PLN,                      // capital wiped when banks fail
+      monAgg: Option[Banking.MonetaryAggregates],    // M0/M1/M2/M3 (when credit diagnostics on)
+      finalHhAgg: Household.Aggregates,              // recomputed HH aggregates
+      vat: PLN,                                      // gross VAT revenue
+      vatAfterEvasion: PLN,                          // VAT after informal evasion
+      pitAfterEvasion: PLN,                          // PIT after informal evasion
+      exciseRevenue: PLN,                            // gross excise revenue
+      exciseAfterEvasion: PLN,                       // excise after informal evasion
+      customsDutyRevenue: PLN,                       // customs duty revenue
+      effectiveShadowShare: Ratio,                   // effective shadow economy share
+      mortgageInterestIncome: PLN,                   // mortgage interest income (bank share)
+      mortgagePrincipal: PLN,                        // mortgage principal repaid
+      mortgageDefaultLoss: PLN,                      // mortgage default loss (bank share)
+      mortgageDefaultAmount: PLN,                    // gross mortgage default amount
+      jstDepositChange: PLN,                         // JST deposit flow (Identity 2)
+      investNetDepositFlow: PLN,                     // investment demand net deposit flow
+      actualBondChange: PLN,                         // net change in gov bonds outstanding
+      unrealizedBondLoss: PLN,                       // mark-to-market loss on gov bond portfolio (SVB channel)
   )
 
   // --- Intermediate result types for sub-methods ---
@@ -162,6 +160,10 @@ object BankUpdateStep:
       jstDepositChange = govJst.jstDepositChange,
       investNetDepositFlow = investNetDepositFlow,
       actualBondChange = bonds.actualBondChange,
+      unrealizedBondLoss = {
+        val yc = (in.s8.monetary.newBondYield - in.w.gov.bondYield).toDouble
+        if yc > 0 then in.w.bank.govBondHoldings * (yc * p.banking.govBondDuration) else PLN.Zero
+      },
     )
 
   /** Government budget update (deficit, debt, bonds) and JST local government
@@ -272,6 +274,10 @@ object BankUpdateStep:
       investNetDepositFlow: PLN,
       jstDepositChange: PLN,
   )(using p: SimParams): Banking.Aggregate =
+    // Mark-to-market loss on gov bond portfolio when yields rise (SVB channel)
+    val yieldChange       = (in.s8.monetary.newBondYield - in.w.gov.bondYield).toDouble
+    val aggUnrealizedLoss = if yieldChange > 0 then in.w.bank.govBondHoldings * (yieldChange * p.banking.govBondDuration) else PLN.Zero
+
     val aggCapitalPnl = Banking.computeCapitalDelta(
       Banking.CapitalPnlInput(
         prevCapital = in.w.bank.capital,
@@ -280,6 +286,7 @@ object BankUpdateStep:
         consumerNplLoss = in.s6.consumerNplLoss,
         corpBondDefaultLoss = in.s8.corpBonds.corpBondBankDefaultLoss,
         bfgLevy = bfgLevy,
+        unrealizedBondLoss = aggUnrealizedLoss,
         intIncome = in.s5.intIncome,
         hhDebtService = in.s6.hhDebtService,
         bondIncome = in.s8.banking.bankBondIncome,
@@ -442,6 +449,10 @@ object BankUpdateStep:
       if p.flags.bankFailure && !b.failed then b.deposits * p.banking.bfgLevyRate.toDouble / 12.0
       else PLN.Zero
 
+    // Per-bank mark-to-market loss (proportional to bond holdings)
+    val bankYieldChange    = (in.s8.monetary.newBondYield - in.w.gov.bondYield).toDouble
+    val bankUnrealizedLoss = if bankYieldChange > 0 then b.govBondHoldings * (bankYieldChange * p.banking.govBondDuration) else PLN.Zero
+
     val capitalPnl = Banking.computeCapitalDelta(
       Banking.CapitalPnlInput(
         prevCapital = b.capital,
@@ -450,6 +461,7 @@ object BankUpdateStep:
         consumerNplLoss = bankCcNplLoss,
         corpBondDefaultLoss = bankCorpBondDefaultLoss,
         bfgLevy = bankBfgLevy,
+        unrealizedBondLoss = bankUnrealizedLoss,
         intIncome = bankIntIncome,
         hhDebtService = hhFlows.hhDebtService,
         bondIncome = bankBondInc,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
@@ -322,6 +322,7 @@ object WorldAssemblyStep:
       bankCapitalDestruction = in.s9.multiCapDestruction,
       investNetDepositFlow = in.s9.investNetDepositFlow,
       firmPrincipalRepaid = in.s5.sumFirmPrincipal,
+      unrealizedBondLoss = in.s9.unrealizedBondLoss,
     )
 
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -504,6 +504,7 @@ object Generators:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   /** Generate (prev, curr, flows) where all 9 SFC identities hold exactly. */
@@ -513,7 +514,7 @@ object Generators:
       flows <- genMonthlyFlows
     yield
       val expectedBankCapChange  = -flows.nplLoss - flows.mortgageNplLoss - flows.consumerNplLoss
-        - flows.corpBondDefaultLoss - flows.bfgLevy - flows.bankCapitalDestruction +
+        - flows.corpBondDefaultLoss - flows.bfgLevy - flows.unrealizedBondLoss - flows.bankCapitalDestruction +
         (flows.interestIncome + flows.hhDebtService + flows.bankBondIncome
           + flows.mortgageInterestIncome + flows.consumerDebtService + flows.corpBondCouponIncome
           - flows.depositInterestPaid

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
@@ -98,6 +98,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   private val baseSnap =

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
@@ -89,6 +89,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         bankCapitalDestruction = PLN.Zero,
         investNetDepositFlow = PLN.Zero,
         firmPrincipalRepaid = PLN.Zero,
+        unrealizedBondLoss = PLN.Zero,
       )
       val result    = Sfc.validate(snap, snap, zeroFlows)
       result shouldBe Right(())

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -228,6 +228,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   // ---- Snapshot tests ----

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -305,6 +305,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   "Sfc" should "pass consumer credit identity with zero flows" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
@@ -99,6 +99,7 @@ class FofSpec extends AnyFlatSpec with Matchers:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   "FofConsWeights" should "sum to 1.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -99,6 +99,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     bankCapitalDestruction = PLN.Zero,
     investNetDepositFlow = PLN.Zero,
     firmPrincipalRepaid = PLN.Zero,
+    unrealizedBondLoss = PLN.Zero,
   )
 
   private def mkBank(


### PR DESCRIPTION
## Summary

When bond yields rise, banks take unrealized mark-to-market losses on their government bond portfolio:

```
unrealizedLoss = govBondHoldings × duration × Δyield
```

Only yield increases generate losses (yield drop = unrealized gain, not booked). Erodes bank capital → CAR drops → can trigger failure cascade. This is the SVB channel: rate hike cycle → bond portfolio losses → bank distress.

## Changes
- `Banking.CapitalPnlInput`: new `unrealizedBondLoss` field
- `Banking.computeCapitalDelta`: rewritten with pure PLN arithmetic (no `.toDouble` wrapping)
- `BankingConfig.govBondDuration`: 4.5 years (avg Polish gov bond portfolio, MF 2024)
- `BankUpdateStep`: compute unrealized loss from `newBondYield − prevBondYield` (both aggregate and per-bank paths)

## Test plan
- [ ] CI tests

Fixes #13