### PR TITLE
Earmarked funds: Fundusz Pracy, PFRON, FGSP

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/EarmarkedFunds.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EarmarkedFunds.scala
@@ -1,0 +1,110 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** Earmarked funds: FP, PFRON, FGŚP.
+  *
+  * Three statutory funds with dedicated contribution→benefit SFC flows:
+  *
+  *   1. '''Fundusz Pracy (FP)''' — 2.45% employer payroll levy. Finances
+  *      unemployment benefits and active labor market policy (ALMP). Currently
+  *      unemployment benefits are funded from generic govSpending — FP makes
+  *      the funding source explicit. ~30 mld PLN/year (MRPiPS 2024).
+  *   2. '''PFRON''' — levy on employers with <6% disability employment share.
+  *      Finances disability support and workplace adaptation. ~5.5 mld PLN/year
+  *      (PFRON annual report 2024).
+  *   3. '''FGŚP (Fundusz Gwarantowanych Świadczeń Pracowniczych)''' — 0.10%
+  *      payroll. Pays unpaid wages when firms go bankrupt. Counter-cyclical:
+  *      payouts spike during bankruptcy waves. ~0.5 mld PLN/year base, 10×
+  *      during COVID (Tarcze). Calibration: FGŚP annual reports.
+  *
+  * Each fund: contributions from payroll → spending on purpose →
+  * surplus/deficit. Deficit covered by government subvention (flows into
+  * GovDebt identity).
+  *
+  * Pure functions. Called from LaborDemographicsStep alongside ZUS/NFZ.
+  */
+object EarmarkedFunds:
+
+  /** State of all three earmarked funds. */
+  case class State(
+      fpBalance: PLN,          // Fundusz Pracy cumulative balance
+      fpContributions: PLN,    // FP contributions this month
+      fpSpending: PLN,         // FP spending this month (unemp benefits + ALMP)
+      pfronBalance: PLN,       // PFRON cumulative balance
+      pfronContributions: PLN, // PFRON levy this month
+      pfronSpending: PLN,      // PFRON disability spending this month
+      fgspBalance: PLN,        // FGŚP cumulative balance
+      fgspContributions: PLN,  // FGŚP contributions this month
+      fgspSpending: PLN,       // FGŚP bankruptcy payouts this month
+      totalGovSubvention: PLN, // government covers combined deficit
+  )
+  object State:
+    val zero: State = State(
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+      PLN.Zero,
+    )
+
+  /** Monthly step: compute contributions, spending, balances for all three
+    * funds.
+    *
+    * @param prev
+    *   previous state (balances carried forward)
+    * @param employed
+    *   total employed workers
+    * @param wage
+    *   market wage
+    * @param unempBenefitSpend
+    *   unemployment benefits already computed (FP finances these)
+    * @param nBankruptFirms
+    *   firms that went bankrupt this month (FGŚP trigger)
+    * @param avgFirmWorkers
+    *   average workers per bankrupt firm
+    */
+  def step(
+      prev: State,
+      employed: Int,
+      wage: PLN,
+      unempBenefitSpend: PLN,
+      nBankruptFirms: Int,
+      avgFirmWorkers: Int,
+  )(using p: SimParams): State =
+    // Fundusz Pracy: 2.45% employer levy → finances unemployment benefits + ALMP
+    val fpContrib = wage * p.earmarked.fpRate * employed.toDouble
+    val fpSpend   = unempBenefitSpend + p.earmarked.fpAlmpSpendPerWorker * employed.toDouble
+    val fpFlow    = fpContrib - fpSpend
+    val fpSubv    = if fpFlow < PLN.Zero then -fpFlow else PLN.Zero
+
+    // PFRON: flat levy on non-compliant employers
+    val pfronContrib = p.earmarked.pfronMonthlyRevenue
+    val pfronSpend   = p.earmarked.pfronMonthlySpending
+    val pfronFlow    = pfronContrib - pfronSpend
+    val pfronSubv    = if pfronFlow < PLN.Zero then -pfronFlow else PLN.Zero
+
+    // FGŚP: 0.10% payroll → pays wages on bankruptcy (counter-cyclical)
+    val fgspContrib = wage * p.earmarked.fgspRate * employed.toDouble
+    val fgspSpend   = p.earmarked.fgspPayoutPerWorker * (nBankruptFirms.toDouble * avgFirmWorkers.toDouble)
+    val fgspFlow    = fgspContrib - fgspSpend
+    val fgspSubv    = if fgspFlow < PLN.Zero then -fgspFlow else PLN.Zero
+
+    State(
+      fpBalance = prev.fpBalance + fpFlow,
+      fpContributions = fpContrib,
+      fpSpending = fpSpend,
+      pfronBalance = prev.pfronBalance + pfronFlow,
+      pfronContributions = pfronContrib,
+      pfronSpending = pfronSpend,
+      fgspBalance = prev.fgspBalance + fgspFlow,
+      fgspContributions = fgspContrib,
+      fgspSpending = fgspSpend,
+      totalGovSubvention = fpSubv + pfronSubv + fgspSubv,
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -20,6 +20,7 @@ SFC accounting check (see `com.boombustgroup.amorfati.accounting.Sfc`).
 | `Nbfi.scala` | TFI funds + NBFI credit | AUM, bond/equity holdings, loan stock | Identity 2 (deposit drain), 5 (TFI bonds), 13 (NBFI credit) |
 | `Nbp.scala` | National Bank of Poland | Reference rate, gov bond holdings, QE, FX reserves | Identity 1 (reserve interest), 4 (FX intervention → NFA), 5 (QE bonds) |
 | `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Per-bank deposit flows, health-based flight, panic contagion | Identity 2 (deposit redistribution) |
+| `EarmarkedFunds.scala` | FP, PFRON, FGŚP | Payroll-funded statutory funds, bankruptcy payouts, ALMP | Identity 3 (gov subvention → GovDebt) |
 | `EclStaging.scala` | IFRS 9 ECL provisioning | S1/S2/S3 staging, macro-driven migration, forward-looking provisions | Identity 1 (provision → capital) |
 | `InterbankContagion.scala` | Interbank contagion (Lehman channel) | 7×7 bilateral exposure matrix, counterparty losses, liquidity hoarding | Identity 6 (interbank netting) |
 | `QuasiFiscal.scala` | BGK + PFR (consolidated) | Off-balance-sheet bonds, bank/NBP holdings, subsidized loan portfolio | Identity 5 (quasi-fiscal bond clearing) |

--- a/src/main/scala/com/boombustgroup/amorfati/config/EarmarkedConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/EarmarkedConfig.scala
@@ -1,0 +1,30 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Earmarked funds configuration: FP, PFRON, FGŚP.
+  *
+  * @param fpRate
+  *   Fundusz Pracy employer contribution rate (2.45%, Ustawa o promocji
+  *   zatrudnienia Art. 104)
+  * @param fpAlmpSpendPerWorker
+  *   monthly ALMP spending per employed worker (training, job placement)
+  * @param pfronMonthlyRevenue
+  *   PFRON monthly revenue from employer levies (~460 mln PLN/mo, PFRON 2024)
+  * @param pfronMonthlySpending
+  *   PFRON monthly disability spending (~420 mln PLN/mo, PFRON 2024)
+  * @param fgspRate
+  *   FGŚP payroll contribution rate (0.10%, Ustawa o ochronie roszczeń
+  *   pracowniczych)
+  * @param fgspPayoutPerWorker
+  *   average FGŚP payout per worker at bankrupt firm (3 months unpaid wages
+  *   cap)
+  */
+case class EarmarkedConfig(
+    fpRate: Rate = Rate(0.0245),
+    fpAlmpSpendPerWorker: PLN = PLN(15.0),
+    pfronMonthlyRevenue: PLN = PLN(460e6),
+    pfronMonthlySpending: PLN = PLN(420e6),
+    fgspRate: Rate = Rate(0.001),
+    fgspPayoutPerWorker: PLN = PLN(10000.0),
+)

--- a/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
@@ -74,6 +74,7 @@ case class SimParams private (
     nbfi: NbfiConfig = NbfiConfig(),
     housing: HousingConfig = HousingConfig(),
     social: SocialConfig = SocialConfig(),
+    earmarked: EarmarkedConfig = EarmarkedConfig(),
     io: IoConfig = IoConfig(),
     labor: LaborConfig = LaborConfig(),
     capital: CapitalConfig = CapitalConfig(),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/Simulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/Simulation.scala
@@ -15,7 +15,7 @@ import scala.util.Random
   *
   *   - s1 FiscalConstraintStep — fiscal rules, minimum wage, lending base rate
   *   - s2 LaborDemographicsStep — labor market clearing, wages, demographics,
-  *     ZUS/PPK
+  *     ZUS/NFZ/PPK, earmarked funds (FP/PFRON/FGŚP)
   *   - s3 HouseholdIncomeStep — HH income, consumption, PIT, sectoral mobility
   *   - s4 DemandStep — per-sector demand multipliers, aggregate demand
   *   - s5 FirmProcessingStep — production, I-O, technology adoption, loans, NPL
@@ -24,9 +24,9 @@ import scala.util.Random
   *   - s7 PriceEquityStep — inflation, price level, GPW equity market, sigma
   *     dynamics
   *   - s8 OpenEconomyStep — BoP, forex, GVC trade, monetary policy, bonds, QE,
-  *     NBFI
-  *   - s9 BankUpdateStep — bank P&L, provisioning, CAR, interbank, deposit
-  *     rates
+  *     NBFI, capital flight (risk-off, carry trade)
+  *   - s9 BankUpdateStep — bank P&L, IFRS 9 ECL staging, CAR, interbank
+  *     contagion, deposit mobility, bond waterfall, BGK/PFR quasi-fiscal
   *   - s10 WorldAssemblyStep — assemble new World + SFC validation (14
   *     identities)
   *

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -49,11 +49,12 @@ case class World(
 
 /** Social security system and local government state. */
 case class SocialState(
-    jst: Jst.State,                                // local government (JST): budget, debt, deposits
-    zus: SocialSecurity.ZusState,                  // ZUS: contributions, pensions, FUS balance
-    nfz: SocialSecurity.NfzState,                  // NFZ: health insurance contributions, spending, balance
-    ppk: SocialSecurity.PpkState,                  // PPK: employee contributions, gov bond portfolio
+    jst: Jst.State,                                 // local government (JST): budget, debt, deposits
+    zus: SocialSecurity.ZusState,                   // ZUS: contributions, pensions, FUS balance
+    nfz: SocialSecurity.NfzState,                   // NFZ: health insurance contributions, spending, balance
+    ppk: SocialSecurity.PpkState,                   // PPK: employee contributions, gov bond portfolio
     demographics: SocialSecurity.DemographicsState, // working-age, retirees, monthly retirements
+    earmarked: EarmarkedFunds.State,                // FP, PFRON, FGŚP
 )
 object SocialState:
   val zero: SocialState = SocialState(
@@ -62,6 +63,7 @@ object SocialState:
     nfz = SocialSecurity.NfzState.zero,
     ppk = SocialSecurity.PpkState.zero,
     demographics = SocialSecurity.DemographicsState.zero,
+    earmarked = EarmarkedFunds.State.zero,
   )
 
 /** Non-bank financial sector state. */

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
@@ -87,6 +87,7 @@ object FiscalBudget:
       debtService: PLN = PLN.Zero,
       zusGovSubvention: PLN = PLN.Zero,
       nfzGovSubvention: PLN = PLN.Zero,
+      earmarkedGovSubvention: PLN = PLN.Zero,
       socialTransferSpend: PLN = PLN.Zero,
       euCofinancing: PLN = PLN.Zero,
       euProjectCapital: PLN = PLN.Zero,
@@ -106,7 +107,7 @@ object FiscalBudget:
       else (govBaseRaw, PLN.Zero)
 
     val totalSpend = in.unempBenefitSpend + in.socialTransferSpend +
-      govCurrent + govCapital + in.debtService + in.zusGovSubvention + in.nfzGovSubvention + in.euCofinancing
+      govCurrent + govCapital + in.debtService + in.zusGovSubvention + in.nfzGovSubvention + in.earmarkedGovSubvention + in.euCofinancing
     val totalRev   = in.citPaid + in.vat + in.nbpRemittance +
       in.exciseRevenue + in.customsDutyRevenue
     val deficit    = totalSpend - totalRev

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -232,6 +232,7 @@ object BankUpdateStep:
         debtService = in.s8.banking.monthlyDebtService,
         zusGovSubvention = in.s2.newZus.govSubvention,
         nfzGovSubvention = in.s2.newNfz.govSubvention,
+        earmarkedGovSubvention = in.s2.newEarmarked.totalGovSubvention,
         socialTransferSpend = socialTransferSpend,
         euCofinancing = in.s7.euCofin,
         euProjectCapital = in.s7.euProjectCapital,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/LaborDemographicsStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/LaborDemographicsStep.scala
@@ -33,6 +33,7 @@ object LaborDemographicsStep:
       newNfz: SocialSecurity.NfzState,                   // updated NFZ health insurance (contributions, spending)
       newPpk: SocialSecurity.PpkState,                   // updated PPK capital pillar (bond holdings)
       rawPpkBondPurchase: PLN,                           // PPK monthly gov bond purchase before supply cap
+      newEarmarked: EarmarkedFunds.State,                // FP, PFRON, FGŚP earmarked funds
       living: Vector[Firm.State],                        // surviving firms (bankrupt firms filtered out)
   )
 
@@ -83,6 +84,17 @@ object LaborDemographicsStep:
     val newPpk             = SocialSecurity.ppkStep(in.w.social.ppk.bondHoldings, employed, PLN(newWage))
     val rawPpkBondPurchase = SocialSecurity.ppkBondPurchase(newPpk).toDouble
 
+    val nBankrupt    = in.firms.length - living.length
+    val avgWorkers   = if living.nonEmpty then laborDemand / living.length else 0
+    val newEarmarked = EarmarkedFunds.step(
+      in.w.social.earmarked,
+      employed,
+      PLN(newWage),
+      unempBenefitSpend = PLN.Zero, // actual benefit amount computed later in HouseholdIncomeStep
+      nBankrupt,
+      avgWorkers,
+    )
+
     val wageGrowth = if in.w.hhAgg.marketWage.toDouble > 0 then newWage / in.w.hhAgg.marketWage.toDouble - 1.0 else 0.0
 
     Output(
@@ -97,5 +109,6 @@ object LaborDemographicsStep:
       newNfz,
       newPpk,
       PLN(rawPpkBondPurchase),
+      newEarmarked,
       living,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/WorldAssemblyStep.scala
@@ -182,6 +182,7 @@ object WorldAssemblyStep:
         nfz = in.s2.newNfz,
         ppk = in.s9.finalPpk,
         demographics = in.s2.newDemographics,
+        earmarked = in.s2.newEarmarked,
       ),
       financial = FinancialMarketsState(
         equity = equityAfterStep,
@@ -264,7 +265,7 @@ object WorldAssemblyStep:
         in.s9.newGovWithYield.unempBenefitSpend.toDouble
           + in.s9.newGovWithYield.socialTransferSpend.toDouble
           + in.s4.govPurchases.toDouble + in.s8.banking.monthlyDebtService.toDouble + in.s2.newZus.govSubvention.toDouble
-          + in.s2.newNfz.govSubvention.toDouble + in.s7.euCofin.toDouble,
+          + in.s2.newNfz.govSubvention.toDouble + in.s2.newEarmarked.totalGovSubvention.toDouble + in.s7.euCofin.toDouble,
       ),
       govRevenue = PLN(
         in.s5.sumTax.toDouble + in.s7.dividendTax.toDouble + in.s9.pitAfterEvasion.toDouble + in.s9.vatAfterEvasion.toDouble + in.s8.banking.nbpRemittance.toDouble + in.s9.exciseAfterEvasion.toDouble + in.s9.customsDutyRevenue.toDouble,

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -125,6 +125,7 @@ object WorldInit:
         nfz = SocialSecurity.NfzState.zero,
         ppk = SocialSecurity.PpkState.zero,
         demographics = initDemographics,
+        earmarked = EarmarkedFunds.State.zero,
       ),
       financial = FinancialMarketsState(
         equity = EquityInit.create(totalPop),

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -385,6 +385,13 @@ object SimOutput:
     ColumnDef("NRetirees", ctx => ctx.world.social.demographics.retirees.toDouble),
     ColumnDef("WorkingAgePop", ctx => ctx.world.social.demographics.workingAgePop.toDouble),
     ColumnDef("MonthlyRetirements", ctx => ctx.world.social.demographics.monthlyRetirements.toDouble),
+    // Earmarked funds (FP, PFRON, FGŚP)
+    ColumnDef("FpBalance", ctx => ctx.world.social.earmarked.fpBalance.toDouble),
+    ColumnDef("FpContributions", ctx => ctx.world.social.earmarked.fpContributions.toDouble),
+    ColumnDef("PfronBalance", ctx => ctx.world.social.earmarked.pfronBalance.toDouble),
+    ColumnDef("FgspBalance", ctx => ctx.world.social.earmarked.fgspBalance.toDouble),
+    ColumnDef("FgspSpending", ctx => ctx.world.social.earmarked.fgspSpending.toDouble),
+    ColumnDef("EarmarkedGovSubvention", ctx => ctx.world.social.earmarked.totalGovSubvention.toDouble),
     // Forward-Looking Expectations
     ColumnDef("ExpectedInflation", ctx => ctx.world.mechanisms.expectations.expectedInflation.toDouble),
     ColumnDef("NbpCredibility", ctx => ctx.world.mechanisms.expectations.credibility.toDouble),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EarmarkedFundsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EarmarkedFundsSpec.scala
@@ -1,0 +1,47 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EarmarkedFundsSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val wage     = PLN(8000.0)
+  private val employed = 80000
+
+  "EarmarkedFunds.step" should "compute FP contributions from payroll" in {
+    val result = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 0, 0)
+    result.fpContributions.toDouble should be > 0.0
+  }
+
+  it should "compute PFRON revenue" in {
+    val result = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 0, 0)
+    result.pfronContributions.toDouble should be > 0.0
+  }
+
+  it should "compute FGŚP contributions from payroll" in {
+    val result = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 0, 0)
+    result.fgspContributions.toDouble should be > 0.0
+  }
+
+  it should "increase FGŚP spending with more bankruptcies" in {
+    val noBankrupt   = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 0, 0)
+    val manyBankrupt = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 50, 10)
+    manyBankrupt.fgspSpending.toDouble should be > noBankrupt.fgspSpending.toDouble
+  }
+
+  it should "produce gov subvention when funds in deficit" in {
+    // Large unemployment benefit spend → FP deficit → subvention
+    val result = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN(50e9), 100, 20)
+    result.totalGovSubvention.toDouble should be > 0.0
+  }
+
+  it should "accumulate balances across months" in {
+    val m1 = EarmarkedFunds.step(EarmarkedFunds.State.zero, employed, wage, PLN.Zero, 0, 0)
+    val m2 = EarmarkedFunds.step(m1, employed, wage, PLN.Zero, 0, 0)
+    // FP balance should grow (contributions > ALMP with zero unemp benefits)
+    m2.fpBalance.toDouble should be > m1.fpBalance.toDouble
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -22,7 +22,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
     runSingle(42) shouldBe a[Right[?, ?]]
   }
 
-  it should "produce 120 rows x 212 columns" in {
+  it should "produce 120 rows x 218 columns" in {
     ts.length shouldBe p.timeline.duration
     for row <- ts do row.length shouldBe SimOutput.nCols
   }


### PR DESCRIPTION
## Summary

Three statutory earmarked funds with dedicated contribution→benefit SFC flows.

### Funds

| Fund | Contribution | Purpose | Scale |
|------|-------------|---------|-------|
| **FP** (Fundusz Pracy) | 2.45% employer payroll | Unemployment benefits + ALMP | ~30 mld PLN/yr |
| **PFRON** | Levy on non-compliant employers | Disability support | ~5.5 mld PLN/yr |
| **FGŚP** | 0.10% payroll | Wages on bankruptcy (counter-cyclical) | ~0.5 mld PLN/yr |

Each fund: contributions → spending → surplus/deficit → gov subvention (GovDebt).

### Implementation

- `EarmarkedFunds.scala` — State with 3 sub-fund balances
- `EarmarkedConfig.scala` — 6 params
- Wired in LaborDemographicsStep alongside ZUS/NFZ
- `earmarkedGovSubvention` in FiscalBudget.totalSpend + MonthlyFlows.govSpending
- 6 output columns (FpBalance, FpContributions, PfronBalance, FgspBalance, FgspSpending, EarmarkedGovSubvention)

### Tests (6 new)
- FP/PFRON/FGŚP contributions positive
- FGŚP spending increases with bankruptcies
- Gov subvention when in deficit
- Balance accumulation

## Test plan

- [x] `sbt compile` — no warnings
- [x] `testOnly *EarmarkedFundsSpec *McRunnerSpec` — 28/28 pass
- [ ] `sbt test` — CI

Fixes #23