### PR TITLE
Skills-biased technological change (SBTC)

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -95,6 +95,7 @@ object Household:
       numDependentChildren: Int,    // children ≤ 18 for 800+ social transfers
       consumerDebt: PLN,            // outstanding unsecured consumer loan
       education: Int,               // education level: 0=Primary, 1=Vocational, 2=Secondary, 3=Tertiary
+      taskRoutineness: Ratio,       // how routine is this worker's task bundle [0,1] (Acemoglu & Restrepo 2020)
   )
 
   /** Aggregate statistics computed from individual households (Paper-06). */
@@ -200,6 +201,7 @@ object Household:
         if rng.nextDouble() < p.household.debtFraction.toDouble then
           PLN(Math.exp(p.household.debtMu + p.household.debtSigma * rng.nextGaussian()) * ConsumerDebtInitFrac)
         else PLN.Zero
+      val routineness   = sampleTaskRoutineness(edu, sectorIdx, rng)
       State(
         id = HhId(hhId),
         savings = savings,
@@ -218,6 +220,7 @@ object Household:
         numDependentChildren = numChildren,
         consumerDebt = consDebt,
         education = edu,
+        taskRoutineness = routineness,
       )
 
     /** Sample education level and skill for a sector, clamped to edu range. */
@@ -229,6 +232,23 @@ object Household:
       val sectorBonus                = Math.min(SectorSkillBonusMax, SectorSkillBonusCoeff * Math.log(sectorSigma))
       val skill                      = Math.max(skillFloor, Math.min(skillCeiling, baseSkill + sectorBonus))
       (edu, skill)
+
+    /** Sample task routineness based on education and sector sigma.
+      *
+      * High-σ sectors (BPO) have more automatable routine tasks; high education
+      * workers tend toward cognitive (non-routine) tasks. Acemoglu & Restrepo
+      * 2020.
+      *
+      * routineness = base(edu) + σ-bonus, clamped to [0.05, 0.95], with noise.
+      */
+    private[agents] def sampleTaskRoutineness(edu: Int, sectorIdx: SectorIdx, rng: Random)(using p: SimParams): Ratio =
+      // Base routineness by education: Primary=0.8, Vocational=0.65, Secondary=0.45, Tertiary=0.25
+      val eduBase  = p.labor.sbtcEduRoutineness(edu)
+      // High-σ sectors (BPO=50) push routineness up; low-σ (Public=1) push down
+      val sigma    = p.sectorDefs(sectorIdx.toInt).sigma
+      val sigmaAdj = 0.05 * Math.log(sigma) / Math.log(10.0) // ±0.05 per log10(σ)
+      val noise    = 0.05 * (rng.nextDouble() - 0.5)         // ±2.5% uniform noise
+      Ratio(eduBase + sigmaAdj + noise).clamp(Ratio(0.05), Ratio(0.95))
 
   // ---- Step flow totals (immutable, folded from per-HH results) ----
 

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -96,6 +96,7 @@ object Immigration:
         numDependentChildren = numChildren,
         consumerDebt = PLN.Zero,
         education = edu,
+        taskRoutineness = Household.Init.sampleTaskRoutineness(edu, sector, rng),
       )
     }.toVector
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
@@ -92,4 +92,5 @@ case class FeatureFlags(
     sectoralMobility: Boolean = false,
     unions: Boolean = false,
     expectations: Boolean = false,
+    sbtc: Boolean = true,
 )

--- a/src/main/scala/com/boombustgroup/amorfati/config/LaborConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/LaborConfig.scala
@@ -58,6 +58,9 @@ case class LaborConfig(
     unionDensity: Vector[Ratio] = Vector(Ratio(0.02), Ratio(0.15), Ratio(0.03), Ratio(0.12), Ratio(0.30), Ratio(0.04)),
     unionWagePremium: Ratio = Ratio(0.08),
     unionRigidity: Ratio = Ratio(0.50),
+    // Skills-biased technological change (Acemoglu & Restrepo 2020, Autor 2024)
+    sbtcEduRoutineness: Vector[Double] = Vector(0.80, 0.65, 0.45, 0.25), // Primary, Vocational, Secondary, Tertiary
+    sbtcComplementPremium: Ratio = Ratio(0.15),                          // max wage premium for AI-complemented cognitive workers
     // Expectations (Carroll 2003, Bewley 1999)
     expLambda: Ratio = Ratio(0.70),
     expCredibilityInit: Ratio = Ratio(0.80),
@@ -67,3 +70,4 @@ case class LaborConfig(
     expBondSensitivity: Ratio = Ratio(0.50),
 ):
   require(unionDensity.length == 6, s"unionDensity must have 6 sectors: ${unionDensity.length}")
+  require(sbtcEduRoutineness.length == 4, s"sbtcEduRoutineness must have 4 education levels: ${sbtcEduRoutineness.length}")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
@@ -96,10 +96,10 @@ object LaborMarket:
     * discount × education premium) but normalized so mean employed wage =
     * marketWage (macro consistency).
     */
