### PR TITLE
Anchor inflation expectations under disinflation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/Expectations.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/Expectations.scala
@@ -19,9 +19,12 @@ import com.boombustgroup.amorfati.types.*
 object Expectations:
 
   // ---- Calibration constants ----
-  private val MinCredibility = 0.01 // floor on credibility index
-  private val OutputGapClamp = 0.05 // ±5 pp unemployment gap clamp
-  private val FgBlendWeight  = 0.6  // weight on forward guidance in expected rate
+  private val MinCredibility             = 0.01 // floor on credibility index
+  private val OutputGapClamp             = 0.05 // ±5 pp unemployment gap clamp
+  private val FgBlendWeight              = 0.6  // weight on forward guidance in expected rate
+  private val UndershootLearningWeight   = 0.35 // below-target inflation updates expectations more slowly
+  private val UndershootCredibilityScale = 0.35 // below-target inflation erodes credibility less than overshooting
+  private val MaxTargetUndershoot        = 0.03 // expectations can drift at most 3pp below target at zero credibility
 
   case class State(
       expectedInflation: Rate,  // πᵉ: anchored inflation expectation
@@ -45,18 +48,20 @@ object Expectations:
   @boundaryEscape
   def step(prev: State, realizedInflation: Double, currentRate: Double, unemployment: Double)(using p: SimParams): State =
     import ComputationBoundary.toDouble
-    val target = toDouble(p.monetary.targetInfl)
-    val lambda = toDouble(p.labor.expLambda)
+    val target          = toDouble(p.monetary.targetInfl)
+    val lambda          = toDouble(p.labor.expLambda)
+    val prevCredibility = toDouble(prev.credibility)
 
     // Adaptive learning: πᵉ_adaptive = πᵉₜ₋₁ + λ(πₜ − πᵉₜ₋₁)
-    val error    = realizedInflation - toDouble(prev.expectedInflation)
-    val adaptive = toDouble(prev.expectedInflation) + lambda * error
+    val error          = realizedInflation - toDouble(prev.expectedInflation)
+    val learningWeight = if realizedInflation < target then UndershootLearningWeight else 1.0
+    val adaptive       = toDouble(prev.expectedInflation) + lambda * learningWeight * error
 
     // Anchoring: blend target with adaptive based on credibility
-    val cred     = toDouble(prev.credibility)
-    val expected = cred * target + (1.0 - cred) * adaptive
+    val anchored = prevCredibility * target + (1.0 - prevCredibility) * adaptive
+    val expected = lowerAnchor(anchored, target, prevCredibility)
 
-    val newCred = updateCredibility(cred, realizedInflation, target)
+    val newCred = updateCredibility(prevCredibility, realizedInflation, target)
     val fgRate  = forwardGuidance(expected, target, unemployment, currentRate)
 
     // Expected rate: adaptive learning on policy rate, blended with FG when enabled
@@ -84,8 +89,18 @@ object Expectations:
     val speed        = toDouble(p.labor.expCredibilitySpeed)
     val raw          =
       if absDeviation <= threshold then cred + speed * (1.0 - cred) * (threshold - absDeviation) / threshold
-      else cred - speed * cred * (absDeviation - threshold) / threshold
+      else
+        val erosionScale = if realizedInflation < target then UndershootCredibilityScale else 1.0
+        cred - speed * cred * erosionScale * (absDeviation - threshold) / threshold
     Math.max(MinCredibility, Math.min(1.0, raw))
+
+  /** Keep disinflationary episodes from fully de-anchoring expectations in the
+    * baseline regime. Low credibility can pull expectations below target, but
+    * only within a bounded undershoot band.
+    */
+  private def lowerAnchor(expected: Double, target: Double, credibility: Double): Double =
+    val lowerBound = target - (1.0 - credibility) * MaxTargetUndershoot
+    Math.max(lowerBound, expected)
 
   /** Taylor-rule forward guidance: r_fg = r* + α(πᵉ − π*) − δ·gap. */
   @boundaryEscape

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExpectationsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExpectationsSpec.scala
@@ -53,6 +53,18 @@ class ExpectationsSpec extends AnyFlatSpec with Matchers:
     td.toDouble(r.expectedInflation) should be > 0.06
   }
 
