### PR TITLE
Replace Double with opaque types in Nbp

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
@@ -10,13 +10,13 @@ object Nbp:
   // Named constants
   // ---------------------------------------------------------------------------
 
-  private val OutputGapCap          = 0.30   // ±cap on output gap in Taylor rule (Svensson 2003)
-  private val DebtThreshold         = 0.40   // debt-to-GDP threshold for fiscal risk premium
-  private val FiscalRiskCap         = 0.10   // maximum fiscal risk premium
-  private val QeCompressionCoeff    = 0.5    // yield compression per unit of NBP bond/GDP share
-  private val ForeignDemandDiscount = 0.005  // yield discount when NFA > 0
-  private val QeActivationSlack     = 0.0025 // rate proximity to floor for QE activation
-  private val QeDeflationThreshold  = 0.01   // inflation must be this much below target for QE
+  private val OutputGapCap          = Ratio(0.30)  // ±cap on output gap in Taylor rule (Svensson 2003)
+  private val DebtThreshold         = Ratio(0.40)  // debt-to-GDP threshold for fiscal risk premium
+  private val FiscalRiskCap         = Rate(0.10)   // maximum fiscal risk premium
+  private val QeCompressionCoeff    = Rate(0.5)    // yield compression per unit of NBP bond/GDP share
+  private val ForeignDemandDiscount = Rate(0.005)  // yield discount when NFA > 0
+  private val QeActivationSlack     = Rate(0.0025) // rate proximity to floor for QE activation
+  private val QeDeflationThreshold  = Rate(0.01)   // inflation must be this much below target for QE
 
   // ---------------------------------------------------------------------------
   // State
@@ -62,37 +62,37 @@ object Nbp:
     */
   private def taylorTarget(
       inflation: Rate,
-      exRateChange: Double,
+      exRateChange: Ratio,
       employed: Int,
       totalPopulation: Int,
-  )(using p: SimParams): Double =
-    val infGap = inflation.toDouble - p.monetary.targetInfl.toDouble
+  )(using p: SimParams): Rate =
+    val infGap    = inflation - p.monetary.targetInfl
+    val unempRate = Ratio.One - Ratio.fraction(employed, totalPopulation)
+    val nairu     = Ratio(p.monetary.nairu.toDouble) // Rate → Ratio: NAIRU is unemployment rate, not interest rate
     if p.flags.nbpSymmetric then
-      val unempRate    = 1.0 - (employed.toDouble / totalPopulation)
-      val rawOutputGap = (unempRate - p.monetary.nairu.toDouble) / p.monetary.nairu.toDouble
-      val outputGap    = Math.max(-OutputGapCap, Math.min(OutputGapCap, rawOutputGap))
-      p.monetary.neutralRate.toDouble +
-        p.monetary.taylorAlpha * infGap -
-        p.monetary.taylorDelta * outputGap +
-        p.monetary.taylorBeta * exRateChange
+      val rawOutputGap = Ratio((unempRate - nairu) / nairu)
+      val outputGap    = rawOutputGap.clamp(Ratio.Zero - OutputGapCap, OutputGapCap)
+      p.monetary.neutralRate +
+        infGap * p.monetary.taylorAlpha -
+        (outputGap * p.monetary.taylorDelta).toRate + // Ratio × coeff → Rate contribution
+        (exRateChange * p.monetary.taylorBeta).toRate // Ratio × coeff → Rate contribution
     else
-      p.monetary.neutralRate.toDouble +
-        p.monetary.taylorAlpha * Math.max(0.0, infGap) +
-        p.monetary.taylorBeta * Math.max(0.0, exRateChange)
+      p.monetary.neutralRate +
+        infGap.max(Rate.Zero) * p.monetary.taylorAlpha +
+        (exRateChange.max(Ratio.Zero) * p.monetary.taylorBeta).toRate
 
   /** Inertia smoothing + max rate change clamping. */