-  def updateWages(households: Vector[Household.State], marketWage: PLN)(using
+  def updateWages(households: Vector[Household.State], firms: Vector[Firm.State], marketWage: PLN)(using
       p: SimParams,
   ): Vector[Household.State] =
-    val rawWages = households.map(rawRelativeWage)
+    val rawWages = households.map(rawRelativeWage(_, firms))
     val rawMean  = employedMeanRawWage(households, rawWages)
     val scale    = if rawMean > Ratio(0.0) then Ratio(1.0 / rawMean.toDouble) else Ratio(1.0)
     applyNormalizedWages(households, rawWages, marketWage, scale)
@@ -156,12 +156,14 @@ object LaborMarket:
           case _                      => f.id -> 0
     }.toMap
 
-  /** Build retain sets: education-ranked workers kept per firm. */
+  /** Build retain sets: when SBTC enabled, low-routineness (cognitive) workers
+    * retained first; otherwise education-ranked.
+    */
   private def retainSets(
       households: Vector[Household.State],
       lostFirms: Set[FirmId],
       counts: Map[FirmId, Int],
-  ): Map[FirmId, Set[Int]] =
+  )(using p: SimParams): Map[FirmId, Set[Int]] =
     households.zipWithIndex
       .flatMap: (hh, idx) =>
         hh.status match
@@ -169,7 +171,11 @@ object LaborMarket:
           case _                                                             => None
       .groupMap(_._1)(_._2)
       .map: (firmId, indices) =>
-        val sorted    = indices.sortBy(i => (-households(i).education, -households(i).skill.toDouble))
+        val sorted    =
+          if p.flags.sbtc then
+            // Low routineness = cognitive = retained; high routineness = routine = displaced
+            indices.sortBy(i => (households(i).taskRoutineness.toDouble, -households(i).skill.toDouble))
+          else indices.sortBy(i => (-households(i).education, -households(i).skill.toDouble))
         val maxRetain = counts.getOrElse(firmId, 0)
         firmId -> sorted.take(maxRetain).toSet
 
@@ -301,17 +307,30 @@ object LaborMarket:
   // --- Wage helpers ---
 
   /** Raw relative wage weight for a household (unnormalized). */
-  private def rawRelativeWage(hh: Household.State)(using p: SimParams): Ratio =
+  private def rawRelativeWage(hh: Household.State, firms: Vector[Firm.State])(using p: SimParams): Ratio =
     hh.status match
-      case HhStatus.Employed(_, sectorIdx, _) =>
+      case HhStatus.Employed(firmId, sectorIdx, _) =>
         val immigrantDiscount =
           if hh.isImmigrant && p.flags.immigration then 1.0 - p.immigration.wageDiscount.toDouble
           else 1.0
+        val aiComplement      = aiComplementFactor(hh, firms(firmId.toInt))
         Ratio(
           Firm.effectiveWageMult(sectorIdx).toDouble * effectiveSkill(hh) * immigrantDiscount *
-            p.social.eduWagePremium(hh.education),
+            p.social.eduWagePremium(hh.education) * aiComplement,
         )
-      case _                                  => Ratio(0.0)
+      case _                                       => Ratio(0.0)
+
+  /** AI-complement wage premium: cognitive workers in automated/hybrid firms
+    * get a wage boost (1 - routineness) × complementPremium. Routine workers
+    * get no boost. Acemoglu & Restrepo 2020.
+    */
+  private def aiComplementFactor(hh: Household.State, firm: Firm.State)(using p: SimParams): Double =
+    if !p.flags.sbtc then 1.0
+    else
+      firm.tech match
+        case _: TechState.Automated | _: TechState.Hybrid =>
+          1.0 + p.labor.sbtcComplementPremium.toDouble * (1.0 - hh.taskRoutineness.toDouble)
+        case _                                            => 1.0
 
   /** Mean raw wage across employed households (Kahan summation). */
   private def employedMeanRawWage(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/FirmProcessingStep.scala
@@ -347,7 +347,7 @@ object FirmProcessingStep:
   )(using p: SimParams): (Vector[Household.State], Int) =
     val afterSep     = LaborMarket.separations(in.s3.updatedHouseholds, in.firms, ioFirms)
     val searchResult = LaborMarket.jobSearch(afterSep, ioFirms, in.s2.newWage, rng)
