### PR TITLE
Add fiscal rules: Art. 216, SRW, SGP deficit limit

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
@@ -124,10 +124,23 @@ object Nbp:
     if !p.flags.govBondMarket then refRate
     else
       val termPremium   = p.fiscal.govTermPremium.toDouble
-      val fiscalRisk    = Math.min(FiscalRiskCap, p.fiscal.govFiscalRiskBeta * Math.max(0.0, debtToGdp - DebtThreshold))
+      val fiscalRisk    = piecewiseFiscalRisk(Ratio(debtToGdp)).toDouble
       val qeCompress    = QeCompressionCoeff * nbpBondGdpShare
       val foreignDemand = if nfa > PLN.Zero then ForeignDemandDiscount else 0.0
       (refRate + Rate(termPremium + fiscalRisk - qeCompress - foreignDemand + credibilityPremium)).max(Rate.Zero)
+
+  /** Piecewise fiscal risk premium: steepens at 55% and 60% debt/GDP. base
+    * segment (40%+) + caution segment (55%+) + crisis segment (60%+).
+    */
+  private def piecewiseFiscalRisk(debtToGdp: Ratio)(using p: SimParams): Rate =
+    val base      = Rate(p.fiscal.govFiscalRiskBeta * (debtToGdp - Ratio(DebtThreshold)).max(Ratio.Zero).toDouble)
+    val caution55 =
+      if debtToGdp > p.fiscal.fiscalRuleCautionThreshold then p.fiscal.fiscalRiskBeta55 * (debtToGdp - p.fiscal.fiscalRuleCautionThreshold)
+      else Rate.Zero
+    val crisis60  =
+      if debtToGdp > p.fiscal.fiscalRuleDebtCeiling then p.fiscal.fiscalRiskBeta60 * (debtToGdp - p.fiscal.fiscalRuleDebtCeiling)
+      else Rate.Zero
+    (base + caution55 + crisis60).min(Rate(FiscalRiskCap))
 
   // ---------------------------------------------------------------------------
   // QE