-  private def smoothAndClamp(prevRate: Rate, taylor: Double)(using p: SimParams): Double =
-    val smoothed = prevRate.toDouble * p.monetary.taylorInertia.toDouble + taylor * (1.0 - p.monetary.taylorInertia.toDouble)
-    if p.monetary.maxRateChange.toDouble > 0 then
-      prevRate.toDouble + Math.max(
-        -p.monetary.maxRateChange.toDouble,
-        Math.min(p.monetary.maxRateChange.toDouble, smoothed - prevRate.toDouble),
-      )
+  private def smoothAndClamp(prevRate: Rate, taylor: Rate)(using p: SimParams): Rate =
+    val inertia  = p.monetary.taylorInertia
+    val smoothed = prevRate * inertia + taylor * (Ratio.One - inertia)
+    if p.monetary.maxRateChange > Rate.Zero then
+      val delta = (smoothed - prevRate).clamp(-p.monetary.maxRateChange, p.monetary.maxRateChange)
+      prevRate + delta
     else smoothed
 
   /** Floor/ceiling clamp to [rateFloor, rateCeiling]. */
-  private def clampRate(rate: Double)(using p: SimParams): Rate =
-    Rate(rate).clamp(p.monetary.rateFloor, p.monetary.rateCeiling)
+  private def clampRate(rate: Rate)(using p: SimParams): Rate =
+    rate.clamp(p.monetary.rateFloor, p.monetary.rateCeiling)
 
   /** Update NBP reference rate via Taylor rule. Symmetric (dual mandate) or
     * asymmetric (inflation-only) depending on flags.nbpSymmetric.
@@ -100,7 +100,7 @@ object Nbp:
   def updateRate(
       prevRate: Rate,
       inflation: Rate,
-      exRateChange: Double,
+      exRateChange: Ratio,
       employed: Int,
       totalPopulation: Int,
   )(using p: SimParams): Rate =
@@ -116,31 +116,30 @@ object Nbp:
     */
   def bondYield(
       refRate: Rate,
-      debtToGdp: Double,
-      nbpBondGdpShare: Double,
+      debtToGdp: Ratio,
+      nbpBondGdpShare: Ratio,
       nfa: PLN,
-      credibilityPremium: Double,
+      credibilityPremium: Rate,
   )(using p: SimParams): Rate =
     if !p.flags.govBondMarket then refRate
     else
-      val termPremium   = p.fiscal.govTermPremium.toDouble
-      val fiscalRisk    = piecewiseFiscalRisk(Ratio(debtToGdp)).toDouble
+      val fiscalRisk    = piecewiseFiscalRisk(debtToGdp)
       val qeCompress    = QeCompressionCoeff * nbpBondGdpShare
-      val foreignDemand = if nfa > PLN.Zero then ForeignDemandDiscount else 0.0
-      (refRate + Rate(termPremium + fiscalRisk - qeCompress - foreignDemand + credibilityPremium)).max(Rate.Zero)
+      val foreignDemand = if nfa > PLN.Zero then ForeignDemandDiscount else Rate.Zero
+      (refRate + p.fiscal.govTermPremium + fiscalRisk - qeCompress - foreignDemand + credibilityPremium).max(Rate.Zero)
 
   /** Piecewise fiscal risk premium: steepens at 55% and 60% debt/GDP. base
     * segment (40%+) + caution segment (55%+) + crisis segment (60%+).
     */
   private def piecewiseFiscalRisk(debtToGdp: Ratio)(using p: SimParams): Rate =
-    val base      = Rate(p.fiscal.govFiscalRiskBeta * (debtToGdp - Ratio(DebtThreshold)).max(Ratio.Zero).toDouble)
+    val base      = Rate(p.fiscal.govFiscalRiskBeta * (debtToGdp - DebtThreshold).max(Ratio.Zero).toDouble)
     val caution55 =
       if debtToGdp > p.fiscal.fiscalRuleCautionThreshold then p.fiscal.fiscalRiskBeta55 * (debtToGdp - p.fiscal.fiscalRuleCautionThreshold)
       else Rate.Zero
     val crisis60  =
       if debtToGdp > p.fiscal.fiscalRuleDebtCeiling then p.fiscal.fiscalRiskBeta60 * (debtToGdp - p.fiscal.fiscalRuleDebtCeiling)
       else Rate.Zero