-    val postWages    = LaborMarket.updateWages(searchResult.households, in.s2.newWage)
+    val postWages    = LaborMarket.updateWages(searchResult.households, ioFirms, in.s2.newWage)
 
     val finalHouseholds =
       if p.flags.immigration then

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/HouseholdIncomeStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/HouseholdIncomeStep.scala
@@ -45,7 +45,7 @@ object HouseholdIncomeStep:
       Math.pow(p.forex.baseExRate / in.w.forex.exchangeRate, ImportErElasticity)
 
     val afterSep           = LaborMarket.separations(in.households, in.firms, in.firms)
-    val afterWages         = LaborMarket.updateWages(afterSep, in.s2.newWage)
+    val afterWages         = LaborMarket.updateWages(afterSep, in.firms, in.s2.newWage)
     val bsec               = in.w.bankingSector
     val nBanksHh           = bsec.banks.length
     val hhBankRates        = Some(

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -291,6 +291,7 @@ object Generators:
     numDependentChildren = 0,
     consumerDebt = PLN.Zero,
     education = 2,
+    taskRoutineness = Ratio(0.5),
   )
 
   // --- World generator ---

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -139,6 +139,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       )
     }.toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -92,6 +92,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN(5000.0),
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     // Bankrupt HH should have consumer debt → NPL
     hh.consumerDebt shouldBe PLN(5000.0)
@@ -197,6 +198,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     hh.consumerDebt shouldBe PLN.Zero
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
@@ -106,6 +106,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     hh.education shouldBe 2
   }
@@ -128,6 +129,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 3,
+      taskRoutineness = Ratio(0.5),
     )
     val copied = hh.copy(savings = PLN(2000.0))
     copied.education shouldBe 3
@@ -197,6 +199,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 0,
+      taskRoutineness = Ratio(0.80),
     )
     val hhTertiary   = Household.State(
       HhId(1),
@@ -215,6 +218,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 3,
+      taskRoutineness = Ratio(0.25),
     )
     val hhVocational = Household.State(
       HhId(2),
@@ -233,6 +237,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 1,
+      taskRoutineness = Ratio(0.65),
     )
 
     val result = LaborMarket.separations(
@@ -306,6 +311,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     val hhHighSkill = Household.State(
       HhId(1),
@@ -324,6 +330,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     val hhMidSkill  = Household.State(
       HhId(2),
@@ -342,6 +349,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
 
     val result = markets.LaborMarket.separations(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdPropertySpec.scala
@@ -161,6 +161,7 @@ class HouseholdPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPro
           numDependentChildren = 0,
           consumerDebt = PLN.Zero,
           education = 2,
+          taskRoutineness = Ratio(0.5),
         )
       }.toVector
       val agg         = Household.computeAggregates(bankruptHhs, PLN(8266.0), PLN(4666.0), 0.40, 0, 0)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -410,6 +410,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
 
   private def mkWorld(): World =

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
@@ -98,6 +98,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ) // 5 natives + 5 immigrants
     }.toVector
     // Request removing 100, but only 5 immigrants exist

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
@@ -45,6 +45,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
     )
     Immigration.computeRemittances(hhs) shouldBe PLN.Zero
@@ -69,6 +70,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
     )
     Immigration.computeRemittances(hhs) shouldBe PLN.Zero
@@ -164,6 +166,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
       Household.State(
         HhId(1),
@@ -182,6 +185,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
       Household.State(
         HhId(2),
@@ -200,6 +204,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
       Household.State(
         HhId(3),
@@ -218,6 +223,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
     )
     val result = Immigration.removeReturnMigrants(hhs, 2)
@@ -247,6 +253,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
       Household.State(
         HhId(1),
@@ -265,6 +272,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
     )
     val result = Immigration.removeReturnMigrants(hhs, 5)
@@ -290,6 +298,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         numDependentChildren = 0,
         consumerDebt = PLN.Zero,
         education = 2,
+        taskRoutineness = Ratio(0.5),
       ),
     )
     Immigration.removeReturnMigrants(hhs, 0) shouldBe hhs

