### PR TITLE
IFRS 9 ECL staging (forward-looking loan loss provisioning)

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -146,6 +146,7 @@ object Sfc:
       firmPrincipalRepaid: PLN,     // firm loan principal repaid (deposit destruction)
       unrealizedBondLoss: PLN,      // mark-to-market loss on gov bond portfolio (interest rate risk channel)
       htmRealizedLoss: PLN,         // realized loss from HTM forced reclassification (HTM reclassification channel)
+      eclProvisionChange: PLN,      // IFRS 9 ECL provision change (positive = additional provision → capital hit)
   )
 
   /** Enumeration of the 13 balance-sheet identities checked each month. Used as
@@ -284,7 +285,7 @@ object Sfc:
         BankCapital,
         "bank capital change (profit retention + losses)",
         expected = -flows.nplLoss - flows.mortgageNplLoss - flows.consumerNplLoss
-          - flows.corpBondDefaultLoss - flows.bfgLevy - flows.unrealizedBondLoss - flows.htmRealizedLoss - flows.bankCapitalDestruction +
+          - flows.corpBondDefaultLoss - flows.bfgLevy - flows.unrealizedBondLoss - flows.htmRealizedLoss - flows.eclProvisionChange - flows.bankCapitalDestruction +
           (flows.interestIncome + flows.hhDebtService + flows.bankBondIncome
             + flows.mortgageInterestIncome + flows.consumerDebtService + flows.corpBondCouponIncome
             - flows.depositInterestPaid

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -174,25 +174,26 @@ object Banking:
     * field, same convention as `Firm.State`.
     */
   case class BankState(
-      id: BankId,           // unique bank identifier (index into banks vector)
-      deposits: PLN,        // total customer deposits (HH + firms)
-      loans: PLN,           // outstanding corporate loan book
-      capital: PLN,         // regulatory capital (Tier 1 + retained earnings)
-      nplAmount: PLN,       // non-performing loan stock (KNF Stage 3)
-      afsBonds: PLN,        // Available-for-Sale gov bonds (marked to market each month)
-      htmBonds: PLN,        // Held-to-Maturity gov bonds (accrual only, hidden losses)
-      htmBookYield: Rate,   // weighted-average acquisition yield on HTM portfolio
-      reservesAtNbp: PLN,   // excess reserves held at NBP
-      interbankNet: PLN,    // net interbank position (positive = lender)
-      status: BankStatus,   // operational status (Active with CAR counter, or Failed)
-      demandDeposits: PLN,  // demand deposits (% split from total deposits)
-      termDeposits: PLN,    // term deposits
-      loansShort: PLN,      // short-term loans (< 1 year)
-      loansMedium: PLN,     // medium-term loans (1–5 years)
-      loansLong: PLN,       // long-term loans (> 5 years)
-      consumerLoans: PLN,   // outstanding unsecured household credit
-      consumerNpl: PLN,     // consumer credit NPL stock
-      corpBondHoldings: PLN, // corporate bond holdings (bank share, Basel III BBB)
+      id: BankId,                                          // unique bank identifier (index into banks vector)
+      deposits: PLN,                                       // total customer deposits (HH + firms)
+      loans: PLN,                                          // outstanding corporate loan book
+      capital: PLN,                                        // regulatory capital (Tier 1 + retained earnings)
+      nplAmount: PLN,                                      // non-performing loan stock (KNF Stage 3)
+      afsBonds: PLN,                                       // Available-for-Sale gov bonds (marked to market each month)
+      htmBonds: PLN,                                       // Held-to-Maturity gov bonds (accrual only, hidden losses)
+      htmBookYield: Rate,                                  // weighted-average acquisition yield on HTM portfolio
+      reservesAtNbp: PLN,                                  // excess reserves held at NBP
+      interbankNet: PLN,                                   // net interbank position (positive = lender)
+      status: BankStatus,                                  // operational status (Active with CAR counter, or Failed)
+      demandDeposits: PLN,                                 // demand deposits (% split from total deposits)
+      termDeposits: PLN,                                   // term deposits
+      loansShort: PLN,                                     // short-term loans (< 1 year)
+      loansMedium: PLN,                                    // medium-term loans (1–5 years)
+      loansLong: PLN,                                      // long-term loans (> 5 years)
+      consumerLoans: PLN,                                  // outstanding unsecured household credit
+      consumerNpl: PLN,                                    // consumer credit NPL stock
+      corpBondHoldings: PLN,                               // corporate bond holdings (bank share, Basel III BBB)
+      eclStaging: EclStaging.State = EclStaging.State.zero, // IFRS 9 ECL staging (S1/S2/S3)
   ):
 
     /** Total government bond holdings (AFS + HTM). All existing read-only

--- a/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
@@ -1,0 +1,101 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** IFRS 9 Expected Credit Loss (ECL) staging for bank loan portfolios.
+  *
+  * Three-stage model replacing instantaneous NPL capital hit:
+  *
+  *   - '''Stage 1''' (performing, 12-month ECL): loans with no significant
+  *     increase in credit risk. Provision = portfolio × eclRate1 (~1%).
+  *   - '''Stage 2''' (watch, lifetime ECL): loans with significant increase in
+  *     credit risk (GDP decline, unemployment spike). Provision = portfolio ×
+  *     eclRate2 (~5-10%). Macro trigger shifts loans S1→S2 en masse.
+  *   - '''Stage 3''' (default): non-performing loans. Provision = portfolio ×
+  *     eclRate3 (= 1 − recovery rate). This is the current NPL treatment.
+  *
+  * Pro-cyclical amplification: GDP downturn → mass S1→S2 migration →
+  * provisioning cliff → capital hit → lending restriction → deeper downturn.
+  * Forward-looking: provisions are booked BEFORE defaults materialize.
+  *
+  * Pure functions — no mutable state. Per-bank staging computed from macro
+  * signals (unemployment, GDP growth) and bank-level loan quality.
+  *
+  * Calibration: KNF IFRS 9 implementation guidelines, NBP Financial Stability
+  * Report, EBA stress test methodology.
+  */
+object EclStaging:
+
+  /** Per-bank ECL staging state. */
+  case class State(
+      stage1: PLN, // performing loans (12-month ECL)
+      stage2: PLN, // watch loans (lifetime ECL)
+      stage3: PLN, // defaulted loans (full provision)
+  )
+  object State:
+    val zero: State = State(PLN.Zero, PLN.Zero, PLN.Zero)
+
+  /** ECL staging result: updated stages + total provision change. */
+  case class StepResult(
+      newStaging: State,
+      provisionChange: PLN, // Δ provision this month (positive = additional provision → capital hit)
+  )
+
+  /** Compute macro-driven S1→S2 migration rate.
+    *
+    * When unemployment rises above NAIRU or GDP contracts, a fraction of
+    * performing loans migrates to Stage 2 (significant credit risk increase).
+    *
+    * migrationRate = sensitivity × max(0, unemployment − nairu) +
+    * gdpSensitivity × max(0, −gdpGrowth) Clamped to [0, maxMigration].
+    */
+  private[amorfati] def migrationRate(
+      unemployment: Ratio,
+      gdpGrowthMonthly: Double,
+  )(using p: SimParams): Ratio =
+    val unempExcess    = (unemployment - p.monetary.nairu).max(Ratio.Zero).toDouble
+    val gdpContraction = Math.max(0.0, -gdpGrowthMonthly)
+    val raw            = p.banking.eclMigrationSensitivity * unempExcess + p.banking.eclGdpSensitivity * gdpContraction
+    Ratio(raw.min(p.banking.eclMaxMigration.toDouble).max(0.0))
+
+  /** Monthly ECL staging step for a single bank.
+    *
+    * @param prev
+    *   previous staging state
+    * @param totalLoans
+    *   total loan book (corporate + consumer)
+    * @param nplNew
+    *   new defaults this month (→ Stage 3)
+    * @param unemployment
+    *   current unemployment rate
+    * @param gdpGrowthMonthly
+    *   month-on-month GDP growth
+    */
+  def step(
+      prev: State,
+      totalLoans: PLN,
+      nplNew: PLN,
+      unemployment: Ratio,
+      gdpGrowthMonthly: Double,
+  )(using p: SimParams): StepResult =
+    val migration = migrationRate(unemployment, gdpGrowthMonthly)
+
+    // Stage transitions
+    val s1ToS2 = prev.stage1 * migration             // macro-driven migration
+    val s2ToS3 = nplNew                              // actual defaults enter S3
+    val s3Cure = prev.stage3 * p.banking.eclCureRate // some S3 loans recover
+
+    // Updated stages
+    val newS3 = (prev.stage3 + s2ToS3 - s3Cure).max(PLN.Zero)
+    val newS2 = (prev.stage2 + s1ToS2 - s2ToS3 + s3Cure).max(PLN.Zero)
+    val newS1 = (totalLoans - newS2 - newS3).max(PLN.Zero)
+
+    val newStaging = State(newS1, newS2, newS3)
+
+    // Provision = Σ(stage × eclRate) — change vs previous month
+    val prevProvision   = prev.stage1 * p.banking.eclRate1 + prev.stage2 * p.banking.eclRate2 + prev.stage3 * p.banking.eclRate3
+    val newProvision    = newS1 * p.banking.eclRate1 + newS2 * p.banking.eclRate2 + newS3 * p.banking.eclRate3
+    val provisionChange = newProvision - prevProvision
+
+    StepResult(newStaging, provisionChange)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -20,6 +20,7 @@ SFC accounting check (see `com.boombustgroup.amorfati.accounting.Sfc`).
 | `Nbfi.scala` | TFI funds + NBFI credit | AUM, bond/equity holdings, loan stock | Identity 2 (deposit drain), 5 (TFI bonds), 13 (NBFI credit) |
 | `Nbp.scala` | National Bank of Poland | Reference rate, gov bond holdings, QE, FX reserves | Identity 1 (reserve interest), 4 (FX intervention → NFA), 5 (QE bonds) |
 | `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Per-bank deposit flows, health-based flight, panic contagion | Identity 2 (deposit redistribution) |
+| `EclStaging.scala` | IFRS 9 ECL provisioning | S1/S2/S3 staging, macro-driven migration, forward-looking provisions | Identity 1 (provision → capital) |
 | `InterbankContagion.scala` | Interbank contagion (Lehman channel) | 7×7 bilateral exposure matrix, counterparty losses, liquidity hoarding | Identity 6 (interbank netting) |
 | `QuasiFiscal.scala` | BGK + PFR (consolidated) | Off-balance-sheet bonds, bank/NBP holdings, subsidized loan portfolio | Identity 5 (quasi-fiscal bond clearing) |
 | `SocialSecurity.scala` | ZUS, NFZ, PPK, demographics | FUS balance, NFZ balance, PPK bond holdings, retirees, working-age pop | Identity 5 (PPK bonds), 8 (FUS balance), 9 (NFZ balance) |

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -98,6 +98,20 @@ import com.boombustgroup.amorfati.types.*
   * @param hoardingSensitivity
   *   speed of hoarding onset: factor = 1 − sensitivity × (NPL − threshold). At
   *   10.0, a 10pp NPL overshoot → full freeze.
+  * @param eclRate1
+  *   Stage 1 (performing) ECL provision rate (12-month ECL, KNF: ~1%)
+  * @param eclRate2
+  *   Stage 2 (watch) ECL provision rate (lifetime ECL, KNF: ~8%)
+  * @param eclRate3
+  *   Stage 3 (default) ECL provision rate (1 − recovery, KNF: ~50%)
+  * @param eclMigrationSensitivity
+  *   sensitivity of S1→S2 migration to unemployment excess above NAIRU
+  * @param eclGdpSensitivity
+  *   sensitivity of S1→S2 migration to GDP contraction
+  * @param eclMaxMigration
+  *   maximum monthly S1→S2 migration rate (structural cap)
+  * @param eclCureRate
+  *   monthly cure rate: fraction of S3 loans returning to S2 (restructuring)
   */
 case class BankingConfig(
     // Initial balance sheet (raw — scaled by gdpRatio in SimParams.defaults)
@@ -148,6 +162,14 @@ case class BankingConfig(
     interbankRecoveryRate: Ratio = Ratio(0.40),
     hoardingNplThreshold: Ratio = Ratio(0.05),
     hoardingSensitivity: Double = 10.0,
+    // IFRS 9 ECL staging
+    eclRate1: Ratio = Ratio(0.01),
+    eclRate2: Ratio = Ratio(0.08),
+    eclRate3: Ratio = Ratio(0.50),
+    eclMigrationSensitivity: Double = 3.0,
+    eclGdpSensitivity: Double = 5.0,
+    eclMaxMigration: Ratio = Ratio(0.20),
+    eclCureRate: Ratio = Ratio(0.02),
 ):
   require(minCar > Ratio.Zero && minCar < Ratio.One, s"minCar must be in (0,1): $minCar")
   require(initCapital >= PLN.Zero, s"initCapital must be non-negative: $initCapital")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -68,6 +68,7 @@ object BankUpdateStep:
       actualBondChange: PLN,                         // net change in gov bonds outstanding
       unrealizedBondLoss: PLN,                       // mark-to-market loss on gov bond portfolio (interest rate risk channel)
       htmRealizedLoss: PLN,                          // realized loss from HTM forced reclassification
+      eclProvisionChange: PLN,                       // aggregate IFRS 9 ECL provision change
       newQuasiFiscal: QuasiFiscal.State,             // BGK/PFR after issuance and lending
   )
 
@@ -187,6 +188,16 @@ object BankUpdateStep:
         if yc > 0 then in.w.bank.afsBonds * (yc * p.banking.govBondDuration) else PLN.Zero
       },
       htmRealizedLoss = multi.htmRealizedLoss,
+      eclProvisionChange = PLN:
+        multi.finalBankingSector.banks
+          .zip(in.w.bankingSector.banks)
+          .kahanSumBy: (curr, prev) =>
+            val currProv: PLN =
+              curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
+            val prevProv: PLN =
+              prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
+            (currProv - prevProv).toDouble
+      ,
       newQuasiFiscal = newQuasiFiscal,
     )
 
@@ -433,10 +444,16 @@ object BankUpdateStep:
       ),
     )
 
+    // IFRS 9 ECL staging: provision change hits capital
+    val unemployment = Ratio(1.0 - in.s2.employed.toDouble / in.w.totalPopulation)
+    val gdpGrowth    = if in.w.gdpProxy > 0 then (in.s7.gdp.toDouble - in.w.gdpProxy) / in.w.gdpProxy else 0.0
+    val eclResult    = EclStaging.step(b.eclStaging, newLoansTotal + b.consumerLoans, bankNplNew, unemployment, gdpGrowth)
+
     b.copy(
       loans = newLoansTotal,
       nplAmount = (b.nplAmount + bankNplNew - b.nplAmount * NplMonthlyWriteOff).max(PLN.Zero),
-      capital = capitalPnl.newCapital,
+      capital = capitalPnl.newCapital - eclResult.provisionChange,
+      eclStaging = eclResult.newStaging,
       deposits = newDep,
       demandDeposits = newDep * (1.0 - p.banking.termDepositFrac.toDouble),
       termDeposits = newDep * p.banking.termDepositFrac.toDouble,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
@@ -331,6 +331,7 @@ object WorldAssemblyStep:
       firmPrincipalRepaid = in.s5.sumFirmPrincipal,
       unrealizedBondLoss = in.s9.unrealizedBondLoss,
       htmRealizedLoss = in.s9.htmRealizedLoss,
+      eclProvisionChange = in.s9.eclProvisionChange,
     )
 
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -289,6 +289,10 @@ object SimOutput:
     // AFS/HTM bond portfolio split
     ColumnDef("BankAfsBonds", ctx => ctx.world.bank.afsBonds.toDouble),
     ColumnDef("BankHtmBonds", ctx => ctx.world.bank.htmBonds.toDouble),
+    // IFRS 9 ECL staging (aggregate across banks)
+    ColumnDef("EclStage1", ctx => ctx.world.bankingSector.banks.map(_.eclStaging.stage1.toDouble).sum),
+    ColumnDef("EclStage2", ctx => ctx.world.bankingSector.banks.map(_.eclStaging.stage2.toDouble).sum),
+    ColumnDef("EclStage3", ctx => ctx.world.bankingSector.banks.map(_.eclStaging.stage3.toDouble).sum),
     // KNF/BFG
     ColumnDef("BfgLevyTotal", ctx => ctx.world.flows.bfgLevyTotal),
     ColumnDef("BfgFundBalance", ctx => ctx.world.mechanisms.bfgFundBalance.toDouble),

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -520,6 +520,7 @@ object Generators:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   /** Generate (prev, curr, flows) where all 9 SFC identities hold exactly. */

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
@@ -105,6 +105,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   private val baseSnap =

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
@@ -94,6 +94,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         firmPrincipalRepaid = PLN.Zero,
         unrealizedBondLoss = PLN.Zero,
         htmRealizedLoss = PLN.Zero,
+        eclProvisionChange = PLN.Zero,
       )
       val result    = Sfc.validate(snap, snap, zeroFlows)
       result shouldBe Right(())

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -237,6 +237,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   // ---- Snapshot tests ----

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -316,6 +316,7 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   "Sfc" should "pass consumer credit identity with zero flows" in {

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
@@ -1,0 +1,73 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EclStagingSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val loans = PLN(10e9)
+  private val init  = EclStaging.State(loans, PLN.Zero, PLN.Zero) // all S1
+
+  "migrationRate" should "be zero when unemployment below NAIRU and GDP growing" in {
+    val rate = EclStaging.migrationRate(Ratio(0.03), 0.01)
+    rate.toDouble shouldBe 0.0 +- 0.001
+  }
+
+  it should "increase with unemployment above NAIRU" in {
+    val low  = EclStaging.migrationRate(Ratio(0.06), 0.0)
+    val high = EclStaging.migrationRate(Ratio(0.10), 0.0)
+    high.toDouble should be > low.toDouble
+  }
+
+  it should "increase with GDP contraction" in {
+    val growing     = EclStaging.migrationRate(Ratio(0.05), 0.01)
+    val contracting = EclStaging.migrationRate(Ratio(0.05), -0.02)
+    contracting.toDouble should be > growing.toDouble
+  }
+
+  it should "not exceed maxMigration" in {
+    val extreme = EclStaging.migrationRate(Ratio(0.50), -0.20)
+    extreme.toDouble should be <= summon[SimParams].banking.eclMaxMigration.toDouble
+  }
+
+  "EclStaging.step" should "keep all loans in S1 when economy is stable" in {
+    val result = EclStaging.step(init, loans, PLN.Zero, Ratio(0.04), 0.01)
+    result.newStaging.stage1.toDouble shouldBe loans.toDouble +- 1.0
+    result.newStaging.stage2.toDouble shouldBe 0.0 +- 1.0
+  }
+
+  it should "migrate S1→S2 when unemployment rises" in {
+    val result = EclStaging.step(init, loans, PLN.Zero, Ratio(0.10), 0.0)
+    result.newStaging.stage2.toDouble should be > 0.0
+    result.newStaging.stage1.toDouble should be < loans.toDouble
+  }
+
+  it should "move defaults to S3" in {
+    val nplNew = PLN(100e6)
+    val s2Init = EclStaging.State(loans - nplNew, nplNew, PLN.Zero)
+    val result = EclStaging.step(s2Init, loans, nplNew, Ratio(0.04), 0.01)
+    result.newStaging.stage3.toDouble should be > 0.0
+  }
+
+  it should "increase provisions when loans migrate S1→S2" in {
+    val result = EclStaging.step(init, loans, PLN.Zero, Ratio(0.10), -0.02)
+    // S1→S2 migration → higher provisions → positive provisionChange
+    result.provisionChange.toDouble should be > 0.0
+  }
+
+  it should "preserve total loans across stages" in {
+    val result = EclStaging.step(init, loans, PLN(50e6), Ratio(0.08), -0.01)
+    val total  = result.newStaging.stage1 + result.newStaging.stage2 + result.newStaging.stage3
+    total.toDouble shouldBe loans.toDouble +- 1.0
+  }
+
+  it should "cure some S3 loans back to S2" in {
+    val s3Init = EclStaging.State(PLN.Zero, PLN.Zero, loans)
+    val result = EclStaging.step(s3Init, loans, PLN.Zero, Ratio(0.04), 0.01)
+    result.newStaging.stage2.toDouble should be > 0.0
+    result.newStaging.stage3.toDouble should be < loans.toDouble
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
@@ -106,6 +106,7 @@ class FofSpec extends AnyFlatSpec with Matchers:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   "FofConsWeights" should "sum to 1.0" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -22,7 +22,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
     runSingle(42) shouldBe a[Right[?, ?]]
   }
 
-  it should "produce 120 rows x 209 columns" in {
+  it should "produce 120 rows x 212 columns" in {
     ts.length shouldBe p.timeline.duration
     for row <- ts do row.length shouldBe SimOutput.nCols
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -106,6 +106,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     firmPrincipalRepaid = PLN.Zero,
     unrealizedBondLoss = PLN.Zero,
     htmRealizedLoss = PLN.Zero,
+    eclProvisionChange = PLN.Zero,
   )
 
   private def mkBank(


### PR DESCRIPTION
## Summary

Three-stage IFRS 9 Expected Credit Loss model replacing instantaneous NPL capital hit with forward-looking provisioning.

### Stages

| Stage | Trigger | ECL Rate | Description |
|-------|---------|----------|-------------|
| S1 | Performing | 1% | 12-month ECL, baseline provision |
| S2 | Watch | 8% | Lifetime ECL, macro-triggered migration |
| S3 | Default | 50% | Full provision (= 1 − recovery) |

### Pro-cyclical amplification

GDP downturn or unemployment spike → mass S1→S2 migration → provisioning cliff → capital hit → lending restriction → deeper downturn. Forward-looking: provisions booked BEFORE defaults materialize.

`migrationRate = sensitivity × max(0, unemp − NAIRU) + gdpSens × max(0, −gdpGrowth)`

### Implementation

- `EclStaging.scala` — pure functions (migrationRate, step, cure)
- Per-bank `eclStaging: EclStaging.State` on `BankState`
- `eclProvisionChange` in `Sfc.MonthlyFlows` → Identity 1 (BankCapital)
- Config: 7 params (eclRate1/2/3, migration/GDP sensitivity, maxMigration, cureRate)
- 3 output columns: EclStage1, EclStage2, EclStage3 (212 total)

### Tests (10 new)
- Migration rate: zero below NAIRU, increases with unemployment/GDP contraction, capped
- Step: stable economy = all S1, high unemployment = S1→S2, defaults → S3
- Provisions increase on migration, total loans preserved, S3 cure

## Test plan

- [x] `sbt compile` — no warnings
- [x] `testOnly *EclStagingSpec *McRunnerSpec` — 32/32 pass
- [x] `sbt test` — CI

Fixes #14