### PR TITLE
Add crowding-out: gov bond yield widens firm lending spread

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -42,6 +42,9 @@ object Banking:
   private val NplApprovalPenalty    = 3.0 // approval drop per unit NPL ratio (e.g. NPL 10% → 30pp)
   private val ReserveDeficitPenalty = 0.5 // 50pp approval drop when free reserves < 0
 
+  // Crowding-out (gov bonds vs firm loans)
+  private val CrowdingOutSensitivity = 0.30 // 30% of bond yield gap passed through to lending spread
+
   // Interbank corridor (NBP: ref ± 100 bps)
   private val DepositSpreadFromRef = 0.01 // deposit facility rate = refRate − 100 bps
   private val LombardSpreadFromRef = 0.01 // lombard facility rate = refRate + 100 bps
@@ -298,18 +301,24 @@ object Banking:
   def hhDepositRate(refRate: Rate)(using p: SimParams): Rate =
     (refRate - p.household.depositSpread).max(Rate.Zero)
 
-  /** Lending rate for a bank: refRate + baseSpread + bankSpread + nplSpread +
-    * carPenalty. Failed banks get flat refRate + FailedBankSpread.
+  /** Lending rate charged to firms. Reflects credit risk (NPL spread), capital
+    * adequacy pressure (CAR penalty), and crowding-out from government bonds —
+    * when risk-free yields are attractive, banks demand higher spreads on risky
+    * firm loans. Failed banks get a flat penalty rate.
     */
-  def lendingRate(bank: BankState, cfg: Config, refRate: Rate)(using p: SimParams): Rate =
+  def lendingRate(bank: BankState, cfg: Config, refRate: Rate, bondYield: Rate)(using p: SimParams): Rate =
     if bank.failed then refRate + Rate(FailedBankSpread)
     else
-      val nplSpread  = Rate((bank.nplRatio * p.banking.nplSpreadFactor).toDouble).min(Rate(NplSpreadCap))
-      val carThresh  = p.banking.minCar.toDouble * CarPenaltyThreshMult
-      val carPenalty =
+      val nplSpread   = Rate((bank.nplRatio * p.banking.nplSpreadFactor).toDouble).min(Rate(NplSpreadCap))
+      val carThresh   = p.banking.minCar.toDouble * CarPenaltyThreshMult
+      val carPenalty  =
         if bank.car.toDouble < carThresh then Rate((carThresh - bank.car.toDouble) * CarPenaltyScale)
         else Rate.Zero
-      refRate + p.banking.baseSpread + cfg.lendingSpread + nplSpread + carPenalty
+      // Crowding-out: banks demand higher lending spread when gov bonds offer
+      // attractive risk-free returns. Sensitivity = 0.3 (30% of yield gap
+      // passed through to lending spread).
+      val crowdingOut = (bondYield - refRate - p.banking.baseSpread).max(Rate.Zero) * CrowdingOutSensitivity
+      refRate + p.banking.baseSpread + cfg.lendingSpread + nplSpread + carPenalty + crowdingOut
 
   /** Interbank rate (WIBOR O/N proxy): blends credit stress (NPL) and liquidity
     * position (excess reserves). Under excess liquidity (post-QE, post-FX

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
@@ -201,7 +201,7 @@ object FirmProcessingStep:
     val bsec    = in.w.bankingSector
     val nBanks  = bsec.banks.length
     val ccyb    = in.w.mechanisms.macropru.ccyb
-    val rates   = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate))
+    val rates   = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate, in.w.gov.bondYield))
     val canLend = (bankId: Int, amt: PLN) => Banking.canLend(bsec.banks(bankId), amt, rng, ccyb)
     val world   = in.w.copy(
       month = in.s1.m,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/HouseholdIncomeStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/HouseholdIncomeStep.scala
@@ -50,7 +50,7 @@ object HouseholdIncomeStep:
     val nBanksHh           = bsec.banks.length
     val hhBankRates        = Some(
       BankRates(
-        lendingRates = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate)),
+        lendingRates = bsec.banks.zip(bsec.configs).map((b, cfg) => Banking.lendingRate(b, cfg, in.s1.lendingBaseRate, in.w.gov.bondYield)),
         depositRates = bsec.banks.map(_ => Banking.hhDepositRate(in.w.nbp.referenceRate)),
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
@@ -92,8 +92,8 @@ class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
       val (lo, hi) = if npl1Frac <= npl2Frac then (npl1Frac, npl2Frac) else (npl2Frac, npl1Frac)
       val bankLo   = mkBank(nplAmount = PLN(loans * lo))
       val bankHi   = mkBank(nplAmount = PLN(loans * hi))
-      val rateLo   = Banking.lendingRate(bankLo, configs(0), Rate(refRate))
-      val rateHi   = Banking.lendingRate(bankHi, configs(0), Rate(refRate))
+      val rateLo   = Banking.lendingRate(bankLo, configs(0), Rate(refRate), Rate.Zero)
+      val rateHi   = Banking.lendingRate(bankHi, configs(0), Rate(refRate), Rate.Zero)
       rateHi should be >= rateLo
     }
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -95,22 +95,22 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
 
   "Banking.lendingRate" should "return high spread for failed bank" in {
     val bank = mkBank(status = BankStatus.Failed(30))
-    val rate = Banking.lendingRate(bank, configs(0), Rate(0.05))
+    val rate = Banking.lendingRate(bank, configs(0), Rate(0.05), Rate.Zero)
     rate.toDouble shouldBe (0.05 + 0.50) +- 0.001
   }
 
   it should "increase with NPL ratio" in {
     val bankLowNpl  = mkBank(nplAmount = PLN(1e4))
     val bankHighNpl = mkBank(nplAmount = PLN(2e5))
-    val rateLow     = Banking.lendingRate(bankLowNpl, configs(0), Rate(0.05))
-    val rateHigh    = Banking.lendingRate(bankHighNpl, configs(0), Rate(0.05))
+    val rateLow     = Banking.lendingRate(bankLowNpl, configs(0), Rate(0.05), Rate.Zero)
+    val rateHigh    = Banking.lendingRate(bankHighNpl, configs(0), Rate(0.05), Rate.Zero)
     rateHigh should be > rateLow
   }
 
   it should "include bank-specific spread" in {
     val bank    = mkBank(nplAmount = PLN.Zero)
-    val ratePko = Banking.lendingRate(bank, configs(0), Rate(0.05)) // spread = -0.002
-    val rateBps = Banking.lendingRate(bank, configs(5), Rate(0.05)) // spread = +0.003
+    val ratePko = Banking.lendingRate(bank, configs(0), Rate(0.05), Rate.Zero) // spread = -0.002
+    val rateBps = Banking.lendingRate(bank, configs(5), Rate(0.05), Rate.Zero) // spread = +0.003
     rateBps should be > ratePko
   }
 


### PR DESCRIPTION
## Summary

When gov bond yield exceeds base lending rate, banks prefer risk-free bonds (0% RWA) over firm loans (100% RWA). The yield gap widens the lending spread at 30% pass-through sensitivity.

Higher deficit → higher yield → wider lending spread → less firm CAPEX → fiscal stimulus partially offset by private investment decline.

## Changes
- `Banking.lendingRate`: crowding-out spread component from bond yield gap
- Callsites pass `in.w.gov.bondYield` (FirmProcessingStep, HouseholdIncomeStep)
- Backward compatible via default `bondYield = Rate.Zero`

## Test plan
- [x] CI tests

Fixes #20