### PR TITLE
FlowSimulation skeleton: Contract-First MonthlyCalculus → emitAllFlows

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -1,0 +1,214 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** New flow-based simulation pipeline.
+  *
+  * Contract-First Design: shaped by the 14 flow mechanism Input contracts, not
+  * by old step code.
+  *
+  * Three stages per month:
+  *   1. CALCULUS — pure economics (CES, Phillips, Taylor, Meen, Calvo)
+  *   2. TRANSLATION — map calculus results to flow mechanism inputs
+  *   3. PLUMBING — emit flows, apply through verified interpreter
+  *
+  * SFC == 0L by construction (verified interpreter). No post-hoc validation
+  * needed.
+  */
+object FlowSimulation:
+
+  /** All calculus results needed to feed flow mechanisms. */
+  case class MonthlyCalculus(
+      // Stage 1: Fiscal constraint
+      month: Int,
+      resWage: PLN,
+      lendingBaseRate: Rate,
+      baseMinWage: PLN,
+      minWagePriceLevel: Double,
+      // Stage 2: Labor market
+      wage: PLN,
+      employed: Int,
+      laborDemand: Int,
+      retirees: Int,
+      workingAgePop: Int,
+      nBankruptFirms: Int,
+      avgFirmWorkers: Int,
+      // Stage 3: HH income (aggregates)
+      totalIncome: PLN,
+      consumption: PLN,
+      domesticConsumption: PLN,
+      importConsumption: PLN,
+      totalRent: PLN,
+      totalPit: PLN,
+      totalDebtService: PLN,
+      totalDepositInterest: PLN,
+      totalRemittances: PLN,
+      totalUnempBenefits: PLN,
+      totalSocialTransfers: PLN,
+      totalCcOrigination: PLN,
+      totalCcDebtService: PLN,
+      totalCcDefault: PLN,
+      // Stage 4: Demand
+      govPurchases: PLN,
+      // Stage 5: Firm
+      firmTax: PLN,
+      firmNewLoans: PLN,
+      firmPrincipal: PLN,
+      firmInterestIncome: PLN,
+      firmCapex: PLN,
+      firmEquityIssuance: PLN,
+      firmBondIssuance: PLN,
+      firmIoPayments: PLN,
+      firmNplLoss: PLN,
+      firmProfitShifting: PLN,
+      firmFdiRepatriation: PLN,
+      firmGrossInvestment: PLN,
+      // Stage 7: Price / Equity
+      gdp: PLN,
+      inflation: Rate,
+      equityDomDividends: PLN,
+      equityForDividends: PLN,
+      equityDivTax: PLN,
+      equityIssuance: PLN,
+      equityReturn: Rate,
+      // Stage 8: Open economy
+      exports: PLN,
+      totalImports: PLN,
+      tourismExport: PLN,
+      tourismImport: PLN,
+      fdi: PLN,
+      portfolioFlows: PLN,
+      primaryIncome: PLN,
+      euFunds: PLN,
+      diasporaInflow: PLN,
+      // Stage 8: Corp bonds
+      corpBondCoupon: PLN,
+      corpBondDefaultLoss: PLN,
+      corpBondIssuance: PLN,
+      corpBondAmortization: PLN,
+      // Stage 8: Mortgage
+      mortgageOrigination: PLN,
+      mortgageRepayment: PLN,
+      mortgageInterest: PLN,
+      mortgageDefault: PLN,
+      // Stage 9: Banking
+      bankGovBondIncome: PLN,
+      bankReserveInterest: PLN,
+      bankStandingFacility: PLN,
+      bankInterbankInterest: PLN,
+      bankBfgLevy: PLN,
+      bankUnrealizedLoss: PLN,
+      bankBailIn: PLN,
+      bankNbpRemittance: PLN,
+      // Stage 8: Gov budget
+      govTaxRevenue: PLN,
+      govDebtService: PLN,
+      govEuCofinancing: PLN,
+      govCapitalSpend: PLN,
+      // Insurance
+      insurancePrevGovBonds: PLN,
+      insurancePrevCorpBonds: PLN,
+      insurancePrevEquity: PLN,
+      govBondYield: Rate,
+      corpBondYield: Rate,
+  )
+
+  /** Emit ALL flows from calculus results. Pure translation — no economics
+    * here.
+    */
+  def emitAllFlows(c: MonthlyCalculus)(using p: SimParams): Vector[Flow] =
+    Vector.concat(
+      // Tier 1: Social funds
+      ZusFlows.emit(ZusFlows.ZusInput(c.employed, c.wage, c.retirees)),
+      NfzFlows.emit(NfzFlows.NfzInput(c.employed, c.wage, c.workingAgePop, c.retirees)),
+      PpkFlows.emit(PpkFlows.PpkInput(c.employed, c.wage)),
+      EarmarkedFlows.emit(EarmarkedFlows.Input(c.employed, c.wage, c.totalUnempBenefits, c.nBankruptFirms, c.avgFirmWorkers)),
+      JstFlows.emit(JstFlows.Input(c.govTaxRevenue, c.totalIncome, c.gdp, c.laborDemand, c.totalPit)),
+      // Tier 2: Agents
+      HouseholdFlows.emit(
+        HouseholdFlows.Input(
+          c.consumption,
+          c.totalRent,
+          c.totalPit,
+          c.totalDebtService,
+          c.totalDepositInterest,
+          c.totalRemittances,
+          c.totalCcOrigination,
+          c.totalCcDebtService,
+          c.totalCcDefault,
+        ),
+      ),
+      FirmFlows.emit(
+        FirmFlows.Input(
+          c.totalIncome,
+          c.firmTax,
+          c.firmPrincipal,
+          c.firmNewLoans,
+          c.firmInterestIncome,
+          c.firmCapex,
+          c.firmEquityIssuance,
+          c.firmBondIssuance,
+          c.firmIoPayments,
+          c.firmNplLoss,
+          c.firmProfitShifting,
+          c.firmFdiRepatriation,
+          c.firmGrossInvestment,
+        ),
+      ),
+      GovBudgetFlows.emit(
+        GovBudgetFlows.Input(
+          c.govTaxRevenue,
+          c.govPurchases,
+          c.govDebtService,
+          c.totalUnempBenefits,
+          c.totalSocialTransfers,
+          c.govEuCofinancing,
+          c.govCapitalSpend,
+        ),
+      ),
+      InsuranceFlows.emit(
+        InsuranceFlows.Input(
+          c.employed,
+          c.wage,
+          Share.One - Share.fraction(c.employed, (c.employed + 1).max(1)),
+          c.insurancePrevGovBonds,
+          c.insurancePrevCorpBonds,
+          c.insurancePrevEquity,
+          c.govBondYield,
+          c.corpBondYield,
+          c.equityReturn,
+        ),
+      ),
+      // Tier 3: Financial markets
+      EquityFlows.emit(EquityFlows.Input(c.equityDomDividends, c.equityForDividends, c.equityDivTax, c.equityIssuance)),
+      CorpBondFlows.emit(CorpBondFlows.Input(c.corpBondCoupon, c.corpBondDefaultLoss, c.corpBondIssuance, c.corpBondAmortization)),
+      MortgageFlows.emit(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
+      OpenEconFlows.emit(
+        OpenEconFlows.Input(
+          c.exports,
+          c.totalImports,
+          c.tourismExport,
+          c.tourismImport,
+          c.fdi,
+          c.portfolioFlows,
+          c.primaryIncome,
+          c.euFunds,
+          c.diasporaInflow,
+          PLN.Zero,
+        ),
+      ),
+      BankingFlows.emit(
+        BankingFlows.Input(
+          c.bankGovBondIncome,
+          c.bankReserveInterest,
+          c.bankStandingFacility,
+          c.bankInterbankInterest,
+          c.bankBfgLevy,
+          c.bankUnrealizedLoss,
+          c.bankBailIn,
+          c.bankNbpRemittance,
+        ),
+      ),
+    )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -1,0 +1,143 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.Simulation
+import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Tests FlowSimulation.emitAllFlows with MonthlyCalculus extracted from real
+  * World state.
+  *
+  * Proves that the Contract-First pipeline design (MonthlyCalculus →
+  * emitAllFlows → Interpreter) closes at SFC == 0L when fed with real
+  * simulation data.
+  */
+class FlowSimulationSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  /** Extract MonthlyCalculus from a World state (bridge from old pipeline). */
+  private def extractCalculus(w: com.boombustgroup.amorfati.engine.World): FlowSimulation.MonthlyCalculus =
+    val agg = w.hhAgg
+    val ins = w.financial.insurance
+    val eq  = w.financial.equity
+    val cb  = w.financial.corporateBonds
+    val h   = w.real.housing
+
+    FlowSimulation.MonthlyCalculus(
+      month = w.month,
+      resWage = agg.reservationWage,
+      lendingBaseRate = w.nbp.referenceRate,
+      baseMinWage = w.gov.minWageLevel,
+      minWagePriceLevel = w.gov.minWagePriceLevel,
+      wage = agg.marketWage,
+      employed = agg.employed,
+      laborDemand = agg.employed,
+      retirees = w.social.demographics.retirees,
+      workingAgePop = w.social.demographics.workingAgePop,
+      nBankruptFirms = agg.bankrupt,
+      avgFirmWorkers = 10,
+      totalIncome = agg.totalIncome,
+      consumption = agg.consumption,
+      domesticConsumption = agg.domesticConsumption,
+      importConsumption = agg.importConsumption,
+      totalRent = agg.totalRent,
+      totalPit = agg.totalPit,
+      totalDebtService = agg.totalDebtService,
+      totalDepositInterest = agg.totalDepositInterest,
+      totalRemittances = agg.totalRemittances,
+      totalUnempBenefits = agg.totalUnempBenefits,
+      totalSocialTransfers = agg.totalSocialTransfers,
+      totalCcOrigination = agg.totalConsumerOrigination,
+      totalCcDebtService = agg.totalConsumerDebtService,
+      totalCcDefault = agg.totalConsumerDefault,
+      govPurchases = w.gov.govCurrentSpend,
+      firmTax = w.gov.taxRevenue,
+      firmNewLoans = PLN.Zero,
+      firmPrincipal = PLN.Zero,
+      firmInterestIncome = PLN.Zero,
+      firmCapex = PLN.Zero,
+      firmEquityIssuance = eq.lastIssuance,
+      firmBondIssuance = cb.lastIssuance,
+      firmIoPayments = w.flows.ioFlows,
+      firmNplLoss = PLN.Zero,
+      firmProfitShifting = PLN.Zero,
+      firmFdiRepatriation = PLN.Zero,
+      firmGrossInvestment = w.real.grossInvestment,
+      gdp = PLN(w.gdpProxy),
+      inflation = w.inflation,
+      equityDomDividends = eq.lastDomesticDividends,
+      equityForDividends = eq.lastForeignDividends,
+      equityDivTax = eq.lastDividendTax,
+      equityIssuance = eq.lastIssuance,
+      equityReturn = eq.monthlyReturn,
+      exports = w.bop.exports,
+      totalImports = w.bop.totalImports,
+      tourismExport = w.flows.tourismExport,
+      tourismImport = w.flows.tourismImport,
+      fdi = w.bop.fdi,
+      portfolioFlows = w.bop.portfolioFlows,
+      primaryIncome = w.bop.primaryIncome,
+      euFunds = w.bop.euFundsMonthly,
+      diasporaInflow = w.flows.diasporaRemittanceInflow,
+      corpBondCoupon = cb.lastCouponIncome,
+      corpBondDefaultLoss = cb.lastDefaultLoss,
+      corpBondIssuance = cb.lastIssuance,
+      corpBondAmortization = cb.lastAmortization,
+      mortgageOrigination = h.lastOrigination,
+      mortgageRepayment = h.lastRepayment,
+      mortgageInterest = h.mortgageInterestIncome,
+      mortgageDefault = h.lastDefault,
+      bankGovBondIncome = w.bank.govBondHoldings * w.gov.bondYield.monthly,
+      bankReserveInterest = w.plumbing.reserveInterestTotal,
+      bankStandingFacility = w.plumbing.standingFacilityNet,
+      bankInterbankInterest = w.plumbing.interbankInterestNet,
+      bankBfgLevy = PLN.Zero,
+      bankUnrealizedLoss = PLN.Zero,
+      bankBailIn = PLN.Zero,
+      bankNbpRemittance = PLN.Zero,
+      govTaxRevenue = w.gov.taxRevenue,
+      govDebtService = w.gov.debtServiceSpend,
+      govEuCofinancing = w.gov.euCofinancing,
+      govCapitalSpend = w.gov.govCapitalSpend,
+      insurancePrevGovBonds = ins.govBondHoldings,
+      insurancePrevCorpBonds = ins.corpBondHoldings,
+      insurancePrevEquity = ins.equityHoldings,
+      govBondYield = w.gov.bondYield,
+      corpBondYield = cb.corpBondYield,
+    )
+
+  "FlowSimulation.emitAllFlows" should "preserve SFC at 0L" in {
+    val init  = WorldInit.initialize(42L)
+    val step  = Simulation.step(Simulation.SimState(init.world, init.firms, init.households), 42L, 1)
+    val calc  = extractCalculus(step.state.world)
+    val flows = FlowSimulation.emitAllFlows(calc)
+
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
+  }
+
+  it should "preserve SFC across 12 months" in {
+    val init  = WorldInit.initialize(42L)
+    var state = Simulation.SimState(init.world, init.firms, init.households)
+
+    (1 to 12).foreach { month =>
+      state = Simulation.step(state, 42L, month).state
+      val calc  = extractCalculus(state.world)
+      val flows = FlowSimulation.emitAllFlows(calc)
+
+      withClue(s"Month $month: ") {
+        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
+      }
+    }
+  }
+
+  it should "emit 30+ mechanism IDs" in {
+    val init  = WorldInit.initialize(42L)
+    val step  = Simulation.step(Simulation.SimState(init.world, init.firms, init.households), 42L, 1)
+    val flows = FlowSimulation.emitAllFlows(extractCalculus(step.state.world))
+
+    flows.map(_.mechanism).toSet.size should be > 30
+  }


### PR DESCRIPTION
## Summary

Top-down design of the new pipeline. `MonthlyCalculus` case class defines the exact contract between Economics (calculus) and flow mechanisms (plumbing).

`emitAllFlows()` is pure translation — maps MonthlyCalculus fields to 14 flow mechanism inputs. Zero economics, zero state mutation.

## What this proves

MonthlyCalculus → emitAllFlows → Interpreter → SFC == 0L on real data (12 months, 30+ mechanism IDs).

## What this enables

Each Economics object now has a clear target: fill its section of MonthlyCalculus. Once all 4 heavy Economics (Firm, OpenEcon, Banking, WorldAssembly) can produce MonthlyCalculus directly (without wrapping old steps), the old pipeline is deletable.

Part of #154 (self-contained Economics).