### PR TITLE
Add relative PPP drift to exchange rate dynamics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/config/OpenEconConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/OpenEconConfig.scala
@@ -64,6 +64,7 @@ case class OpenEconConfig(
     fdiBase: PLN = PLN(583.1e6),     // raw — scaled by gdpRatio
     portfolioSensitivity: Double = 0.20,
     riskPremiumSensitivity: Double = 0.10,
+    pppSpeed: Ratio = Ratio(0.10),   // annual convergence speed toward PPP equilibrium (Rogoff 1996: 3-5yr half-life)
 ):
   require(erFloor > 0, s"erFloor must be positive: $erFloor")
   require(erFloor < erCeiling, s"erFloor ($erFloor) must be < erCeiling ($erCeiling)")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -143,6 +143,7 @@ object OpenEconomy:
       priceLevel: Double,
       sectorOutputs: Vector[PLN],
       month: Int,
+      inflation: Rate = Rate.Zero, // domestic CPI YoY for PPP drift
       nbpFxReserves: PLN = PLN.Zero,
       gvcExports: Option[PLN] = None,
       gvcIntermImports: Option[Vector[PLN]] = None,
@@ -263,10 +264,11 @@ object OpenEconomy:
     val realPrice = if priceLevel > 0 && nominalER > 0 then priceLevel / nominalER else 1.0
     Math.pow(1.0 / Math.max(MinRealPrice, realPrice), p.openEcon.exportPriceElasticity)
 
-  /** New nominal exchange rate for the next period, driven by BoP flows. ER
-    * adjusts to close the BoP gap: surplus → appreciation, deficit →
-    * depreciation. Includes NFA risk premium (negative NFA → weaker PLN) and
-    * NBP FX intervention. Clamped to [erFloor, erCeiling].
+  /** New nominal exchange rate for the next period, driven by BoP flows and
+    * relative PPP. ER adjusts to close the BoP gap: surplus → appreciation,
+    * deficit → depreciation. PPP drift depreciates PLN when domestic inflation
+    * exceeds foreign (Rogoff 1996). Includes NFA risk premium (negative NFA →
+    * weaker PLN) and NBP FX intervention. Clamped to [erFloor, erCeiling].
     */
   private def computeExchangeRate(
       in: StepInput,
@@ -278,7 +280,9 @@ object OpenEconomy:
     val nfaGdpRatio = if in.gdp > PLN.Zero then in.prevBop.nfa / annualGdp else 0.0
     val bopGdpRatio = if in.gdp > PLN.Zero then (ca + capitalAccount) / in.gdp else 0.0
     val nfaRisk     = p.openEcon.riskPremiumSensitivity * Math.min(0.0, nfaGdpRatio)
-    val erChange    = p.forex.exRateAdjSpeed.toDouble * (-bopGdpRatio + nfaRisk) + fxErEffect
+    // Relative PPP: higher domestic inflation → PLN depreciates (positive erChange)
+    val pppDrift    = ((in.inflation - p.gvc.foreignInflation) * p.openEcon.pppSpeed).monthly.toDouble
+    val erChange    = p.forex.exRateAdjSpeed.toDouble * (-bopGdpRatio + nfaRisk) + fxErEffect + pppDrift
     Math.max(p.openEcon.erFloor, Math.min(p.openEcon.erCeiling, in.prevForex.exchangeRate * (1.0 + erChange)))
 
   /** NFA valuation adjustment from ER movement between periods. Not a flow

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/OpenEconomyStep.scala
@@ -212,6 +212,7 @@ object OpenEconomyStep:
           autoRatio = in.s7.autoR,
           domesticRate = in.w.nbp.referenceRate,
           gdp = in.s7.gdp,
+          inflation = in.w.inflation,
           priceLevel = in.w.priceLevel,
           sectorOutputs = sectorOutputs,
           month = in.s1.m,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
@@ -113,3 +113,33 @@ class OpenEconomySpec extends AnyFlatSpec with Matchers:
     r.forex.exchangeRate should be >= p.openEcon.erFloor
     r.forex.exchangeRate should be <= p.openEcon.erCeiling
   }
+
+  // ---- PPP drift ----
+
+  it should "depreciate PLN when domestic inflation exceeds foreign" in {
+    val highInfl = baseInput().copy(inflation = Rate(0.10)) // 10% domestic vs 2% foreign
+    val lowInfl  = baseInput().copy(inflation = Rate(0.02)) // equal to foreign
+    val rHigh    = OpenEconomy.step(highInfl)
+    val rLow     = OpenEconomy.step(lowInfl)
+    // Higher domestic inflation → weaker PLN (higher ER)
+    rHigh.forex.exchangeRate should be > rLow.forex.exchangeRate
+  }
+
+  it should "appreciate PLN when domestic inflation below foreign" in {
+    val lowInfl = baseInput().copy(inflation = Rate(0.00)) // 0% domestic vs 2% foreign
+    val eqInfl  = baseInput().copy(inflation = Rate(0.02)) // equal
+    val rLow    = OpenEconomy.step(lowInfl)
+    val rEq     = OpenEconomy.step(eqInfl)
+    // Lower domestic inflation → stronger PLN (lower ER)
+    rLow.forex.exchangeRate should be < rEq.forex.exchangeRate
+  }
+
+  it should "have no PPP drift when inflation equals foreign" in {
+    val eqInfl   = baseInput().copy(inflation = p.gvc.foreignInflation)
+    val zeroInfl = baseInput().copy(inflation = Rate.Zero)
+    val rEq      = OpenEconomy.step(eqInfl)
+    val rZero    = OpenEconomy.step(zeroInfl)
+    // With equal inflation, PPP drift is zero — ER difference comes only from other channels
+    // Zero inflation case has negative PPP drift (domestic < foreign) → stronger PLN
+    rEq.forex.exchangeRate should be > rZero.forex.exchangeRate
+  }


### PR DESCRIPTION
## Summary
- Add relative PPP component to ER dynamics: `erDrift = (π_domestic − π_foreign) × pppSpeed / 12`
- Higher domestic inflation → PLN depreciates; lower → appreciates
- New param `OpenEconConfig.pppSpeed: Ratio = 0.10` (annual convergence, Rogoff 1996 half-life)
- Pass `World.inflation` into `OpenEconomy.StepInput` for PPP computation
- Reuses existing `GvcConfig.foreignInflation` (2% annual) as partner benchmark

## Design
- **Injection point**: `OpenEconomy.computeExchangeRate()` — PPP drift added alongside BoP adjustment, NFA risk, and FX intervention
- **Formula**: `(domesticInflation − foreignInflation) × pppSpeed` converted to monthly Rate
- **No SFC impact**: ER is a price, not a flow — no accounting identity affected
- **Feedback loops preserved**: ER depreciation → import push inflation → further PPP drift (but dampened by Taylor rule response)

## Test plan
- [x] 3 new tests: depreciation on high inflation, appreciation on low inflation, differential sign correctness
- [x] All 1271 tests pass (1268 existing + 3 new)
- [x] `sbt scalafmtAll` clean

Fixes #34