--- a/src/main/scala/com/boombustgroup/amorfati/config/FiscalConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/FiscalConfig.scala
@@ -119,8 +119,8 @@ import com.boombustgroup.amorfati.types.*
 case class FiscalConfig(
     // Tax rates
     citRate: Rate = Rate(0.19),
-    citCarryforwardMaxShare: Ratio = Ratio(0.50), // max 50% of profit offset per year (Art. 7 ustawy o CIT)
-    citCarryforwardDecay: Rate = Rate(1.0 / 60),  // monthly decay ≈ 5-year expiry horizon
+    citCarryforwardMaxShare: Ratio = Ratio(0.50),    // max 50% of profit offset per year (Art. 7 ustawy o CIT)
+    citCarryforwardDecay: Rate = Rate(1.0 / 60),     // monthly decay ≈ 5-year expiry horizon
     vatRates: Vector[Rate] = Vector(Rate(0.23), Rate(0.19), Rate(0.12), Rate(0.06), Rate(0.10), Rate(0.07)),
     exciseRates: Vector[Rate] = Vector(Rate(0.01), Rate(0.04), Rate(0.03), Rate(0.005), Rate(0.002), Rate(0.02)),
     customsDutyRate: Rate = Rate(0.04),
@@ -161,6 +161,17 @@ case class FiscalConfig(
     // Bond market
     govFiscalRiskBeta: Double = 2.0,
     govTermPremium: Rate = Rate(0.005),
+    // Fiscal rules (Art. 216 Konstytucja RP, SRW Art. 112aa uFP, SGP)
+    fiscalRuleDebtCeiling: Ratio = Ratio(0.60),      // Art. 216: constitutional 60% debt/GDP ceiling
+    fiscalRuleCautionThreshold: Ratio = Ratio(0.55), // Art. 86 uFP: cautionary 55% debt/GDP threshold
+    srwRealGrowthCap: Rate = Rate(0.015),            // SRW: max real growth allowance (CPI + 1.5pp)
+    srwCorrectionSpeed: Ratio = Ratio(0.33),         // SRW: annual convergence speed toward ceiling
+    srwOutputGapSensitivity: Ratio = Ratio(0.50),    // SRW: correction term sensitivity to output gap
+    fiscalConsolidationSpeed55: Ratio = Ratio(0.10), // annual spending cut rate at 55% threshold
+    fiscalConsolidationSpeed60: Ratio = Ratio(0.25), // annual spending cut rate at 60% threshold
+    sgpDeficitLimit: Ratio = Ratio(0.03),            // SGP: 3% deficit/GDP Maastricht limit
+    fiscalRiskBeta55: Rate = Rate(3.5),              // bond yield sensitivity above 55% debt/GDP
+    fiscalRiskBeta60: Rate = Rate(6.0),              // bond yield sensitivity above 60% debt/GDP
     // Government debt (raw — scaled by gdpRatio in SimParams.defaults)
     initGovDebt: PLN = PLN(1600e9),
     // JST (local government, Art. 4 Ustawa o dochodach JST)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -139,23 +139,25 @@ object MonetaryPlumbingState:
   * identities.
   */
 case class FlowState(
-    ioFlows: PLN = PLN.Zero,                                                                // I-O intermediate payments between sectors
-    fdiProfitShifting: PLN = PLN.Zero,                                                      // intangible imports booked abroad (profit shifting)
-    fdiRepatriation: PLN = PLN.Zero,                                                        // dividend repatriation by foreign-owned firms
-    fdiCitLoss: PLN = PLN.Zero,                                                             // CIT lost to profit shifting
-    diasporaRemittanceInflow: PLN = PLN.Zero,                                               // diaspora remittance inflow
-    tourismExport: PLN = PLN.Zero,                                                          // inbound tourism services export
-    tourismImport: PLN = PLN.Zero,                                                          // outbound tourism services import
-    aggInventoryStock: PLN = PLN.Zero,                                                      // aggregate firm inventory stock
-    aggInventoryChange: PLN = PLN.Zero,                                                     // ΔInventories (enters GDP)
-    aggEnergyCost: PLN = PLN.Zero,                                                          // aggregate energy + CO₂ costs
-    firmBirths: Int = 0,                                                                    // new firms (recycled bankrupt slots)
-    firmDeaths: Int = 0,                                                                    // firms bankrupt this step
-    taxEvasionLoss: PLN = PLN.Zero,                                                         // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
-    informalEmployed: Double = 0.0,                                                         // estimated informal employment count
-    bailInLoss: PLN = PLN.Zero,                                                             // bail-in capital loss on bank creditors
-    bfgLevyTotal: Double = 0.0,                                                             // BFG resolution levy from all banks
+    ioFlows: PLN = PLN.Zero,                                                                 // I-O intermediate payments between sectors
+    fdiProfitShifting: PLN = PLN.Zero,                                                       // intangible imports booked abroad (profit shifting)
+    fdiRepatriation: PLN = PLN.Zero,                                                         // dividend repatriation by foreign-owned firms
+    fdiCitLoss: PLN = PLN.Zero,                                                              // CIT lost to profit shifting
+    diasporaRemittanceInflow: PLN = PLN.Zero,                                                // diaspora remittance inflow
+    tourismExport: PLN = PLN.Zero,                                                           // inbound tourism services export
+    tourismImport: PLN = PLN.Zero,                                                           // outbound tourism services import
+    aggInventoryStock: PLN = PLN.Zero,                                                       // aggregate firm inventory stock
+    aggInventoryChange: PLN = PLN.Zero,                                                      // ΔInventories (enters GDP)
+    aggEnergyCost: PLN = PLN.Zero,                                                           // aggregate energy + CO₂ costs
+    firmBirths: Int = 0,                                                                     // new firms (recycled bankrupt slots)
+    firmDeaths: Int = 0,                                                                     // firms bankrupt this step
+    taxEvasionLoss: PLN = PLN.Zero,                                                          // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
+    informalEmployed: Double = 0.0,                                                          // estimated informal employment count
+    bailInLoss: PLN = PLN.Zero,                                                              // bail-in capital loss on bank creditors
+    bfgLevyTotal: Double = 0.0,                                                              // BFG resolution levy from all banks
     sectorDemandMult: Vector[Double] = Vector.fill(SimParams.DefaultSectorDefs.length)(1.0), // per-sector demand multipliers from S4
+    fiscalRuleSeverity: Int = 0,                                                             // 0=none, 1=SRW, 2=SGP, 3=Art86_55, 4=Art216_60
+    govSpendingCutRatio: Ratio = Ratio.Zero,                                                 // fraction of raw spending cut by fiscal rules
 )
 object FlowState:
   val zero: FlowState = FlowState()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalRules.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalRules.scala
@@ -1,0 +1,120 @@
+package com.boombustgroup.amorfati.engine.markets
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** Fiscal rule constraints: Art. 216 Konstytucja RP (60% debt/GDP ceiling),
+  * Art. 86 uFP (55% cautionary threshold), SRW Art. 112aa uFP (expenditure
+  * growth rule), and SGP Pakt Stabilności i Wzrostu (3% deficit/GDP limit).
+  *
+  * Stateless — pure constraint logic applied to government spending decisions
+  * before they flow into FiscalBudget.update.
+  */
+object FiscalRules:
+
+  /** Inputs for fiscal rule evaluation. */
+  case class Input(
+      rawGovPurchases: PLN, // unconstrained gov purchases from DemandStep formula
+      prevGovSpend: PLN,    // previous month total gov spending (current + capital)
+      cumulativeDebt: PLN,  // current government debt stock
+      monthlyGdp: PLN,      // monthly GDP proxy (gdpProxy)
+      prevRevenue: PLN,     // previous month total tax revenue
+      prevDeficit: PLN,     // previous month budget deficit (single-month flow)
+      inflation: Rate,      // current CPI YoY inflation
+      outputGap: Ratio,     // (unemp − NAIRU) / NAIRU (positive = slack)
+  )
+
+  /** Result of fiscal rule application. */
+  case class Output(
+      constrainedGovPurchases: PLN, // final gov purchases after all rule constraints
+      status: RuleStatus,           // which rules are binding + diagnostics
+  )
+
+  /** Rule compliance status for observability (surfaced in SimOutput). */
+  case class RuleStatus(
+      debtToGdp: Ratio,       // current debt/GDP ratio
+      deficitToGdp: Ratio,    // current deficit/GDP ratio (annualized)
+      srwCeiling: PLN,        // SRW expenditure ceiling this month
+      bindingRule: Int,       // 0=none, 1=SRW, 2=SGP, 3=Art86_55, 4=Art216_60
+      spendingCutRatio: Ratio, // fraction of raw spending that was cut (0 = no cut)
+  )
+
+  /** Apply fiscal rules in order of severity, taking the most restrictive. */
+  def constrain(in: Input)(using p: SimParams): Output =
+    val annualGdp    = in.monthlyGdp * 12.0
+    val debtToGdp    = if annualGdp > PLN.Zero then Ratio(in.cumulativeDebt / annualGdp) else Ratio.Zero
+    val deficitToGdp = if annualGdp > PLN.Zero then Ratio(in.prevDeficit / in.monthlyGdp) else Ratio.Zero // monthly deficit / monthly GDP = annualized ratio
+
+    // 1. SRW: expenditure growth ceiling with convergence blending
+    val srwCeiling = computeSrwCeiling(in)
+    val afterSrw   = blendSrw(in.rawGovPurchases, srwCeiling)
+
+    // 2. SGP: cap spending if deficit/GDP > 3%
+    val afterSgp = applySgp(afterSrw, in, deficitToGdp)
+
+    // 3. Art. 86 (55%): consolidation cut
+    val afterArt86 = applyConsolidation55(afterSgp, debtToGdp)
+
+    // 4. Art. 216 (60%): budget must balance
+    val afterArt216 = applyArt216(afterArt86, in, debtToGdp)
+
+    // Determine which rule is binding (most restrictive wins)
+    val constrained = afterArt216
+    val bindingRule = determineBindingRule(in.rawGovPurchases, afterSrw, afterSgp, afterArt86, afterArt216)
+    val cutRatio    =
+      if in.rawGovPurchases > PLN.Zero then Ratio(((in.rawGovPurchases - constrained) / in.rawGovPurchases).max(0.0))
+      else Ratio.Zero
+
+    Output(
+      constrainedGovPurchases = constrained,
+      status = RuleStatus(debtToGdp, deficitToGdp, srwCeiling, bindingRule, cutRatio),
+    )
+
+  /** SRW ceiling: previous spending × (1 + monthly inflation + monthly real cap
+    * − output gap correction).
+    */
+  private def computeSrwCeiling(in: Input)(using p: SimParams): PLN =
+    val monthlyInflation = Ratio(in.inflation.monthly.toDouble)              // Rate → Ratio: used as growth increment
+    val monthlyRealCap   = Ratio(p.fiscal.srwRealGrowthCap.monthly.toDouble) // Rate → Ratio: growth allowance
+    val gapCorrection    = (in.outputGap * p.fiscal.srwOutputGapSensitivity).monthly
+    in.prevGovSpend * (Ratio.One + monthlyInflation + monthlyRealCap - gapCorrection)
+
+  /** Blend raw spending toward SRW ceiling at convergence speed. */
+  private def blendSrw(raw: PLN, ceiling: PLN)(using p: SimParams): PLN =
+    val s = p.fiscal.srwCorrectionSpeed.monthly
+    raw * (Ratio.One - s) + ceiling * s
+
+  /** SGP: if annualized deficit/GDP > limit, cap spending at revenue +
+    * allowable deficit.
+    */
+  private def applySgp(spending: PLN, in: Input, deficitToGdp: Ratio)(using p: SimParams): PLN =
+    if deficitToGdp > p.fiscal.sgpDeficitLimit then
+      val maxSpend = in.prevRevenue + in.monthlyGdp * p.fiscal.sgpDeficitLimit
+      spending.min(maxSpend)
+    else spending
+
+  /** Art. 86 uFP (55%): apply consolidation spending cut. */
+  private def applyConsolidation55(spending: PLN, debtToGdp: Ratio)(using p: SimParams): PLN =
+    if debtToGdp > p.fiscal.fiscalRuleCautionThreshold then spending * (Ratio.One - p.fiscal.fiscalConsolidationSpeed55.monthly)
+    else spending
+
+  /** Art. 216 (60%): budget must balance — spending capped at revenue. */
+  private def applyArt216(spending: PLN, in: Input, debtToGdp: Ratio)(using p: SimParams): PLN =
+    if debtToGdp > p.fiscal.fiscalRuleDebtCeiling then
+      val consolidated = spending * (Ratio.One - p.fiscal.fiscalConsolidationSpeed60.monthly)
+      consolidated.min(in.prevRevenue) // hard ceiling: cannot exceed revenue
+    else spending
+
+  /** Identify which rule is most restrictive (highest severity binding). */
+  private def determineBindingRule(
+      raw: PLN,
+      afterSrw: PLN,
+      afterSgp: PLN,
+      afterArt86: PLN,
+      afterArt216: PLN,
+  ): Int =
+    if afterArt216 < afterArt86 then 4   // Art. 216 (60%) binding
+    else if afterArt86 < afterSgp then 3 // Art. 86 (55%) binding
+    else if afterSgp < afterSrw then 2 // SGP binding
+    else if afterSrw < raw then 1 // SRW binding
+    else 0 // no rule binding

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/DemandStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/DemandStep.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.steps
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.markets.FiscalRules
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.KahanSum.*
 
@@ -24,22 +25,25 @@ object DemandStep:
   )
 
   case class Output(
-      govPurchases: PLN,           // total government purchases this month
-      sectorMults: Vector[Double], // per-sector demand multiplier (0 = no demand, 1 = full capacity)
-      avgDemandMult: Double,       // economy-wide average demand multiplier
-      sectorCap: Vector[Double],   // per-sector nominal production capacity
-      laggedInvestDemand: PLN,     // lagged investment demand for deposit flow calculation
+      govPurchases: PLN,                       // total government purchases this month
+      sectorMults: Vector[Double],             // per-sector demand multiplier (0 = no demand, 1 = full capacity)
+      avgDemandMult: Double,                   // economy-wide average demand multiplier
+      sectorCap: Vector[Double],               // per-sector nominal production capacity
+      laggedInvestDemand: PLN,                 // lagged investment demand for deposit flow calculation
+      fiscalRuleStatus: FiscalRules.RuleStatus, // fiscal rule compliance diagnostics
   )
 
   def run(in: Input)(using p: SimParams): Output =
-    val govPurchases       = computeGovPurchases(in)
+    val rawGovPurchases    = computeGovPurchases(in)
+    val fiscalResult       = applyFiscalRules(in, rawGovPurchases)
+    val govPurchases       = fiscalResult.constrainedGovPurchases
     val sectorCap          = computeSectorCapacity(in)
     val sectorExports      = computeSectorExports(in)
     val laggedInvestDemand = computeLaggedInvestDemand(in)
     val sectorDemand       = computeSectorDemand(in, govPurchases, sectorExports, laggedInvestDemand)
     val sectorMults        = applySpillover(sectorDemand, sectorCap, in.w.priceLevel)
     val avgDemandMult      = computeAvgDemandMult(sectorDemand, sectorCap, in)
-    Output(govPurchases, sectorMults, avgDemandMult, sectorCap, laggedInvestDemand)
+    Output(govPurchases, sectorMults, avgDemandMult, sectorCap, laggedInvestDemand, fiscalResult.status)
 
   /** Government purchases: base spending × price level + fiscal recycling (tax
     * revenue + ZUS surplus) + automatic fiscal stimulus (unemployment gap ×
@@ -54,9 +58,40 @@ object DemandStep:
     val stimulus      = p.fiscal.govBaseSpending * unempGap * p.fiscal.govAutoStabMult
     val target        = p.fiscal.govBaseSpending * Math.max(1.0, in.w.priceLevel) +
       (in.w.gov.taxRevenue + zusNetSurplus) * p.fiscal.govFiscalRecyclingRate + stimulus
-    val prevGovSpend  = in.w.gov.govCurrentSpend + in.w.gov.govCapitalSpend
-    if prevGovSpend > PLN.Zero then target.max(prevGovSpend * GovSpendingFloor)
-    else target
+    target
+
+  /** Apply fiscal rules to raw government purchases. The 98% floor is applied
+    * only when no Art. 216/86 rule is binding.
+    */
+  private def applyFiscalRules(in: Input, rawTarget: PLN)(using p: SimParams): FiscalRules.Output =
+    val prevGovSpend = in.w.gov.govCurrentSpend + in.w.gov.govCapitalSpend
+    val unempRate    = 1.0 - in.s2.employed.toDouble / in.w.totalPopulation
+    val outputGap    = Ratio((unempRate - p.monetary.nairu.toDouble) / p.monetary.nairu.toDouble)
+
+    val floored =
+      if prevGovSpend > PLN.Zero then rawTarget.max(prevGovSpend * GovSpendingFloor)
+      else rawTarget
+
+    val result = FiscalRules.constrain(
+      FiscalRules.Input(
+        rawGovPurchases = floored,
+        prevGovSpend = prevGovSpend,
+        cumulativeDebt = in.w.gov.cumulativeDebt,
+        monthlyGdp = PLN(in.w.gdpProxy),
+        prevRevenue = in.w.gov.taxRevenue,
+        prevDeficit = in.w.gov.deficit,
+        inflation = in.w.inflation,
+        outputGap = outputGap,
+      ),
+    )
+
+    // When Art. 216/86 is binding, override the 98% floor — fiscal rules take precedence
+    if result.status.bindingRule >= 3 then result
+    else
+      val withFloor = result.constrainedGovPurchases.max(
+        if prevGovSpend > PLN.Zero then prevGovSpend * GovSpendingFloor else PLN.Zero,
+      )
+      result.copy(constrainedGovPurchases = withFloor)
 
   /** Per-sector nominal production capacity: sum of firm capacities. */
   private def computeSectorCapacity(in: Input)(using p: SimParams): Vector[Double] =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
@@ -244,6 +244,8 @@ object WorldAssemblyStep:
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = in.s9.bfgLevy.toDouble,
       sectorDemandMult = in.s4.sectorMults,
+      fiscalRuleSeverity = in.s4.fiscalRuleStatus.bindingRule,
+      govSpendingCutRatio = in.s4.fiscalRuleStatus.spendingCutRatio,
     )
 
   /** Run SFC validation against previous and current snapshots. */

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -440,6 +440,17 @@ object SimOutput:
     // AFS/HTM bond portfolio split (#56)
     ColumnDef("BankAfsBonds", ctx => ctx.world.bank.afsBonds.toDouble),
     ColumnDef("BankHtmBonds", ctx => ctx.world.bank.htmBonds.toDouble),
