### PR TITLE
Equity + CorpBond + Mortgage flow migration: SFC == 0L

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
@@ -1,0 +1,31 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Corporate bond market emitting flows.
+  *
+  * Coupon (Firm→Holders), default (Firm→Holders loss), issuance (Holders→Firm),
+  * amortization (Firm→Holders principal return).
+  *
+  * Account IDs: 0=Firm, 1=BondHolders (banks+PPK+other)
+  */
+object CorpBondFlows:
+
+  val FIRM_ACCOUNT: Int   = 0
+  val HOLDER_ACCOUNT: Int = 1
+
+  case class Input(
+      coupon: PLN,
+      defaultLoss: PLN,
+      issuance: PLN,
+      amortization: PLN,
+  )
+
+  def emit(input: Input): Vector[Flow] =
+    val flows = Vector.newBuilder[Flow]
+    if input.coupon.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.coupon.toLong, FlowMechanism.CorpBondCoupon.toInt)
+    if input.defaultLoss.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.defaultLoss.toLong, FlowMechanism.CorpBondDefault.toInt)
+    if input.issuance.toLong > 0L then flows += Flow(HOLDER_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.CorpBondIssuance.toInt)
+    if input.amortization.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.amortization.toLong, FlowMechanism.CorpBondAmortization.toInt)
+    flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -1,0 +1,35 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** GPW equity market emitting flows.
+  *
+  * Dividends: domestic (Firm→HH net of Belka tax), foreign (Firm→Foreign).
+  * Issuance: HH→Firm (equity capital).
+  *
+  * Account IDs: 0=Firm, 1=HH, 2=Foreign, 3=Gov (Belka tax)
+  */
+object EquityFlows:
+
+  val FIRM_ACCOUNT: Int    = 0
+  val HH_ACCOUNT: Int      = 1
+  val FOREIGN_ACCOUNT: Int = 2
+  val GOV_ACCOUNT: Int     = 3
+
+  case class Input(
+      netDomesticDividends: PLN,
+      foreignDividends: PLN,
+      dividendTax: PLN,
+      issuance: PLN,
+  )
+
+  def emit(input: Input): Vector[Flow] =
+    val flows = Vector.newBuilder[Flow]
+    if input.netDomesticDividends.toLong > 0L then
+      flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.netDomesticDividends.toLong, FlowMechanism.EquityDomDividend.toInt)
+    if input.foreignDividends.toLong > 0L then
+      flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.foreignDividends.toLong, FlowMechanism.EquityForDividend.toInt)
+    if input.dividendTax.toLong > 0L then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.dividendTax.toLong, FlowMechanism.EquityDividendTax.toInt)
+    if input.issuance.toLong > 0L then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.EquityIssuance.toInt)
+    flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -65,3 +65,18 @@ object FlowMechanism:
   val FirmProfitShifting: MechanismId   = MechanismId(51)
   val FirmFdiRepatriation: MechanismId  = MechanismId(52)
   val FirmGrossInvestment: MechanismId  = MechanismId(53)
+  // Equity market (GPW)
+  val EquityDomDividend: MechanismId    = MechanismId(54)
+  val EquityForDividend: MechanismId    = MechanismId(55)
+  val EquityDividendTax: MechanismId    = MechanismId(56)
+  val EquityIssuance: MechanismId       = MechanismId(57)
+  // Corporate bonds
+  val CorpBondCoupon: MechanismId       = MechanismId(58)
+  val CorpBondDefault: MechanismId      = MechanismId(59)
+  val CorpBondIssuance: MechanismId     = MechanismId(60)
+  val CorpBondAmortization: MechanismId = MechanismId(61)
+  // Housing / mortgages
+  val MortgageOrigination: MechanismId  = MechanismId(62)
+  val MortgageRepayment: MechanismId    = MechanismId(63)
+  val MortgageInterest: MechanismId     = MechanismId(64)
+  val MortgageDefault: MechanismId      = MechanismId(65)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
@@ -1,0 +1,31 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Housing/mortgage market emitting flows.
+  *
+  * Origination (Bank→HH), repayment (HH→Bank principal), interest (HH→Bank),
+  * default (HH→Bank loss).
+  *
+  * Account IDs: 0=HH, 1=Bank
+  */
+object MortgageFlows:
+
+  val HH_ACCOUNT: Int   = 0
+  val BANK_ACCOUNT: Int = 1
+
+  case class Input(
+      origination: PLN,
+      principalRepayment: PLN,
+      interest: PLN,
+      defaultAmount: PLN,
+  )
+
+  def emit(input: Input): Vector[Flow] =
+    val flows = Vector.newBuilder[Flow]
+    if input.origination.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.origination.toLong, FlowMechanism.MortgageOrigination.toInt)
+    if input.principalRepayment.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.principalRepayment.toLong, FlowMechanism.MortgageRepayment.toInt)
+    if input.interest.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.interest.toLong, FlowMechanism.MortgageInterest.toInt)
+    if input.defaultAmount.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.defaultAmount.toLong, FlowMechanism.MortgageDefault.toInt)
+    flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlowsSpec.scala
@@ -1,0 +1,30 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CorpBondFlowsSpec extends AnyFlatSpec with Matchers:
+
+  "CorpBondFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0)))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have firm balance = issuance - coupon - default - amortization" in {
+    val input    = CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))
+    val flows    = CorpBondFlows.emit(input)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    balances(CorpBondFlows.FIRM_ACCOUNT) shouldBe (input.issuance - input.coupon - input.defaultLoss - input.amortization).toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    val input    = CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, CorpBondFlows.emit(input))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
@@ -1,0 +1,30 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EquityFlowsSpec extends AnyFlatSpec with Matchers:
+
+  "EquityFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0)))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have firm balance = -dividends + issuance" in {
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))
+    val flows    = EquityFlows.emit(input)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    balances(EquityFlows.FIRM_ACCOUNT) shouldBe (input.issuance - input.netDomesticDividends - input.foreignDividends).toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, EquityFlows.emit(input))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlowsSpec.scala
@@ -1,0 +1,30 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MortgageFlowsSpec extends AnyFlatSpec with Matchers:
+
+  "MortgageFlows" should "preserve total wealth at exactly 0L" in {
+    val flows    = MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0)))
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "have bank balance = repayment + interest + default - origination" in {
+    val input    = MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))
+    val flows    = MortgageFlows.emit(input)
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    balances(MortgageFlows.BANK_ACCOUNT) shouldBe (input.principalRepayment + input.interest + input.defaultAmount - input.origination).toLong
+  }
+
+  it should "preserve SFC across 120 months" in {
+    val input    = MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))
+    var balances = Map.empty[Int, Long]
+    (1 to 120).foreach { _ =>
+      balances = Interpreter.applyAll(balances, MortgageFlows.emit(input))
+      Interpreter.totalWealth(balances) shouldBe 0L
+    }
+  }


### PR DESCRIPTION
## Summary

Three financial market mechanisms migrated:
- **Equity (GPW)**: domestic/foreign dividends, Belka tax, issuance
- **Corporate bonds**: coupon, default, issuance, amortization
- **Mortgages**: origination, repayment, interest, default

## Verification

- SFC == 0L across 120 months for all three
- 55 flow tests pass

Tier 3 remaining: #126 (OpenEcon), #125 (Banking)

Fixes #127, fixes #128, fixes #129