### PR TITLE
Use PLN.Zero instead of .toLong > 0L in flow mechanisms

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
@@ -24,8 +24,8 @@ object CorpBondFlows:
 
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
-    if input.coupon.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.coupon.toLong, FlowMechanism.CorpBondCoupon.toInt)
-    if input.defaultLoss.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.defaultLoss.toLong, FlowMechanism.CorpBondDefault.toInt)
-    if input.issuance.toLong > 0L then flows += Flow(HOLDER_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.CorpBondIssuance.toInt)
-    if input.amortization.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.amortization.toLong, FlowMechanism.CorpBondAmortization.toInt)
+    if input.coupon > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.coupon.toLong, FlowMechanism.CorpBondCoupon.toInt)
+    if input.defaultLoss > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.defaultLoss.toLong, FlowMechanism.CorpBondDefault.toInt)
+    if input.issuance > PLN.Zero then flows += Flow(HOLDER_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.CorpBondIssuance.toInt)
+    if input.amortization > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.amortization.toLong, FlowMechanism.CorpBondAmortization.toInt)
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
@@ -36,26 +36,26 @@ object EarmarkedFlows:
     val fpSpend   = input.unempBenefitSpend + input.employed * p.earmarked.fpAlmpSpendPerWorker
     val fpDeficit = fpSpend - fpContrib
 
-    if fpContrib.toLong > 0L then flows += Flow(HH_ACCOUNT, FP_ACCOUNT, fpContrib.toLong, FlowMechanism.FpContribution.toInt)
-    if fpSpend.toLong > 0L then flows += Flow(FP_ACCOUNT, SERVICES_ACCOUNT, fpSpend.toLong, FlowMechanism.FpSpending.toInt)
-    if fpDeficit.toLong > 0L then flows += Flow(GOV_ACCOUNT, FP_ACCOUNT, fpDeficit.toLong, FlowMechanism.FpGovSubvention.toInt)
+    if fpContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, FP_ACCOUNT, fpContrib.toLong, FlowMechanism.FpContribution.toInt)
+    if fpSpend > PLN.Zero then flows += Flow(FP_ACCOUNT, SERVICES_ACCOUNT, fpSpend.toLong, FlowMechanism.FpSpending.toInt)
+    if fpDeficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, FP_ACCOUNT, fpDeficit.toLong, FlowMechanism.FpGovSubvention.toInt)
 
     // PFRON: flat levy → disability spending
     val pfronContrib = p.earmarked.pfronMonthlyRevenue
     val pfronSpend   = p.earmarked.pfronMonthlySpending
     val pfronDeficit = pfronSpend - pfronContrib
 
-    if pfronContrib.toLong > 0L then flows += Flow(HH_ACCOUNT, PFRON_ACCOUNT, pfronContrib.toLong, FlowMechanism.PfronContribution.toInt)
-    if pfronSpend.toLong > 0L then flows += Flow(PFRON_ACCOUNT, SERVICES_ACCOUNT, pfronSpend.toLong, FlowMechanism.PfronSpending.toInt)
-    if pfronDeficit.toLong > 0L then flows += Flow(GOV_ACCOUNT, PFRON_ACCOUNT, pfronDeficit.toLong, FlowMechanism.PfronGovSubvention.toInt)
+    if pfronContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, PFRON_ACCOUNT, pfronContrib.toLong, FlowMechanism.PfronContribution.toInt)
+    if pfronSpend > PLN.Zero then flows += Flow(PFRON_ACCOUNT, SERVICES_ACCOUNT, pfronSpend.toLong, FlowMechanism.PfronSpending.toInt)
+    if pfronDeficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, PFRON_ACCOUNT, pfronDeficit.toLong, FlowMechanism.PfronGovSubvention.toInt)
 
     // FGSP: payroll levy → bankruptcy payouts (counter-cyclical)
     val fgspContrib = input.employed * (input.wage * p.earmarked.fgspRate)
     val fgspSpend   = (input.nBankruptFirms * input.avgFirmWorkers) * p.earmarked.fgspPayoutPerWorker
     val fgspDeficit = fgspSpend - fgspContrib
 
