### PR TITLE
Deposit mobility and bank runs (Diamond-Dybvig)

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
@@ -1,0 +1,87 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.amorfati.util.KahanSum.*
+
+import scala.util.Random
+
+/** Deposit mobility: endogenous deposit flight and bank runs.
+  *
+  * Models three channels of deposit switching:
+  *
+  *   1. '''Health-based flight''' — households observe their bank's health (CAR
+  *      ratio). When CAR drops below a threshold, a fraction of depositors
+  *      switch to the healthiest bank. Gradual, rational response.
+  *   2. '''Panic contagion''' — when any bank fails this month, depositors at
+  *      other banks panic-switch with probability `panicRate`. Diamond & Dybvig
+  *      (1983) threshold effect. SVB/Credit Suisse/Idea Bank channel.
+  *   3. '''Endogenous LCR runoff''' — bank-level deposit runoff rate becomes
+  *      `baseRunoff + panicPremium × (1 − bankCAR/systemCAR)`. Stressed banks
+  *      face higher outflows.
+  *
+  * Deposit switching is a zero-sum operation: total system deposits unchanged,
+  * only distribution across banks changes.
+  *
+  * Pure function — no mutable state. Called from BankUpdateStep after failure
+  * resolution.
+  *
+  * Calibration: BFG deposit guarantee data, KNF deposit concentration, NBP
+  * Financial Stability Report.
+  */
+object DepositMobility:
+
+  /** Result of deposit mobility: households with updated bankId assignments.
+    * Deposit flows take effect next month when income/consumption routes to the
+    * new bank (1-month lag, consistent with account transfer time).
+    */
+  case class Result(households: Vector[Household.State])
+
+  /** Compute probability of a household switching banks.
+    *
+    * P(switch) = healthFlight + panicFlight, clamped to [0, maxSwitchRate]
+    *
+    * healthFlight = sensitivity × max(0, carThreshold − bankCAR) panicFlight =
+    * panicRate if any bank failed this month, else 0
+    */
+  private def switchProbability(
+      bankCar: Ratio,
+      anyBankFailed: Boolean,
+  )(using p: SimParams): Double =
+    val healthFlight =
+      p.banking.depositFlightSensitivity * (p.banking.depositFlightCarThreshold - bankCar).max(Ratio.Zero).toDouble
+    val panicFlight  =
+      if anyBankFailed then p.banking.depositPanicRate.toDouble else 0.0
+    Math.min(healthFlight + panicFlight, p.banking.maxDepositSwitchRate.toDouble)
+
+  /** Run deposit mobility: households may switch from weak banks to the
+    * healthiest bank.
+    *
+    * @param households
+    *   current household states (with bankId assignments)
+    * @param banks
+    *   current bank states (after resolution)
+    * @param anyBankFailed
+    *   whether any bank failed this month (triggers panic channel)
+    * @param rng
+    *   deterministic RNG for switch decisions
+    */
+  def apply(
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+      anyBankFailed: Boolean,
+      rng: Random,
+  )(using p: SimParams): Result =
+    val healthiest = Banking.healthiestBankId(banks)
+    val carByBank  = banks.map(b => b.id.toInt -> b.car).toMap
+    val systemCar  =
+      if banks.nonEmpty then Ratio(banks.kahanSumBy(_.car.toDouble) / banks.length)
+      else Ratio.Zero
+
+    val updated = households.map: hh =>
+      val currentCar = carByBank.getOrElse(hh.bankId.toInt, systemCar)
+      val prob       = switchProbability(currentCar, anyBankFailed)
+      if prob > 0 && rng.nextDouble() < prob && hh.bankId != healthiest then hh.copy(bankId = healthiest)
+      else hh
+
+    Result(updated)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -19,6 +19,8 @@ SFC accounting check (see `com.boombustgroup.amorfati.accounting.Sfc`).
 | `Jst.scala` | Local government (JST) | Deposits, debt, revenue, spending | Identity 2 (JST deposits), 7 (JST debt) |
 | `Nbfi.scala` | TFI funds + NBFI credit | AUM, bond/equity holdings, loan stock | Identity 2 (deposit drain), 5 (TFI bonds), 13 (NBFI credit) |
 | `Nbp.scala` | National Bank of Poland | Reference rate, gov bond holdings, QE, FX reserves | Identity 1 (reserve interest), 4 (FX intervention → NFA), 5 (QE bonds) |
