### PR TITLE
Add Sigma and Shock opaque types

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/config/GvcConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/GvcConfig.scala
@@ -39,12 +39,12 @@ import com.boombustgroup.amorfati.types.*
   * @param commodityDrift
   *   annual commodity price drift (long-run trend, IMF commodity outlook)
   * @param commodityVolatility
-  *   monthly GBM volatility (σ) for commodity price noise
+  *   monthly GBM standard deviation (σ) for commodity price noise
   * @param commodityShockMonth
   *   simulation month when commodity price shock hits (0 = no shock)
   * @param commodityShockMag
-  *   one-time shock magnitude as multiplicative increment (e.g., 3.0 = +300%
-  *   gas price, 2022-style). Not Ratio because can exceed 1.0.
+  *   one-time shock magnitude as multiplicative increment (e.g., Shock(3.0) =
+  *   +300% gas price, 2022-style). Unbounded — can exceed 1.0.
   */
 case class GvcConfig(
     euTradeShare: Ratio = Ratio(0.70),
@@ -60,9 +60,9 @@ case class GvcConfig(
     disruptionRecovery: Ratio = Ratio(0.05),
     // Commodity prices (Poland imports ~95% of oil/gas)
     commodityDrift: Rate = Rate(0.02),
-    commodityVolatility: Double = 0.03,
+    commodityVolatility: Sigma = Sigma(0.03),
     commodityShockMonth: Int = 0,
-    commodityShockMag: Double = 0.0,
+    commodityShockMag: Shock = Shock.Zero,
 ):
   require(exportShares.length == 6, s"exportShares must have 6 sectors: ${exportShares.length}")
   require(depth.length == 6, s"depth must have 6 sectors: ${depth.length}")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
@@ -87,25 +87,27 @@ object GvcTrade:
   )
 
   def step(in: StepInput)(using p: SimParams): State =
-    val nSectors         = in.prev.sectorExports.size
-    val monthlyInflation = p.gvc.foreignInflation.monthly.toDouble
-    val newForeignPrice  = in.prev.foreignPriceIndex * (1.0 + monthlyInflation)
+    val nSectors            = in.prev.sectorExports.size
+    val monthlyInflation    = p.gvc.foreignInflation.monthly
+    val monthlyInflationRaw = monthlyInflation.toDouble // for pre-existing helpers taking Double
+    val newForeignPrice     = in.prev.foreignPriceIndex * (monthlyInflation + 1.0)
     // Commodity price: GBM drift + volatility + optional shock
-    val commodityDrift   = p.gvc.commodityDrift.monthly.toDouble
-    val commodityNoise   = p.gvc.commodityVolatility * in.rng.nextGaussian()
-    val commodityShock   =
+    val commodityDrift      = p.gvc.commodityDrift.monthly
+    val commodityNoise      = p.gvc.commodityVolatility * in.rng.nextGaussian()
+    val commodityShock      =
       if p.gvc.commodityShockMonth > 0 && in.month == p.gvc.commodityShockMonth then p.gvc.commodityShockMag
-      else 0.0
-    val newCommodity     = in.prev.commodityPriceIndex * (1.0 + commodityDrift + commodityNoise + commodityShock)
-    val newImportCost    = newForeignPrice * newCommodity
-    val shockActive      = p.gvc.demandShockMonth > 0 && in.month >= p.gvc.demandShockMonth
-    val shockMag         = if shockActive then p.gvc.demandShockSize else Ratio.Zero
-    val updatedFirms     = evolveFirms(in.prev.foreignFirms, monthlyInflation, shockActive, in.month)
-    val foreignGdpFactor = Math.pow(1.0 + p.gvc.foreignGdpGrowth.monthly.toDouble, in.month.toDouble)
-    val erEffect         = realExchangeRateEffect(in.priceLevel, in.exchangeRate)
-    val exports          = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio)
-    val imports          = computeSectorImports(updatedFirms, nSectors, in.sectorOutputs, in.priceLevel, in.exchangeRate)
-    val euShare          = p.gvc.euTradeShare.toDouble
+      else Shock.Zero
+    val commodityGrowth     = commodityShock + (commodityDrift + 1.0 + commodityNoise)
+    val newCommodity        = in.prev.commodityPriceIndex * commodityGrowth
+    val newImportCost       = newForeignPrice * newCommodity
+    val shockActive         = p.gvc.demandShockMonth > 0 && in.month >= p.gvc.demandShockMonth
+    val shockMag            = if shockActive then p.gvc.demandShockSize else Ratio.Zero
+    val updatedFirms        = evolveFirms(in.prev.foreignFirms, monthlyInflationRaw, shockActive, in.month)
+    val foreignGdpFactor    = Math.pow(1.0 + p.gvc.foreignGdpGrowth.monthly.toDouble, in.month.toDouble)
+    val erEffect            = realExchangeRateEffect(in.priceLevel, in.exchangeRate)
+    val exports             = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio)
+    val imports             = computeSectorImports(updatedFirms, nSectors, in.sectorOutputs, in.priceLevel, in.exchangeRate)
+    val euShare             = p.gvc.euTradeShare.toDouble
 
     State(
       foreignFirms = updatedFirms,

--- a/src/main/scala/com/boombustgroup/amorfati/types.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/types.scala
@@ -92,6 +92,8 @@ object types:
       inline def min(other: Rate): Rate          = math.min(r, other)
       inline def clamp(lo: Rate, hi: Rate): Rate = math.max(lo, math.min(hi, r))
       inline def monthly: Rate                   = r / 12.0
+      @targetName("ratePlusDouble")
+      inline def +(scalar: Double): Double       = r + scalar
       inline def toDouble: Double                = r
       inline def >(other: Rate): Boolean         = r > other
       inline def <(other: Rate): Boolean         = r < other
@@ -177,3 +179,25 @@ object types:
       inline def toDouble: Double                 = p
       inline def >(other: PriceIndex): Boolean    = p > other
       inline def <(other: PriceIndex): Boolean    = p < other
+
+  // === Volatility (standard deviation, σ per period) ===
+  opaque type Sigma = Double
+  object Sigma:
+    inline def apply(d: Double): Sigma = d
+    val Zero: Sigma                    = 0.0
+    extension (s: Sigma)
+      inline def *(scalar: Double): Double = s * scalar
+      inline def +(other: Double): Double  = s + other
+      inline def toDouble: Double          = s
+
+  // === Shock magnitude (one-time multiplicative increment, unbounded) ===
+  opaque type Shock = Double
+  object Shock:
+    inline def apply(d: Double): Shock = d
+    val Zero: Shock                    = 0.0
+    extension (s: Shock)
+      inline def toDouble: Double         = s
+      inline def +(other: Double): Double = s + other
+      inline def >(other: Shock): Boolean = s > other
+      @targetName("shockPlusShock")
+      inline def +(other: Shock): Shock   = Shock(s + (other: Double))


### PR DESCRIPTION
## Summary

Proper semantic types for volatility and shock parameters — eliminates raw `Double` from commodity price logic.

- **`Sigma`** opaque type — standard deviation (σ per period). For `commodityVolatility` and future vol params.
- **`Shock`** opaque type — one-time multiplicative increment (unbounded, can exceed 1.0). For `commodityShockMag`.
- **`Rate + Double → Double`** operator for `(monthlyRate + 1.0)` pattern
- GvcTrade commodity lines: zero `.toDouble` in new code (old helpers keep bridge conversion)
- GvcConfig scaladoc updated

## Test plan

- [ ] `sbt scalafmtAll` — no reformats
- [ ] `sbt compile` — no warnings
- [ ] `sbt test` — all tests pass