-    (base + caution55 + crisis60).min(Rate(FiscalRiskCap))
+    (base + caution55 + crisis60).min(FiscalRiskCap)
 
   // ---------------------------------------------------------------------------
   // QE
@@ -149,8 +148,8 @@ object Nbp:
   /** Should NBP activate QE? Rate near floor + inflation well below target. */
   def shouldActivateQe(refRate: Rate, inflation: Rate)(using p: SimParams): Boolean =
     p.flags.nbpQe &&
-      refRate.toDouble <= p.monetary.rateFloor.toDouble + QeActivationSlack &&
-      inflation.toDouble < p.monetary.targetInfl.toDouble - QeDeflationThreshold
+      refRate <= p.monetary.rateFloor + QeActivationSlack &&
+      inflation < p.monetary.targetInfl - QeDeflationThreshold
 
   /** Should NBP taper QE? Inflation returned above target. */
   def shouldTaperQe(inflation: Rate)(using p: SimParams): Boolean =
@@ -160,9 +159,9 @@ object Nbp:
   def executeQe(nbp: State, bankBondHoldings: PLN, annualGdp: PLN)(using p: SimParams): QeResult =
     if !nbp.qeActive then QeResult(nbp, PLN.Zero)
     else
-      val maxByGdp  = (annualGdp * p.monetary.qeMaxGdpShare.toDouble - nbp.govBondHoldings).max(PLN.Zero)
+      val maxByGdp  = (annualGdp * p.monetary.qeMaxGdpShare - nbp.govBondHoldings).max(PLN.Zero)
       val available = bankBondHoldings
-      val purchase  = PLN.Zero.max(maxByGdp.min(available).min(PLN(p.monetary.qePace.toDouble)))
+      val purchase  = PLN.Zero.max(maxByGdp.min(available).min(p.monetary.qePace))
       val newNbp    = nbp.copy(
         govBondHoldings = nbp.govBondHoldings + purchase,
         qeCumulative = nbp.qeCumulative + purchase,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
@@ -279,7 +279,7 @@ object OpenEconomyStep:
     )
 
   private def stepRateAndExpectations(in: Input, newForex: OpenEconomy.ForexState)(using p: SimParams): RateExpResult =
-    val exRateChg       = (newForex.exchangeRate / in.w.forex.exchangeRate) - 1.0
+    val exRateChg       = Ratio((newForex.exchangeRate / in.w.forex.exchangeRate) - 1.0)
     val newRefRate      = Nbp.updateRate(
       in.w.nbp.referenceRate,
       in.s7.newInfl,
@@ -307,16 +307,15 @@ object OpenEconomyStep:
       fxResult: Nbp.FxInterventionResult,
       interbank: InterbankResult,
   )(using p: SimParams): BondQeResult =
-    val annualGdpForBonds = in.w.gdpProxy * 12.0
-    val debtToGdp         = if annualGdpForBonds > 0 then in.w.gov.cumulativeDebt.toDouble / annualGdpForBonds else 0.0
-    val nbpBondGdpShare   = if annualGdpForBonds > 0 then in.w.nbp.qeCumulative.toDouble / annualGdpForBonds else 0.0
+    val annualGdpForBonds = PLN(in.w.gdpProxy * 12.0)
+    val debtToGdp         = if annualGdpForBonds > PLN.Zero then Ratio(in.w.gov.cumulativeDebt / annualGdpForBonds) else Ratio.Zero
+    val nbpBondGdpShare   = if annualGdpForBonds > PLN.Zero then Ratio(in.w.nbp.qeCumulative / annualGdpForBonds) else Ratio.Zero
     // Channel 3: De-anchored expectations -> higher bond yields
     val credPremium       = if p.flags.expectations then
