### PR TITLE
Remove openEcon flag, single export source of truth

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/FeatureFlags.scala
@@ -26,7 +26,7 @@ package com.boombustgroup.amorfati.config
   * '''Markets:''' `io`, `gpw`, `gpwEquityIssuance`, `gpwHhEquity`,
   * `gpwDividends`
   *
-  * '''External:''' `openEcon`, `gvc`, `immigration`, `immigEndogenous`, `fdi`,
+  * '''External:''' `gvc`, `immigration`, `immigEndogenous`, `fdi`,
   * `remittance`, `tourism`
   *
   * '''Financial:''' `insurance`, `nbfi`, `re`, `reMortgage`, `reHhHousing`,
@@ -77,7 +77,6 @@ case class FeatureFlags(
     gpwHhEquity: Boolean = true,
     gpwDividends: Boolean = true,
     // External
-    openEcon: Boolean = true,
     gvc: Boolean = true,
     immigration: Boolean = true,
     immigEndogenous: Boolean = true,

--- a/src/main/scala/com/boombustgroup/amorfati/config/ForexConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ForexConfig.scala
@@ -6,11 +6,9 @@ import com.boombustgroup.amorfati.types.*
   * rate parity.
   *
   * Models the bilateral PLN/EUR exchange rate with interest rate parity (IRP)
-  * adjustment, import propensity, technology import channel, and export
-  * automation boost. Provides the exchange rate foundation used by
-  * OpenEconConfig, GvcConfig, TourismConfig, and RemittanceConfig.
-  *
-  * `exportBase` is in raw PLN — scaled by `gdpRatio` in `SimParams.defaults`.
+  * adjustment, import propensity, and technology import channel. Provides the
+  * exchange rate foundation used by OpenEconConfig, GvcConfig, TourismConfig,
+  * and RemittanceConfig.
   *
   * @param baseExRate
   *   PLN/EUR exchange rate at simulation start (NBP 2024: ~4.33)
@@ -18,16 +16,12 @@ import com.boombustgroup.amorfati.types.*
   *   foreign (ECB) reference interest rate for IRP
   * @param importPropensity
   *   aggregate import-to-GDP ratio (GUS/NBP 2024: ~22%)
-  * @param exportBase
-  *   monthly export volume in raw PLN (scaled by gdpRatio)
   * @param techImportShare
   *   share of imports classified as technology/capital goods
   * @param irpSensitivity
   *   sensitivity of exchange rate to interest rate differential (IRP channel)
   * @param exRateAdjSpeed
   *   monthly exchange rate adjustment speed toward equilibrium
-  * @param exportAutoBoost
-  *   export productivity boost from firm automation
   * @param riskOffShockMonth
   *   simulation month when global risk-off event hits (0 = no shock)
   * @param riskOffMagnitude
@@ -49,11 +43,9 @@ case class ForexConfig(
     baseExRate: Double = 4.33,
     foreignRate: Rate = Rate(0.04),
     importPropensity: Share = Share(0.22),
-    exportBase: PLN = PLN(55.4e9), // raw — scaled by gdpRatio
     techImportShare: Share = Share(0.40),
     irpSensitivity: Coefficient = Coefficient(0.15),
     exRateAdjSpeed: Coefficient = Coefficient(0.02),
-    exportAutoBoost: Share = Share(0.15),
     // Capital flight (risk-off, carry trade)
     riskOffShockMonth: Int = 0,
     riskOffMagnitude: Share = Share(0.10),

--- a/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
@@ -166,9 +166,7 @@ object SimParams:
         initNbpGovBonds = PLN(300e9 * r),
         initConsumerLoans = PLN(200e9 * r),
       ),
-      forex = ForexConfig(
-        exportBase = PLN(55.4e9 * r),
-      ),
+      forex = ForexConfig(),
       openEcon = OpenEconConfig(
         exportBase = PLN(138.5e9 * r),
         euTransfers = PLN(1.458e9 * r),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
@@ -111,7 +111,7 @@ object DemandEconomics:
     * aggregate split when GVC sector exports are zero (init month).
     */
   private def computeSectorExports(in: Input)(using p: SimParams): Vector[PLN] =
-    if p.flags.gvc && p.flags.openEcon then
+    if p.flags.gvc then
       val gvcExports = in.w.external.gvc.sectorExports
       if gvcExports.exists(_ > PLN.Zero) then gvcExports
       else p.fiscal.fofExportShares.map(_ * in.w.forex.exports)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -170,7 +170,7 @@ object OpenEconEconomics:
 
     // 2. GVC trade
     val newGvc =
-      if p.flags.gvc && p.flags.openEcon then
+      if p.flags.gvc then
         GvcTrade.step(
           GvcTrade.StepInput(
             in.w.external.gvc,
@@ -185,37 +185,33 @@ object OpenEconEconomics:
       else in.w.external.gvc
 
     // 3. Forex / BoP
-    val (gvcExp, gvcImp) = if p.flags.gvc && p.flags.openEcon then (Some(newGvc.totalExports), Some(newGvc.sectorImports)) else (None, None)
+    val (gvcExp, gvcImp) = if p.flags.gvc then (Some(newGvc.totalExports), Some(newGvc.sectorImports)) else (None, None)
     val totalTechImp     = in.totalTechAndInvImports + in.investmentImports
 
-    val (forex, bop, valEffect, fxResult) = if p.flags.openEcon then
-      val oe = OpenEconomy.step(
-        OpenEconomy.StepInput(
-          prevBop = in.w.bop,
-          prevForex = in.w.forex,
-          importCons = in.importConsumption,
-          techImports = totalTechImp,
-          autoRatio = in.autoRatio,
-          domesticRate = in.w.nbp.referenceRate,
-          gdp = in.gdp,
-          priceLevel = in.w.priceLevel,
-          sectorOutputs = sectorOutputs,
-          month = in.month,
-          inflation = in.w.inflation,
-          nbpFxReserves = in.w.nbp.fxReserves,
-          gvcExports = gvcExp,
-          gvcIntermImports = gvcImp,
-          remittanceOutflow = in.remittanceOutflow,
-          euFundsMonthly = in.euMonthly,
-          diasporaInflow = in.diasporaInflow,
-          tourismExport = in.tourismExport,
-          tourismImport = in.tourismImport,
-        ),
-      )
-      (oe.forex, oe.bop, oe.valuationEffect, oe.fxIntervention)
-    else
-      val fx = OpenEconomy.updateForeign(in.w.forex, in.importConsumption, totalTechImp, in.autoRatio, in.w.nbp.referenceRate, in.gdp)
-      (fx, in.w.bop, PLN.Zero, Nbp.FxInterventionResult(0.0, PLN.Zero, in.w.nbp.fxReserves, PLN.Zero))
+    val oe                                = OpenEconomy.step(
+      OpenEconomy.StepInput(
+        prevBop = in.w.bop,
+        prevForex = in.w.forex,
+        importCons = in.importConsumption,
+        techImports = totalTechImp,
+        autoRatio = in.autoRatio,
+        domesticRate = in.w.nbp.referenceRate,
+        gdp = in.gdp,
+        priceLevel = in.w.priceLevel,
+        sectorOutputs = sectorOutputs,
+        month = in.month,
+        inflation = in.w.inflation,
+        nbpFxReserves = in.w.nbp.fxReserves,
+        gvcExports = gvcExp,
+        gvcIntermImports = gvcImp,
+        remittanceOutflow = in.remittanceOutflow,
+        euFundsMonthly = in.euMonthly,
+        diasporaInflow = in.diasporaInflow,
+        tourismExport = in.tourismExport,
+        tourismImport = in.tourismImport,
+      ),
+    )
+    val (forex, bop, valEffect, fxResult) = (oe.forex, oe.bop, oe.valuationEffect, oe.fxIntervention)
 
     // Adjust BoP for FDI and dividends
     val fdiCitLoss = in.profitShifting * p.fiscal.citRate
@@ -476,7 +472,7 @@ object OpenEconEconomics:
   @boundaryEscape
   private def runStepGvc(in: StepInput, sectorOutputs: Vector[PLN])(using p: SimParams): GvcTrade.State =
     import ComputationBoundary.toDouble
-    if p.flags.gvc && p.flags.openEcon then
+    if p.flags.gvc then
       GvcTrade.step(
         GvcTrade.StepInput(
           prev = in.w.external.gvc,
@@ -492,49 +488,38 @@ object OpenEconEconomics:
 
   private def runStepForex(in: StepInput, sectorOutputs: Vector[PLN], newGvc: GvcTrade.State)(using p: SimParams): ForexResult =
     val (gvcExp, gvcImp) =
-      if p.flags.gvc && p.flags.openEcon then (Some(newGvc.totalExports), Some(newGvc.sectorImports))
+      if p.flags.gvc then (Some(newGvc.totalExports), Some(newGvc.sectorImports))
       else (None, None)
 
     val totalTechAndInvImports = in.s5.sumTechImp + in.s7.investmentImports
-    if p.flags.openEcon then
-      val oeResult = OpenEconomy.step(
-        OpenEconomy.StepInput(
-          prevBop = in.w.bop,
-          prevForex = in.w.forex,
-          importCons = in.s3.importCons,
-          techImports = totalTechAndInvImports,
-          autoRatio = in.s7.autoR,
-          domesticRate = in.w.nbp.referenceRate,
-          gdp = in.s7.gdp,
-          inflation = in.w.inflation,
-          priceLevel = in.w.priceLevel,
-          sectorOutputs = sectorOutputs,
-          month = in.s1.m,
-          nbpFxReserves = in.w.nbp.fxReserves,
-          gvcExports = gvcExp,
-          gvcIntermImports = gvcImp,
-          remittanceOutflow = in.s6.remittanceOutflow,
-          euFundsMonthly = in.s7.euMonthly,
-          diasporaInflow = in.s6.diasporaInflow,
-          tourismExport = in.s6.tourismExport,
-          tourismImport = in.s6.tourismImport,
-        ),
-      )
-      ForexResult(oeResult.forex, oeResult.bop, oeResult.valuationEffect, oeResult.fxIntervention)
-    else
-      val fx = OpenEconomy.updateForeign(
-        in.w.forex,
-        in.s3.importCons,
-        totalTechAndInvImports,
-        in.s7.autoR,
-        in.w.nbp.referenceRate,
-        in.s7.gdp,
-      )
-      ForexResult(fx, in.w.bop, PLN.Zero, Nbp.FxInterventionResult(0.0, PLN.Zero, in.w.nbp.fxReserves, PLN.Zero))
+    val oeResult               = OpenEconomy.step(
+      OpenEconomy.StepInput(
+        prevBop = in.w.bop,
+        prevForex = in.w.forex,
+        importCons = in.s3.importCons,
+        techImports = totalTechAndInvImports,
+        autoRatio = in.s7.autoR,
+        domesticRate = in.w.nbp.referenceRate,
+        gdp = in.s7.gdp,
+        inflation = in.w.inflation,
+        priceLevel = in.w.priceLevel,
+        sectorOutputs = sectorOutputs,
+        month = in.s1.m,
+        nbpFxReserves = in.w.nbp.fxReserves,
+        gvcExports = gvcExp,
+        gvcIntermImports = gvcImp,
+        remittanceOutflow = in.s6.remittanceOutflow,
+        euFundsMonthly = in.s7.euMonthly,
+        diasporaInflow = in.s6.diasporaInflow,
+        tourismExport = in.s6.tourismExport,
+        tourismImport = in.s6.tourismImport,
+      ),
+    )
+    ForexResult(oeResult.forex, oeResult.bop, oeResult.valuationEffect, oeResult.fxIntervention)
 
   private def runStepAdjustBop(in: StepInput, bop0: OpenEconomy.BopState)(using p: SimParams): (OpenEconomy.BopState, PLN) =
     val bop1             =
-      if in.s7.foreignDividendOutflow > PLN.Zero && p.flags.openEcon then
+      if in.s7.foreignDividendOutflow > PLN.Zero then
         bop0.copy(
           currentAccount = bop0.currentAccount - in.s7.foreignDividendOutflow,
           nfa = bop0.nfa - in.s7.foreignDividendOutflow,
@@ -542,7 +527,7 @@ object OpenEconEconomics:
       else bop0
     val fdiTotalBopDebit = in.s5.sumProfitShifting + in.s5.sumFdiRepatriation
     val bop2             =
-      if fdiTotalBopDebit > PLN.Zero && p.flags.fdi && p.flags.openEcon then
+      if fdiTotalBopDebit > PLN.Zero && p.flags.fdi then
         bop1.copy(
           currentAccount = bop1.currentAccount - fdiTotalBopDebit,
           nfa = bop1.nfa - fdiTotalBopDebit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -75,29 +75,6 @@ object OpenEconomy:
   private val FdiNfaDampening      = 0.5
   private val ValuationPassThrough = 0.3
 
-  @boundaryEscape
-  def updateForeign(
-      prev: ForexState,
-      importConsumption: PLN,
-      techImports: PLN,
-      autoRatio: Share,
-      domesticRate: Rate,
-      gdp: PLN,
-  )(using p: SimParams): ForexState =
-    import ComputationBoundary.toDouble
-    val techComp  = 1.0 + toDouble(autoRatio) * toDouble(p.forex.exportAutoBoost)
-    val totalImp  = importConsumption + techImports
-    val exComp    = prev.exchangeRate / p.forex.baseExRate
-    val exports   = p.forex.exportBase * Multiplier(exComp * techComp)
-    val tradeBal  = exports - totalImp
-    val rateDiff  = toDouble(domesticRate - p.forex.foreignRate)
-    val capAcct   = PLN(toDouble(gdp) * rateDiff * toDouble(p.forex.irpSensitivity))
-    val bop       = tradeBal + capAcct
-    val bopRatio  = if gdp > PLN.Zero then bop / gdp else 0.0
-    val exRateChg = -toDouble(p.forex.exRateAdjSpeed) * bopRatio
-    val newRate   = Math.max(3.0, Math.min(8.0, prev.exchangeRate * (1.0 + exRateChg)))
-    ForexState(newRate, totalImp, exports, tradeBal, techImports)
-
   case class Result(
       forex: ForexState,
       bop: BopState,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/PriceLevel.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/PriceLevel.scala
@@ -46,9 +46,7 @@ object PriceLevel:
     val demandPull    = (demandMult - 1.0) * DemandPullWeight
     val costPush      = wageGrowth * CostPushWeight
     val rawImportPush = Math.max(0.0, exRateDeviation) * toDouble(p.forex.importPropensity) * ImportPushWeight
-    val importPush    =
-      if p.flags.openEcon then Math.min(rawImportPush, toDouble(p.openEcon.importPushCap))
-      else rawImportPush
+    val importPush    = Math.min(rawImportPush, toDouble(p.openEcon.importPushCap))
     val techDeflation = autoRatio * AutoDeflation + hybridRatio * HybridDeflation
 
     val rawMonthly = demandPull + costPush + importPush - techDeflation

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
@@ -40,8 +40,7 @@ object TaxRevenue:
     val exciseRevenue = in.consumption * weights.zip(excRates).map((w, r) => w * r).sum
 
     val customsDutyRevenue =
-      if p.flags.openEcon then in.totalImports * toDouble(p.fiscal.customsNonEuShare) * toDouble(p.fiscal.customsDutyRate)
-      else 0.0
+      in.totalImports * toDouble(p.fiscal.customsNonEuShare) * toDouble(p.fiscal.customsDutyRate)
 
     // Informal economy: aggregate tax evasion
     val effectiveShadowShare =

--- a/src/main/scala/com/boombustgroup/amorfati/init/GvcInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/GvcInit.scala
@@ -7,5 +7,5 @@ import com.boombustgroup.amorfati.engine.markets.GvcTrade
 object GvcInit:
 
   def create()(using p: SimParams): GvcTrade.State =
-    if p.flags.gvc && p.flags.openEcon then GvcTrade.initial
+    if p.flags.gvc then GvcTrade.initial
     else GvcTrade.zero

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -84,7 +84,7 @@ object WorldInit:
       forex = OpenEconomy.ForexState(
         exchangeRate = p.forex.baseExRate,
         imports = PLN.Zero,
-        exports = if p.flags.openEcon then p.openEcon.exportBase else p.forex.exportBase,
+        exports = p.openEcon.exportBase,
         tradeBalance = PLN.Zero,
         techImports = PLN.Zero,
       ),

--- a/src/test/scala/com/boombustgroup/amorfati/config/SimParamsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/SimParamsSpec.scala
@@ -54,10 +54,6 @@ class SimParamsSpec extends AnyFlatSpec with Matchers:
 
   // ── External sector sub-configs ──
 
-  "ForexConfig" should "have gdpRatio-scaled exportBase" in {
-    td.toDouble(p.forex.exportBase) shouldBe (55.4e9 * p.gdpRatio) +- 1.0
-  }
-
   "OpenEconConfig" should "have gdpRatio-scaled values" in {
     td.toDouble(p.openEcon.exportBase) shouldBe (138.5e9 * p.gdpRatio) +- 1.0
     td.toDouble(p.openEcon.euTransfers) shouldBe (1.458e9 * p.gdpRatio) +- 1.0
@@ -93,7 +89,6 @@ class SimParamsSpec extends AnyFlatSpec with Matchers:
 
   "Config delegation" should "match SimParams for all key external paths" in {
     p.forex.baseExRate shouldBe p.forex.baseExRate
-    td.toDouble(p.forex.exportBase) shouldBe td.toDouble(p.forex.exportBase)
     td.toDouble(p.openEcon.exportBase) shouldBe td.toDouble(p.openEcon.exportBase)
     td.toDouble(p.gvc.euTradeShare) shouldBe td.toDouble(p.gvc.euTradeShare)
     p.fdi.foreignShares.map(s => td.toDouble(s)) shouldBe p.fdi.foreignShares.map(s => td.toDouble(s))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
@@ -141,7 +141,7 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
 
   "secondaryIncome" should "include diasporaInflow as credit" in {
     val prevBop   = OpenEconomy.BopState.zero
-    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN(td.toDouble(p.forex.exportBase)), PLN.Zero, PLN.Zero)
+    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.openEcon.exportBase, PLN.Zero, PLN.Zero)
 
     val base          = OpenEconomy.StepInput(
       prevBop = prevBop,
@@ -163,7 +163,7 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
 
   it should "net outflow and inflow" in {
     val prevBop   = OpenEconomy.BopState.zero
-    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN(td.toDouble(p.forex.exportBase)), PLN.Zero, PLN.Zero)
+    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.openEcon.exportBase, PLN.Zero, PLN.Zero)
 
     val base   = OpenEconomy.StepInput(
       prevBop = prevBop,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExciseCustomsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExciseCustomsSpec.scala
@@ -38,16 +38,6 @@ class ExciseCustomsSpec extends AnyFlatSpec with Matchers:
     td.toDouble(p.fiscal.customsNonEuShare) should be <= 1.0
   }
 
-  "Customs revenue" should "be zero when OPEN_ECON=false" in {
-    // When OeEnabled is false, customs duty = 0 regardless of imports
-    if !p.flags.openEcon then
-      val imports = 1000000.0
-      val customs =
-        if p.flags.openEcon then imports * td.toDouble(p.fiscal.customsNonEuShare) * td.toDouble(p.fiscal.customsDutyRate)
-        else 0.0
-      customs shouldBe 0.0
-  }
-
   "Excise" should "always be positive for positive consumption" in {
     val consumption = 1000000.0
     val excise      = consumption * p.fiscal.fofConsWeights

--- a/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
@@ -12,7 +12,7 @@ class OpenEconomySpec extends AnyFlatSpec with Matchers:
   private val p: SimParams = summon[SimParams]
   private val td           = ComputationBoundary
 
-  private val baseForex         = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.forex.exportBase, PLN.Zero, PLN.Zero)
+  private val baseForex         = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.openEcon.exportBase, PLN.Zero, PLN.Zero)
   private val baseSectorOutputs = Vector(30000.0, 160000.0, 450000.0, 60000.0, 220000.0, 80000.0).map(PLN(_))
   private val gdp               = PLN(1e9)
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.boombustgroup.amorfati.Generators.*
 import com.boombustgroup.amorfati.agents.Nbp
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, LaborMarket, OpenEconomy, PriceLevel}
+import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, LaborMarket, PriceLevel}
 import com.boombustgroup.amorfati.types.*
 
 class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks:
@@ -141,14 +141,4 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       val govWithRemit                      = FiscalBudget.update(base.copy(nbpRemittance = PLN(nbpRemit)))
       // nbpRemittance reduces deficit
       td.toDouble(govWithRemit.deficit) shouldBe (td.toDouble(govNoRemit.deficit) - nbpRemit +- 1.0)
-    }
-
-  // --- updateForeign properties ---
-
-  "updateForeign" should "keep exchange rate in [3.0, 8.0]" in
-    forAll(genForexState, Gen.choose(0.0, 1e8), Gen.choose(0.0, 1e7), genFraction, genRate, Gen.choose(1e6, 1e10)) {
-      (prev: OpenEconomy.ForexState, importCons: Double, techImp: Double, autoR: Double, rate: Double, gdp: Double) =>
-        val fx = OpenEconomy.updateForeign(prev, PLN(importCons), PLN(techImp), Share(autoR), Rate(rate), PLN(gdp))
-        fx.exchangeRate should be >= 3.0
-        fx.exchangeRate should be <= 8.0
     }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
@@ -195,7 +195,7 @@ class TourismSpec extends AnyFlatSpec with Matchers:
 
   "OpenEconomy exports" should "include tourismExport" in {
     val prevBop   = OpenEconomy.BopState.zero
-    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN(td.toDouble(p.forex.exportBase)), PLN.Zero, PLN.Zero)
+    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.openEcon.exportBase, PLN.Zero, PLN.Zero)
 
     val base          = OpenEconomy.StepInput(
       prevBop = prevBop,
@@ -217,7 +217,7 @@ class TourismSpec extends AnyFlatSpec with Matchers:
 
   "OpenEconomy imports" should "include tourismImport" in {
     val prevBop   = OpenEconomy.BopState.zero
-    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN(td.toDouble(p.forex.exportBase)), PLN.Zero, PLN.Zero)
+    val prevForex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, p.openEcon.exportBase, PLN.Zero, PLN.Zero)
 
     val base          = OpenEconomy.StepInput(
       prevBop = prevBop,


### PR DESCRIPTION
## Summary
- Delete `openEcon` feature flag from `FeatureFlags` — open economy is always on
- Delete `updateForeign()` legacy path that used `forex.exportBase` (55.4e9) instead of `openEcon.exportBase` (138.5e9), causing FX rate to see 2.5× lower export volume
- Remove `exportBase` and `exportAutoBoost` from `ForexConfig` (dead after `updateForeign` removal)
- Simplify all `flags.gvc && flags.openEcon` → `flags.gvc`
- Remove unconditional wrappers in PriceLevel, TaxRevenue, WorldInit
- Clean up 6 test files (remove dead tests, fix fixture export bases)

Net: -147 lines, +70 lines across 16 files. No behavioral change — `openEcon` defaulted to `true`.

Fixes #107

## Test plan
- [x] `sbt test` — all tests pass (unused import fix included)
- [x] `sbt assembly && java -jar target/scala-3.8.2/amor-fati.jar 10 test-tolerance` — Monte Carlo stable