-    if fgspContrib.toLong > 0L then flows += Flow(HH_ACCOUNT, FGSP_ACCOUNT, fgspContrib.toLong, FlowMechanism.FgspContribution.toInt)
-    if fgspSpend.toLong > 0L then flows += Flow(FGSP_ACCOUNT, SERVICES_ACCOUNT, fgspSpend.toLong, FlowMechanism.FgspSpending.toInt)
-    if fgspDeficit.toLong > 0L then flows += Flow(GOV_ACCOUNT, FGSP_ACCOUNT, fgspDeficit.toLong, FlowMechanism.FgspGovSubvention.toInt)
+    if fgspContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, FGSP_ACCOUNT, fgspContrib.toLong, FlowMechanism.FgspContribution.toInt)
+    if fgspSpend > PLN.Zero then flows += Flow(FGSP_ACCOUNT, SERVICES_ACCOUNT, fgspSpend.toLong, FlowMechanism.FgspSpending.toInt)
+    if fgspDeficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, FGSP_ACCOUNT, fgspDeficit.toLong, FlowMechanism.FgspGovSubvention.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -26,10 +26,9 @@ object EquityFlows:
 
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
-    if input.netDomesticDividends.toLong > 0L then
+    if input.netDomesticDividends > PLN.Zero then
       flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.netDomesticDividends.toLong, FlowMechanism.EquityDomDividend.toInt)