-      val target = p.monetary.targetInfl.toDouble
-      (1.0 - in.w.mechanisms.expectations.credibility.toDouble) *
-        Math.abs(in.w.mechanisms.expectations.expectedInflation.toDouble - target) *
-        p.labor.expBondSensitivity.toDouble
-    else 0.0
+      val deAnchor = (Ratio.One - in.w.mechanisms.expectations.credibility) *
+        Ratio((in.w.mechanisms.expectations.expectedInflation - p.monetary.targetInfl).abs.toDouble)
+      Rate(deAnchor.toDouble * p.labor.expBondSensitivity.toDouble)
+    else Rate.Zero
     val newBondYield      = Nbp.bondYield(newRefRate, debtToGdp, nbpBondGdpShare, in.w.bop.nfa, credPremium)
 
     // Debt service: use LAGGED bond stock
@@ -334,7 +333,7 @@ object OpenEconomyStep:
       else if qeTaper then false
       else in.w.nbp.qeActive
     val preQeNbp         = Nbp.State(newRefRate, in.w.nbp.govBondHoldings, qeActive, in.w.nbp.qeCumulative, in.w.nbp.fxReserves, in.w.nbp.lastFxTraded)
-    val qeResult         = Nbp.executeQe(preQeNbp, in.w.bank.govBondHoldings, PLN(annualGdpForBonds))
+    val qeResult         = Nbp.executeQe(preQeNbp, in.w.bank.govBondHoldings, annualGdpForBonds)
     val postQeNbp        = qeResult.state
     val qePurchaseAmount = qeResult.purchased
     val postFxNbp        = postQeNbp.copy(fxReserves = fxResult.newReserves, lastFxTraded = fxResult.eurTraded)

--- a/src/main/scala/com/boombustgroup/amorfati/types.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/types.scala
@@ -111,9 +111,10 @@ object types:
   // === Ratios (0-1 range: shares, probabilities, adoption rates) ===
   opaque type Ratio = Double
   object Ratio:
-    inline def apply(d: Double): Ratio = d
-    val Zero: Ratio                    = 0.0
-    val One: Ratio                     = 1.0
+    inline def apply(d: Double): Ratio             = d
+    inline def fraction(num: Int, den: Int): Ratio = num.toDouble / den.toDouble
+    val Zero: Ratio                                = 0.0
+    val One: Ratio                                 = 1.0
     extension (r: Ratio)
       inline def +(other: Ratio): Ratio             = r + other
       inline def -(other: Ratio): Ratio             = r - other
@@ -124,16 +125,19 @@ object types:
       inline def *(p: PLN): PLN                     = p * r
       @targetName("ratioDivScalar")
       inline def /(scalar: Double): Ratio           = r / scalar
+      @targetName("ratioDivRatio")
+      inline def /(other: Ratio): Double            = r / other
       inline def max(other: Ratio): Ratio           = math.max(r, other)
       inline def min(other: Ratio): Ratio           = math.min(r, other)
       inline def clamp(lo: Ratio, hi: Ratio): Ratio = math.max(lo, math.min(hi, r))
       inline def monthly: Ratio                     = r / 12.0
+      inline def toRate: Rate                       = Rate(r) // explicit Ratio → Rate at semantic boundary
       inline def toDouble: Double                   = r
       inline def >(other: Ratio): Boolean           = r > other
       inline def <(other: Ratio): Boolean           = r < other
       inline def >=(other: Ratio): Boolean          = r >= other
       inline def <=(other: Ratio): Boolean          = r <= other
-    given Ordering[Ratio]              = Ordering.Double.TotalOrdering
+    given Ordering[Ratio]                          = Ordering.Double.TotalOrdering
     given Numeric[Ratio] with
       def plus(x: Ratio, y: Ratio): Ratio         = x + y
       def minus(x: Ratio, y: Ratio): Ratio        = x - y

