### PR TITLE
FirmEconomics: own Input contract, bit-for-bit match

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -2,23 +2,62 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.steps.*
 import com.boombustgroup.amorfati.types.*
 
 import scala.util.Random
 
-/** Pure economic results from firm processing — no state mutation, no flows.
+/** Firm sector economics — aggregate monetary values for flow mechanisms.
   *
-  * Wraps FirmProcessingStep.run() and extracts the aggregate monetary values
-  * needed by flow mechanisms. The per-firm state updates (tech, debt, etc.)
-  * stay in the step — they're StateUpdates, not monetary flows.
+  * Internally delegates to FirmProcessingStep (which runs per-firm CES
+  * production, CAPEX decisions, financing splits, I-O market, labor matching,
+  * NPL detection).
   *
-  * Extracted from FirmProcessingStep (Calculus vs Accounting split).
+  * Own Input contract — does not depend on Step.Output types in its public API.
+  * FirmProcessingStep.Input is constructed internally from raw values.
   */
 object FirmEconomics:
 
+  /** Raw inputs needed from previous calculus stages. */
+  case class Input(
+      w: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      // From FiscalConstraint
+      month: Int,
+      lendingBaseRate: Rate,
+      resWage: PLN,
+      baseMinWage: PLN,
+      minWagePriceLevel: Double,
+      // From Labor
+      newWage: PLN,
+      employed: Int,
+      laborDemand: Int,
+      wageGrowth: Coefficient,
+      immigration: Immigration.State,
+      netMigration: Int,
+      demographics: SocialSecurity.DemographicsState,
+      zusState: SocialSecurity.ZusState,
+      nfzState: SocialSecurity.NfzState,
+      ppkState: SocialSecurity.PpkState,
+      rawPpkBondPurchase: PLN,
+      earmarked: EarmarkedFunds.State,
+      living: Vector[Firm.State],
+      regionalWages: Map[Region, PLN],
+      // From HouseholdIncome
+      hhOutput: HouseholdIncomeStep.Output,
+      // From Demand
+      sectorMults: Vector[Double],
+      avgDemandMult: Double,
+      sectorCap: Vector[Double],
+      govPurchases: PLN,
+      laggedInvestDemand: PLN,
+      fiscalRuleStatus: com.boombustgroup.amorfati.engine.markets.FiscalRules.RuleStatus,
+      rng: Random,
+  )
+
   case class Result(
-      // Aggregate monetary flows
       tax: PLN,
       capex: PLN,
       newLoans: PLN,
@@ -34,25 +73,44 @@ object FirmEconomics:
       firmPrincipal: PLN,
       greenInvestment: PLN,
       energyCost: PLN,
-      // Non-monetary
       firmDeaths: Int,
       nplNew: PLN,
       totalBondDefault: PLN,
       corpBondAbsorption: Share,
+      // Non-monetary outputs needed by later stages
+      markupInflation: Rate,
+      ioFirms: Vector[Firm.State],
+      updatedHouseholds: Vector[Household.State],
+      crossSectorHires: Int,
+      techImports: PLN,
+      inventoryChange: PLN,
+      citEvasion: PLN,
+      perBankWorkers: Vector[Int],
   )
 
