### PR TITLE
Allow households to smooth consumption from savings buffers

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -574,7 +574,9 @@ object Household:
     val credit              = processConsumerCredit(hh, income, disposablePreCredit, thisDebtService, world, bankRates, rng)
     val fullObligations     = obligations + credit.debtService
     val disposable          = (income - fullObligations).max(PLN.Zero)
-    val consumption         = (disposable + credit.newLoan) * hh.mpc
+    val savingsDrawdown     = computeSavingsDrawdown(hh, income, newStatus)
+    val consumptionBudget   = disposable + credit.newLoan + savingsDrawdown
+    val consumption         = consumptionBudget * hh.mpc
 
     // Social network precautionary effect
     val neighborDistress = neighborDistressRatioFast(hh, distressedIds)
@@ -814,6 +816,26 @@ object Household:
         case _: HhStatus.Unemployed => Share.One + p.household.mpcUnemployedBoost
         case _                      => Share.One
       (baseMpc * bufferAdj * unemployedAdj).clamp(Share(MpcFloor), Share(MpcCeiling))
+
+  /** Controlled drawdown from liquid savings buffers.
+    *
+    * Employed households only draw from savings above their target buffer.
+    * Stressed households may also draw from the lower half of the buffer, but
+    * still keep a protected floor.
+    */
+  private[amorfati] def computeSavingsDrawdown(
+      hh: State,
+      cashOnHand: PLN,
+      status: HhStatus,
+  )(using p: SimParams): PLN =
+    val targetIncome  = cashOnHand.max(p.household.baseReservationWage)
+    val targetSavings = targetIncome * Multiplier(p.household.bufferTargetMonths)
+    val protectedBuff = targetSavings * p.household.bufferProtectedShare
+    status match
+      case _: HhStatus.Unemployed | _: HhStatus.Retraining =>
+        (hh.savings - protectedBuff).max(PLN.Zero) * p.household.bufferStressDrawdownRate
+      case _: HhStatus.Employed | HhStatus.Bankrupt        =>
+        (hh.savings - targetSavings).max(PLN.Zero) * p.household.bufferExcessDrawdownRate
 
   /** Fraction of social neighbors in distress (BitSet, O(k) per HH). */
   private def neighborDistressRatioFast(hh: State, distressedIds: java.util.BitSet): Share =

--- a/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
@@ -113,6 +113,9 @@ case class HouseholdConfig(
     bufferTargetMonths: Double = 6.0,                  // target savings = 6 months of income
     bufferSensitivity: Coefficient = Coefficient(0.4), // MPC adjustment strength (0 = static, 1 = fully responsive)
     mpcUnemployedBoost: Share = Share(0.10),           // MPC uplift when unemployed (desperate spending)
+    bufferProtectedShare: Share = Share(0.50),         // protected share of target buffer under stress
+    bufferExcessDrawdownRate: Share = Share(0.20),     // monthly drawdown rate for savings above target buffer
+    bufferStressDrawdownRate: Share = Share(0.35),     // monthly drawdown rate for savings above protected buffer under stress
     // Skill decay & scarring
     skillDecayRate: Share = Share(0.02),
     scarringRate: Share = Share(0.02),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BufferStockMpcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BufferStockMpcSpec.scala
@@ -89,3 +89,24 @@ class BufferStockMpcSpec extends AnyFlatSpec with Matchers:
         mpcs(i) should be >= mpcs(i + 1)
       }
   }
+
+  "computeSavingsDrawdown" should "draw only excess savings for employed households" in {
+    val hh       = mkHh(savings = PLN(120000.0))
+    val drawdown = Household.computeSavingsDrawdown(hh, income, hh.status)
+
+    drawdown shouldBe PLN(14400.0)
+  }
+
+  it should "allow stressed households to draw below the full target buffer but above the protected floor" in {
+    val hh       = mkHh(savings = PLN(30000.0)).copy(status = HhStatus.Unemployed(4))
+    val drawdown = Household.computeSavingsDrawdown(hh, income, hh.status)
+
+    drawdown shouldBe PLN(2100.0)
+  }
+
+  it should "return zero when savings are already below the protected floor under stress" in {
+    val hh       = mkHh(savings = PLN(10000.0)).copy(status = HhStatus.Unemployed(4))
+    val drawdown = Household.computeSavingsDrawdown(hh, income, hh.status)
+
+    drawdown shouldBe PLN.Zero
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -144,6 +144,15 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
     pbf shouldBe None
   }
 
+  it should "let unemployed households smooth consumption by drawing down savings" in {
+    val rng               = new Random(42)
+    val hh                = mkHousehold(0, HhStatus.Unemployed(1), savings = PLN(30000.0), rent = PLN(1800.0))
+    val (updated, agg, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), 0.4, rng)
+
+    agg.consumption should be > PLN.Zero
+    updated(0).savings should be < hh.savings
+  }
+
   // --- Variable-rate debt service + deposit interest ---
 
   "Household.step with bankRates" should "use variable lending rate for debt service" in {


### PR DESCRIPTION
## Summary
- let household consumption draw down liquid savings buffers instead of relying on current cashflow and new credit only
- add explicit protected-buffer and stressed drawdown parameters to the household config
- cover the new savings drawdown semantics with targeted household tests

## Verification
- sbt scalafmtAll
- sbt 'testOnly *BufferStockMpcSpec* *HouseholdSpec*'
- sbt 'runMain com.boombustgroup.amorfati.diagnostics.runInflationProbe 1 24'

## Diagnostic effect
Compared with fresh `main`, the household buffer fix materially improved the mid-horizon demand slump:
- `m10` inflation: `1.58% -> 3.14%`
- `m11` inflation: `-1.93% -> -0.69%`
- `m12` inflation: `-4.77% -> -3.64%`

Late-horizon deflation remains, so this fixes a real household-demand bug but not the whole macro path.

Fixes #196