-    if input.foreignDividends.toLong > 0L then
-      flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.foreignDividends.toLong, FlowMechanism.EquityForDividend.toInt)
-    if input.dividendTax.toLong > 0L then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.dividendTax.toLong, FlowMechanism.EquityDividendTax.toInt)
-    if input.issuance.toLong > 0L then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.EquityIssuance.toInt)
+    if input.foreignDividends > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.foreignDividends.toLong, FlowMechanism.EquityForDividend.toInt)
+    if input.dividendTax > PLN.Zero then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.dividendTax.toLong, FlowMechanism.EquityDividendTax.toInt)
+    if input.issuance > PLN.Zero then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.EquityIssuance.toInt)
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
@@ -40,20 +40,18 @@ object FirmFlows:
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 
-    if input.wages.toLong > 0L then flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.wages.toLong, FlowMechanism.FirmWages.toInt)
-    if input.cit.toLong > 0L then flows += Flow(FIRM_ACCOUNT, GOV_ACCOUNT, input.cit.toLong, FlowMechanism.FirmCit.toInt)
-    if input.loanRepayment.toLong > 0L then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.loanRepayment.toLong, FlowMechanism.FirmLoanRepayment.toInt)
-    if input.newLoans.toLong > 0L then flows += Flow(BANK_ACCOUNT, FIRM_ACCOUNT, input.newLoans.toLong, FlowMechanism.FirmNewLoan.toInt)
-    if input.interestPaid.toLong > 0L then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.interestPaid.toLong, FlowMechanism.FirmInterestPaid.toInt)
-    if input.capex.toLong > 0L then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.capex.toLong, FlowMechanism.FirmCapex.toInt)
-    if input.equityIssuance.toLong > 0L then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.equityIssuance.toLong, FlowMechanism.FirmEquityIssuance.toInt)
-    if input.bondIssuance.toLong > 0L then flows += Flow(BONDMARKET_ACCOUNT, FIRM_ACCOUNT, input.bondIssuance.toLong, FlowMechanism.FirmBondIssuance.toInt)
-    if input.ioPayments.toLong > 0L then flows += Flow(FIRM_ACCOUNT, FIRM_ACCOUNT + 100, input.ioPayments.toLong, FlowMechanism.FirmIoPayment.toInt)
-    if input.nplDefault.toLong > 0L then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.nplDefault.toLong, FlowMechanism.FirmNplDefault.toInt)
-    if input.profitShifting.toLong > 0L then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.profitShifting.toLong, FlowMechanism.FirmProfitShifting.toInt)
-    if input.fdiRepatriation.toLong > 0L then
-      flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.fdiRepatriation.toLong, FlowMechanism.FirmFdiRepatriation.toInt)
-    if input.grossInvestment.toLong > 0L then
-      flows += Flow(FIRM_ACCOUNT, CAPITAL_ACCOUNT, input.grossInvestment.toLong, FlowMechanism.FirmGrossInvestment.toInt)
+    if input.wages > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.wages.toLong, FlowMechanism.FirmWages.toInt)
+    if input.cit > PLN.Zero then flows += Flow(FIRM_ACCOUNT, GOV_ACCOUNT, input.cit.toLong, FlowMechanism.FirmCit.toInt)
+    if input.loanRepayment > PLN.Zero then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.loanRepayment.toLong, FlowMechanism.FirmLoanRepayment.toInt)
+    if input.newLoans > PLN.Zero then flows += Flow(BANK_ACCOUNT, FIRM_ACCOUNT, input.newLoans.toLong, FlowMechanism.FirmNewLoan.toInt)
+    if input.interestPaid > PLN.Zero then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.interestPaid.toLong, FlowMechanism.FirmInterestPaid.toInt)
+    if input.capex > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.capex.toLong, FlowMechanism.FirmCapex.toInt)
+    if input.equityIssuance > PLN.Zero then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.equityIssuance.toLong, FlowMechanism.FirmEquityIssuance.toInt)
+    if input.bondIssuance > PLN.Zero then flows += Flow(BONDMARKET_ACCOUNT, FIRM_ACCOUNT, input.bondIssuance.toLong, FlowMechanism.FirmBondIssuance.toInt)
+    if input.ioPayments > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FIRM_ACCOUNT + 100, input.ioPayments.toLong, FlowMechanism.FirmIoPayment.toInt)
+    if input.nplDefault > PLN.Zero then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.nplDefault.toLong, FlowMechanism.FirmNplDefault.toInt)
+    if input.profitShifting > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.profitShifting.toLong, FlowMechanism.FirmProfitShifting.toInt)
+    if input.fdiRepatriation > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.fdiRepatriation.toLong, FlowMechanism.FirmFdiRepatriation.toInt)
+    if input.grossInvestment > PLN.Zero then flows += Flow(FIRM_ACCOUNT, CAPITAL_ACCOUNT, input.grossInvestment.toLong, FlowMechanism.FirmGrossInvestment.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
@@ -41,21 +41,20 @@ object GovBudgetFlows:
     val flows = Vector.newBuilder[Flow]
 
     // Revenue: taxes → GOV
-    if input.taxRevenue.toLong > 0L then flows += Flow(TAXPAYER_ACCOUNT, GOV_ACCOUNT, input.taxRevenue.toLong, FlowMechanism.GovTaxRevenue.toInt)
+    if input.taxRevenue > PLN.Zero then flows += Flow(TAXPAYER_ACCOUNT, GOV_ACCOUNT, input.taxRevenue.toLong, FlowMechanism.GovTaxRevenue.toInt)
 
     // Spending: GOV → various recipients
-    if input.govPurchases.toLong > 0L then flows += Flow(GOV_ACCOUNT, FIRM_ACCOUNT, input.govPurchases.toLong, FlowMechanism.GovPurchases.toInt)
+    if input.govPurchases > PLN.Zero then flows += Flow(GOV_ACCOUNT, FIRM_ACCOUNT, input.govPurchases.toLong, FlowMechanism.GovPurchases.toInt)
 
-    if input.debtService.toLong > 0L then flows += Flow(GOV_ACCOUNT, BONDHOLDER_ACCOUNT, input.debtService.toLong, FlowMechanism.GovDebtService.toInt)
+    if input.debtService > PLN.Zero then flows += Flow(GOV_ACCOUNT, BONDHOLDER_ACCOUNT, input.debtService.toLong, FlowMechanism.GovDebtService.toInt)
 
-    if input.unempBenefitSpend.toLong > 0L then flows += Flow(GOV_ACCOUNT, HH_ACCOUNT, input.unempBenefitSpend.toLong, FlowMechanism.GovUnempBenefit.toInt)
+    if input.unempBenefitSpend > PLN.Zero then flows += Flow(GOV_ACCOUNT, HH_ACCOUNT, input.unempBenefitSpend.toLong, FlowMechanism.GovUnempBenefit.toInt)
 
-    if input.socialTransferSpend.toLong > 0L then
-      flows += Flow(GOV_ACCOUNT, HH_ACCOUNT, input.socialTransferSpend.toLong, FlowMechanism.GovSocialTransfer.toInt)
+    if input.socialTransferSpend > PLN.Zero then flows += Flow(GOV_ACCOUNT, HH_ACCOUNT, input.socialTransferSpend.toLong, FlowMechanism.GovSocialTransfer.toInt)
 
-    if input.euCofinancing.toLong > 0L then flows += Flow(GOV_ACCOUNT, INFRASTRUCTURE_ACCOUNT, input.euCofinancing.toLong, FlowMechanism.GovEuCofin.toInt)
+    if input.euCofinancing > PLN.Zero then flows += Flow(GOV_ACCOUNT, INFRASTRUCTURE_ACCOUNT, input.euCofinancing.toLong, FlowMechanism.GovEuCofin.toInt)
 
-    if input.govCapitalSpend.toLong > 0L then
+    if input.govCapitalSpend > PLN.Zero then
       flows += Flow(GOV_ACCOUNT, INFRASTRUCTURE_ACCOUNT, input.govCapitalSpend.toLong, FlowMechanism.GovCapitalInvestment.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
@@ -40,14 +40,14 @@ object HouseholdFlows:
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 
-    if input.consumption.toLong > 0L then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.consumption.toLong, FlowMechanism.HhConsumption.toInt)
-    if input.rent.toLong > 0L then flows += Flow(HH_ACCOUNT, LANDLORD_ACCOUNT, input.rent.toLong, FlowMechanism.HhRent.toInt)
-    if input.pit.toLong > 0L then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.pit.toLong, FlowMechanism.HhPit.toInt)
-    if input.debtService.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.debtService.toLong, FlowMechanism.HhDebtService.toInt)
-    if input.depositInterest.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.depositInterest.toLong, FlowMechanism.HhDepositInterest.toInt)
-    if input.remittances.toLong > 0L then flows += Flow(HH_ACCOUNT, FOREIGN_ACCOUNT, input.remittances.toLong, FlowMechanism.HhRemittance.toInt)
-    if input.ccOrigination.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.ccOrigination.toLong, FlowMechanism.HhCcOrigination.toInt)
-    if input.ccDebtService.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDebtService.toLong, FlowMechanism.HhCcDebtService.toInt)
-    if input.ccDefault.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDefault.toLong, FlowMechanism.HhCcDefault.toInt)
+    if input.consumption > PLN.Zero then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.consumption.toLong, FlowMechanism.HhConsumption.toInt)
+    if input.rent > PLN.Zero then flows += Flow(HH_ACCOUNT, LANDLORD_ACCOUNT, input.rent.toLong, FlowMechanism.HhRent.toInt)
+    if input.pit > PLN.Zero then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.pit.toLong, FlowMechanism.HhPit.toInt)
+    if input.debtService > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.debtService.toLong, FlowMechanism.HhDebtService.toInt)
+    if input.depositInterest > PLN.Zero then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.depositInterest.toLong, FlowMechanism.HhDepositInterest.toInt)
+    if input.remittances > PLN.Zero then flows += Flow(HH_ACCOUNT, FOREIGN_ACCOUNT, input.remittances.toLong, FlowMechanism.HhRemittance.toInt)
+    if input.ccOrigination > PLN.Zero then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.ccOrigination.toLong, FlowMechanism.HhCcOrigination.toInt)
+    if input.ccDebtService > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDebtService.toLong, FlowMechanism.HhCcDebtService.toInt)
+    if input.ccDefault > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.ccDefault.toLong, FlowMechanism.HhCcDefault.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
@@ -47,10 +47,10 @@ object InsuranceFlows:
 
     val flows = Vector.newBuilder[Flow]
 
