### PR TITLE
Base dividend distributions on realized profits

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -318,8 +318,7 @@ object PriceEquityEconomics:
     val dividends              =
       if p.flags.gpw && p.flags.gpwDividends then
         EquityMarket.computeDividends(
-          equityAfterIssuance.dividendYield,
-          equityAfterIssuance.marketCap,
+          PLN(firmProfits),
           equityAfterIssuance.foreignOwnership,
         )
       else EquityMarket.DividendResultZero

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
@@ -144,15 +144,16 @@ object EquityMarket:
 
   val DividendResultZero: DividendResult = DividendResult(PLN.Zero, PLN.Zero, PLN.Zero)
 
-  /** Compute dividends from market cap and yields. */
+  /** Compute cash dividends from realized profits, not directly from market
+    * valuation.
+    */
   def computeDividends(
-      divYield: Rate,
-      marketCap: PLN,
+      realizedProfits: PLN,
       foreignShare: Share,
   )(using p: SimParams): DividendResult =
-    if marketCap <= PLN.Zero then DividendResultZero
+    if realizedProfits <= PLN.Zero then DividendResultZero
     else
-      val totalDividends   = marketCap * divYield.monthly
+      val totalDividends   = realizedProfits * Share(PayoutRatio)
       val foreignDividends = totalDividends * foreignShare
       val domesticGross    = totalDividends - foreignDividends
       val dividendTax      = domesticGross * p.equity.divTax

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
@@ -57,19 +57,19 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
   // --- computeDividends properties ---
 
   "EquityMarket.computeDividends" should "have non-negative outputs for positive inputs" in
-    forAll(Gen.choose(0.01, 0.15), Gen.choose(1e6, 1e13), genFraction) { (divYield, mcap, foreignShare) =>
-      val r = EquityMarket.computeDividends(Rate(divYield), PLN(mcap), Share(foreignShare))
+    forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
+      val r = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
       r.netDomestic should be >= PLN.Zero
       r.foreign should be >= PLN.Zero
       r.tax should be >= PLN.Zero
     }
 
