### PR TITLE
ZUS flow migration: SFC == 0L proof-of-concept

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -1,0 +1,14 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.ledger.*
+
+/** Mechanism IDs for audit trail. Each mechanism that emits flows gets a unique
+  * ID. amor-fati specific — the ledger only sees MechanismId(Int).
+  */
+object FlowMechanism:
+  val ZusContribution: MechanismId  = MechanismId(1)
+  val ZusPension: MechanismId       = MechanismId(2)
+  val ZusGovSubvention: MechanismId = MechanismId(3)
+  val NfzContribution: MechanismId  = MechanismId(4)
+  val NfzSpending: MechanismId      = MechanismId(5)
+  val NfzGovSubvention: MechanismId = MechanismId(6)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
@@ -1,0 +1,48 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** ZUS/FUS mechanism emitting flows instead of mutating state.
+  *
+  * Same economic logic as SocialSecurity.zusStep — same formulas, same
+  * calibration. But instead of returning ZusState via .copy(), returns
+  * Vector[Flow] for the interpreter.
+  *
+  * Three flows per month:
+  *   1. Contributions: HH → FUS (employed × wage × rate × scale)
+  *   2. Pensions: FUS → HH (retirees × basePension)
+  *   3. Gov subvention: GOV → FUS (covers deficit, if any)
+  *
+  * Account IDs (flat namespace for Flow): 0 = HH aggregate, 1 = FUS, 2 = GOV
+  */
+object ZusFlows:
+
+  val HH_ACCOUNT: Int  = 0
+  val FUS_ACCOUNT: Int = 1
+  val GOV_ACCOUNT: Int = 2
+
+  case class ZusInput(
+      employed: Int,
+      wage: PLN,
+      nRetirees: Int,
+  )
+
+  def emit(input: ZusInput)(using p: SimParams): Vector[Flow] =
+    if !p.flags.zus then Vector.empty
+    else
+      val contributions = input.employed * (input.wage * p.social.zusContribRate * p.social.zusScale)
+      val pensions      = input.nRetirees * p.social.zusBasePension
+      val deficit       = pensions - contributions
+
+      val flows = Vector.newBuilder[Flow]
+
+      if contributions.toLong > 0L then
+        flows += Flow(from = HH_ACCOUNT, to = FUS_ACCOUNT, amount = contributions.toLong, mechanism = FlowMechanism.ZusContribution.toInt)
+
+      if pensions.toLong > 0L then flows += Flow(from = FUS_ACCOUNT, to = HH_ACCOUNT, amount = pensions.toLong, mechanism = FlowMechanism.ZusPension.toInt)
+
+      if deficit.toLong > 0L then flows += Flow(from = GOV_ACCOUNT, to = FUS_ACCOUNT, amount = deficit.toLong, mechanism = FlowMechanism.ZusGovSubvention.toInt)
+
+      flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/ZusFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/ZusFlowsSpec.scala
@@ -1,0 +1,100 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** ZUS mechanism through flow interpreter — SFC proof of concept.
+  *
+  * Verifies that ZUS contributions, pensions, and gov subvention close at
+  * exactly 0L when applied through the verified interpreter. No tolerance, no
+  * rounding residual.
+  */
+class ZusFlowsSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  "ZusFlows" should "emit contribution + pension flows with correct amounts" in {
+    val input = ZusFlows.ZusInput(employed = 80000, wage = PLN(7000.0), nRetirees = 1000)
+    val flows = ZusFlows.emit(input)
+
+    flows should not be empty
+
+    val contribFlow = flows.find(_.mechanism == FlowMechanism.ZusContribution.toInt).get
+    contribFlow.from shouldBe ZusFlows.HH_ACCOUNT
+    contribFlow.to shouldBe ZusFlows.FUS_ACCOUNT
+    contribFlow.amount should be > 0L
+
+    val pensionFlow = flows.find(_.mechanism == FlowMechanism.ZusPension.toInt).get
+    pensionFlow.from shouldBe ZusFlows.FUS_ACCOUNT
+    pensionFlow.to shouldBe ZusFlows.HH_ACCOUNT
+    pensionFlow.amount should be > 0L
+  }
+
+  it should "preserve total wealth at exactly 0L (SFC by construction)" in {
+    val input    = ZusFlows.ZusInput(employed = 80000, wage = PLN(7000.0), nRetirees = 1000)
+    val flows    = ZusFlows.emit(input)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    // SFC: total wealth is exactly zero (started from empty, all flows are transfers)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have FUS balance = contributions - pensions + govSubvention" in {
+    val input    = ZusFlows.ZusInput(employed = 80000, wage = PLN(7000.0), nRetirees = 1000)
+    val flows    = ZusFlows.emit(input)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    val contribs   = flows.filter(_.mechanism == FlowMechanism.ZusContribution.toInt).map(_.amount).sum
+    val pensions   = flows.filter(_.mechanism == FlowMechanism.ZusPension.toInt).map(_.amount).sum
+    val subvention = flows.filter(_.mechanism == FlowMechanism.ZusGovSubvention.toInt).map(_.amount).sum
+
+    // FUS receives contributions + subvention, pays out pensions
+    balances(ZusFlows.FUS_ACCOUNT) shouldBe (contribs - pensions + subvention)
+  }
+
+  it should "emit gov subvention only when pensions exceed contributions" in {
+    // High retirees, low employed → deficit
+    val deficit = ZusFlows.ZusInput(employed = 1000, wage = PLN(5000.0), nRetirees = 5000)
+    val flows1  = ZusFlows.emit(deficit)
+    flows1.exists(_.mechanism == FlowMechanism.ZusGovSubvention.toInt) shouldBe true
+
+    // High employed, low retirees → surplus
+    val surplus = ZusFlows.ZusInput(employed = 80000, wage = PLN(7000.0), nRetirees = 100)
+    val flows2  = ZusFlows.emit(surplus)
+    flows2.exists(_.mechanism == FlowMechanism.ZusGovSubvention.toInt) shouldBe false
+  }
+
+  it should "match old SocialSecurity.zusStep amounts exactly" in {
+    val employed  = 80000
+    val wage      = PLN(7000.0)
+    val nRetirees = 1000
+
+    // Old path
+    val oldZus = com.boombustgroup.amorfati.agents.SocialSecurity.zusStep(PLN.Zero, employed, wage, nRetirees)
+
+    // New path
+    val flows = ZusFlows.emit(ZusFlows.ZusInput(employed, wage, nRetirees))
+
+    val newContribs   = flows.filter(_.mechanism == FlowMechanism.ZusContribution.toInt).map(_.amount).sum
+    val newPensions   = flows.filter(_.mechanism == FlowMechanism.ZusPension.toInt).map(_.amount).sum
+    val newSubvention = flows.filter(_.mechanism == FlowMechanism.ZusGovSubvention.toInt).map(_.amount).sum
+
+    // Amounts must match bit-for-bit (same formulas, same Long arithmetic)
+    newContribs shouldBe oldZus.contributions.toLong
+    newPensions shouldBe oldZus.pensionPayments.toLong
+    newSubvention shouldBe oldZus.govSubvention.toLong
+  }
+
+  it should "preserve SFC across multiple months" in {
+    val input = ZusFlows.ZusInput(employed = 80000, wage = PLN(7000.0), nRetirees = 1000)
+
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      val flows = ZusFlows.emit(input)
+      balances = Interpreter.applyAll(balances, flows)
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }


### PR DESCRIPTION
## Summary

First mechanism migrated to flow-based architecture. ZusFlows.emit() produces Vector[Flow] instead of mutating ZusState. Same formulas, same calibration — new plumbing.

Three flows per month:
1. **Contributions**: HH → FUS (employed x wage x zusContribRate x zusScale)
2. **Pensions**: FUS → HH (retirees x basePension)
3. **Gov subvention**: GOV → FUS (covers deficit)

## SFC verification

All flows applied through the verified ledger Interpreter (Stainless/Z3 proved):
- Total wealth exactly **0L** — no tolerance, no rounding residual
- FUS balance = contributions - pensions + subvention (exact)
- **Bit-for-bit match** with old SocialSecurity.zusStep amounts
- SFC holds across **120 months** continuously

## New files

- `engine/flows/FlowMechanism.scala` — MechanismId constants (audit trail)
- `engine/flows/ZusFlows.scala` — ZUS mechanism emitting Vector[Flow]
- `engine/flows/ZusFlowsSpec.scala` — 6 tests, all pass

## What this proves

The flow-based architecture works. SFC closes by construction at exact 0L. No post-hoc validation needed. Ready to migrate remaining mechanisms.