-    if lifePrem.toLong > 0L then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, lifePrem.toLong, FlowMechanism.InsLifePremium.toInt)
-    if nonLifePrem.toLong > 0L then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, nonLifePrem.toLong, FlowMechanism.InsNonLifePremium.toInt)
-    if lifeCl.toLong > 0L then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, lifeCl.toLong, FlowMechanism.InsLifeClaim.toInt)
-    if nonLifeCl.toLong > 0L then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, nonLifeCl.toLong, FlowMechanism.InsNonLifeClaim.toInt)
-    if invIncome.toLong > 0L then flows += Flow(MARKETS_ACCOUNT, INS_ACCOUNT, invIncome.toLong, FlowMechanism.InsInvestmentIncome.toInt)
+    if lifePrem > PLN.Zero then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, lifePrem.toLong, FlowMechanism.InsLifePremium.toInt)
+    if nonLifePrem > PLN.Zero then flows += Flow(HH_ACCOUNT, INS_ACCOUNT, nonLifePrem.toLong, FlowMechanism.InsNonLifePremium.toInt)
+    if lifeCl > PLN.Zero then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, lifeCl.toLong, FlowMechanism.InsLifeClaim.toInt)
+    if nonLifeCl > PLN.Zero then flows += Flow(INS_ACCOUNT, HH_ACCOUNT, nonLifeCl.toLong, FlowMechanism.InsNonLifeClaim.toInt)
+    if invIncome > PLN.Zero then flows += Flow(MARKETS_ACCOUNT, INS_ACCOUNT, invIncome.toLong, FlowMechanism.InsInvestmentIncome.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
@@ -40,8 +40,8 @@ object JstFlows:
       val totalSpending = totalRevenue * p.fiscal.jstSpendingMult
 
       val flows = Vector.newBuilder[Flow]
-      if totalRevenue.toLong > 0L then flows += Flow(TAXPAYER_ACCOUNT, JST_ACCOUNT, totalRevenue.toLong, FlowMechanism.JstRevenue.toInt)
-      if totalSpending.toLong > 0L then flows += Flow(JST_ACCOUNT, SERVICES_ACCOUNT, totalSpending.toLong, FlowMechanism.JstSpending.toInt)
+      if totalRevenue > PLN.Zero then flows += Flow(TAXPAYER_ACCOUNT, JST_ACCOUNT, totalRevenue.toLong, FlowMechanism.JstRevenue.toInt)
+      if totalSpending > PLN.Zero then flows += Flow(JST_ACCOUNT, SERVICES_ACCOUNT, totalSpending.toLong, FlowMechanism.JstSpending.toInt)
       flows.result()
 
   private val FallbackPitRate = 0.12

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
@@ -24,8 +24,8 @@ object MortgageFlows:
 
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
-    if input.origination.toLong > 0L then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.origination.toLong, FlowMechanism.MortgageOrigination.toInt)
-    if input.principalRepayment.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.principalRepayment.toLong, FlowMechanism.MortgageRepayment.toInt)
-    if input.interest.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.interest.toLong, FlowMechanism.MortgageInterest.toInt)
-    if input.defaultAmount.toLong > 0L then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.defaultAmount.toLong, FlowMechanism.MortgageDefault.toInt)
+    if input.origination > PLN.Zero then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.origination.toLong, FlowMechanism.MortgageOrigination.toInt)
+    if input.principalRepayment > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.principalRepayment.toLong, FlowMechanism.MortgageRepayment.toInt)
+    if input.interest > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.interest.toLong, FlowMechanism.MortgageInterest.toInt)
+    if input.defaultAmount > PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.defaultAmount.toLong, FlowMechanism.MortgageDefault.toInt)
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
@@ -37,10 +37,10 @@ object NfzFlows:
 
       val flows = Vector.newBuilder[Flow]
 
