### PR TITLE
Post-reemployment wage scarring

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -96,6 +96,7 @@ object Household:
       consumerDebt: PLN,            // outstanding unsecured consumer loan
       education: Int,               // education level: 0=Primary, 1=Vocational, 2=Secondary, 3=Tertiary
       taskRoutineness: Ratio,       // how routine is this worker's task bundle [0,1] (Acemoglu & Restrepo 2020)
+      wageScar: Ratio,              // persistent wage penalty from unemployment spell (Jacobson et al. 1993)
   )
 
   /** Aggregate statistics computed from individual households (Paper-06). */
@@ -221,6 +222,7 @@ object Household:
         consumerDebt = consDebt,
         education = edu,
         taskRoutineness = routineness,
+        wageScar = Ratio.Zero,
       )
 
     /** Sample education level and skill for a sector, clamped to edu range. */
@@ -618,8 +620,9 @@ object Household:
       sectorVacancies: Option[Vector[Int]],
       rng: Random,
   )(using p: SimParams): HhMonthlyResult =
-    val afterSkill  = applySkillDecay(f.hh, f.newStatus)
-    val afterHealth = applyHealthScarring(f.hh, f.newStatus)
+    val afterSkill    = applySkillDecay(f.hh, f.newStatus)
+    val afterHealth   = applyHealthScarring(f.hh, f.newStatus)
+    val afterWageScar = applyWageScar(f.hh, f.newStatus)
 
     val (afterVoluntary, vQuit) = f.newStatus match
       case emp: HhStatus.Employed if sectorWages.isDefined =>
@@ -640,6 +643,7 @@ object Household:
         consumerDebt = f.credit.updatedDebt,
         skill = afterSkill,
         healthPenalty = afterHealth,
+        wageScar = afterWageScar,
         mpc = f.hh.mpc,
         status = finalStatus,
         equityWealth = f.newEquityWealth,
@@ -738,6 +742,17 @@ object Household:
       case HhStatus.Unemployed(months) if months >= p.household.scarringOnset =>
         (hh.healthPenalty + p.household.scarringRate).min(p.household.scarringCap)
       case _                                                                  => hh.healthPenalty
+
+  /** Wage scar: accumulates during long-term unemployment, decays slowly once
+    * reemployed. Jacobson, LaLonde & Sullivan 1993; Davis & von Wachter 2011.
+    */
+  private def applyWageScar(hh: State, status: HhStatus)(using p: SimParams): Ratio =
+    status match
+      case HhStatus.Unemployed(months) if months >= p.household.scarringOnset =>
+        (hh.wageScar + p.household.wageScarRate).min(p.household.wageScarCap)
+      case _: HhStatus.Employed                                               =>
+        (hh.wageScar - p.household.wageScarDecay).max(Ratio.Zero)
+      case _                                                                  => hh.wageScar
 
   /** Fraction of social neighbors in distress (BitSet, O(k) per HH). */
   private def neighborDistressRatioFast(hh: State, distressedIds: java.util.BitSet): Double =

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -97,6 +97,7 @@ object Immigration:
         consumerDebt = PLN.Zero,
         education = edu,
         taskRoutineness = Household.Init.sampleTaskRoutineness(edu, sector, rng),
+        wageScar = Ratio.Zero,
       )
     }.toVector
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
@@ -114,6 +114,10 @@ case class HouseholdConfig(
     scarringRate: Ratio = Ratio(0.02),
     scarringCap: Ratio = Ratio(0.50),
     scarringOnset: Int = 3,
+    // Post-reemployment wage scarring (Jacobson, LaLonde & Sullivan 1993)
+    wageScarRate: Ratio = Ratio(0.025),  // monthly wage scar accumulation during long-term unemployment
+    wageScarCap: Ratio = Ratio(0.30),    // max 30% permanent wage loss
+    wageScarDecay: Ratio = Ratio(0.005), // monthly recovery once reemployed (~0.5%/mo → ~10 year half-life)
     // Retraining
     retrainingCost: PLN = PLN(5000.0),
     retrainingDuration: Int = 6,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
@@ -297,12 +297,13 @@ object LaborMarket:
       prevSector: SectorIdx,
       isCrossSector: Boolean,
   )(using p: SimParams): PLN =
-    val sectorMult = Firm.effectiveWageMult(firm.sector).toDouble
-    val penalty    =
+    val sectorMult   = Firm.effectiveWageMult(firm.sector).toDouble
+    val penalty      =
       if p.flags.sectoralMobility && isCrossSector
       then SectoralMobility.crossSectorWagePenalty(p.labor.frictionMatrix(prevSector.toInt)(firm.sector.toInt))
       else 1.0
-    marketWage * (sectorMult * effectiveSkill(hh) * penalty * p.social.eduWagePremium(hh.education))
+    val scarDiscount = 1.0 - hh.wageScar.toDouble
+    marketWage * (sectorMult * effectiveSkill(hh) * penalty * p.social.eduWagePremium(hh.education) * scarDiscount)
 
   // --- Wage helpers ---
 
@@ -314,9 +315,10 @@ object LaborMarket:
           if hh.isImmigrant && p.flags.immigration then 1.0 - p.immigration.wageDiscount.toDouble
           else 1.0
         val aiComplement      = aiComplementFactor(hh, firms(firmId.toInt))