--- a/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
@@ -132,6 +132,7 @@ class SocialTransferSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )
     hh.numDependentChildren shouldBe 0
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
@@ -112,7 +112,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(5000.0)), skill = 0.8),
       mkHousehold(1, HhStatus.Unemployed(3)),
     )
-    val result = LaborMarket.updateWages(hhs, PLN(10000.0))
+    val result = LaborMarket.updateWages(hhs, mkFirms(hhs.length), PLN(10000.0))
     result(0).status match
       case HhStatus.Employed(_, _, wage) =>
         // Single employed: normalized to marketWage
@@ -127,7 +127,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(5000.0)), skill = 0.8, healthPenalty = 0.0),
       mkHousehold(1, HhStatus.Employed(FirmId(1), SectorIdx(2), PLN(5000.0)), skill = 0.8, healthPenalty = 0.2),
     )
-    val result = LaborMarket.updateWages(hhs, PLN(10000.0))
+    val result = LaborMarket.updateWages(hhs, mkFirms(hhs.length), PLN(10000.0))
     val wage0  = result(0).status.asInstanceOf[HhStatus.Employed].wage
     val wage1  = result(1).status.asInstanceOf[HhStatus.Employed].wage
     // wage1 should be less than wage0 (health penalty reduces relative wage)
@@ -146,7 +146,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(5000.0)), skill = 0.7).copy(isImmigrant = false),
       mkHousehold(1, HhStatus.Employed(FirmId(1), SectorIdx(2), PLN(5000.0)), skill = 0.7).copy(isImmigrant = true),
     )
-    val result = LaborMarket.updateWages(hhs, PLN(10000.0))
+    val result = LaborMarket.updateWages(hhs, mkFirms(hhs.length), PLN(10000.0))
     val wage0  = result(0).status.asInstanceOf[HhStatus.Employed].wage
     val wage1  = result(1).status.asInstanceOf[HhStatus.Employed].wage
     // Both same sector, same skill, ImmigEnabled=false → same raw weight → same wage
@@ -159,7 +159,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
     val immigrant  =
       mkHousehold(1, HhStatus.Employed(FirmId(1), SectorIdx(2), PLN(5000.0)), skill = 0.8).copy(isImmigrant = true)
     val hhs        = Vector(native, immigrant)
-    val result     = LaborMarket.updateWages(hhs, PLN(10000.0))
+    val result     = LaborMarket.updateWages(hhs, mkFirms(hhs.length), PLN(10000.0))
     val wageNative = result(0).status.asInstanceOf[HhStatus.Employed].wage
     val wageImmig  = result(1).status.asInstanceOf[HhStatus.Employed].wage
     // Same skill, same sector → identical weight → identical wage
@@ -215,4 +215,5 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
@@ -108,6 +108,7 @@ class SectoralMobilityPropertySpec extends AnyFlatSpec with Matchers with ScalaC
           numDependentChildren = 0,
           consumerDebt = PLN.Zero,
           education = 2,
+          taskRoutineness = Ratio(0.5),
         ),
       )
       .toVector

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
@@ -206,4 +206,5 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
+      taskRoutineness = Ratio(0.5),
     )


### PR DESCRIPTION
## Summary

Acemoglu & Restrepo 2020, Autor 2024: AI displaces routine tasks first, complements cognitive workers.

- **`taskRoutineness: Ratio`** added to `Household.State` — sampled from `education × sector sigma` at init (Primary=0.80, Tertiary=0.25, high-σ sectors push up)
- **Displacement**: when `sbtc=true`, workers sorted by routineness (high = displaced first) instead of pure education ranking
- **AI-complement wage premium**: cognitive workers in automated/hybrid firms get `(1 - routineness) × 15%` wage boost
- **Params**: `sbtcEduRoutineness` (4 edu levels), `sbtcComplementPremium` in `LaborConfig`
- **Flag**: `sbtc = true` (default on)

## Test plan

- [x] `sbt scalafmtAll` — no reformats
- [x] `sbt compile` — no warnings
- [x] `sbt test` — 1286 tests pass

Fixes #31