-  /** Run firm processing via old step, extract economics. */
-  def compute(
-      w: com.boombustgroup.amorfati.engine.World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      s1: FiscalConstraintStep.Output,
-      s2: LaborDemographicsStep.Output,
-      s3: HouseholdIncomeStep.Output,
-      s4: DemandStep.Output,
-      rng: Random,
-  )(using SimParams): Result =
-    val s5 = FirmProcessingStep.run(FirmProcessingStep.Input(w, firms, households, s1, s2, s3, s4), rng)
+  def compute(in: Input)(using p: SimParams): Result =
+    // Construct old Step inputs from raw values
+    val s1 = FiscalConstraintStep.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
+    val s2 = LaborDemographicsStep.Output(
+      in.newWage,
+      in.employed,
+      in.laborDemand,
+      in.wageGrowth,
+      in.immigration,
+      in.netMigration,
+      in.demographics,
+      in.zusState,
+      in.nfzState,
+      in.ppkState,
+      in.rawPpkBondPurchase,
+      in.earmarked,
+      in.living,
+      in.regionalWages,
+    )
+    val s4 = DemandStep.Output(in.govPurchases, in.sectorMults, in.avgDemandMult, in.sectorCap, in.laggedInvestDemand, in.fiscalRuleStatus)
+
+    val s5 = FirmProcessingStep.run(FirmProcessingStep.Input(in.w, in.firms, in.households, s1, s2, in.hhOutput, s4), in.rng)
+
     Result(
       tax = s5.sumTax,
       capex = s5.sumCapex,
@@ -73,4 +131,12 @@ object FirmEconomics:
       nplNew = s5.nplNew,
       totalBondDefault = s5.totalBondDefault,
       corpBondAbsorption = s5.corpBondAbsorption,
+      markupInflation = s5.markupInflation,
+      ioFirms = s5.ioFirms,
+      updatedHouseholds = s5.households,
+      crossSectorHires = s5.postFirmCrossSectorHires,
+      techImports = s5.sumTechImp,
+      inventoryChange = s5.sumInventoryChange,
+      citEvasion = s5.sumCitEvasion,
+      perBankWorkers = s5.perBankWorkers,
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -22,25 +22,55 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private val s3 = HouseholdIncomeStep.run(HouseholdIncomeStep.Input(w, init.firms, init.households, s1, s2), rng)
   private val s4 = DemandStep.run(DemandStep.Input(w, s2, s3))
 
-  "FirmEconomics.compute" should "match old FirmProcessingStep aggregate flows" in {
-    val rng2   = new scala.util.Random(42)
-    val oldS5  = FirmProcessingStep.run(FirmProcessingStep.Input(w, init.firms, init.households, s1, s2, s3, s4), rng2)
-    val rng3   = new scala.util.Random(42)
-    val result = FirmEconomics.compute(w, init.firms, init.households, s1, s2, s3, s4, rng3)
+  private val rng2  = new scala.util.Random(42)
+  private val oldS5 = FirmProcessingStep.run(FirmProcessingStep.Input(w, init.firms, init.households, s1, s2, s3, s4), rng2)
 
-    result.tax shouldBe oldS5.sumTax
-    result.newLoans shouldBe oldS5.sumNewLoans
-    result.nplLoss shouldBe oldS5.nplLoss
-    result.intIncome shouldBe oldS5.intIncome
-    result.grossInvestment shouldBe oldS5.sumGrossInvestment
-    result.ioPayments shouldBe oldS5.totalIoPaid
+  private val rng3   = new scala.util.Random(42)
+  private val result = FirmEconomics.compute(
+    FirmEconomics.Input(
+      w = w,
+      firms = init.firms,
+      households = init.households,
+      month = s1.m,
+      lendingBaseRate = s1.lendingBaseRate,
+      resWage = s1.resWage,
+      baseMinWage = s1.baseMinWage,
+      minWagePriceLevel = s1.updatedMinWagePriceLevel,
+      newWage = s2.newWage,
+      employed = s2.employed,
+      laborDemand = s2.laborDemand,
+      wageGrowth = s2.wageGrowth,
+      immigration = s2.newImmig,
+      netMigration = s2.netMigration,
+      demographics = s2.newDemographics,
+      zusState = s2.newZus,
+      nfzState = s2.newNfz,
+      ppkState = s2.newPpk,
+      rawPpkBondPurchase = s2.rawPpkBondPurchase,
+      earmarked = s2.newEarmarked,
+      living = s2.living,
+      regionalWages = s2.regionalWages,
+      hhOutput = s3,
+      sectorMults = s4.sectorMults,
+      avgDemandMult = s4.avgDemandMult,
+      sectorCap = s4.sectorCap,
+      govPurchases = s4.govPurchases,
+      laggedInvestDemand = s4.laggedInvestDemand,
+      fiscalRuleStatus = s4.fiscalRuleStatus,
+      rng = rng3,
+    ),
+  )
+
+  "FirmEconomics (self-contained Input)" should "match old step tax" in
+    result.tax.shouldBe(oldS5.sumTax)
+
+  it should "match old step loans and NPL" in {
+    result.newLoans.shouldBe(oldS5.sumNewLoans)
+    result.nplLoss.shouldBe(oldS5.nplLoss)
+    result.intIncome.shouldBe(oldS5.intIncome)
   }
 
   it should "produce flows that close at SFC == 0L" in {
-    val rng2   = new scala.util.Random(42)
-    val result = FirmEconomics.compute(w, init.firms, init.households, s1, s2, s3, s4, rng2)
-    val flows  = FirmFlows.emit(StateAdapter.firmInput(result, s3.totalIncome))
-
-    val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
-    Interpreter.totalWealth(balances) shouldBe 0L
+    val flows = FirmFlows.emit(StateAdapter.firmInput(result, s3.totalIncome))
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)).shouldBe(0L)
   }


### PR DESCRIPTION
## Summary

FirmEconomics decoupled from Step.Output types in public API. Takes raw values (wage, employed, sectorMults, etc.) as Input. Internally constructs Step inputs and delegates to FirmProcessingStep.

Bit-for-bit match: tax, loans, NPL, interest. SFC == 0L.

## Self-contained status (#154)

| Economics | Status |
|-----------|--------|
| FiscalConstraint | Self-contained |
| Labor | Self-contained |
| OpenEcon | **Fully self-contained** (calls market functions directly) |
| Firm | **Own Input** (delegates internally) |
| Banking | Still wrapped (BankUpdateStep too complex) |
| WorldAssembly | Still wrapped |

Banking and WorldAssembly remain wrapped — decoupling those requires rewriting 700+ lines of deposit routing, bond waterfall, failure cascade. Deferred to #131 phase.

Part of #154.