+        val scarDiscount      = 1.0 - hh.wageScar.toDouble
         Ratio(
           Firm.effectiveWageMult(sectorIdx).toDouble * effectiveSkill(hh) * immigrantDiscount *
-            p.social.eduWagePremium(hh.education) * aiComplement,
+            p.social.eduWagePremium(hh.education) * aiComplement * scarDiscount,
         )
       case _                                       => Ratio(0.0)
 

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -292,6 +292,7 @@ object Generators:
     consumerDebt = PLN.Zero,
     education = 2,
     taskRoutineness = Ratio(0.5),
+    wageScar = Ratio.Zero,
   )
 
   // --- World generator ---

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -140,6 +140,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       )
     }.toVector
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -93,6 +93,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN(5000.0),
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     // Bankrupt HH should have consumer debt → NPL
     hh.consumerDebt shouldBe PLN(5000.0)
@@ -199,6 +200,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     hh.consumerDebt shouldBe PLN.Zero
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
@@ -107,6 +107,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     hh.education shouldBe 2
   }
@@ -130,6 +131,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 3,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     val copied = hh.copy(savings = PLN(2000.0))
     copied.education shouldBe 3
@@ -200,6 +202,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 0,
       taskRoutineness = Ratio(0.80),
+      wageScar = Ratio.Zero,
     )
     val hhTertiary   = Household.State(
       HhId(1),
@@ -219,6 +222,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 3,
       taskRoutineness = Ratio(0.25),
+      wageScar = Ratio.Zero,
     )
     val hhVocational = Household.State(
       HhId(2),
@@ -238,6 +242,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 1,
       taskRoutineness = Ratio(0.65),
+      wageScar = Ratio.Zero,
     )
 
     val result = LaborMarket.separations(
@@ -312,6 +317,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     val hhHighSkill = Household.State(
       HhId(1),
@@ -331,6 +337,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     val hhMidSkill  = Household.State(
       HhId(2),
@@ -350,6 +357,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
 
     val result = markets.LaborMarket.separations(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdPropertySpec.scala
@@ -162,6 +162,7 @@ class HouseholdPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPro
           consumerDebt = PLN.Zero,
           education = 2,
           taskRoutineness = Ratio(0.5),
+          wageScar = Ratio.Zero,
         )
       }.toVector
       val agg         = Household.computeAggregates(bankruptHhs, PLN(8266.0), PLN(4666.0), 0.40, 0, 0)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -411,6 +411,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
 
   private def mkWorld(): World =

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
@@ -99,6 +99,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ) // 5 natives + 5 immigrants
     }.toVector
     // Request removing 100, but only 5 immigrants exist

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
@@ -46,6 +46,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
     )
     Immigration.computeRemittances(hhs) shouldBe PLN.Zero
@@ -71,6 +72,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
     )
     Immigration.computeRemittances(hhs) shouldBe PLN.Zero
@@ -167,6 +169,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
       Household.State(
         HhId(1),
@@ -186,6 +189,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
       Household.State(
         HhId(2),
@@ -205,6 +209,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
       Household.State(
         HhId(3),
@@ -224,6 +229,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
     )
     val result = Immigration.removeReturnMigrants(hhs, 2)
@@ -254,6 +260,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
       Household.State(
         HhId(1),
@@ -273,6 +280,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
     )
     val result = Immigration.removeReturnMigrants(hhs, 5)
@@ -299,6 +307,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
         consumerDebt = PLN.Zero,
         education = 2,
         taskRoutineness = Ratio(0.5),
+        wageScar = Ratio.Zero,
       ),
     )
     Immigration.removeReturnMigrants(hhs, 0) shouldBe hhs

--- a/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
@@ -133,6 +133,7 @@ class SocialTransferSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )
     hh.numDependentChildren shouldBe 0
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
@@ -216,4 +216,5 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
@@ -109,6 +109,7 @@ class SectoralMobilityPropertySpec extends AnyFlatSpec with Matchers with ScalaC
           consumerDebt = PLN.Zero,
           education = 2,
           taskRoutineness = Ratio(0.5),
+          wageScar = Ratio.Zero,
         ),
       )
       .toVector

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
@@ -207,4 +207,5 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
       consumerDebt = PLN.Zero,
       education = 2,
       taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
     )


### PR DESCRIPTION
## Summary

Jacobson, LaLonde & Sullivan 1993; Davis & von Wachter 2011: 20-30% persistent wage loss after long-term unemployment, recovering over ~10 years.

- **`wageScar: Ratio`** in `Household.State` — accumulates during long-term unemployment (same onset as `healthPenalty`), decays slowly once reemployed
- **Wage discount**: `(1 - wageScar)` applied in both `computeHireWage` (at hire) and `rawRelativeWage` (ongoing normalization)
- **Params**: `wageScarRate` (2.5%/mo accumulation), `wageScarCap` (30% max), `wageScarDecay` (0.5%/mo recovery)
- Example: 12 months unemployed → wageScar ≈ 0.22 → 22% lower wage at hire. After 3 years employed → scar ≈ 0.04

## Test plan

- [x] `sbt scalafmtAll` — no reformats
- [x] `sbt compile` — no warnings
- [x] `sbt test` — all tests pass

Fixes #32