### PR TITLE
NFZ + PPK flow migration: SFC == 0L

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -12,3 +12,5 @@ object FlowMechanism:
   val NfzContribution: MechanismId  = MechanismId(4)
   val NfzSpending: MechanismId      = MechanismId(5)
   val NfzGovSubvention: MechanismId = MechanismId(6)
+  val PpkContribution: MechanismId  = MechanismId(7)
+  val PpkBondPurchase: MechanismId  = MechanismId(8)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
@@ -1,0 +1,46 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** NFZ (National Health Fund) mechanism emitting flows.
+  *
+  * Same logic as SocialSecurity.nfzStep. 9% skladka zdrowotna from employed,
+  * spending = per-capita cost x (working-age + retirees x aging elasticity).
+  * Deficit covered by government subvention.
+  *
+  * Account IDs: 0 = HH, 1 = NFZ, 2 = GOV, 3 = Healthcare (spending sink)
+  */
+object NfzFlows:
+
+  val HH_ACCOUNT: Int         = 0
+  val NFZ_ACCOUNT: Int        = 1
+  val GOV_ACCOUNT: Int        = 2
+  val HEALTHCARE_ACCOUNT: Int = 3
+
+  case class NfzInput(
+      employed: Int,
+      wage: PLN,
+      workingAge: Int,
+      nRetirees: Int,
+  )
+
+  def emit(input: NfzInput)(using p: SimParams): Vector[Flow] =
+    if !p.flags.nfz then Vector.empty
+    else
+      val contributions = input.employed * (input.wage * p.social.nfzContribRate)
+      val spending      =
+        input.workingAge * p.social.nfzPerCapitaCost +
+          input.nRetirees * (p.social.nfzPerCapitaCost * p.social.nfzAgingElasticity)
+      val deficit       = spending - contributions
+
+      val flows = Vector.newBuilder[Flow]
+
+      if contributions.toLong > 0L then flows += Flow(HH_ACCOUNT, NFZ_ACCOUNT, contributions.toLong, FlowMechanism.NfzContribution.toInt)
+
+      if spending.toLong > 0L then flows += Flow(NFZ_ACCOUNT, HEALTHCARE_ACCOUNT, spending.toLong, FlowMechanism.NfzSpending.toInt)
+
+      if deficit.toLong > 0L then flows += Flow(GOV_ACCOUNT, NFZ_ACCOUNT, deficit.toLong, FlowMechanism.NfzGovSubvention.toInt)
+
+      flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
@@ -1,0 +1,34 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** PPK (Pracownicze Plany Kapitalowe) mechanism emitting flows.
+  *
+  * Same logic as SocialSecurity.ppkStep. Employee + employer contributions, PPK
+  * buys government bonds proportional to contributions x bond allocation.
+  *
+  * Account IDs: 0 = HH, 1 = PPK, 2 = GovBondMarket
+  */
+object PpkFlows:
+
+  val HH_ACCOUNT: Int          = 0
+  val PPK_ACCOUNT: Int         = 1
+  val BOND_MARKET_ACCOUNT: Int = 2
+
+  case class PpkInput(employed: Int, wage: PLN)
+
+  def emit(input: PpkInput)(using p: SimParams): Vector[Flow] =
+    if !p.flags.ppk then Vector.empty
+    else
+      val contributions = input.employed * (input.wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
+      val bondPurchase  = contributions * p.social.ppkBondAlloc
+
+      val flows = Vector.newBuilder[Flow]
+
+      if contributions.toLong > 0L then flows += Flow(HH_ACCOUNT, PPK_ACCOUNT, contributions.toLong, FlowMechanism.PpkContribution.toInt)
+
+      if bondPurchase.toLong > 0L then flows += Flow(PPK_ACCOUNT, BOND_MARKET_ACCOUNT, bondPurchase.toLong, FlowMechanism.PpkBondPurchase.toInt)
+
+      flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NfzFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NfzFlowsSpec.scala
@@ -1,0 +1,62 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NfzFlowsSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  "NfzFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have NFZ balance = contributions - spending + govSubvention" in {
+    val flows    = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    val contribs   = flows.filter(_.mechanism == FlowMechanism.NfzContribution.toInt).map(_.amount).sum
+    val spending   = flows.filter(_.mechanism == FlowMechanism.NfzSpending.toInt).map(_.amount).sum
+    val subvention = flows.filter(_.mechanism == FlowMechanism.NfzGovSubvention.toInt).map(_.amount).sum
+
+    balances(NfzFlows.NFZ_ACCOUNT) shouldBe (contribs - spending + subvention)
+  }
+
+  it should "emit gov subvention only when spending exceeds contributions" in {
+    // High retirees = high spending (aging elasticity 2.5x)
+    val deficit = NfzFlows.emit(NfzFlows.NfzInput(employed = 1000, wage = PLN(5000.0), workingAge = 5000, nRetirees = 5000))
+    deficit.exists(_.mechanism == FlowMechanism.NfzGovSubvention.toInt) shouldBe true
+
+    // Very high wages, tiny population = surplus
+    val surplus = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(50000.0), workingAge = 1000, nRetirees = 10))
+    surplus.exists(_.mechanism == FlowMechanism.NfzGovSubvention.toInt) shouldBe false
+  }
+
+  it should "match old SocialSecurity.nfzStep amounts exactly" in {
+    val employed = 80000; val wage = PLN(7000.0); val workingAge = 90000; val nRetirees = 1000
+
+    val oldNfz = com.boombustgroup.amorfati.agents.SocialSecurity.nfzStep(PLN.Zero, employed, wage, workingAge, nRetirees)
+    val flows  = NfzFlows.emit(NfzFlows.NfzInput(employed, wage, workingAge, nRetirees))
+
+    val newContribs   = flows.filter(_.mechanism == FlowMechanism.NfzContribution.toInt).map(_.amount).sum
+    val newSpending   = flows.filter(_.mechanism == FlowMechanism.NfzSpending.toInt).map(_.amount).sum
+    val newSubvention = flows.filter(_.mechanism == FlowMechanism.NfzGovSubvention.toInt).map(_.amount).sum
+
+    newContribs shouldBe oldNfz.contributions.toLong
+    newSpending shouldBe oldNfz.spending.toLong
+    newSubvention shouldBe oldNfz.govSubvention.toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    val input    = NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000)
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, NfzFlows.emit(input))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/PpkFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/PpkFlowsSpec.scala
@@ -1,0 +1,39 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PpkFlowsSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  "PpkFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = PpkFlows.emit(PpkFlows.PpkInput(employed = 80000, wage = PLN(7000.0)))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "match old SocialSecurity.ppkStep amounts exactly" in {
+    val employed = 80000; val wage = PLN(7000.0)
+    val oldPpk   = com.boombustgroup.amorfati.agents.SocialSecurity.ppkStep(PLN.Zero, employed, wage)
+    val oldBond  = com.boombustgroup.amorfati.agents.SocialSecurity.ppkBondPurchase(oldPpk)
+    val flows    = PpkFlows.emit(PpkFlows.PpkInput(employed, wage))
+
+    val newContribs = flows.filter(_.mechanism == FlowMechanism.PpkContribution.toInt).map(_.amount).sum
+    val newBond     = flows.filter(_.mechanism == FlowMechanism.PpkBondPurchase.toInt).map(_.amount).sum
+
+    newContribs shouldBe oldPpk.contributions.toLong
+    newBond shouldBe oldBond.toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    val input    = PpkFlows.PpkInput(employed = 80000, wage = PLN(7000.0))
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, PpkFlows.emit(input))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }


### PR DESCRIPTION
## Summary

NFZ and PPK migrated to flow-based architecture. Same pattern as ZUS (PR #116).

**NFZ**: contributions (HH→NFZ), spending (NFZ→Healthcare), gov subvention (GOV→NFZ)
**PPK**: contributions (HH→PPK), bond purchase (PPK→BondMarket)

## Verification

- SFC == 0L across 120 months for all three funds
- Bit-for-bit match with old SocialSecurity amounts
- 20 flow tests pass (ZUS 6 + NFZ 5 + PPK 3 + shared 6)

Fixes #117, fixes #118