+  it should "keep expected inflation meaningfully anchored under deflation when credibility is high" in {
+    val prev = Expectations.initial.copy(credibility = Share(0.90))
+    val r    = Expectations.step(prev, -0.10, 0.0100, 0.10)
+    td.toDouble(r.expectedInflation) should be > 0.015
+  }
+
+  it should "bound downward de-anchoring even when credibility is low" in {
+    val prev = Expectations.initial.copy(credibility = Share(0.05), expectedInflation = Rate(0.01))
+    val r    = Expectations.step(prev, -0.20, 0.0100, 0.12)
+    td.toDouble(r.expectedInflation) should be >= -0.005
+  }
+
   // --- Credibility dynamics ---
 
   it should "build credibility when inflation is near target" in {
@@ -66,6 +78,15 @@ class ExpectationsSpec extends AnyFlatSpec with Matchers:
     // 10% inflation -> well above 2pp threshold
     val r    = Expectations.step(prev, 0.10, 0.0575, 0.05)
     td.toDouble(r.credibility) should be < 0.8
+  }
+
+  it should "erode credibility less under equal undershooting than overshooting" in {
+    val prev          = Expectations.initial.copy(credibility = Share(0.8))
+    val target        = td.toDouble(p.monetary.targetInfl)
+    val sameDeviation = 0.05
+    val low           = Expectations.step(prev, target - sameDeviation, 0.0575, 0.08)
+    val high          = Expectations.step(prev, target + sameDeviation, 0.0575, 0.05)
+    td.toDouble(low.credibility) should be > td.toDouble(high.credibility)
   }
 
   it should "bound credibility in [0.01, 1.0]" in {
@@ -113,4 +134,10 @@ class ExpectationsSpec extends AnyFlatSpec with Matchers:
     td.toDouble(s.credibility) should be > 0.9
     td.toDouble(s.expectedInflation) shouldBe td.toDouble(p.monetary.targetInfl) +- 0.005
     td.toDouble(s.forecastError) shouldBe 0.0 +- 0.005
+  }
+
+  it should "avoid free-fall expected inflation under repeated deflation" in {
+    var s = Expectations.initial.copy(credibility = Share(0.2))
+    for _ <- 0 until 24 do s = Expectations.step(s, -0.10, 0.0100, 0.12)
+    td.toDouble(s.expectedInflation) should be >= -0.005
   }


### PR DESCRIPTION
## Summary

This PR redesigns the inflation expectations block so that baseline disinflation does not mechanically de-anchor expectations into deep negative territory.

## Why

Issue #184 is about the expectations layer, not the whole nominal system.

After #183, the model still showed a severe nominal instability pattern, but the expectations block remained a clear amplifier:

- realized inflation fell
- adaptive expectations followed it downward too easily
- credibility erosion weakened the target anchor
- `expectedInflation` could free-fall into strongly negative values

This PR makes that behavior more resistant to ordinary disinflation while keeping expectations adaptive and target-aware.

## Changes

- slow adaptive learning under below-target inflation
- erode credibility less under undershooting than under symmetric overshooting
- add a lower anchor so `expectedInflation` cannot drift arbitrarily far below target in baseline mode
- extend `ExpectationsSpec` with semantic tests for undershooting / bounded de-anchoring behavior

## Verification

- `sbt scalafmtAll`
- `sbt 'testOnly *ExpectationsSpec*'`

## Notes

This PR does not claim to solve the full nominal-instability problem on its own.
It addresses the expectations amplifier specifically.

In the follow-up `1 seed / 24m` diagnostic run:

- realized inflation at `m24` remained strongly negative
- but `expectedInflation` no longer free-fell with it

That is the intended scope of this change.

Fixes #184
