### PR TITLE
Remove direct technology deflation from CPI block

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -14,8 +14,6 @@ object InflationProbe:
   private val DemandPullWeight = 0.15
   private val CostPushWeight   = 0.25
   private val ImportPushWeight = 0.25
-  private val AutoDeflation    = 0.060
-  private val HybridDeflation  = 0.018
   private val DeflationFloor   = -0.015
   private val FloorPassThrough = 0.3
   private val SmoothingLambda  = 0.3
@@ -126,8 +124,7 @@ object InflationProbe:
       val costPushM     = toDouble(s2.wageGrowth) * CostPushWeight
       val rawImportPush = Math.max(0.0, exDev) * toDouble(summon[SimParams].forex.importPropensity) * ImportPushWeight
       val importPushM   = Math.min(rawImportPush, toDouble(summon[SimParams].openEcon.importPushCap))
-      val techDeflM     = toDouble(s7.autoR) * AutoDeflation + toDouble(s7.hybR) * HybridDeflation
-      val rawMonthly    = demandPullM + costPushM + importPushM - techDeflM
+      val rawMonthly    = demandPullM + costPushM + importPushM
       val flooredM      = softFloor(rawMonthly)
       val baseAnnual    = toDouble(world.inflation) * (1.0 - SmoothingLambda) + (flooredM * 12.0) * SmoothingLambda
       val totalInfl     = toDouble(s7.newInfl)
@@ -153,7 +150,7 @@ object InflationProbe:
         f"m=$month%2d u=${unemp * 100.0}%.2f%% pi=${totalInfl * 100.0}%.2f%% wage=${toDouble(s2.newWage)}%.0f wg=${toDouble(s2.wageGrowth) * 100.0}%.2f%% demand=${s4.avgDemandMult}%.3f markup=${markupAnnual * 100.0}%.2f%%",
       )
       println(
-        f"  channels monthly: demand=${demandPullM * 100.0}%.2fpp cost=${costPushM * 100.0}%.2fpp import=${importPushM * 100.0}%.2fpp tech=-${techDeflM * 100.0}%.2fpp raw=${rawMonthly * 100.0}%.2fpp floor=${flooredM * 100.0}%.2fpp",
+        f"  channels monthly: demand=${demandPullM * 100.0}%.2fpp cost=${costPushM * 100.0}%.2fpp import=${importPushM * 100.0}%.2fpp raw=${rawMonthly * 100.0}%.2fpp floor=${flooredM * 100.0}%.2fpp",
       )
       println(
         f"  annualized: base=${baseAnnual * 100.0}%.2f%% markup=${markupAnnual * 100.0}%.2f%% total=${totalInfl * 100.0}%.2f%% exDev=${exDev * 100.0}%.2f%% importCost=${toDouble(world.external.gvc.importCostIndex)}%.3f commodity=${toDouble(world.external.gvc.commodityPriceIndex)}%.3f",

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -74,7 +74,7 @@ equilibrium prices, quantities, or flows given current state.
 | File | Domain |
 |------|--------|
 | `LaborMarket.scala` | Wage Phillips curve, worker separations, job search with sectoral priority |
-| `PriceLevel.scala` | Inflation: demand-pull + cost-push + import pass-through − tech deflation, soft floor |
+| `PriceLevel.scala` | Inflation: demand-pull + cost-push + import pass-through, soft floor |
 | `CalvoPricing.scala` | Calvo staggered pricing: per-firm markup lottery (θ=15%), endogenous markup, sticky prices |
 | `OpenEconomy.scala` | BoP, floating exchange rate, trade balance, capital account, NFA |
 | `FiscalBudget.scala` | Government budget: revenue (CIT/VAT/excise/customs), spending, deficit, bond issuance |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -278,8 +278,6 @@ object PriceEquityEconomics:
       in.avgDemandMult,
       toDouble(in.wageGrowth),
       exDev,
-      autoR,
-      hybR,
     )
     // Calvo markup contribution (already annualized Rate from FirmProcessingStep)
     val newInfl  = toDouble(priceUpd.inflation + in.s5.markupInflation)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/PriceLevel.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/PriceLevel.scala
