### PR TITLE
Flow pipeline skeleton: real World → Economics → Flows → SFC == 0L

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
@@ -1,0 +1,76 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.types.*
+
+/** Temporary bridge between old World state and new flow mechanisms.
+  *
+  * Translates LaborEconomics.Result + World into XxxFlows.Input for each
+  * mechanism. Deleted in Phase 4 when new pipeline replaces old steps entirely.
+  *
+  * Performance is irrelevant here — correctness only. This runs alongside old
+  * pipeline to prove equivalence.
+  */
+object StateAdapter:
+
+  /** Build ZUS flow input from labor economics result. */
+  def zusInput(labor: LaborEconomics.Result): ZusFlows.ZusInput =
+    ZusFlows.ZusInput(
+      employed = labor.employed,
+      wage = labor.wage,
+      nRetirees = labor.demographics.retirees,
+    )
+
+  /** Build NFZ flow input from labor economics result. */
+  def nfzInput(labor: LaborEconomics.Result): NfzFlows.NfzInput =
+    NfzFlows.NfzInput(
+      employed = labor.employed,
+      wage = labor.wage,
+      workingAge = labor.demographics.workingAgePop,
+      nRetirees = labor.demographics.retirees,
+    )
+
+  /** Build PPK flow input from labor economics result. */
+  def ppkInput(labor: LaborEconomics.Result): PpkFlows.PpkInput =
+    PpkFlows.PpkInput(employed = labor.employed, wage = labor.wage)
+
+  /** Build Earmarked flow input from labor economics result. */
+  def earmarkedInput(labor: LaborEconomics.Result): EarmarkedFlows.Input =
+    EarmarkedFlows.Input(
+      employed = labor.employed,
+      wage = labor.wage,
+      unempBenefitSpend = PLN.Zero, // computed later in HH step
+      nBankruptFirms = labor.nBankruptFirms,
+      avgFirmWorkers = labor.avgFirmWorkers,
+    )
+
+  /** Build HH flow input from HH aggregates. */
+  def hhInput(agg: Household.Aggregates): HouseholdFlows.Input =
+    HouseholdFlows.Input(
+      consumption = agg.consumption,
+      rent = agg.totalRent,
+      pit = agg.totalPit,
+      debtService = agg.totalDebtService,
+      depositInterest = agg.totalDepositInterest,
+      remittances = agg.totalRemittances,
+      ccOrigination = agg.totalConsumerOrigination,
+      ccDebtService = agg.totalConsumerDebtService,
+      ccDefault = agg.totalConsumerDefault,
+    )
+
+  /** Build Insurance flow input from world state. */
+  def insuranceInput(w: World, labor: LaborEconomics.Result): InsuranceFlows.Input =
+    val ins = w.financial.insurance
+    InsuranceFlows.Input(
+      employed = labor.employed,
+      wage = labor.wage,
+      unempRate = Share.One - Share.fraction(labor.employed, w.totalPopulation.max(1)),
+      prevGovBondHoldings = ins.govBondHoldings,
+      prevCorpBondHoldings = ins.corpBondHoldings,
+      prevEquityHoldings = ins.equityHoldings,
+      govBondYield = w.gov.bondYield,
+      corpBondYield = w.financial.corporateBonds.corpBondYield,
+      equityReturn = w.financial.equity.monthlyReturn,
+    )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -1,0 +1,92 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.steps.FiscalConstraintStep
+import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Flow Pipeline integration test: real World → Economics → Flows →
+  * Interpreter.
+  *
+  * First end-to-end test of the new pipeline with real initialized state.
+  * Proves that Economics + StateAdapter + Flow mechanisms + Interpreter compose
+  * correctly on production data.
+  */
+class FlowPipelineSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+  private val init           = WorldInit.initialize(42L)
+  private val w              = init.world
+
+  /** Run one month through the new flow pipeline (partial — Steps 1-2 economics
+    * + all fund flows).
+    */
+  private def runOneMonth: (Map[Int, Long], LaborEconomics.Result) =
+    // Step 1: Fiscal constraints (pure calculus)
+    val fiscal = FiscalConstraintEconomics.compute(w)
+
+    // Step 2: Labor economics (pure calculus)
+    val s1    = FiscalConstraintStep.Output(
+      m = fiscal.month,
+      baseMinWage = fiscal.baseMinWage,
+      updatedMinWagePriceLevel = fiscal.updatedMinWagePriceLevel,
+      resWage = fiscal.resWage,
+      lendingBaseRate = fiscal.lendingBaseRate,
+    )
+    val labor = LaborEconomics.compute(w, init.firms, init.households, s1)
+
+    // Emit flows from fund mechanisms using adapter
+    val flows = Vector.concat(
+      ZusFlows.emit(StateAdapter.zusInput(labor)),
+      NfzFlows.emit(StateAdapter.nfzInput(labor)),
+      PpkFlows.emit(StateAdapter.ppkInput(labor)),
+      EarmarkedFlows.emit(StateAdapter.earmarkedInput(labor)),
+      InsuranceFlows.emit(StateAdapter.insuranceInput(w, labor)),
+    )
+
+    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
+    (balances, labor)
+
+  "Flow pipeline (real World)" should "preserve SFC at 0L" in {
+    val (balances, _) = runOneMonth
+    Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "produce realistic wage" in {
+    val (_, labor) = runOneMonth
+    val td         = ComputationBoundary
+    td.toDouble(labor.wage) should be > 3000.0
+    td.toDouble(labor.wage) should be < 20000.0
+  }
+
+  it should "produce realistic employment" in {
+    val (_, labor) = runOneMonth
+    labor.employed should be > 50000
+    labor.employed should be < 120000
+  }
+
+  it should "emit non-trivial fund flows" in {
+    val fiscal = FiscalConstraintEconomics.compute(w)
+    val s1     = FiscalConstraintStep.Output(
+      m = fiscal.month,
+      baseMinWage = fiscal.baseMinWage,
+      updatedMinWagePriceLevel = fiscal.updatedMinWagePriceLevel,
+      resWage = fiscal.resWage,
+      lendingBaseRate = fiscal.lendingBaseRate,
+    )
+    val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
+
+    val flows = Vector.concat(
+      ZusFlows.emit(StateAdapter.zusInput(labor)),
+      NfzFlows.emit(StateAdapter.nfzInput(labor)),
+      PpkFlows.emit(StateAdapter.ppkInput(labor)),
+      EarmarkedFlows.emit(StateAdapter.earmarkedInput(labor)),
+    )
+
+    flows.length should be > 5
+    flows.map(_.amount).sum should be > 0L
+  }


### PR DESCRIPTION
## Summary

First end-to-end flow pipeline with real initialized World state.

- **StateAdapter**: translates Economics results + World into flow mechanism inputs
- **FlowPipelineSpec**: FiscalConstraint → Labor → ZUS/NFZ/PPK/Earmarked/Insurance flows → Interpreter → SFC == 0L

## What this proves

Economics (pure calculus) + StateAdapter (bridge) + Flow mechanisms + Verified interpreter compose correctly on production data. Realistic wage, employment, non-trivial flows.

State Hydration Bridge pattern (Opcja C) — old World coexists with new flow pipeline.

## Next

Wire remaining steps (Demand, HH, Firm, PriceEquity, OpenEcon) through the same pattern. Then tackle heavy steps (BankUpdate, FirmProcessing) via micro-pipeline.