-  it should "have domestic + foreign + tax approx total dividends" in
-    forAll(Gen.choose(0.01, 0.15), Gen.choose(1e6, 1e13), Gen.choose(0.0, 1.0)) { (divYield, mcap, foreignShare) =>
-      whenever(divYield >= 0.005 && foreignShare >= 0.0) {
-        val r             = EquityMarket.computeDividends(Rate(divYield), PLN(mcap), Share(foreignShare))
-        val expectedTotal = divYield * mcap / 12.0
-        val tol           = Math.max(1.0, mcap * 0.0001) // fixed-point /12 rounding: up to mcap/Scale error
+  it should "have domestic + foreign + tax approx payout-scaled profits" in
+    forAll(Gen.choose(1e6, 1e13), Gen.choose(0.0, 1.0)) { (profits, foreignShare) =>
+      whenever(foreignShare >= 0.0) {
+        val r             = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+        val expectedTotal = profits * 0.57
+        val tol           = Math.max(1.0, profits * 0.0001)
         td.toDouble(r.netDomestic + r.tax + r.foreign) shouldBe (expectedTotal +- tol)
       }
     }
@@ -77,27 +77,25 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
   // --- Additional dividend properties ---
 
   it should "have foreign dividends <= total dividends" in
-    forAll(Gen.choose(0.01, 0.15), Gen.choose(1e6, 1e13), genFraction) { (divYield, mcap, foreignShare) =>
-      whenever(divYield >= 0.005) {
-        val r     = EquityMarket.computeDividends(Rate(divYield), PLN(mcap), Share(foreignShare))
-        val total = divYield * mcap / 12.0
-        val tol   = Math.max(1.0, mcap * 0.0001)
-        td.toDouble(r.foreign) should be <= (total + tol)
-      }
+    forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
+      val r     = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val total = profits * 0.57
+      val tol   = Math.max(1.0, profits * 0.0001)
+      td.toDouble(r.foreign) should be <= (total + tol)
     }
 
   it should "have dividend tax <= domestic gross" in
-    forAll(Gen.choose(0.01, 0.15), Gen.choose(1e6, 1e13), genFraction) { (divYield, mcap, foreignShare) =>
-      val r        = EquityMarket.computeDividends(Rate(divYield), PLN(mcap), Share(foreignShare))
-      val total    = divYield * mcap / 12.0
+    forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
+      val r        = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val total    = profits * 0.57
       val domGross = total * (1.0 - foreignShare)
       td.toDouble(r.tax) should be <= (domGross + 1.0)
     }
 
-  it should "scale dividends linearly with market cap" in
-    forAll(Gen.choose(1e6, 1e12), Gen.choose(0.01, 0.15), genFraction) { (mcap, divYield, foreignShare) =>
-      val r1 = EquityMarket.computeDividends(Rate(divYield), PLN(mcap), Share(foreignShare))
-      val r2 = EquityMarket.computeDividends(Rate(divYield), PLN(mcap * 2.0), Share(foreignShare))
+  it should "scale dividends linearly with realized profits" in
+    forAll(Gen.choose(1e6, 1e12), genFraction) { (profits, foreignShare) =>
+      val r1 = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val r2 = EquityMarket.computeDividends(PLN(profits * 2.0), Share(foreignShare))
       whenever(r1.netDomestic > PLN(1e-6) && r1.foreign > PLN(1e-6) && r1.tax > PLN(1e-6)) {
         (td.toDouble(r2.netDomestic) / td.toDouble(r1.netDomestic)) shouldBe (2.0 +- 1e-6)
         (td.toDouble(r2.foreign) / td.toDouble(r1.foreign)) shouldBe (2.0 +- 1e-6)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
@@ -65,17 +65,16 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
     result.lastIssuance shouldBe PLN(5e8)
   }
 
-  "EquityMarket.computeDividends" should "return zeros for zero market cap" in {
-    val r = EquityMarket.computeDividends(Rate(0.057), PLN.Zero, Share(0.67))
+  "EquityMarket.computeDividends" should "return zeros for zero realized profits" in {
+    val r = EquityMarket.computeDividends(PLN.Zero, Share(0.67))
     r shouldBe EquityMarket.DividendResultZero
   }
 
-  "EquityMarket.computeDividends" should "compute correct split for given parameters" in {
-    val mcap             = PLN(1e12)
-    val divYield         = Rate(0.057)
+  "EquityMarket.computeDividends" should "compute correct split from realized profits and payout ratio" in {
+    val profits          = PLN(1e12)
     val foreignShare     = Share(0.67)
-    val r                = EquityMarket.computeDividends(divYield, mcap, foreignShare)
-    val expectedTotal    = 0.057 * 1e12 / 12.0
+    val r                = EquityMarket.computeDividends(profits, foreignShare)
+    val expectedTotal    = 1e12 * 0.57
     val expectedForeign  = expectedTotal * 0.67
     val expectedDomGross = expectedTotal - expectedForeign
     val expectedTax      = expectedDomGross * td.toDouble(p.equity.divTax)
@@ -87,33 +86,39 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return no foreign dividends when foreign share is zero" in {
-    val r           = EquityMarket.computeDividends(Rate(0.057), PLN(1e12), Share.Zero)
+    val r           = EquityMarket.computeDividends(PLN(1e12), Share.Zero)
     r.foreign shouldBe PLN.Zero
-    val total       = 0.057 * 1e12 / 12.0
+    val total       = 1e12 * 0.57
     val expectedTax = total * td.toDouble(p.equity.divTax)
     td.toDouble(r.netDomestic) shouldBe (total - expectedTax +- 1e8)
     td.toDouble(r.tax) shouldBe (expectedTax +- 1e8)
   }
 
   it should "return no domestic dividends when foreign share is 1.0" in {
-    val r     = EquityMarket.computeDividends(Rate(0.057), PLN(1e12), Share.One)
+    val r     = EquityMarket.computeDividends(PLN(1e12), Share.One)
     r.netDomestic shouldBe PLN.Zero
     r.tax shouldBe PLN.Zero
-    val total = 0.057 * 1e12 / 12.0
+    val total = 1e12 * 0.57
     td.toDouble(r.foreign) shouldBe (total +- 1e8)
   }
 
   it should "apply Belka tax rate correctly" in {
-    val mcap     = PLN(1e12)
-    val r        = EquityMarket.computeDividends(Rate(0.06), mcap, Share(0.50))
-    val total    = 0.06 * 1e12 / 12.0
+    val profits  = PLN(1e12)
+    val r        = EquityMarket.computeDividends(profits, Share(0.50))
+    val total    = 1e12 * 0.57
     val domGross = total * 0.50
     td.toDouble(r.tax) shouldBe (domGross * 0.19 +- 1.0)
     td.toDouble(r.netDomestic) shouldBe (domGross * 0.81 +- 1.0)
   }
 
-  it should "compute dividends based on market cap, not firm profits" in {
-    // firmProfits param was removed -- dividends depend only on divYield x marketCap
-    val r = EquityMarket.computeDividends(Rate(0.057), PLN(1e12), Share(0.67))
+  it should "compute dividends based on realized profits" in {
+    val r = EquityMarket.computeDividends(PLN(1e12), Share(0.67))
     r.netDomestic should be > PLN.Zero
+  }
+
+  it should "not depend on market valuation directly" in {
+    val lowProfits  = EquityMarket.computeDividends(PLN(1e9), Share(0.67))
+    val highProfits = EquityMarket.computeDividends(PLN(1e12), Share(0.67))
+
+    highProfits.tax should be > lowProfits.tax
   }


### PR DESCRIPTION
## Summary
- base cash dividend distributions on realized firm profits instead of equity valuation
- keep dividend tax tied to distributed domestic dividends rather than market cap-driven yield mechanics
- update equity tests to reflect payout-from-profits semantics

## Verification
- sbt 'testOnly *EquityMarketSpec* *EquityMarketPropertySpec* *PriceEquityEconomicsSpec*'
- sbt 'runMain com.boombustgroup.amorfati.diagnostics.runInflationProbe 1 14'

Fixes #193