-      if contributions.toLong > 0L then flows += Flow(HH_ACCOUNT, NFZ_ACCOUNT, contributions.toLong, FlowMechanism.NfzContribution.toInt)
+      if contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, NFZ_ACCOUNT, contributions.toLong, FlowMechanism.NfzContribution.toInt)
 
-      if spending.toLong > 0L then flows += Flow(NFZ_ACCOUNT, HEALTHCARE_ACCOUNT, spending.toLong, FlowMechanism.NfzSpending.toInt)
+      if spending > PLN.Zero then flows += Flow(NFZ_ACCOUNT, HEALTHCARE_ACCOUNT, spending.toLong, FlowMechanism.NfzSpending.toInt)
 
-      if deficit.toLong > 0L then flows += Flow(GOV_ACCOUNT, NFZ_ACCOUNT, deficit.toLong, FlowMechanism.NfzGovSubvention.toInt)
+      if deficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, NFZ_ACCOUNT, deficit.toLong, FlowMechanism.NfzGovSubvention.toInt)
 
       flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
@@ -34,26 +34,26 @@ object OpenEconFlows:
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 
-    if input.exports.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.exports.toLong, FlowMechanism.TradeExports.toInt)
-    if input.imports.toLong > 0L then flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, input.imports.toLong, FlowMechanism.TradeImports.toInt)
-    if input.tourismExport.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.tourismExport.toLong, FlowMechanism.TourismExport.toInt)
-    if input.tourismImport.toLong > 0L then flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, input.tourismImport.toLong, FlowMechanism.TourismImport.toInt)
+    if input.exports > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.exports.toLong, FlowMechanism.TradeExports.toInt)
+    if input.imports > PLN.Zero then flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, input.imports.toLong, FlowMechanism.TradeImports.toInt)
+    if input.tourismExport > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.tourismExport.toLong, FlowMechanism.TourismExport.toInt)
+    if input.tourismImport > PLN.Zero then flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, input.tourismImport.toLong, FlowMechanism.TourismImport.toInt)
 
