### PR TITLE
WorldAssembly extraction — all Economics complete

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -1,0 +1,40 @@
+package com.boombustgroup.amorfati.engine.economics
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.steps.*
+
+import scala.util.Random
+
+/** WorldAssembly economics: aggregation, informal economy, observables.
+  *
+  * Wraps WorldAssemblyStep.run() and returns the assembled World. In the new
+  * pipeline, this becomes the final stage that converts MutableWorldState back
+  * to World for output/SFC validation.
+  */
+object WorldAssemblyEconomics:
+
+  case class Result(
+      world: World,
+      firms: Vector[com.boombustgroup.amorfati.agents.Firm.State],
+      households: Vector[com.boombustgroup.amorfati.agents.Household.State],
+  )
+
+  def compute(
+      w: World,
+      firms: Vector[com.boombustgroup.amorfati.agents.Firm.State],
+      households: Vector[com.boombustgroup.amorfati.agents.Household.State],
+      s1: FiscalConstraintStep.Output,
+      s2: LaborDemographicsStep.Output,
+      s3: HouseholdIncomeStep.Output,
+      s4: DemandStep.Output,
+      s5: FirmProcessingStep.Output,
+      s6: HouseholdFinancialStep.Output,
+      s7: PriceEquityStep.Output,
+      s8: OpenEconomyStep.Output,
+      s9: BankUpdateStep.Output,
+      rng: Random,
+      migRng: Random,
+  )(using SimParams): Result =
+    val s10 = WorldAssemblyStep.run(WorldAssemblyStep.Input(w, firms, households, s1, s2, s3, s4, s5, s6, s7, s8, s9), rng, migRng)
+    Result(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -1,0 +1,23 @@
+package com.boombustgroup.amorfati.engine.economics
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.Simulation
+import com.boombustgroup.amorfati.init.WorldInit
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  "WorldAssemblyEconomics" should "produce valid world after simulation step" in {
+    val init  = WorldInit.initialize(42L)
+    val state = Simulation.SimState(init.world, init.firms, init.households)
+    val step  = Simulation.step(state, 42L, 1)
+    val w     = step.state.world
+
+    w.month shouldBe 1
+    w.totalPopulation should be > 0
+    w.hhAgg.employed should be > 0
+    w.external.tourismSeasonalFactor should not be 0.0
+  }


### PR DESCRIPTION
## Summary

Final Economics extraction. All 6 done:

| Economics | Old Step | .copy() | Status |
|-----------|----------|---------|--------|
| FiscalConstraintEconomics | Step 1 | 0 | Extracted |
| LaborEconomics | Step 2 | 0 | Extracted |
| FirmEconomics | Step 5 | 7 | Extracted (wraps old) |
| OpenEconEconomics | Step 8 | 5 | Extracted (wraps old) |
| BankingEconomics | Step 9 | 11 | Extracted (wraps old) |
| WorldAssemblyEconomics | Step 10 | 5 | Extracted (wraps old) |

Steps 3,4,6,7 are already pure calculus — no extraction needed.

10 economics tests pass. Ready for #131 (delete legacy).

Fixes #151