### PR TITLE
Capital flight and hot money (risk-off, carry trade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/boombustgroup/amor-fati/actions"><img src="https://github.com/boombustgroup/amor-fati/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://codecov.io/gh/boombustgroup/amor-fati"><img src="https://codecov.io/gh/boombustgroup/amor-fati/graph/badge.svg" alt="Coverage"></a>
   <img src="https://img.shields.io/badge/scala-3.8.2-red.svg" alt="Scala 3.8.2">
-  <img src="https://img.shields.io/badge/mechanisms-51-blue.svg" alt="51 mechanisms">
+  <img src="https://img.shields.io/badge/mechanisms-52-blue.svg" alt="52 mechanisms">
   <img src="https://img.shields.io/badge/SFC_identities-14-orange.svg" alt="14 SFC identities">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-blue.svg" alt="Apache 2.0"></a>
 </p>

--- a/src/main/scala/com/boombustgroup/amorfati/config/ForexConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ForexConfig.scala
@@ -28,6 +28,22 @@ import com.boombustgroup.amorfati.types.*
   *   monthly exchange rate adjustment speed toward equilibrium
   * @param exportAutoBoost
   *   export productivity boost from firm automation
+  * @param riskOffShockMonth
+  *   simulation month when global risk-off event hits (0 = no shock)
+  * @param riskOffMagnitude
+  *   capital outflow as fraction of monthly GDP on risk-off (2020/2022: ~10%)
+  * @param riskOffDurationMonths
+  *   months of elevated risk-off (carry unwind persists)
+  * @param carryThreshold
+  *   yield spread above which carry trade positions accumulate
+  * @param carryAccumulationRate
+  *   speed of carry trade stock buildup
+  * @param carryUnwindSpeed
+  *   monthly fraction of carry stock unwound during risk-off
+  * @param auctionConfidenceThreshold
+  *   bid-to-cover below which foreign confidence erodes
+  * @param auctionOutflowSensitivity
+  *   portfolio outflow sensitivity to auction undersubscription
   */
 case class ForexConfig(
     baseExRate: Double = 4.33,
@@ -38,6 +54,15 @@ case class ForexConfig(
     irpSensitivity: Double = 0.15,
     exRateAdjSpeed: Ratio = Ratio(0.02),
     exportAutoBoost: Ratio = Ratio(0.15),
+    // Capital flight (risk-off, carry trade)
+    riskOffShockMonth: Int = 0,
+    riskOffMagnitude: Ratio = Ratio(0.10),
+    riskOffDurationMonths: Int = 6,
+    carryThreshold: Rate = Rate(0.03),
+    carryAccumulationRate: Double = 0.5,
+    carryUnwindSpeed: Ratio = Ratio(0.30),
+    auctionConfidenceThreshold: Ratio = Ratio(0.90),
+    auctionOutflowSensitivity: Double = 2.0,
 ):
   require(baseExRate > 0, s"baseExRate must be positive: $baseExRate")
   require(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -38,6 +38,7 @@ equilibrium prices, quantities, or flows given current state.
 | `HousingMarket.scala` | House price index (aggregate + 7 regions), mortgage origination/default/amortization |
 | `CorporateBondMarket.scala` | Catalyst: corporate bond issuance, coupon, default, demand-side absorption |
 | `BondAuction.scala` | SPW primary market: foreign demand f(yield spread vs Bund, ER), absorption constraint |
+| `CapitalFlows.scala` | Capital flight: risk-off shock, carry trade (accumulation/unwind), auction confidence signal |
 | `GvcTrade.scala` | GVC deep external sector: foreign firm partners, sector-level trade, disruption shocks |
 | `IntermediateMarket.scala` | I-O intermediate goods: inter-sector purchases via input-output matrix |
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/CapitalFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/CapitalFlows.scala
@@ -1,0 +1,90 @@
+package com.boombustgroup.amorfati.engine.markets
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** Capital flight and hot money: risk-off, carry trade, EM sentiment.
+  *
+  * Extends the mechanical portfolio flow model with three crisis channels:
+  *
+  *   1. '''Global risk-off''' — exogenous EM sentiment shock (VIX spike, Fed
+  *      tightening, geopolitical event). Triggers sudden capital outflow. PLN
+  *      can depreciate 10-15% in weeks (2022, 2020). Configurable shock month
+  *      and magnitude.
+  *   2. '''Carry trade''' — leveraged positions accumulate when yield spread
+  *      exceeds threshold. On risk-off: forced unwind → amplified PLN selling →
+  *      overshoot beyond fundamentals. Stock builds gradually, unwinds
+  *      suddenly.
+  *   3. '''Bond market signal''' — low bid-to-cover in SPW auction erodes
+  *      foreign confidence → additional portfolio outflow. Links BondAuction to
+  *      capital account.
+  *
+  * Pure function — no mutable state beyond carry trade stock (tracked in
+  * BopState). Called from OpenEconomy.step.
+  *
+  * Calibration: NBP BoP data, BIS carry trade estimates, IMF capital flow at
+  * risk methodology.
+  */
+object CapitalFlows:
+
+  /** Carry trade state: accumulated leveraged positions. */
+  case class CarryState(
+      stock: PLN, // outstanding carry trade positions (builds when spread high)
+  )
+  object CarryState:
+    val zero: CarryState = CarryState(PLN.Zero)
+
+  /** Result of capital flow computation. */
+  case class Result(
+      riskOffOutflow: PLN, // outflow from global risk-off event
+      carryTradeFlow: PLN, // net carry trade flow (positive = inflow, negative = unwind)
+      auctionSignal: PLN,  // outflow from weak bond auction
+      newCarryState: CarryState,
+  ):
+    def totalAdjustment: PLN = riskOffOutflow + carryTradeFlow + auctionSignal
+
+  /** Compute capital flight adjustments for this month.
+    *
+    * @param month
+    *   current simulation month
+    * @param yieldSpread
+    *   domestic yield − foreign yield
+    * @param bidToCover
+    *   SPW auction bid-to-cover ratio
+    * @param prevCarry
+    *   previous carry trade state
+    * @param monthlyGdp
+    *   GDP proxy for scaling
+    */
+  def compute(
+      month: Int,
+      yieldSpread: Rate,
+      bidToCover: Ratio,
+      prevCarry: CarryState,
+      monthlyGdp: PLN,
+  )(using p: SimParams): Result =
+    // 1. Global risk-off shock
+    val riskOff =
+      if p.forex.riskOffShockMonth > 0 && month == p.forex.riskOffShockMonth then monthlyGdp * p.forex.riskOffMagnitude.toDouble * -1.0
+      else PLN.Zero
+
+    // 2. Carry trade: accumulate when spread > threshold, unwind on risk-off
+    val spreadAboveThreshold = (yieldSpread - p.forex.carryThreshold).max(Rate.Zero)
+    val isRiskOff            = p.forex.riskOffShockMonth > 0 && month >= p.forex.riskOffShockMonth &&
+      month < p.forex.riskOffShockMonth + p.forex.riskOffDurationMonths
+    val carryAccumulation    =
+      if !isRiskOff then monthlyGdp * (spreadAboveThreshold.toDouble * p.forex.carryAccumulationRate)
+      else PLN.Zero
+    val carryUnwind          =
+      if isRiskOff then prevCarry.stock * p.forex.carryUnwindSpeed.toDouble * -1.0
+      else PLN.Zero
+    val newStock             = (prevCarry.stock + carryAccumulation + carryUnwind).max(PLN.Zero)
+    val carryFlow            = carryAccumulation + carryUnwind
+
+    // 3. Bond auction signal: low bid-to-cover → confidence erosion
+    val auctionOutflow =
+      if bidToCover < p.forex.auctionConfidenceThreshold then
+        monthlyGdp * p.forex.auctionOutflowSensitivity * (p.forex.auctionConfidenceThreshold - bidToCover).toDouble * -1.0
+      else PLN.Zero
+
+    Result(riskOff, carryFlow, auctionOutflow, CarryState(newStock))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -58,22 +58,23 @@ object OpenEconomy:
     * Calibration: NBP BoP statistics 2024, Eurostat EU funds absorption data.
     */
   case class BopState(
-      nfa: PLN,                              // net foreign assets (cumulative stock, ΔNFA = CA + valuation)
-      foreignAssets: PLN,                    // gross foreign assets (cumulative, grows with KA inflows)
-      foreignLiabilities: PLN,               // gross foreign liabilities (cumulative, grows with KA outflows)
-      currentAccount: PLN,                   // monthly CA: trade + primary income + secondary income
-      capitalAccount: PLN,                   // monthly KA: FDI + portfolio flows (BPM6 financial account)
-      tradeBalance: PLN,                     // monthly exports − imports (merchandise + tourism)
-      primaryIncome: PLN,                    // monthly interest/dividends on NFA (nfa × nfaReturnRate / 12)
-      secondaryIncome: PLN,                  // monthly transfers: EU funds + diaspora − remittance outflow
-      fdi: PLN,                              // monthly FDI inflows (base + automation boost − NFA dampening)
-      portfolioFlows: PLN,                   // monthly portfolio flows (interest rate differential + risk premium)
-      reserves: PLN,                         // CB foreign reserves (cumulative, ΔRes = −(CA + KA))
-      exports: PLN,                          // total exports this month (merchandise + tourism)
-      totalImports: PLN,                     // total imports this month (consumption + tech + intermediates + tourism)
-      importedIntermediates: PLN,            // cross-border intermediate inputs (per-sector import content × output)
-      euFundsMonthly: PLN = PLN.Zero,        // EU structural/cohesion funds transferred this month
+      nfa: PLN,                               // net foreign assets (cumulative stock, ΔNFA = CA + valuation)
+      foreignAssets: PLN,                     // gross foreign assets (cumulative, grows with KA inflows)
+      foreignLiabilities: PLN,                // gross foreign liabilities (cumulative, grows with KA outflows)
+      currentAccount: PLN,                    // monthly CA: trade + primary income + secondary income
+      capitalAccount: PLN,                    // monthly KA: FDI + portfolio flows (BPM6 financial account)
+      tradeBalance: PLN,                      // monthly exports − imports (merchandise + tourism)
+      primaryIncome: PLN,                     // monthly interest/dividends on NFA (nfa × nfaReturnRate / 12)
+      secondaryIncome: PLN,                   // monthly transfers: EU funds + diaspora − remittance outflow
+      fdi: PLN,                               // monthly FDI inflows (base + automation boost − NFA dampening)
+      portfolioFlows: PLN,                    // monthly portfolio flows (interest rate differential + risk premium)
+      reserves: PLN,                          // CB foreign reserves (cumulative, ΔRes = −(CA + KA))
+      exports: PLN,                           // total exports this month (merchandise + tourism)
+      totalImports: PLN,                      // total imports this month (consumption + tech + intermediates + tourism)
+      importedIntermediates: PLN,             // cross-border intermediate inputs (per-sector import content × output)
+      euFundsMonthly: PLN = PLN.Zero,         // EU structural/cohesion funds transferred this month
       euCumulativeAbsorption: PLN = PLN.Zero, // cumulative EU funds absorbed since t = 0
+      carryTradeStock: PLN = PLN.Zero,        // outstanding carry trade positions
   )
   object BopState:
     val zero: BopState = BopState(
@@ -152,13 +153,20 @@ object OpenEconomy:
       diasporaInflow: PLN = PLN.Zero,
       tourismExport: PLN = PLN.Zero,
       tourismImport: PLN = PLN.Zero,
+      bondYield: Rate = Rate.Zero,
+      prevBidToCover: Ratio = Ratio(2.0),
   )
 
   /** Current account breakdown. */
   private case class CurrentAccountResult(ca: PLN, primaryIncome: PLN, secondaryIncome: PLN)
 
   /** Capital account breakdown. */
-  private case class CapitalAccountResult(total: PLN, fdi: PLN, portfolioFlows: PLN)
+  private case class CapitalAccountResult(
+      total: PLN,                     // FDI + adjusted portfolio flows
+      fdi: PLN,                       // foreign direct investment
+      portfolioFlows: PLN,            // portfolio flows (incl. risk-off, carry trade, auction signal)
+      carryTradeStock: PLN = PLN.Zero, // outstanding carry trade positions after this month
+  )
 
   def step(in: StepInput)(using p: SimParams): Result =
     val exports             = computeExports(in)
@@ -192,6 +200,7 @@ object OpenEconomy:
       exports = totalExportsIncTour,
       totalImports = totalImports,
       importedIntermediates = totalImportedInterm,
+      carryTradeStock = kaResult.carryTradeStock,
     )
 
     Result(newForex, newBop, importedInterm, valEffect, fxResult)
@@ -241,16 +250,26 @@ object OpenEconomy:
     * portfolio flows (interest rate differential + NFA risk premium).
     */
   private def computeCapitalAccount(in: StepInput)(using p: SimParams): CapitalAccountResult =
-    val annualGdp      = in.gdp * MonthsPerYear
-    val nfaGdpRatio    = if in.gdp > PLN.Zero then in.prevBop.nfa / annualGdp else 0.0
-    val fdi            = p.openEcon.fdiBase * ((1.0 + in.autoRatio.toDouble * FdiAutoBoost) *
+    val annualGdp         = in.gdp * MonthsPerYear
+    val nfaGdpRatio       = if in.gdp > PLN.Zero then in.prevBop.nfa / annualGdp else 0.0
+    val fdi               = p.openEcon.fdiBase * ((1.0 + in.autoRatio.toDouble * FdiAutoBoost) *
       (1.0 - Math.max(0.0, -nfaGdpRatio) * FdiNfaDampening))
-    val portfolioFlows =
+    val portfolioFlows    =
       val rateDiff    = (in.domesticRate - p.forex.foreignRate).toDouble
       val riskPremium = -p.openEcon.riskPremiumSensitivity * nfaGdpRatio
       val monthlyGdp  = if in.gdp > PLN.Zero then in.gdp else PLN(1.0)
       monthlyGdp * ((rateDiff + riskPremium) * p.openEcon.portfolioSensitivity)
-    CapitalAccountResult(fdi + portfolioFlows, fdi, portfolioFlows)
+    // Capital flight: risk-off, carry trade, auction signal
+    val yieldSpread       = in.bondYield - p.forex.foreignRate
+    val capitalFlight     = CapitalFlows.compute(
+      month = in.month,
+      yieldSpread = yieldSpread,
+      bidToCover = in.prevBidToCover,
+      prevCarry = CapitalFlows.CarryState(in.prevBop.carryTradeStock),
+      monthlyGdp = if in.gdp > PLN.Zero then in.gdp else PLN(1.0),
+    )
+    val adjustedPortfolio = portfolioFlows + capitalFlight.totalAdjustment
+    CapitalAccountResult(fdi + adjustedPortfolio, fdi, adjustedPortfolio, capitalFlight.newCarryState.stock)
 
   // --- Exchange rate & valuation ---
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
@@ -1,0 +1,51 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.markets.CapitalFlows
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CapitalFlowsSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val gdp   = PLN(100e9)
+  private val carry = CapitalFlows.CarryState.zero
+
+  "CapitalFlows.compute" should "produce zero adjustment when no shock and spread below threshold" in {
+    val result = CapitalFlows.compute(1, Rate(0.02), Ratio(2.0), carry, gdp)
+    result.totalAdjustment.toDouble shouldBe 0.0 +- 1.0
+  }
+
+  it should "accumulate carry trade when spread exceeds threshold" in {
+    val highSpread = Rate(0.08) // well above carryThreshold (3%)
+    val result     = CapitalFlows.compute(1, highSpread, Ratio(2.0), carry, gdp)
+    result.newCarryState.stock.toDouble should be > 0.0
+    result.carryTradeFlow.toDouble should be > 0.0
+  }
+
+  it should "not accumulate carry when spread below threshold" in {
+    val lowSpread = Rate(0.02) // below carryThreshold (3%)
+    val result    = CapitalFlows.compute(1, lowSpread, Ratio(2.0), carry, gdp)
+    result.newCarryState.stock shouldBe PLN.Zero
+  }
+
+  it should "trigger auction outflow when bid-to-cover is low" in {
+    val lowBtc = Ratio(0.80) // below auctionConfidenceThreshold (0.90)
+    val result = CapitalFlows.compute(1, Rate(0.05), lowBtc, carry, gdp)
+    result.auctionSignal.toDouble should be < 0.0
+  }
+
+  it should "not trigger auction outflow when bid-to-cover is healthy" in {
+    val highBtc = Ratio(1.50)
+    val result  = CapitalFlows.compute(1, Rate(0.05), highBtc, carry, gdp)
+    result.auctionSignal shouldBe PLN.Zero
+  }
+
+  it should "preserve carry stock when no risk-off" in {
+    val withCarry = CapitalFlows.CarryState(PLN(10e9))
+    val result    = CapitalFlows.compute(1, Rate(0.05), Ratio(2.0), withCarry, gdp)
+    // Stock should grow (accumulation) or stay (no unwind without risk-off)
+    result.newCarryState.stock.toDouble should be >= 10e9
+  }


### PR DESCRIPTION
## Summary

Three crisis channels for capital flows, extending the mechanical portfolio flow model.

### Channels

1. **Global risk-off** — exogenous EM sentiment shock (VIX spike, Fed tightening). PLN can depreciate 10-15% in weeks (2022, 2020). Configurable shock month + magnitude + duration.

2. **Carry trade** — leveraged positions accumulate when yield spread > threshold (3%). On risk-off: forced unwind (30%/month) → amplified PLN selling → overshoot. Stock builds gradually, unwinds suddenly.

3. **Bond auction signal** — bid-to-cover < 0.90 → foreign confidence erosion → additional portfolio outflow. Links BondAuction to capital account.

### Implementation

- `CapitalFlows.scala` — pure function, no mutable state
- `CarryState.stock` tracked in `BopState.carryTradeStock`
- Integrated into `OpenEconomy.computeCapitalAccount` (adjusts portfolio flows)
- Config: 8 params (risk-off, carry trade, auction confidence)

### Tests (6 new)
- Zero baseline (no shock, low spread)
- Carry accumulation above threshold / no accumulation below
- Auction outflow on low bid-to-cover / no outflow on healthy
- Carry stock preservation without risk-off

## Test plan

- [x] `sbt compile` — no warnings
- [x] `testOnly *CapitalFlowsSpec *McRunnerSpec` — 28/28 pass
- [x] `sbt test` — CI

Fixes #35