-    if input.fdi.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.fdi.toLong, FlowMechanism.Fdi.toInt)
+    if input.fdi > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.fdi.toLong, FlowMechanism.Fdi.toInt)
 
     // Portfolio flows: positive = inflow (Foreign→Domestic), negative = outflow
-    if input.portfolioFlows.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.portfolioFlows.toLong, FlowMechanism.PortfolioFlow.toInt)
-    else if input.portfolioFlows.toLong < 0L then
+    if input.portfolioFlows > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.portfolioFlows.toLong, FlowMechanism.PortfolioFlow.toInt)
+    else if input.portfolioFlows < PLN.Zero then
       flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, (-input.portfolioFlows).toLong, FlowMechanism.PortfolioFlow.toInt)
 
     // Primary income: positive = NFA earning (Foreign→Domestic), negative = payment
-    if input.primaryIncome.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.primaryIncome.toLong, FlowMechanism.PrimaryIncome.toInt)
-    else if input.primaryIncome.toLong < 0L then
+    if input.primaryIncome > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.primaryIncome.toLong, FlowMechanism.PrimaryIncome.toInt)
+    else if input.primaryIncome < PLN.Zero then
       flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, (-input.primaryIncome).toLong, FlowMechanism.PrimaryIncome.toInt)
 
-    if input.euFunds.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.euFunds.toLong, FlowMechanism.EuFunds.toInt)
-    if input.diasporaInflow.toLong > 0L then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.diasporaInflow.toLong, FlowMechanism.DiasporaInflow.toInt)
-    if input.capitalFlightOutflow.toLong > 0L then
+    if input.euFunds > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.euFunds.toLong, FlowMechanism.EuFunds.toInt)
+    if input.diasporaInflow > PLN.Zero then flows += Flow(FOREIGN_ACCOUNT, DOMESTIC_ACCOUNT, input.diasporaInflow.toLong, FlowMechanism.DiasporaInflow.toInt)
+    if input.capitalFlightOutflow > PLN.Zero then
       flows += Flow(DOMESTIC_ACCOUNT, FOREIGN_ACCOUNT, input.capitalFlightOutflow.toLong, FlowMechanism.CapitalFlight.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
@@ -27,8 +27,8 @@ object PpkFlows:
 
       val flows = Vector.newBuilder[Flow]
 
-      if contributions.toLong > 0L then flows += Flow(HH_ACCOUNT, PPK_ACCOUNT, contributions.toLong, FlowMechanism.PpkContribution.toInt)
+      if contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, PPK_ACCOUNT, contributions.toLong, FlowMechanism.PpkContribution.toInt)
 
-      if bondPurchase.toLong > 0L then flows += Flow(PPK_ACCOUNT, BOND_MARKET_ACCOUNT, bondPurchase.toLong, FlowMechanism.PpkBondPurchase.toInt)
+      if bondPurchase > PLN.Zero then flows += Flow(PPK_ACCOUNT, BOND_MARKET_ACCOUNT, bondPurchase.toLong, FlowMechanism.PpkBondPurchase.toInt)
 
       flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
@@ -38,11 +38,11 @@ object ZusFlows:
 
       val flows = Vector.newBuilder[Flow]
 
-      if contributions.toLong > 0L then
+      if contributions > PLN.Zero then
         flows += Flow(from = HH_ACCOUNT, to = FUS_ACCOUNT, amount = contributions.toLong, mechanism = FlowMechanism.ZusContribution.toInt)
 
-      if pensions.toLong > 0L then flows += Flow(from = FUS_ACCOUNT, to = HH_ACCOUNT, amount = pensions.toLong, mechanism = FlowMechanism.ZusPension.toInt)
+      if pensions > PLN.Zero then flows += Flow(from = FUS_ACCOUNT, to = HH_ACCOUNT, amount = pensions.toLong, mechanism = FlowMechanism.ZusPension.toInt)
 
-      if deficit.toLong > 0L then flows += Flow(from = GOV_ACCOUNT, to = FUS_ACCOUNT, amount = deficit.toLong, mechanism = FlowMechanism.ZusGovSubvention.toInt)
+      if deficit > PLN.Zero then flows += Flow(from = GOV_ACCOUNT, to = FUS_ACCOUNT, amount = deficit.toLong, mechanism = FlowMechanism.ZusGovSubvention.toInt)
 
       flows.result()


### PR DESCRIPTION
Cleanup: replace raw Long comparisons with typed PLN.Zero across all flow emit() methods. 60 tests pass.