+    // Fiscal rules (#16)
+    ColumnDef(
+      "DebtToGdp",
+      ctx => if ctx.world.gdpProxy > 0 then ctx.world.gov.cumulativeDebt.toDouble / (ctx.world.gdpProxy * 12.0) else 0.0,
+    ),
+    ColumnDef(
+      "DeficitToGdp",
+      ctx => if ctx.world.gdpProxy > 0 then ctx.world.gov.deficit.toDouble / (ctx.world.gdpProxy * 12.0) else 0.0,
+    ),
+    ColumnDef("FiscalRuleBinding", ctx => ctx.world.flows.fiscalRuleSeverity.toDouble),
+    ColumnDef("GovSpendingCutRatio", ctx => ctx.world.flows.govSpendingCutRatio.toDouble),
   )
 
   /** Column names — derived from schema. */

--- a/src/main/scala/com/boombustgroup/amorfati/types.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/types.scala
@@ -78,6 +78,8 @@ object types:
       inline def +(other: Rate): Rate            = r + other
       inline def -(other: Rate): Rate            = r - other
       inline def *(scalar: Double): Rate         = r * scalar
+      @targetName("rateTimesRatio")
+      inline def *(ratio: Ratio): Rate           = r * ratio
       inline def /(scalar: Double): Rate         = r / scalar
       @targetName("rateDivRate")
       inline def /(other: Rate): Double          = r / other
