### PR TITLE
Fix nairu type: Rate → Ratio

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
@@ -68,7 +68,7 @@ object Nbp:
   )(using p: SimParams): Rate =
     val infGap    = inflation - p.monetary.targetInfl
     val unempRate = Ratio.One - Ratio.fraction(employed, totalPopulation)
-    val nairu     = Ratio(p.monetary.nairu.toDouble) // Rate → Ratio: NAIRU is unemployment rate, not interest rate
+    val nairu     = p.monetary.nairu
     if p.flags.nbpSymmetric then
       val rawOutputGap = Ratio((unempRate - nairu) / nairu)
       val outputGap    = rawOutputGap.clamp(Ratio.Zero - OutputGapCap, OutputGapCap)

--- a/src/main/scala/com/boombustgroup/amorfati/config/MonetaryConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/MonetaryConfig.scala
@@ -66,7 +66,7 @@ case class MonetaryConfig(
     rateFloor: Rate = Rate(0.001),
     rateCeiling: Rate = Rate(0.25),
     maxRateChange: Rate = Rate(0.0),
-    nairu: Rate = Rate(0.05),
+    nairu: Ratio = Ratio(0.05),
     taylorDelta: Double = 0.5,
     reserveRateMult: Ratio = Ratio(0.5),
     depositFacilitySpread: Rate = Rate(0.01),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/Expectations.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/Expectations.scala
@@ -87,7 +87,7 @@ object Expectations:
   private def forwardGuidance(expected: Double, target: Double, unemployment: Double, currentRate: Double)(using p: SimParams): Double =
     if !p.flags.nbpForwardGuidance then currentRate
     else
-      val nairu        = p.monetary.nairu.toDouble
+      val nairu        = p.monetary.nairu.toDouble // Ratio → Double: function operates in Double space
       val rawOutputGap = (unemployment - nairu) / nairu
       val outputGap    = Math.max(-OutputGapClamp, Math.min(OutputGapClamp, rawOutputGap))
       val rawFg        = p.monetary.neutralRate.toDouble + p.monetary.taylorAlpha * (expected - target) - p.monetary.taylorDelta * outputGap

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/DemandStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/DemandStep.scala
@@ -54,7 +54,7 @@ object DemandStep:
       if p.flags.zus then (in.w.social.zus.contributions - in.w.social.zus.pensionPayments).max(PLN.Zero)
       else PLN.Zero
     val unempRate     = Ratio(1.0 - in.s2.employed.toDouble / in.w.totalPopulation)
-    val unempGap      = (unempRate - Ratio(p.monetary.nairu.toDouble)).max(Ratio.Zero)
+    val unempGap      = (unempRate - p.monetary.nairu).max(Ratio.Zero)
     val stimulus      = p.fiscal.govBaseSpending * unempGap * p.fiscal.govAutoStabMult
     val target        = p.fiscal.govBaseSpending * Math.max(1.0, in.w.priceLevel) +
       (in.w.gov.taxRevenue + zusNetSurplus) * p.fiscal.govFiscalRecyclingRate + stimulus
@@ -65,8 +65,8 @@ object DemandStep:
     */
   private def applyFiscalRules(in: Input, rawTarget: PLN)(using p: SimParams): FiscalRules.Output =
     val prevGovSpend = in.w.gov.govCurrentSpend + in.w.gov.govCapitalSpend
-    val unempRate    = 1.0 - in.s2.employed.toDouble / in.w.totalPopulation
-    val outputGap    = Ratio((unempRate - p.monetary.nairu.toDouble) / p.monetary.nairu.toDouble)
+    val unempRate    = Ratio.One - Ratio.fraction(in.s2.employed, in.w.totalPopulation)
+    val outputGap    = Ratio((unempRate - p.monetary.nairu) / p.monetary.nairu)
 
     val floored =
       if prevGovSpend > PLN.Zero then rawTarget.max(prevGovSpend * GovSpendingFloor)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -159,7 +159,10 @@ object SimOutput:
     ColumnDef("ImportedInterm", ctx => ctx.world.bop.importedIntermediates.toDouble),
     ColumnDef("FDI", ctx => ctx.world.bop.fdi.toDouble),
     ColumnDef("UnempBenefitSpend", ctx => ctx.world.gov.unempBenefitSpend.toDouble),
-    ColumnDef("OutputGap", ctx => (ctx.unemployPct - ctx.p.monetary.nairu.toDouble) / ctx.p.monetary.nairu.toDouble),
+    ColumnDef(
+      "OutputGap",
+      ctx => (ctx.unemployPct - ctx.p.monetary.nairu.toDouble) / ctx.p.monetary.nairu.toDouble,
+    ), // Ratio.toDouble: ColumnDef computes Double
     // Bond market
     ColumnDef("BondYield", ctx => ctx.world.gov.bondYield.toDouble),
     ColumnDef("BondsOutstanding", ctx => ctx.world.gov.bondsOutstanding.toDouble),


### PR DESCRIPTION
## Summary
- Change `MonetaryConfig.nairu` from `Rate(0.05)` to `Ratio(0.05)` — NAIRU is an unemployment rate (dimensionless share), not an interest rate
- Remove forced `.toDouble` conversions at all 5 call sites: Nbp, DemandStep (×2), Expectations, SimOutput

## Test plan
- [x] 1268 tests pass
- [x] `sbt scalafmtAll` clean
- [x] No behavioral change (opaque types are both Double underneath)