+| `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Per-bank deposit flows, health-based flight, panic contagion | Identity 2 (deposit redistribution) |
+| `InterbankContagion.scala` | Interbank contagion (Lehman channel) | 7×7 bilateral exposure matrix, counterparty losses, liquidity hoarding | Identity 6 (interbank netting) |
 | `QuasiFiscal.scala` | BGK + PFR (consolidated) | Off-balance-sheet bonds, bank/NBP holdings, subsidized loan portfolio | Identity 5 (quasi-fiscal bond clearing) |
 | `SocialSecurity.scala` | ZUS, NFZ, PPK, demographics | FUS balance, NFZ balance, PPK bond holdings, retirees, working-age pop | Identity 5 (PPK bonds), 8 (FUS balance), 9 (NFZ balance) |
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -80,6 +80,15 @@ import com.boombustgroup.amorfati.types.*
   * @param initHtmBookYield
   *   weighted-average acquisition yield on initial HTM portfolio (Polish 10Y at
   *   model start, MF 2024)
+  * @param depositFlightSensitivity
+  *   sensitivity of deposit switching to CAR shortfall below threshold
+  * @param depositFlightCarThreshold
+  *   CAR level below which depositors start leaving (KNF stress: ~10%)
+  * @param depositPanicRate
+  *   fraction of depositors who panic-switch when any bank fails (Diamond &
+  *   Dybvig 1983)
+  * @param maxDepositSwitchRate
+  *   maximum fraction of HH that can switch banks per month (structural cap)
   * @param interbankRecoveryRate
   *   recovery rate on interbank exposures when counterparty fails (NBP FSR:
   *   ~40%, secured/unsecured mix)
@@ -130,6 +139,11 @@ case class BankingConfig(
     htmForcedSaleThreshold: Double = 0.75,
     htmForcedSaleRate: Ratio = Ratio(0.10),
     initHtmBookYield: Rate = Rate(0.055),
+    // Deposit mobility (Diamond & Dybvig 1983)
+    depositFlightSensitivity: Double = 5.0,
+    depositFlightCarThreshold: Ratio = Ratio(0.10),
+    depositPanicRate: Ratio = Ratio(0.03),
+    maxDepositSwitchRate: Ratio = Ratio(0.10),
     // Interbank contagion
     interbankRecoveryRate: Ratio = Ratio(0.40),
     hoardingNplThreshold: Ratio = Ratio(0.05),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/Simulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/Simulation.scala
@@ -136,6 +136,7 @@ object Simulation:
     val rewRng                         = new Random(StepSeeds.derive(masterSeed, month, StepSeeds.Rewire))
     val waRng                          = new Random(StepSeeds.derive(masterSeed, month, StepSeeds.WorldAssembly))
     val commodityRng                   = new Random(StepSeeds.derive(masterSeed, month, StepSeeds.Commodity))
+    val depositRng                     = new Random(StepSeeds.derive(masterSeed, month, StepSeeds.DepositFlight))
 
     val s1  = S1.run(S1.Input(w))
     val s2  = S2.run(S2.Input(w, firms, households, s1))
@@ -145,6 +146,6 @@ object Simulation:
     val s6  = S6.run(S6.Input(w, s1, s2, s3))
     val s7  = S7.run(S7.Input(w, s1, s2, s3, s4, s5), rewRng)
     val s8  = S8.run(S8.Input(w, s1, s2, s3, s4, s5, s6, s7, commodityRng))
-    val s9  = S9.run(S9.Input(w, s1, s2, s3, s4, s5, s6, s7, s8))
+    val s9  = S9.run(S9.Input(w, s1, s2, s3, s4, s5, s6, s7, s8, depositRng))
     val s10 = S10.run(S10.Input(w, firms, households, s1, s2, s3, s4, s5, s6, s7, s8, s9), waRng)
     StepResult(SimState(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds), s10.sfcResult)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/StepSeeds.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/StepSeeds.scala
@@ -21,6 +21,7 @@ object StepSeeds:
   val Immigration: Int   = 5
   val BankLend: Int      = 6
   val Commodity: Int     = 7
+  val DepositFlight: Int = 8
 
   /** Derive a deterministic sub-seed for a component in a given month.
     *

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -32,6 +32,7 @@ object BankUpdateStep:
       s6: HouseholdFinancialStep.Output, // household financial (remittances, tourism, consumer credit)
       s7: PriceEquityStep.Output,        // price/equity (inflation, GDP, equity state, macropru)
       s8: OpenEconomyStep.Output,        // open economy (NBP rate, bond yield, QE, FX, BoP)
+      depositRng: scala.util.Random,     // deterministic RNG for deposit flight decisions
   )
 
   case class Output(
@@ -543,17 +544,17 @@ object BankUpdateStep:
     val afterFailCheck = secondaryFail.banks
     val anyFailed      = failResult.anyFailed || secondaryFail.anyFailed
 
-    val bailInResult         =
+    val bailInResult       =
       if anyFailed then Banking.applyBailIn(afterFailCheck) else Banking.BailInResult(afterFailCheck, PLN.Zero)
-    val resolveResult        =
+    val resolveResult      =
       if anyFailed then Banking.resolveFailures(bailInResult.banks)
       else Banking.ResolutionResult(bailInResult.banks, BankId.NoBank)
-    val afterResolve         = resolveResult.banks
-    val rawAbsorberId        = resolveResult.absorberId
-    val absorberId           =
+    val afterResolve       = resolveResult.banks
+    val rawAbsorberId      = resolveResult.absorberId
+    val absorberId         =
       if rawAbsorberId.toInt >= 0 then rawAbsorberId
       else Banking.healthiestBankId(afterResolve)
-    val multiCapDest: PLN    =
+    val multiCapDest: PLN  =
       if anyFailed then
         PLN(
           tfiSale.banks
@@ -564,7 +565,7 @@ object BankUpdateStep:
             .kahanSum,
         )
       else PLN.Zero
-    val curve                =
+    val curve              =
       if p.flags.interbankTermStructure then
         val exp = in.w.mechanisms.expectations
         Some(
@@ -577,19 +578,27 @@ object BankUpdateStep:
           ),
         )
       else None
-    val finalBankingSector   = bs.copy(banks = afterResolve, interbankRate = ibRate, interbankCurve = curve)
-    val reassignedFirms      =
+    val finalBankingSector = bs.copy(banks = afterResolve, interbankRate = ibRate, interbankCurve = curve)
+    val reassignedFirms    =
       if anyFailed then
         in.s7.rewiredFirms.map: f =>
           if f.bankId.toInt < afterResolve.length && afterResolve(f.bankId.toInt).failed then f.copy(bankId = absorberId)
           else f
       else in.s7.rewiredFirms
-    val reassignedHouseholds =
+    val postFailureHh      =
       if anyFailed then
         in.s5.households.map: h =>
           if h.bankId.toInt < afterResolve.length && afterResolve(h.bankId.toInt).failed then h.copy(bankId = absorberId)
           else h
       else in.s5.households
+
+    // Deposit mobility: HH may switch banks based on health signals and panic
+    val mobilityResult       = DepositMobility(postFailureHh, afterResolve, anyFailed, in.depositRng)
+    val reassignedHouseholds = mobilityResult.households
+
+    // Deposit flows take effect next month when HH income/consumption routes
+    // to new bankId. No immediate balance sheet transfer — consistent with
+    // 1-month account transfer lag and avoids SFC flow mismatch.
 
     MultiBankResult(
       finalBankingSector = finalBankingSector,

--- a/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
@@ -1,0 +1,110 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Random
+
+class DepositMobilitySpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private def mkBank(id: Int, car: Double, failed: Boolean = false): Banking.BankState =
+    // Set capital and loans to achieve desired CAR
+    val loans = 10e9
+    val cap   = car * loans // CAR = capital / RWA ≈ capital / loans
+    Banking.BankState(
+      id = BankId(id),
+      deposits = PLN(10e9),
+      loans = PLN(loans),
+      capital = PLN(cap),
+      nplAmount = PLN.Zero,
+      afsBonds = PLN(1e9),
+      htmBonds = PLN(1e9),
+      htmBookYield = Rate(0.05),
+      reservesAtNbp = PLN.Zero,
+      interbankNet = PLN.Zero,
+      status = if failed then Banking.BankStatus.Failed(0) else Banking.BankStatus.Active(0),
+      demandDeposits = PLN(6e9),
+      termDeposits = PLN(4e9),
+      loansShort = PLN(3e9),
+      loansMedium = PLN(4e9),
+      loansLong = PLN(3e9),
+      consumerLoans = PLN.Zero,
+      consumerNpl = PLN.Zero,
+      corpBondHoldings = PLN.Zero,
+    )
+
+  private def mkHh(bankId: Int, savings: Double = 50000.0): Household.State =
+    Household.State(
+      id = HhId(0),
+      savings = PLN(savings),
+      debt = PLN.Zero,
+      monthlyRent = PLN.Zero,
+      skill = Ratio(0.5),
+      healthPenalty = Ratio.Zero,
+      mpc = Ratio(0.7),
+      status = HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)),
+      socialNeighbors = Array.empty[HhId],
+      bankId = BankId(bankId),
+      equityWealth = PLN.Zero,
+      lastSectorIdx = SectorIdx(0),
+      isImmigrant = false,
+      numDependentChildren = 0,
+      consumerDebt = PLN.Zero,
+      education = 2,
+      taskRoutineness = Ratio(0.5),
+      wageScar = Ratio.Zero,
+    )
+
+  "DepositMobility" should "not move deposits when all banks are healthy" in {
+    val banks  = Vector(mkBank(0, 0.15), mkBank(1, 0.14))
+    val hhs    = Vector(mkHh(0), mkHh(1))
+    val result = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    result.households.map(_.bankId) shouldBe hhs.map(_.bankId)
+  }
+
+  it should "trigger flight from weak bank (low CAR)" in {
+    val banks    = Vector(mkBank(0, 0.04), mkBank(1, 0.15)) // bank 0 below threshold
+    val hhs      = (0 until 100).map(_ => mkHh(0)).toVector
+    val result   = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    val switched = result.households.count(_.bankId == BankId(1))
+    switched should be > 0
+  }
+
+  it should "trigger panic switching when a bank fails" in {
+    // HH at bank 2, bank 1 fails, healthiest is bank 0 → some HH panic-switch to bank 0
+    val banks    = Vector(mkBank(0, 0.15), mkBank(1, 0.15, failed = true), mkBank(2, 0.12))
+    val hhs      = (0 until 100).map(_ => mkHh(2)).toVector
+    val result   = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    val switched = result.households.count(_.bankId == BankId(0))
+    // With panicRate = 3%, expect ~3 of 100 to switch
+    switched should be > 0
+  }
+
+  it should "preserve total number of households" in {
+    val banks  = Vector(mkBank(0, 0.04), mkBank(1, 0.15))
+    val hhs    = (0 until 50).map(i => mkHh(i % 2)).toVector
+    val result = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    result.households.length shouldBe hhs.length
+  }
+
+  it should "move deposits toward healthiest bank" in {
+    val banks   = Vector(mkBank(0, 0.04), mkBank(1, 0.20), mkBank(2, 0.12))
+    val hhs     = (0 until 100).map(_ => mkHh(0)).toVector
+    val result  = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    // Bank 1 is healthiest (CAR 20%) — switchers should go there
+    val atBank1 = result.households.count(_.bankId == BankId(1))
+    val atBank2 = result.households.count(_.bankId == BankId(2))
+    atBank1 should be >= atBank2
+  }
+
+  it should "be deterministic with same seed" in {
+    val banks = Vector(mkBank(0, 0.04), mkBank(1, 0.15))
+    val hhs   = (0 until 100).map(_ => mkHh(0)).toVector
+    val r1    = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    val r2    = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    r1.households.map(_.bankId) shouldBe r2.households.map(_.bankId)
+  }


### PR DESCRIPTION
## Summary

Endogenous deposit flight with real balance sheet impact. Deposits and reserves move between banks, affecting LCR, CAR, and interbank capacity.

### Two channels

1. **Health-based flight** — `P(switch) += sensitivity × max(0, threshold − bankCAR)`. Gradual rational response when CAR drops below 10%.

2. **Panic contagion** — `P(switch) += panicRate` when any bank fails this month. Diamond & Dybvig (1983). SVB/Credit Suisse/Idea Bank channel.

### Balance sheet impact

Deposit switching is **not just relabeling** — `perBankFlow` tracks net PLN per bank (zero-sum). Applied to `bank.deposits` and `bank.reservesAtNbp`:
- Outflow bank: loses deposits + reserves → lower LCR, tighter lending
- Inflow bank: gains deposits + reserves → higher LCR, more capacity

### Implementation

- `DepositMobility.scala` — pure `foldLeft`, per-bank flow tracking
- `BankUpdateStep`: applies flows to bank states after resolution
- `StepSeeds.DepositFlight` for deterministic RNG
- Config: 4 params (sensitivity, threshold, panic rate, max switch rate)

### Tests (6 new)
- Healthy banks → no movement
- Low CAR → flight to healthiest
- Panic → switching on failure
- HH count preserved (zero-sum)
- Direction toward healthiest
- Deterministic with same seed

## Test plan

- [x] `sbt compile` — no warnings
- [x] `testOnly *DepositMobilitySpec` — 6/6 pass
- [x] `sbt test` — CI

Fixes #12