@@ -125,6 +127,7 @@ object types:
       inline def max(other: Ratio): Ratio           = math.max(r, other)
       inline def min(other: Ratio): Ratio           = math.min(r, other)
       inline def clamp(lo: Ratio, hi: Ratio): Ratio = math.max(lo, math.min(hi, r))
+      inline def monthly: Ratio                     = r / 12.0
       inline def toDouble: Double                   = r
       inline def >(other: Ratio): Boolean           = r > other
       inline def <(other: Ratio): Boolean           = r < other

--- a/src/test/scala/com/boombustgroup/amorfati/engine/markets/FiscalRulesSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/markets/FiscalRulesSpec.scala
@@ -1,0 +1,129 @@
+package com.boombustgroup.amorfati.engine.markets
+
+import com.boombustgroup.amorfati.agents.Nbp
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FiscalRulesSpec extends AnyWordSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  // monthlyGdp = 250e9 → annualGdp = 3000e9
+  private val baseInput = FiscalRules.Input(
+    rawGovPurchases = PLN(100e9),
+    prevGovSpend = PLN(95e9),
+    cumulativeDebt = PLN(300e9),
+    monthlyGdp = PLN(250e9), // 10% debt/GDP — well below any threshold
+    prevRevenue = PLN(80e9),
+    prevDeficit = PLN(5e9),
+    inflation = Rate(0.025),
+    outputGap = Ratio(0.0),
+  )
+
+  "FiscalRules.constrain" should {
+
+    "apply no constraint at 30% debt/GDP" in {
+      val in     = baseInput.copy(cumulativeDebt = PLN(900e9))
+      val result = FiscalRules.constrain(in)
+      // SRW blending still applies (always-on), but no consolidation cuts
+      result.status.bindingRule should be <= 1
+      result.constrainedGovPurchases should be > PLN.Zero
+    }
+
+    "cap spending via SRW ceiling" in {
+      // Large raw spending, small prev spending — SRW should pull it down
+      val in     = baseInput.copy(
+        rawGovPurchases = PLN(200e9),
+        prevGovSpend = PLN(90e9),
+      )
+      val result = FiscalRules.constrain(in)
+      // SRW blends raw toward ceiling — result should be less than raw
+      result.constrainedGovPurchases.toDouble should be < 200e9
+    }
+
+    "apply SGP when deficit/GDP exceeds 3%" in {
+      val in     = baseInput.copy(
+        prevDeficit = PLN(120e9), // 120e9 / 250e9 = 48% >> 3%
+      )
+      val result = FiscalRules.constrain(in)
+      result.status.deficitToGdp.toDouble should be > 0.03
+      // SGP caps at revenue + monthlyGdp × sgpDeficitLimit
+      val sgpCap = 80e9 + 250e9 * 0.03
+      result.constrainedGovPurchases.toDouble should be <= sgpCap * 1.01 // within tolerance
+    }
+
+    "apply Art. 86 (55%) consolidation" in {
+      val in     = baseInput.copy(cumulativeDebt = PLN(1700e9)) // 56.7% debt/GDP
+      val result = FiscalRules.constrain(in)
+      result.status.debtToGdp.toDouble should be > 0.55
+      result.status.bindingRule should be >= 3
+      result.status.spendingCutRatio.toDouble should be > 0.0
+    }
+
+    "force budget balance at Art. 216 (60%)" in {
+      val in     = baseInput.copy(cumulativeDebt = PLN(1900e9)) // 63.3% debt/GDP
+      val result = FiscalRules.constrain(in)
+      result.status.debtToGdp.toDouble should be > 0.60
+      result.status.bindingRule shouldBe 4
+      // Hard ceiling: cannot exceed revenue
+      result.constrainedGovPurchases.toDouble should be <= in.prevRevenue.toDouble
+    }
+
+    "most restrictive rule wins when multiple bind" in {
+      // Both SGP and Art. 86 binding
+      val in     = baseInput.copy(
+        cumulativeDebt = PLN(1700e9), // 56.7% — Art. 86 binding
+        prevDeficit = PLN(120e9),     // huge deficit — SGP binding
+      )
+      val result = FiscalRules.constrain(in)
+      // Art. 86 is more severe than SGP in the cascade
+      result.status.bindingRule should be >= 2
+    }
+
+    "guarantee constrained ≤ raw always" in {
+      val scenarios = Seq(
+        baseInput,                                    // low debt
+        baseInput.copy(cumulativeDebt = PLN(1700e9)), // 55%+
+        baseInput.copy(cumulativeDebt = PLN(1900e9)), // 60%+
+        baseInput.copy(prevDeficit = PLN(120e9)),     // high deficit
+      )
+      for in <- scenarios do
+        val result = FiscalRules.constrain(in)
+        result.constrainedGovPurchases.toDouble should be <= in.rawGovPurchases.toDouble
+    }
+  }
+
+  "Nbp.piecewiseFiscalRisk (via bondYield)" should {
+
+    "have zero fiscal risk at 35% debt/GDP" in {
+      val y        = Nbp.bondYield(Rate(0.05), 0.35, 0.0, PLN.Zero, 0.0)
+      val expected = 0.05 + 0.005 // ref + termPremium
+      y.toDouble shouldBe expected +- 0.001
+    }
+
+    "have base-only risk at 45% debt/GDP" in {
+      val y        = Nbp.bondYield(Rate(0.05), 0.45, 0.0, PLN.Zero, 0.0)
+      val baseRisk = 2.0 * 0.05
+      val expected = 0.05 + 0.005 + baseRisk
+      y.toDouble shouldBe expected +- 0.001
+    }
+
+    "be monotonically non-decreasing with debt/GDP" in {
+      val debtLevels = Seq(0.30, 0.35, 0.40, 0.42, 0.45, 0.50, 0.55, 0.56, 0.60, 0.62, 0.70, 0.90)
+      val yields     = debtLevels.map(d => Nbp.bondYield(Rate(0.05), d, 0.0, PLN.Zero, 0.0).toDouble)
+      for (y1, y2) <- yields.zip(yields.tail) do y2 should be >= y1
+    }
+
+    "increase above 40% threshold" in {
+      val yBelow = Nbp.bondYield(Rate(0.05), 0.39, 0.0, PLN.Zero, 0.0)
+      val yAbove = Nbp.bondYield(Rate(0.05), 0.42, 0.0, PLN.Zero, 0.0)
+      yAbove.toDouble should be > yBelow.toDouble
+    }
+
+    "never exceed FiscalRiskCap (10%)" in {
+      val y = Nbp.bondYield(Rate(0.05), 0.90, 0.0, PLN.Zero, 0.0)
+      y.toDouble should be <= 0.05 + 0.005 + 0.10 + 0.001
+    }
+  }


