### PR TITLE
CES production function replacing Cobb-Douglas

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -217,23 +217,39 @@ object Firm:
     else base
 
   /** Monthly production capacity in PLN. Scales with tech, sector, firm size;
-    * augmented by physical capital (Cobb-Douglas) when enabled.
+    * augmented by physical capital via CES production function when enabled.
+    *
+    * CES: Y = A × [α·K^ρ + (1-α)·L^ρ]^(1/ρ) where ρ = (σ-1)/σ. High-σ sectors
+    * (BPO=50) substitute K/L easily; low-σ (Public=1) resist.
     */
   def computeCapacity(f: State)(using p: SimParams): PLN =
     val sec       = p.sectorDefs(f.sector.toInt)
-    val sizeScale = f.initialSize.toDouble / p.pop.workersPerFirm
-    val base: PLN = f.tech match
-      case TechState.Traditional(w) => p.firm.baseRevenue * (sizeScale * sec.revenueMultiplier * Math.sqrt(w.toDouble / f.initialSize))
-      case TechState.Hybrid(w, eff) =>
-        p.firm.baseRevenue * (sizeScale * sec.revenueMultiplier * (HybridLaborCapShare * Math.sqrt(w.toDouble / f.initialSize) + HybridAiCapShare * eff))
-      case TechState.Automated(eff) => p.firm.baseRevenue * (sizeScale * sec.revenueMultiplier * eff)
-      case _: TechState.Bankrupt    => PLN.Zero
-    if p.flags.physCap && f.capitalStock > PLN.Zero && base > PLN.Zero then
-      val targetK       = workerCount(f).toDouble * p.capital.klRatios.map(_.toDouble)(f.sector.toInt)
-      val kRatio        = if targetK > 0 then f.capitalStock.toDouble / targetK else 1.0
-      val capitalFactor = Math.pow(Math.min(2.0, Math.max(0.1, kRatio)), p.capital.prodElast.toDouble)
-      base * capitalFactor
-    else base
+    val sizeScale = Ratio(f.initialSize.toDouble / p.pop.workersPerFirm)
+    val laborEff  = f.tech match
+      case TechState.Traditional(w) => Ratio(Math.sqrt(w.toDouble / f.initialSize))
+      case TechState.Hybrid(w, eff) => Ratio(HybridLaborCapShare * Math.sqrt(w.toDouble / f.initialSize) + HybridAiCapShare * eff)
+      case TechState.Automated(eff) => Ratio(eff)
+      case _: TechState.Bankrupt    => Ratio.Zero
+    val tfp       = sizeScale * sec.revenueMultiplier
+    if p.flags.physCap && f.capitalStock > PLN.Zero && laborEff > Ratio.Zero then
+      val targetK: PLN  = workerCount(f) * p.capital.klRatios(f.sector.toInt)
+      val k: Ratio      = Ratio(if targetK > PLN.Zero then f.capitalStock / targetK else 1.0).clamp(Ratio(0.1), Ratio(2.0))
+      val alpha: Ratio  = p.capital.prodElast
+      val sigma: Double = sec.sigma
+      p.firm.baseRevenue * tfp * cesOutput(alpha, k, laborEff, sigma)
+    else p.firm.baseRevenue * tfp * laborEff
+
+  /** CES aggregator: [α·K^ρ + (1-α)·L^ρ]^(1/ρ). Degrades gracefully: σ→1 ≈
+    * Cobb-Douglas, σ→∞ ≈ linear (perfect substitutes).
+    */
+  private[amorfati] def cesOutput(alpha: Ratio, k: Ratio, l: Ratio, sigma: Double): Ratio =
+    if sigma <= 1.001 then // near-Leontief/Cobb-Douglas boundary — use Cobb-Douglas
+      Ratio(Math.pow(k.toDouble, alpha.toDouble) * Math.pow(l.toDouble, 1.0 - alpha.toDouble))
+    else
+      val rho   = (sigma - 1.0) / sigma
+      val kTerm = alpha.toDouble * Math.pow(k.toDouble, rho)
+      val lTerm = (1.0 - alpha.toDouble) * Math.pow(l.toDouble, rho)
+      Ratio(Math.pow(kTerm + lTerm, 1.0 / rho))
 
   /** Effective AI CAPEX for sector — sublinear in firm size (exponent 0.6),
     * digital readiness discount.

--- a/src/main/scala/com/boombustgroup/amorfati/config/CapitalConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CapitalConfig.scala
@@ -23,7 +23,7 @@ import com.boombustgroup.amorfati.types.*
   * @param adjustSpeed
   *   monthly speed of capital stock adjustment toward target
   * @param prodElast
-  *   output elasticity of capital in Cobb-Douglas production function
+  *   capital share α in CES production function (also Cobb-Douglas when σ≈1)
   * @param costReplace
   *   replacement cost of capital as fraction of original value
   * @param inventoryTargetRatios

--- a/src/main/scala/com/boombustgroup/amorfati/types.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/types.scala
@@ -55,6 +55,9 @@ object types:
       inline def <(other: PLN): Boolean       = p < other
       inline def >=(other: PLN): Boolean      = p >= other
       inline def <=(other: PLN): Boolean      = p <= other
+    extension (n: Int)
+      @targetName("intTimesPln")
+      inline def *(p: PLN): PLN      = p * n.toDouble
     given Ordering[PLN]              = Ordering.Double.TotalOrdering
     given Numeric[PLN] with
       def plus(x: PLN, y: PLN): PLN             = x + y

--- a/src/test/scala/com/boombustgroup/amorfati/agents/CesProductionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/CesProductionSpec.scala
@@ -1,0 +1,113 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CesProductionSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams          = SimParams.defaults
+  private val p: SimParams = summon[SimParams]
+
+  private val alpha = Ratio(0.30)
+  private val tol   = 1e-6
+
+  // --- cesOutput unit tests ---
+
+  "cesOutput" should "return 1.0 when K=1 and L=1 for any sigma" in {
+    for sigma <- Seq(1.0, 2.0, 5.0, 50.0, 1000.0) do
+      withClue(s"sigma=$sigma: ") {
+        Firm.cesOutput(alpha, Ratio.One, Ratio.One, sigma).toDouble shouldBe 1.0 +- tol
+      }
+  }
+
+  it should "approximate Cobb-Douglas when sigma <= 1.001" in {
+    val k        = Ratio(1.5)
+    val l        = Ratio(0.8)
+    val expected = Math.pow(k.toDouble, alpha.toDouble) * Math.pow(l.toDouble, 1.0 - alpha.toDouble)
+    Firm.cesOutput(alpha, k, l, 1.0).toDouble shouldBe expected +- tol
+  }
+
+  it should "approach linear when sigma is very large" in {
+    val k      = Ratio(2.0)
+    val l      = Ratio(0.5)
+    val linear = alpha.toDouble * k.toDouble + (1.0 - alpha.toDouble) * l.toDouble
+    val result = Firm.cesOutput(alpha, k, l, 10000.0).toDouble
+    result shouldBe linear +- 0.01
+  }
+
+  it should "produce higher output for high-sigma with K>L (easier substitution)" in {
+    val k         = Ratio(2.0)
+    val l         = Ratio(0.5)
+    val lowSigma  = Firm.cesOutput(alpha, k, l, 2.0).toDouble
+    val highSigma = Firm.cesOutput(alpha, k, l, 50.0).toDouble
+    highSigma should be > lowSigma
+  }
+
+  it should "be symmetric: swapping K/L with alpha/(1-alpha) gives same result" in {
+    val k       = Ratio(1.5)
+    val l       = Ratio(0.8)
+    val normal  = Firm.cesOutput(alpha, k, l, 5.0).toDouble
+    val swapped = Firm.cesOutput(Ratio(1.0 - alpha.toDouble), l, k, 5.0).toDouble
+    normal shouldBe swapped +- tol
+  }
+
+  it should "be monotonic in K" in {
+    val l     = Ratio(1.0)
+    val kLow  = Firm.cesOutput(alpha, Ratio(0.5), l, 5.0).toDouble
+    val kMid  = Firm.cesOutput(alpha, Ratio(1.0), l, 5.0).toDouble
+    val kHigh = Firm.cesOutput(alpha, Ratio(1.5), l, 5.0).toDouble
+    kLow should be < kMid
+    kMid should be < kHigh
+  }
+
+  // --- computeCapacity integration ---
+
+  private def mkFirm(
+      tech: TechState = TechState.Traditional(10),
+      sector: Int = 0,
+      capitalStock: PLN = PLN(1_200_000.0),
+  ): Firm.State =
+    Firm.State(
+      FirmId(0),
+      PLN(50000.0),
+      PLN.Zero,
+      tech,
+      Ratio(0.5),
+      1.0,
+      Ratio(0.3),
+      SectorIdx(sector),
+      Vector.empty[FirmId],
+      bankId = BankId(0),
+      equityRaised = PLN.Zero,
+      initialSize = 10,
+      capitalStock = capitalStock,
+      bondDebt = PLN.Zero,
+      foreignOwned = false,
+      inventory = PLN.Zero,
+      greenCapital = PLN.Zero,
+      accumulatedLoss = PLN.Zero,
+    )
+
+  "computeCapacity" should "produce non-zero output for Traditional firm" in {
+    Firm.computeCapacity(mkFirm()) should be > PLN.Zero
+  }
+
+  it should "produce higher capacity for high-sigma sector (BPO) than low-sigma (Public) at same K/L" in {
+    val bpo    = Firm.computeCapacity(mkFirm(sector = 0)) // sigma=50
+    val public = Firm.computeCapacity(mkFirm(sector = 4)) // sigma=1
+    // BPO has higher revenueMultiplier too, but the CES effect amplifies the difference
+    bpo should be > public
+  }
+
+  it should "produce zero for bankrupt firm" in {
+    Firm.computeCapacity(mkFirm(tech = TechState.Bankrupt(BankruptReason.AiDebtTrap))) shouldBe PLN.Zero
+  }
+
+  it should "increase capacity with more capital" in {
+    assume(p.flags.physCap, "physCap=true required")
+    val poor = Firm.computeCapacity(mkFirm(capitalStock = PLN(100_000.0)))
+    val rich = Firm.computeCapacity(mkFirm(capitalStock = PLN(5_000_000.0)))
+    rich should be > poor
+  }


### PR DESCRIPTION
## Summary

- **CES production**: `Y = A × [α·K^ρ + (1-α)·L^ρ]^(1/ρ)` where `ρ = (σ-1)/σ`
- High-σ sectors (BPO=50) substitute K/L easily; low-σ (Public=1) resist
- Degrades to Cobb-Douglas when σ≈1, approaches linear when σ→∞
- Full opaque types: `Ratio` for alpha/k/l/output, `PLN` for targetK
- Add `Int * PLN → PLN` operator
- 10 new tests: cesOutput properties + computeCapacity integration

## Test plan

- [ ] `sbt scalafmtAll` — no reformats
- [ ] `sbt compile` — no warnings
- [ ] `sbt test` — 1286 tests pass (10 new)

Fixes #28