### PR TITLE
Insurance flow migration: SFC == 0L

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -35,3 +35,9 @@ object FlowMechanism:
   val GovUnempBenefit: MechanismId      = MechanismId(24)
   val GovSocialTransfer: MechanismId    = MechanismId(25)
   val GovEuCofin: MechanismId           = MechanismId(26)
+  // Insurance
+  val InsLifePremium: MechanismId       = MechanismId(27)
+  val InsNonLifePremium: MechanismId    = MechanismId(28)
+  val InsLifeClaim: MechanismId         = MechanismId(29)
+  val InsNonLifeClaim: MechanismId      = MechanismId(30)
+  val InsInvestmentIncome: MechanismId  = MechanismId(31)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
@@ -1,0 +1,56 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Insurance sector emitting flows.
+  *
+  * Same logic as Insurance.step. Life + non-life premiums from HH, claims back
+  * to HH, investment income from asset holdings.
+  *
+  * Account IDs: 0=HH, 1=Insurance, 2=Markets (investment income source)
+  */
+object InsuranceFlows:
+
+  val HH_ACCOUNT: Int      = 0
+  val INS_ACCOUNT: Int     = 1
+  val MARKETS_ACCOUNT: Int = 2
+
+  private val NonLifeUnempThreshold = 0.05
+
+  case class Input(
+      employed: Int,
+      wage: PLN,
+      unempRate: Share,
+      prevGovBondHoldings: PLN,
+      prevCorpBondHoldings: PLN,
+      prevEquityHoldings: PLN,
+      govBondYield: Rate,
+      corpBondYield: Rate,
+      equityReturn: Rate,
+  )
+
+  def emit(input: Input)(using p: SimParams): Vector[Flow] =
+    val lifePrem    = input.employed * (input.wage * p.ins.lifePremiumRate)
+    val nonLifePrem = input.employed * (input.wage * p.ins.nonLifePremiumRate)
+
+    val lifeCl      = lifePrem * p.ins.lifeLossRatio
+    val nonLifeBase = nonLifePrem * p.ins.nonLifeLossRatio
+    val stressGap   = (input.unempRate - Share(NonLifeUnempThreshold)).max(Share.Zero)
+    val stressAdj   = (stressGap * p.ins.nonLifeUnempSens).toMultiplier
+    val nonLifeCl   = nonLifeBase * (Multiplier.One + stressAdj)
+
+    val invIncome = input.prevGovBondHoldings * input.govBondYield.monthly +
+      input.prevCorpBondHoldings * input.corpBondYield.monthly +
+      input.prevEquityHoldings * input.equityReturn
+
+    val flows = Vector.newBuilder[Flow]
+
+    if lifePrem.toLong > 0L then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, lifePrem.toLong, FlowMechanism.InsLifePremium.toInt)
+    if nonLifePrem.toLong > 0L then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, nonLifePrem.toLong, FlowMechanism.InsNonLifePremium.toInt)
+    if lifeCl.toLong > 0L then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, lifeCl.toLong, FlowMechanism.InsLifeClaim.toInt)
+    if nonLifeCl.toLong > 0L then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, nonLifeCl.toLong, FlowMechanism.InsNonLifeClaim.toInt)
+    if invIncome.toLong > 0L then flows += Flow(MARKETS_ACCOUNT, INS_ACCOUNT, invIncome.toLong, FlowMechanism.InsInvestmentIncome.toInt)
+
+    flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
@@ -1,0 +1,66 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.agents.Insurance
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class InsuranceFlowsSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  private val baseInput = InsuranceFlows.Input(
+    employed = 80000,
+    wage = PLN(7000.0),
+    unempRate = Share(0.05),
+    prevGovBondHoldings = PLN(50000000.0),
+    prevCorpBondHoldings = PLN(20000000.0),
+    prevEquityHoldings = PLN(10000000.0),
+    govBondYield = Rate(0.06),
+    corpBondYield = Rate(0.08),
+    equityReturn = Rate(0.01),
+  )
+
+  "InsuranceFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = InsuranceFlows.emit(baseInput)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have insurance net = premiums - claims + investment income" in {
+    val flows    = InsuranceFlows.emit(baseInput)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    val premiums  =
+      flows.filter(f => f.mechanism == FlowMechanism.InsLifePremium.toInt || f.mechanism == FlowMechanism.InsNonLifePremium.toInt).map(_.amount).sum
+    val claims    = flows.filter(f => f.mechanism == FlowMechanism.InsLifeClaim.toInt || f.mechanism == FlowMechanism.InsNonLifeClaim.toInt).map(_.amount).sum
+    val invIncome = flows.filter(_.mechanism == FlowMechanism.InsInvestmentIncome.toInt).map(_.amount).sum
+
+    balances(InsuranceFlows.INS_ACCOUNT) shouldBe (premiums - claims + invIncome)
+  }
+
+  it should "match old Insurance.step premium and claim amounts" in {
+    val prev   = Insurance.initial
+    val oldIns = Insurance.step(prev, 80000, PLN(7000.0), 1.0, Share(0.05), Rate(0.06), Rate(0.08), Rate(0.01))
+    val flows  = InsuranceFlows.emit(baseInput)
+
+    val newLifePrem    = flows.filter(_.mechanism == FlowMechanism.InsLifePremium.toInt).map(_.amount).sum
+    val newNonLifePrem = flows.filter(_.mechanism == FlowMechanism.InsNonLifePremium.toInt).map(_.amount).sum
+    val newLifeCl      = flows.filter(_.mechanism == FlowMechanism.InsLifeClaim.toInt).map(_.amount).sum
+    val newNonLifeCl   = flows.filter(_.mechanism == FlowMechanism.InsNonLifeClaim.toInt).map(_.amount).sum
+
+    newLifePrem shouldBe oldIns.lastLifePremium.toLong
+    newNonLifePrem shouldBe oldIns.lastNonLifePremium.toLong
+    newLifeCl shouldBe oldIns.lastLifeClaims.toLong
+    newNonLifeCl shouldBe oldIns.lastNonLifeClaims.toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, InsuranceFlows.emit(baseInput))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }


### PR DESCRIPTION
## Summary

Insurance sector migrated to flow-based architecture. Life + non-life premiums, claims with unemployment stress, investment income from asset holdings.

## Verification

- SFC == 0L across 120 months
- Bit-for-bit match with old Insurance.step
- 36 flow tests pass

Fixes #123