### PR TITLE
Fix ConsumerCredit SFC violation and init forex exports

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/steps/BankUpdateStep.scala
@@ -473,7 +473,7 @@ object BankUpdateStep:
       loansShort = newLoansTotal * ShortLoanFrac,
       loansMedium = newLoansTotal * MediumLoanFrac,
       loansLong = newLoansTotal * LongLoanFrac,
-      consumerLoans = (b.consumerLoans + hhFlows.ccOrigination - bankCcPrincipal - hhFlows.ccDefault).max(PLN.Zero),
+      consumerLoans = PLN(terms(b.consumerLoans.toDouble, hhFlows.ccOrigination.toDouble, -bankCcPrincipal.toDouble, -hhFlows.ccDefault.toDouble)),
       consumerNpl = (b.consumerNpl + hhFlows.ccDefault - b.consumerNpl * NplMonthlyWriteOff).max(PLN.Zero),
       corpBondHoldings = in.s8.corpBonds.newCorpBonds.bankHoldings * ws,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -83,7 +83,7 @@ object WorldInit:
       forex = OpenEconomy.ForexState(
         exchangeRate = p.forex.baseExRate,
         imports = PLN.Zero,
-        exports = p.forex.exportBase,
+        exports = if p.flags.openEcon then p.openEcon.exportBase else p.forex.exportBase,
         tradeBalance = PLN.Zero,
         techImports = PLN.Zero,
       ),


### PR DESCRIPTION
## Summary

- **ConsumerCredit SFC fix**: `.max(PLN.Zero)` clamp on per-bank consumer loans silently absorbed negative stock values, breaking SFC identity (diff=270K PLN). Removed — stock must be consistent with flows.
- **Init forex exports**: `forex.exports` initialized from `openEcon.exportBase` when openEcon enabled (138.5e9 vs 55.4e9). Fixes m1 deflation shock (-27% → +12.5%).

## Result (seed=1, 120 months)

| Metric | Before | After |
|--------|--------|-------|
| m1 inflation | -27% (shock) | +12.5% (healthy) |
| Unemployment (120mo) | 18.8% | 19.2% |
| Without immigration | 5.3% | 4.9% |
| SFC violations | 0 | 0 |

## Test plan

- [x] `sbt test` — 1,348/1,348 pass
- [x] Zero SFC violations on jar run (seed=1, 120 months)

Fixes #108. Fixes #105.