@@ -5,9 +5,9 @@ import com.boombustgroup.amorfati.types.*
 
 /** Aggregate price level: Phillips-curve-style monthly inflation update.
   *
-  * Four channels: demand-pull (output gap proxy via demandMult), cost-push
-  * (wage growth pass-through), import push (exchange rate deviation × import
-  * propensity), and tech deflation (automation + hybrid digitalization).
+  * Three channels: demand-pull (output gap proxy via demandMult), cost-push
+  * (wage growth pass-through), and import push (exchange rate deviation ×
+  * import propensity).
   *
   * A soft floor at −1.5%/month with 30% pass-through approximates downward
   * nominal rigidity (cf. Bewley 1999). These are calibration choices, not
@@ -22,8 +22,6 @@ object PriceLevel:
   private val DemandPullWeight = 0.15   // sensitivity of inflation to demand gap
   private val CostPushWeight   = 0.25   // wage growth pass-through to prices
   private val ImportPushWeight = 0.25   // FX depreciation pass-through
-  private val AutoDeflation    = 0.060  // monthly tech deflation per unit automation ratio
-  private val HybridDeflation  = 0.018  // monthly tech deflation per unit hybrid ratio
   private val DeflationFloor   = -0.015 // soft floor: −1.5%/month
   private val FloorPassThrough = 0.3    // beyond floor, 30% pass-through
   private val SmoothingLambda  = 0.3    // EWM weight on new observation
@@ -39,17 +37,14 @@ object PriceLevel:
       demandMult: Double,
       wageGrowth: Double,
       exRateDeviation: Double,
-      autoRatio: Double,
-      hybridRatio: Double,
   )(using p: SimParams): Result =
     import ComputationBoundary.toDouble
     val demandPull    = (demandMult - 1.0) * DemandPullWeight
     val costPush      = wageGrowth * CostPushWeight
     val rawImportPush = Math.max(0.0, exRateDeviation) * toDouble(p.forex.importPropensity) * ImportPushWeight
     val importPush    = Math.min(rawImportPush, toDouble(p.openEcon.importPushCap))
-    val techDeflation = autoRatio * AutoDeflation + hybridRatio * HybridDeflation
 
-    val rawMonthly = demandPull + costPush + importPush - techDeflation
+    val rawMonthly = demandPull + costPush + importPush
     val monthly    = softFloor(rawMonthly)
     val annualized = monthly * 12.0
     val smoothed   = toDouble(prevInflation) * (1.0 - SmoothingLambda) + annualized * SmoothingLambda

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
@@ -65,22 +65,22 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
 
   "updateInflation" should "keep price >= 0.30 floor" in
     forAll(genInflInputs) { (inputs: (Double, Double, Double, Double, Double, Double, Double)) =>
-      val (prevInfl, prevPrice, demandMult, wageGrowth, exRateDev, autoR, hybR) = inputs
-      val r                                                                     = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, exRateDev, autoR, hybR)
+      val (prevInfl, prevPrice, demandMult, wageGrowth, exRateDev, _, _) = inputs
+      val r                                                              = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, exRateDev)
       r.priceLevel should be >= 0.30
     }
 
   it should "apply soft deflation floor (price >= 0.30)" in {
-    val r = PriceLevel.update(Rate(-0.30), 1.0, 0.5, -0.10, 0.0, 0.80, 0.15)
+    val r = PriceLevel.update(Rate(-0.30), 1.0, 0.5, -0.10, 0.0)
     r.priceLevel should be >= 0.30
   }
 
-  it should "produce lower inflation with more automation" in
-    forAll(genInflation, genPrice, Gen.choose(0.8, 1.2), Gen.choose(-0.02, 0.02)) {
-      (prevInfl: Double, prevPrice: Double, demandMult: Double, wageGrowth: Double) =>
-        val r1 = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, 0.0, 0.05, 0.0)
-        val r2 = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, 0.0, 0.50, 0.0)
-        td.toDouble(r2.inflation) should be <= (td.toDouble(r1.inflation) + 1e-10)
+  it should "produce higher inflation with more import pressure" in
+    forAll(genInflation, genPrice, Gen.choose(0.8, 1.2), Gen.choose(-0.02, 0.02), Gen.choose(0.0, 0.15), Gen.choose(0.16, 0.40)) {
+      (prevInfl: Double, prevPrice: Double, demandMult: Double, wageGrowth: Double, exLow: Double, exHigh: Double) =>
+        val r1 = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, exLow)
+        val r2 = PriceLevel.update(Rate(prevInfl), prevPrice, demandMult, wageGrowth, exHigh)
+        td.toDouble(r2.inflation) should be >= (td.toDouble(r1.inflation) - 1e-10)
     }
 
   // --- updateLaborMarket properties ---

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
@@ -31,25 +31,24 @@ class SimulationSpec extends AnyFlatSpec with Matchers:
   // --- updateInflation ---
 
   "PriceLevel.update" should "produce higher inflation with higher demand" in {
-    val r1 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.0, 0.0, 0.0)
-    val r2 = PriceLevel.update(Rate(0.02), 1.0, 1.5, 0.0, 0.0, 0.0, 0.0)
+    val r1 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.0)
+    val r2 = PriceLevel.update(Rate(0.02), 1.0, 1.5, 0.0, 0.0)
     r2.inflation should be > r1.inflation
   }
 
-  it should "produce tech deflation with more automation" in {
-    val r1 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.0, 0.0, 0.0)
-    val r2 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.0, 0.8, 0.0)
-    r2.inflation should be < r1.inflation
+  it should "produce higher inflation with FX import pressure" in {
+    val r1 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.0)
+    val r2 = PriceLevel.update(Rate(0.02), 1.0, 1.0, 0.0, 0.2)
+    r2.inflation should be > r1.inflation
   }
 
   it should "enforce price floor at 0.30" in {
-    val r = PriceLevel.update(Rate(-0.50), 0.31, 0.5, -0.1, 0.0, 0.9, 0.0)
+    val r = PriceLevel.update(Rate(-0.50), 0.31, 0.5, -0.1, 0.0)
     r.priceLevel should be >= 0.30
   }
 
   it should "apply soft deflation floor at -1.5%/mo" in {
-    // Strong deflation scenario: heavy automation, no demand, negative wage growth
-    val r = PriceLevel.update(Rate(-0.10), 1.0, 0.5, -0.05, 0.0, 0.9, 0.0)
+    val r = PriceLevel.update(Rate(-0.10), 1.0, 0.5, -0.05, 0.0)
     // The soft floor means deflation doesn't accelerate as fast
     // Raw monthly would be very negative; with floor, annualized should be bounded
     td.toDouble(r.inflation) should be > -1.0 // deflation shouldn't exceed 100% annualized


### PR DESCRIPTION
## Summary

This PR removes direct technology deflation from the aggregate CPI block.

The price block now models inflation from:

- demand pull
- cost push
- import push

and no longer subtracts a direct `techDeflation` term from `PriceLevel`.

## Why

This is the first structural step under #183.

The previous design treated automation / hybrid adoption as a persistent direct drag on CPI, which made the nominal block harder to reason about and introduced an architectural deflation bias in baseline runs.

This PR is intentionally scoped as a cleanup of the CPI block only.
It does not attempt to solve the full nominal-instability problem by itself.

## Changes

- remove direct `techDeflation` from `PriceLevel`
- update the `PriceEquityEconomics` call site to the narrower CPI interface
- update `InflationProbe` channel decomposition
- update engine docs
- update `SimulationSpec` and `SimulationPropertySpec`

## Verification

- `sbt scalafmtAll`
- `sbt 'testOnly *SimulationSpec*'`
- `sbt 'testOnly *SimulationPropertySpec*'`

Fixes #183
