### PR TITLE
Interbank contagion: bilateral exposures and liquidity hoarding

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -389,17 +389,20 @@ object Banking:
   // Interbank market
   // ---------------------------------------------------------------------------
 
-  /** Clear the interbank market: excess reserves → lender/borrower netting. */
-  def clearInterbank(banks: Vector[BankState], configs: Vector[Config])(using
+  /** Clear the interbank market: excess reserves → lender/borrower netting.
+    * Hoarding factor [0,1] scales lending: 0 = full freeze, 1 = normal.
+    */
+  def clearInterbank(banks: Vector[BankState], configs: Vector[Config], hoarding: Ratio = Ratio.One)(using
       p: SimParams,
   ): Vector[BankState] =
+    val hf     = hoarding.toDouble
     val excess = banks
       .zip(configs)
       .map: (b, _) =>
         if b.failed then 0.0
         else (b.deposits * (1.0 - p.banking.reserveReq.toDouble) - b.loans - b.govBondHoldings).toDouble
 
-    val totalLending   = excess.filter(_ > 0).kahanSum
+    val totalLending   = excess.filter(_ > 0).kahanSum * hf // hoarding reduces lending
     val totalBorrowing = -excess.filter(_ < 0).kahanSum
 
     if totalLending <= 0 || totalBorrowing <= 0 then banks.map(_.copy(interbankNet = PLN.Zero, reservesAtNbp = PLN.Zero))
@@ -410,7 +413,7 @@ object Banking:
         .map: (b, ex) =>
           if b.failed then b.copy(interbankNet = PLN.Zero, reservesAtNbp = PLN.Zero)
           else if ex > 0 then
-            val lent = ex * Math.min(1.0, totalBorrowing / totalLending)
+            val lent = ex * hf * Math.min(1.0, totalBorrowing / totalLending)
             b.copy(interbankNet = PLN(lent), reservesAtNbp = PLN(ex - lent))
           else if ex < 0 then
             val borrowed = -ex * scale

--- a/src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala
@@ -1,0 +1,101 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** Interbank contagion: bilateral exposures, counterparty losses, liquidity
+  * hoarding.
+  *
+  * Models the Lehman/Bear Stearns channel: bank failure → counterparty losses
+  * proportional to bilateral exposure → secondary failures → systemic freeze.
+  *
+  * Three mechanisms:
+  *
+  *   1. '''Bilateral exposure matrix''' — 7×7 matrix where entry (i,j) = amount
+  *      bank i has lent to bank j on the interbank market. Generated from
+  *      `clearInterbank` surplus/deficit proportional allocation.
+  *   2. '''Contagion loss''' — when bank j fails, bank i loses
+  *      `exposure(i→j) × (1 − recoveryRate)`. This reduces bank i capital,
+  *      potentially triggering secondary failure (cascade).
+  *   3. '''Liquidity hoarding''' — when system-wide NPL ratio exceeds a
+  *      threshold, banks cut interbank lending by a hoarding factor. This
+  *      reduces available liquidity, amplifying stress.
+  *
+  * Pure functions — no mutable state. Called from `processInterbankAndFailures`
+  * in BankUpdateStep.
+  *
+  * Calibration: NBP Financial Stability Report, KNF interbank exposure data.
+  */
+object InterbankContagion:
+
+  /** Bilateral exposure matrix: `exposures(i)(j)` = PLN bank i lent to bank j.
+    * Diagonal is always zero (no self-lending).
+    */
+  type ExposureMatrix = Vector[Vector[PLN]]
+
+  /** Build bilateral exposure matrix from interbank surplus/deficit.
+    *
+    * Each lender i allocates lending proportionally to each borrower j's
+    * deficit share:
+    * `exposure(i→j) = lender_i_surplus × (borrower_j_deficit / totalBorrowing)`.
+    * This produces a dense matrix where every lender is exposed to every
+    * borrower.
+    */
+  def buildExposureMatrix(banks: Vector[Banking.BankState]): ExposureMatrix =
+    val n        = banks.length
+    val nets     = banks.map(_.interbankNet.toDouble)
+    val totalBor = nets.filter(_ < 0).map(-_).sum
+    if totalBor <= 0 then Vector.fill(n)(Vector.fill(n)(PLN.Zero))
+    else
+      Vector.tabulate(n): i =>
+        Vector.tabulate(n): j =>
+          if i == j then PLN.Zero
+          else if nets(i) > 0 && nets(j) < 0 then PLN(nets(i) * (-nets(j) / totalBor))
+          else PLN.Zero
+
+  /** Apply contagion losses from failed banks to their interbank
+    * counterparties.
+    *
+    * For each failed bank j, every lender i loses
+    * `exposure(i→j) × (1 − recoveryRate)` from capital. If capital goes
+    * negative, bank i may subsequently fail in the next `checkFailures` round.
+    */
+  def applyContagionLosses(
+      banks: Vector[Banking.BankState],
+      exposures: ExposureMatrix,
+  )(using p: SimParams): Vector[Banking.BankState] =
+    val recovery = p.banking.interbankRecoveryRate
+    banks.zipWithIndex.map: (b, i) =>
+      if b.failed then b
+      else
+        val loss = banks.zipWithIndex.foldLeft(PLN.Zero):
+          case (acc, (counterparty, j)) =>
+            if counterparty.failed && i != j then acc + exposures(i)(j) * (Ratio.One - recovery).toDouble
+            else acc
+        if loss > PLN.Zero then b.copy(capital = b.capital - loss)
+        else b
+
+  /** Compute liquidity hoarding factor: reduces interbank lending when system
+    * NPL rises above threshold.
+    *
+    * `hoardingFactor = clamp(1 − sensitivity × (systemNPL − threshold), 0, 1)`
+    *
+    * At factor = 0, interbank market freezes completely (all banks hoard). At
+    * factor = 1, normal interbank activity.
+    */
+  def hoardingFactor(systemNplRatio: Ratio)(using p: SimParams): Ratio =
+    val excess = (systemNplRatio - p.banking.hoardingNplThreshold).max(Ratio.Zero)
+    (Ratio.One - Ratio(excess.toDouble * p.banking.hoardingSensitivity)).clamp(Ratio.Zero, Ratio.One)
+
+  /** Total contagion loss across all non-failed banks. */
+  def totalContagionLoss(
+      before: Vector[Banking.BankState],
+      after: Vector[Banking.BankState],
+  ): PLN =
+    PLN(
+      before
+        .zip(after)
+        .map: (pre, post) =>
+          if !pre.failed then (pre.capital - post.capital).max(PLN.Zero).toDouble else 0.0
+        .sum,
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -80,6 +80,15 @@ import com.boombustgroup.amorfati.types.*
   * @param initHtmBookYield
   *   weighted-average acquisition yield on initial HTM portfolio (Polish 10Y at
   *   model start, MF 2024)
+  * @param interbankRecoveryRate
+  *   recovery rate on interbank exposures when counterparty fails (NBP FSR:
+  *   ~40%, secured/unsecured mix)
+  * @param hoardingNplThreshold
+  *   system NPL ratio above which banks start hoarding liquidity (reducing
+  *   interbank lending)
+  * @param hoardingSensitivity
+  *   speed of hoarding onset: factor = 1 − sensitivity × (NPL − threshold). At
+  *   10.0, a 10pp NPL overshoot → full freeze.
   */
 case class BankingConfig(
     // Initial balance sheet (raw — scaled by gdpRatio in SimParams.defaults)
@@ -121,6 +130,10 @@ case class BankingConfig(
     htmForcedSaleThreshold: Double = 0.75,
     htmForcedSaleRate: Ratio = Ratio(0.10),
     initHtmBookYield: Rate = Rate(0.055),
+    // Interbank contagion
+    interbankRecoveryRate: Ratio = Ratio(0.40),
+    hoardingNplThreshold: Ratio = Ratio(0.05),
+    hoardingSensitivity: Double = 10.0,
 ):
   require(minCar > Ratio.Zero && minCar < Ratio.One, s"minCar must be in (0,1): $minCar")
   require(initCapital >= PLN.Zero, s"initCapital must be non-negative: $initCapital")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -493,7 +493,9 @@ object BankUpdateStep:
       wf: BondWaterfallInputs,
   )(using p: SimParams): MultiBankResult =
     val ibRate           = Banking.interbankRate(updatedBanks, in.w.nbp.referenceRate)
-    val afterInterbank   = Banking.clearInterbank(updatedBanks, bs.configs)
+    // Liquidity hoarding: reduce interbank lending when system NPL is high
+    val hoarding         = InterbankContagion.hoardingFactor(in.w.bank.nplRatio)
+    val afterInterbank   = Banking.clearInterbank(updatedBanks, bs.configs, hoarding)
     val afterFxInjection = distributeFxInjection(afterInterbank, in.s8.monetary.fxPlnInjection)
     // HTM forced reclassification: LCR-stressed banks reclassify HTM→AFS, realizing hidden losses
     val htmResult        = Banking.processHtmForcedSale(afterFxInjection, in.s8.monetary.newBondYield)
@@ -528,10 +530,19 @@ object BankUpdateStep:
     val finalNbfi                = in.s8.nonBank.newNbfi.copy(tfiGovBondHoldings = in.w.financial.nbfi.tfiGovBondHoldings + tfiSale.actualSold)
     val finalForeignBondHoldings = in.w.gov.foreignBondHoldings + foreignSale.actualSold
 
-    val failResult           =
+    val failResult =
       Banking.checkFailures(tfiSale.banks, in.s1.m, p.flags.bankFailure, in.s7.newMacropru.ccyb)
-    val afterFailCheck       = failResult.banks
-    val anyFailed            = failResult.anyFailed
+
+    // Interbank contagion: failed banks impose losses on counterparties
+    val exposures      = InterbankContagion.buildExposureMatrix(tfiSale.banks)
+    val afterContagion =
+      if failResult.anyFailed then InterbankContagion.applyContagionLosses(failResult.banks, exposures)
+      else failResult.banks
+    // Re-check for secondary failures triggered by contagion losses
+    val secondaryFail  = Banking.checkFailures(afterContagion, in.s1.m, p.flags.bankFailure, in.s7.newMacropru.ccyb)
+    val afterFailCheck = secondaryFail.banks
+    val anyFailed      = failResult.anyFailed || secondaryFail.anyFailed
+
     val bailInResult         =
       if anyFailed then Banking.applyBailIn(afterFailCheck) else Banking.BailInResult(afterFailCheck, PLN.Zero)
     val resolveResult        =

--- a/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
@@ -1,0 +1,96 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class InterbankContagionSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val p = summon[SimParams]
+
+  // Helper: create a minimal bank state with given interbank net
+  private def mkBank(id: Int, interbankNet: Double, capital: Double = 1e9, failed: Boolean = false): Banking.BankState =
+    Banking.BankState(
+      id = BankId(id),
+      deposits = PLN(10e9),
+      loans = PLN(5e9),
+      capital = PLN(capital),
+      nplAmount = PLN.Zero,
+      afsBonds = PLN(2e9),
+      htmBonds = PLN(1e9),
+      htmBookYield = Rate(0.05),
+      reservesAtNbp = PLN.Zero,
+      interbankNet = PLN(interbankNet),
+      status = if failed then Banking.BankStatus.Failed(0) else Banking.BankStatus.Active(0),
+      demandDeposits = PLN(6e9),
+      termDeposits = PLN(4e9),
+      loansShort = PLN(1.5e9),
+      loansMedium = PLN(2e9),
+      loansLong = PLN(1.5e9),
+      consumerLoans = PLN.Zero,
+      consumerNpl = PLN.Zero,
+      corpBondHoldings = PLN.Zero,
+    )
+
+  "buildExposureMatrix" should "have zero diagonal" in {
+    val banks  = Vector(mkBank(0, 100.0), mkBank(1, -50.0), mkBank(2, -50.0))
+    val matrix = InterbankContagion.buildExposureMatrix(banks)
+    for i <- 0 until 3 do matrix(i)(i) shouldBe PLN.Zero
+  }
+
+  it should "have lender → borrower exposures proportional to deficit share" in {
+    val banks  = Vector(mkBank(0, 100.0), mkBank(1, -60.0), mkBank(2, -40.0))
+    val matrix = InterbankContagion.buildExposureMatrix(banks)
+    // Bank 0 lends 100, borrower 1 has 60% of deficit, borrower 2 has 40%
+    matrix(0)(1).toDouble shouldBe 60.0 +- 0.01
+    matrix(0)(2).toDouble shouldBe 40.0 +- 0.01
+    // Borrowers don't lend
+    matrix(1)(0) shouldBe PLN.Zero
+    matrix(2)(0) shouldBe PLN.Zero
+  }
+
+  it should "return zero matrix when no borrowing" in {
+    val banks  = Vector(mkBank(0, 100.0), mkBank(1, 50.0))
+    val matrix = InterbankContagion.buildExposureMatrix(banks)
+    matrix.flatten.forall(_ == PLN.Zero) shouldBe true
+  }
+
+  "applyContagionLosses" should "reduce capital of exposed lenders when counterparty fails" in {
+    val lender       = mkBank(0, 100.0, capital = 1e9)
+    val borrower     = mkBank(1, -100.0, capital = -1.0, failed = true)
+    val banks        = Vector(lender, borrower)
+    val matrix       = InterbankContagion.buildExposureMatrix(banks)
+    val after        = InterbankContagion.applyContagionLosses(banks, matrix)
+    // Lender loses exposure × (1 - recovery)
+    val expectedLoss = 100.0 * (1.0 - p.banking.interbankRecoveryRate.toDouble)
+    after(0).capital.toDouble shouldBe (1e9 - expectedLoss) +- 0.01
+  }
+
+  it should "not affect banks with no exposure to failed bank" in {
+    val safe     = mkBank(0, 0.0, capital = 1e9)
+    val borrower = mkBank(1, -100.0, capital = -1.0, failed = true)
+    val lender   = mkBank(2, 100.0, capital = 1e9)
+    val banks    = Vector(safe, borrower, lender)
+    val matrix   = InterbankContagion.buildExposureMatrix(banks)
+    val after    = InterbankContagion.applyContagionLosses(banks, matrix)
+    after(0).capital.toDouble shouldBe 1e9 +- 0.01 // safe bank untouched
+  }
+
+  "hoardingFactor" should "be 1.0 when NPL below threshold" in {
+    val factor = InterbankContagion.hoardingFactor(Ratio(0.02))
+    factor.toDouble shouldBe 1.0 +- 0.01
+  }
+
+  it should "decrease when NPL exceeds threshold" in {
+    val factor = InterbankContagion.hoardingFactor(Ratio(0.10))
+    factor.toDouble should be < 1.0
+    factor.toDouble should be >= 0.0
+  }
+
+  it should "be zero (full freeze) at very high NPL" in {
+    val factor = InterbankContagion.hoardingFactor(Ratio(0.50))
+    factor.toDouble shouldBe 0.0 +- 0.01
+  }


### PR DESCRIPTION
## Summary

Lehman/Bear Stearns channel for the Polish banking system. Bank failure triggers counterparty losses proportional to bilateral interbank exposure, potentially cascading to secondary failures.

### Three mechanisms

1. **Bilateral exposure matrix** — 7×7 matrix where `exposure(i→j)` = lender i surplus × (borrower j deficit / total borrowing). Every lender is exposed to every borrower proportionally.

2. **Contagion losses** — when bank j fails, lender i loses `exposure(i→j) × (1 − recoveryRate)` from capital. If capital goes negative → secondary failure in next `checkFailures` round.

3. **Liquidity hoarding** — when system NPL > threshold (5%), banks reduce interbank lending: `hoardingFactor = clamp(1 − sensitivity × (NPL − threshold), 0, 1)`. At factor 0 = full interbank freeze.

### Implementation

- `InterbankContagion.scala` — pure functions (buildExposureMatrix, applyContagionLosses, hoardingFactor)
- `clearInterbank` now accepts hoarding factor parameter
- BankUpdateStep: contagion after failure check → secondary failure round
- Config: `interbankRecoveryRate` (40%, NBP FSR), `hoardingNplThreshold` (5%), `hoardingSensitivity` (10.0)

### Tests (8 new)
- Exposure matrix: zero diagonal, proportional allocation, zero when no borrowing
- Contagion: capital reduction, no effect on unexposed banks
- Hoarding: below/above threshold, full freeze at high NPL

## Test plan

- [x] `sbt compile` — no warnings
- [x] `sbt test` — 1284/1284 pass

Fixes #11