--- a/src/test/scala/com/boombustgroup/amorfati/agents/CentralBankPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/CentralBankPropertySpec.scala
@@ -21,14 +21,14 @@ class CentralBankPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckP
   "Nbp.bondYield" should "be >= 0 for all inputs" in
     forAll(genRate, Gen.choose(0.0, 2.0), Gen.choose(0.0, 0.50), Gen.choose(-1e10, 1e10)) {
       (refRate: Double, debtToGdp: Double, nbpBondGdpShare: Double, nfa: Double) =>
-        val y = Nbp.bondYield(Rate(refRate), debtToGdp, nbpBondGdpShare, PLN(nfa), 0.0)
+        val y = Nbp.bondYield(Rate(refRate), Ratio(debtToGdp), Ratio(nbpBondGdpShare), PLN(nfa), Rate.Zero)
         y.toDouble should be >= 0.0
     }
 
   it should "cap fiscal risk premium at 10% even at extreme debtToGdp" in
     forAll(genRate, Gen.choose(1.0, 100.0), Gen.choose(0.0, 0.50), Gen.choose(-1e10, 1e10)) {
       (refRate: Double, debtToGdp: Double, nbpBondGdpShare: Double, nfa: Double) =>
-        val y = Nbp.bondYield(Rate(refRate), debtToGdp, nbpBondGdpShare, PLN(nfa), 0.0)
+        val y = Nbp.bondYield(Rate(refRate), Ratio(debtToGdp), Ratio(nbpBondGdpShare), PLN(nfa), Rate.Zero)
         // Fiscal risk ≤ 0.10, so yield ≤ refRate + termPremium + 0.10
         y.toDouble should be <= (refRate + p.fiscal.govTermPremium.toDouble + 0.10 + 0.001)
     }
@@ -36,15 +36,15 @@ class CentralBankPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckP
   it should "be monotonic in debtToGdp (higher debt → higher yield)" in
     forAll(genRate, Gen.choose(0.0, 1.0), Gen.choose(0.0, 0.50), Gen.choose(-1e10, 1e10)) {
       (refRate: Double, baseDebt: Double, nbpBondGdpShare: Double, nfa: Double) =>
-        val low  = Nbp.bondYield(Rate(refRate), baseDebt, nbpBondGdpShare, PLN(nfa), 0.0)
-        val high = Nbp.bondYield(Rate(refRate), baseDebt + 0.10, nbpBondGdpShare, PLN(nfa), 0.0)
+        val low  = Nbp.bondYield(Rate(refRate), Ratio(baseDebt), Ratio(nbpBondGdpShare), PLN(nfa), Rate.Zero)
+        val high = Nbp.bondYield(Rate(refRate), Ratio(baseDebt + 0.10), Ratio(nbpBondGdpShare), PLN(nfa), Rate.Zero)
         high.toDouble should be >= (low.toDouble - 1e-10)
     }
 
   it should "be monotonically decreasing in nbpBondGdpShare (QE effect)" in
     forAll(genRate, Gen.choose(0.0, 1.0), Gen.choose(0.0, 0.30), Gen.choose(-1e10, 1e10)) { (refRate: Double, debtToGdp: Double, baseQe: Double, nfa: Double) =>
-      val low  = Nbp.bondYield(Rate(refRate), debtToGdp, baseQe + 0.10, PLN(nfa), 0.0)
-      val high = Nbp.bondYield(Rate(refRate), debtToGdp, baseQe, PLN(nfa), 0.0)
+      val low  = Nbp.bondYield(Rate(refRate), Ratio(debtToGdp), Ratio(baseQe + 0.10), PLN(nfa), Rate.Zero)
+      val high = Nbp.bondYield(Rate(refRate), Ratio(debtToGdp), Ratio(baseQe), PLN(nfa), Rate.Zero)
       high.toDouble should be >= (low.toDouble - 1e-10)
     }
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/CentralBankSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/CentralBankSpec.scala
@@ -16,39 +16,39 @@ class CentralBankSpec extends AnyFlatSpec with Matchers:
     // When bond market off, yield = refRate (no risk premium, no QE)
     // This test depends on p.flags.govBondMarket which is true by default.
     // We test the positive path instead.