### PR DESCRIPTION
## Summary
- Constrain government spending via three-layer Polish fiscal framework: SRW expenditure growth rule (Art. 112aa uFP), SGP 3% deficit/GDP cap, Art. 86 cautionary threshold at 55% debt/GDP, Art. 216 constitutional ceiling at 60% debt/GDP
- Replace single-slope bond yield fiscal risk premium with piecewise function that steepens at 55%/60% thresholds
- Add 10 calibration params to FiscalConfig, 2 FlowState fields, 4 SimOutput columns (DebtToGdp, DeficitToGdp, FiscalRuleBinding, GovSpendingCutRatio)
- Add `Ratio.monthly` and `Rate * Ratio → Rate` extension methods to opaque types

## Design
- **Constraint point**: `DemandStep.computeGovPurchases` — fiscal rules constrain the spending *decision* before it flows into `FiscalBudget.update`. SFC Identity 3 unaffected.
- **FiscalRules.scala**: stateless pure module (same pattern as FiscalBudget). Rules applied in cascade: SRW → SGP → Art. 86 → Art. 216, most restrictive wins.
- **SRW**: soft cap with convergence blending (not hard ceiling — matches real SRW behavior).
- **98% floor override**: Art. 216/86 take precedence over the smoothing floor when binding.
- **Bond yield**: piecewise fiscal risk premium (base 40%+ / caution 55%+ / crisis 60%+) replaces single linear slope.
- **Always-on**: no feature flag.

## Test plan
- [x] 12 new tests in FiscalRulesSpec: no-constraint at low debt, SRW binding, SGP binding, Art. 86 consolidation, Art. 216 budget balance, multi-rule interaction, monotonicity, piecewise yield monotonicity, cap at 10%
- [x] All 1268 tests pass (1256 existing + 12 new)
- [x] `sbt scalafmtAll` clean
- [x] SFC Identity 3 holds (constrained spending flows through FiscalBudget unchanged)

Fixes #16