### PR TITLE
Household flow migration: SFC == 0L

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -41,3 +41,13 @@ object FlowMechanism:
   val InsLifeClaim: MechanismId         = MechanismId(29)
   val InsNonLifeClaim: MechanismId      = MechanismId(30)
   val InsInvestmentIncome: MechanismId  = MechanismId(31)
+  // Household
+  val HhConsumption: MechanismId        = MechanismId(32)
+  val HhRent: MechanismId               = MechanismId(33)
+  val HhPit: MechanismId                = MechanismId(34)
+  val HhDebtService: MechanismId        = MechanismId(35)
+  val HhDepositInterest: MechanismId    = MechanismId(36)
+  val HhRemittance: MechanismId         = MechanismId(37)
+  val HhCcOrigination: MechanismId      = MechanismId(38)
+  val HhCcDebtService: MechanismId      = MechanismId(39)
+  val HhCcDefault: MechanismId          = MechanismId(40)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
@@ -1,0 +1,53 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Household sector emitting flows from aggregate data.
+  *
+  * Aggregate level (Phase 1): total consumption, rent, PIT, debt service, etc.
+  * Per-agent BatchedFlow.Scatter will replace this when the new pipeline is
+  * built.
+  *
+  * Wages (Firm→HH) are NOT here — emitted by Firm mechanism (#122).
+  * Unemployment benefits and social transfers are NOT here — emitted by
+  * GovBudgetFlows (#124).
+  *
+  * Account IDs: 0=HH, 1=Firms (consumption), 2=Landlord (rent), 3=Gov (PIT),
+  * 4=Bank (debt service/deposits), 5=Foreign (remittances)
+  */
+object HouseholdFlows:
+
+  val HH_ACCOUNT: Int       = 0
+  val FIRM_ACCOUNT: Int     = 1
+  val LANDLORD_ACCOUNT: Int = 2
+  val GOV_ACCOUNT: Int      = 3
+  val BANK_ACCOUNT: Int     = 4
+  val FOREIGN_ACCOUNT: Int  = 5
+
+  case class Input(
+      consumption: PLN,
+      rent: PLN,
+      pit: PLN,
+      debtService: PLN,
+      depositInterest: PLN,
+      remittances: PLN,
+      ccOrigination: PLN,
+      ccDebtService: PLN,
+      ccDefault: PLN,
+  )
+
+  def emit(input: Input): Vector[Flow] =
+    val flows = Vector.newBuilder[Flow]
+
+    if input.consumption.toLong > 0L then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.consumption.toLong, FlowMechanism.HhConsumption.toInt)
+    if input.rent.toLong > 0L then flows += Flow(HH_ACCOUNT, LANDLORD_ACCOUNT, input.rent.toLong, FlowMechanism.HhRent.toInt)
+    if input.pit.toLong > 0L then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.pit.toLong, FlowMechanism.HhPit.toInt)
+    if input.debtService.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.debtService.toLong, FlowMechanism.HhDebtService.toInt)
+    if input.depositInterest.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.depositInterest.toLong, FlowMechanism.HhDepositInterest.toInt)
+    if input.remittances.toLong > 0L then flows += Flow(HH_ACCOUNT, FOREIGN_ACCOUNT, input.remittances.toLong, FlowMechanism.HhRemittance.toInt)
+    if input.ccOrigination.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.ccOrigination.toLong, FlowMechanism.HhCcOrigination.toInt)
+    if input.ccDebtService.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDebtService.toLong, FlowMechanism.HhCcDebtService.toInt)
+    if input.ccDefault.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDefault.toLong, FlowMechanism.HhCcDefault.toInt)
+
+    flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlowsSpec.scala
@@ -1,0 +1,62 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HouseholdFlowsSpec extends AnyFlatSpec with Matchers:
+
+  private val baseInput = HouseholdFlows.Input(
+    consumption = PLN(40000000.0),
+    rent = PLN(8000000.0),
+    pit = PLN(5000000.0),
+    debtService = PLN(3000000.0),
+    depositInterest = PLN(1000000.0),
+    remittances = PLN(500000.0),
+    ccOrigination = PLN(2000000.0),
+    ccDebtService = PLN(1500000.0),
+    ccDefault = PLN(200000.0),
+  )
+
+  "HouseholdFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = HouseholdFlows.emit(baseInput)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have HH balance = -outflows + inflows" in {
+    val flows    = HouseholdFlows.emit(baseInput)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    val outflows = baseInput.consumption + baseInput.rent + baseInput.pit +
+      baseInput.debtService + baseInput.remittances + baseInput.ccDebtService + baseInput.ccDefault
+    val inflows  = baseInput.depositInterest + baseInput.ccOrigination
+
+    balances(HouseholdFlows.HH_ACCOUNT) shouldBe (inflows - outflows).toLong
+  }
+
+  it should "have bank balance = debtService + ccDebtService + ccDefault - depositInterest - ccOrigination" in {
+    val flows    = HouseholdFlows.emit(baseInput)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+
+    val bankNet = baseInput.debtService + baseInput.ccDebtService + baseInput.ccDefault -
+      baseInput.depositInterest - baseInput.ccOrigination
+
+    balances(HouseholdFlows.BANK_ACCOUNT) shouldBe bankNet.toLong
+  }
+
+  it should "skip zero-amount flows" in {
+    val minimal = HouseholdFlows.Input(PLN(1000000.0), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+    val flows   = HouseholdFlows.emit(minimal)
+    flows.length shouldBe 1
+    flows.head.mechanism shouldBe FlowMechanism.HhConsumption.toInt
+  }
+
+  it should "preserve SFC across 120 months" in {
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, HouseholdFlows.emit(baseInput))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }


### PR DESCRIPTION
## Summary

Household sector flows: consumption, rent, PIT, debt service, deposit interest, remittances, consumer credit (origination/service/default).

Aggregate level — per-agent BatchedFlow.Scatter deferred to new pipeline (#130).

9 flow types, 41 tests pass, SFC == 0L.

Fixes #121