-    val y = Nbp.bondYield(Rate(0.05), 0.50, 0.0, PLN.Zero, 0.0)
+    val y = Nbp.bondYield(Rate(0.05), Ratio(0.50), Ratio.Zero, PLN.Zero, Rate.Zero)
     // debtToGdp=0.50 > 0.40 → raw fiscalRisk = 2.0 * 0.10 = 0.20, capped at 0.10
     // yield = 0.05 + 0.005 + 0.10 - 0 - 0 = 0.155
     y.toDouble shouldBe 0.155 +- 0.001
   }
 
   it should "increase with debtToGdp (fiscal risk premium)" in {
-    val low  = Nbp.bondYield(Rate(0.05), 0.30, 0.0, PLN.Zero, 0.0)
-    val high = Nbp.bondYield(Rate(0.05), 0.70, 0.0, PLN.Zero, 0.0)
+    val low  = Nbp.bondYield(Rate(0.05), Ratio(0.30), Ratio.Zero, PLN.Zero, Rate.Zero)
+    val high = Nbp.bondYield(Rate(0.05), Ratio(0.70), Ratio.Zero, PLN.Zero, Rate.Zero)
     high.toDouble should be > low.toDouble
   }
 
   it should "decrease with nbpBondGdpShare (QE compression)" in {
-    val noQe   = Nbp.bondYield(Rate(0.05), 0.50, 0.0, PLN.Zero, 0.0)
-    val withQe = Nbp.bondYield(Rate(0.05), 0.50, 0.20, PLN.Zero, 0.0)
+    val noQe   = Nbp.bondYield(Rate(0.05), Ratio(0.50), Ratio.Zero, PLN.Zero, Rate.Zero)
+    val withQe = Nbp.bondYield(Rate(0.05), Ratio(0.50), Ratio(0.20), PLN.Zero, Rate.Zero)
     withQe.toDouble should be < noQe.toDouble
   }
 
   it should "apply foreign demand discount when NFA > 0" in {
-    val nfaNeg = Nbp.bondYield(Rate(0.05), 0.50, 0.0, PLN(-1000.0), 0.0)
-    val nfaPos = Nbp.bondYield(Rate(0.05), 0.50, 0.0, PLN(1000.0), 0.0)
+    val nfaNeg = Nbp.bondYield(Rate(0.05), Ratio(0.50), Ratio.Zero, PLN(-1000.0), Rate.Zero)
+    val nfaPos = Nbp.bondYield(Rate(0.05), Ratio(0.50), Ratio.Zero, PLN(1000.0), Rate.Zero)
     nfaPos.toDouble should be < nfaNeg.toDouble
   }
 
   it should "have a floor at 0" in {
     // Very high QE compression → yield should not go negative
-    val y = Nbp.bondYield(Rate(0.01), 0.30, 0.50, PLN(1000.0), 0.0)
+    val y = Nbp.bondYield(Rate(0.01), Ratio(0.30), Ratio(0.50), PLN(1000.0), Rate.Zero)
     y.toDouble should be >= 0.0
   }
 
   it should "have zero fiscal risk when debtToGdp <= 0.40" in {
-    val y1 = Nbp.bondYield(Rate(0.05), 0.30, 0.0, PLN.Zero, 0.0)
-    val y2 = Nbp.bondYield(Rate(0.05), 0.40, 0.0, PLN.Zero, 0.0)
+    val y1 = Nbp.bondYield(Rate(0.05), Ratio(0.30), Ratio.Zero, PLN.Zero, Rate.Zero)
+    val y2 = Nbp.bondYield(Rate(0.05), Ratio(0.40), Ratio.Zero, PLN.Zero, Rate.Zero)
     // Both below threshold → same yield (only termPremium differs)
     y1 shouldBe y2
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
@@ -46,7 +46,7 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
 
   "updateCbRate" should "be in [RateFloor, RateCeiling] for PLN" in
     forAll(genRate, genInflation, Gen.choose(-0.10, 0.10), Gen.choose(0, totalPop)) { (prevRate: Double, inflation: Double, exRateChg: Double, employed: Int) =>
-      val r = Nbp.updateRate(Rate(prevRate), Rate(inflation), exRateChg, employed, totalPop)
+      val r = Nbp.updateRate(Rate(prevRate), Rate(inflation), Ratio(exRateChg), employed, totalPop)
       r.toDouble should be >= p.monetary.rateFloor.toDouble
       r.toDouble should be <= p.monetary.rateCeiling.toDouble
     }
@@ -55,8 +55,8 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
     forAll(genRate, Gen.choose(-0.10, 0.30), Gen.choose(0, totalPop)) { (prevRate: Double, baseInflation: Double, employed: Int) =>
       val lowInfl  = baseInflation
       val highInfl = baseInflation + 0.10
-      val rLow     = Nbp.updateRate(Rate(prevRate), Rate(lowInfl), 0.0, employed, totalPop)
-      val rHigh    = Nbp.updateRate(Rate(prevRate), Rate(highInfl), 0.0, employed, totalPop)
+      val rLow     = Nbp.updateRate(Rate(prevRate), Rate(lowInfl), Ratio.Zero, employed, totalPop)
+      val rHigh    = Nbp.updateRate(Rate(prevRate), Rate(highInfl), Ratio.Zero, employed, totalPop)
       rHigh.toDouble should be >= (rLow.toDouble - 1e-10)
     }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
@@ -57,16 +57,16 @@ class SimulationSpec extends AnyFlatSpec with Matchers:
   // --- updateCbRate ---
 
   "Nbp.updateRate" should "increase rate when inflation rises (PLN)" in {
-    val rate1 = Nbp.updateRate(Rate(0.0575), Rate(0.03), 0.0, totalPop * 95 / 100, totalPop)
-    val rate2 = Nbp.updateRate(Rate(0.0575), Rate(0.10), 0.0, totalPop * 95 / 100, totalPop)
+    val rate1 = Nbp.updateRate(Rate(0.0575), Rate(0.03), Ratio.Zero, totalPop * 95 / 100, totalPop)
+    val rate2 = Nbp.updateRate(Rate(0.0575), Rate(0.10), Ratio.Zero, totalPop * 95 / 100, totalPop)
     rate2.toDouble should be > rate1.toDouble
   }
 
   it should "bound rate between floor and ceiling" in {
-    val rateLow = Nbp.updateRate(Rate(0.005), Rate(-0.50), 0.0, totalPop * 95 / 100, totalPop)
+    val rateLow = Nbp.updateRate(Rate(0.005), Rate(-0.50), Ratio.Zero, totalPop * 95 / 100, totalPop)
     rateLow.toDouble should be >= p.monetary.rateFloor.toDouble
 
-    val rateHigh = Nbp.updateRate(Rate(0.25), Rate(1.0), 0.5, totalPop * 95 / 100, totalPop)
+    val rateHigh = Nbp.updateRate(Rate(0.25), Rate(1.0), Ratio(0.5), totalPop * 95 / 100, totalPop)
     rateHigh.toDouble should be <= p.monetary.rateCeiling.toDouble
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/markets/FiscalRulesSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/markets/FiscalRulesSpec.scala
@@ -98,13 +98,13 @@ class FiscalRulesSpec extends AnyWordSpec with Matchers:
   "Nbp.piecewiseFiscalRisk (via bondYield)" should {
 
     "have zero fiscal risk at 35% debt/GDP" in {
-      val y        = Nbp.bondYield(Rate(0.05), 0.35, 0.0, PLN.Zero, 0.0)
+      val y        = Nbp.bondYield(Rate(0.05), Ratio(0.35), Ratio.Zero, PLN.Zero, Rate.Zero)
       val expected = 0.05 + 0.005 // ref + termPremium
       y.toDouble shouldBe expected +- 0.001
     }
 
     "have base-only risk at 45% debt/GDP" in {
-      val y        = Nbp.bondYield(Rate(0.05), 0.45, 0.0, PLN.Zero, 0.0)
+      val y        = Nbp.bondYield(Rate(0.05), Ratio(0.45), Ratio.Zero, PLN.Zero, Rate.Zero)
       val baseRisk = 2.0 * 0.05
       val expected = 0.05 + 0.005 + baseRisk
       y.toDouble shouldBe expected +- 0.001
@@ -112,18 +112,18 @@ class FiscalRulesSpec extends AnyWordSpec with Matchers:
 
     "be monotonically non-decreasing with debt/GDP" in {
       val debtLevels = Seq(0.30, 0.35, 0.40, 0.42, 0.45, 0.50, 0.55, 0.56, 0.60, 0.62, 0.70, 0.90)
-      val yields     = debtLevels.map(d => Nbp.bondYield(Rate(0.05), d, 0.0, PLN.Zero, 0.0).toDouble)
+      val yields     = debtLevels.map(d => Nbp.bondYield(Rate(0.05), Ratio(d), Ratio.Zero, PLN.Zero, Rate.Zero).toDouble)
       for (y1, y2) <- yields.zip(yields.tail) do y2 should be >= y1
     }
 
     "increase above 40% threshold" in {
-      val yBelow = Nbp.bondYield(Rate(0.05), 0.39, 0.0, PLN.Zero, 0.0)
-      val yAbove = Nbp.bondYield(Rate(0.05), 0.42, 0.0, PLN.Zero, 0.0)
+      val yBelow = Nbp.bondYield(Rate(0.05), Ratio(0.39), Ratio.Zero, PLN.Zero, Rate.Zero)
+      val yAbove = Nbp.bondYield(Rate(0.05), Ratio(0.42), Ratio.Zero, PLN.Zero, Rate.Zero)
       yAbove.toDouble should be > yBelow.toDouble
     }
 
     "never exceed FiscalRiskCap (10%)" in {
-      val y = Nbp.bondYield(Rate(0.05), 0.90, 0.0, PLN.Zero, 0.0)
+      val y = Nbp.bondYield(Rate(0.05), Ratio(0.90), Ratio.Zero, PLN.Zero, Rate.Zero)
       y.toDouble should be <= 0.05 + 0.005 + 0.10 + 0.001
     }
   }


### PR DESCRIPTION
## Summary
- Type all 7 named constants in Nbp.scala with opaque types (Ratio/Rate) instead of bare Double
- Type public API signatures: `bondYield(Ratio, Ratio, Rate)`, `updateRate(Ratio)` instead of Double
- Taylor rule: `unempRate` as `Ratio`, output gap via `Ratio / Ratio`, no bare `1.0`/`0.0` literals
- `smoothAndClamp`: `Rate * Ratio` via `taylorInertia` directly, no `.toDouble` intermediaries
- Add `Ratio.fraction(Int, Int)`, `Ratio / Ratio → Double`, `Ratio.toRate`, `Rate * Ratio → Rate` to types.scala

## Design
- **Semantic boundaries explicit**: `Ratio → Rate` only at Taylor coefficient application (gap × coeff → rate contribution) via `.toRate`
- **NAIRU**: converted `Rate → Ratio` with comment — NAIRU is unemployment rate, not interest rate (config type mismatch is pre-existing)
- **No behavioral change**: all opaque types are Double underneath, pure refactor

## Test plan
- [ ] 1268 tests pass
- [x] `sbt scalafmtAll` clean
- [x] No `.toDouble` in Nbp except NAIRU boundary conversion