### PR TITLE
Reconcile labor outputs after firm-side employment changes

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -123,15 +123,7 @@ object InflationProbe:
       val s4                = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
       val s5                = FirmEconomics.runStep(world, firms, hhs, s1, s2Pre, s3, s4, rng)
       val living            = s5.ioFirms.filter(Firm.isAlive)
-      val s2                = s2Pre.copy(
-        employed = s5.households.count(hh =>
-          hh.status match
-            case HhStatus.Employed(_, _, _) => true
-            case _                          => false,
-        ),
-        laborDemand = living.map(Firm.workerCount).sum,
-        living = living,
-      )
+      val s2                = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
       val s6                = HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, rng)
       val s7                = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -185,14 +185,15 @@ object LaborDemandProbe:
       val s3     = HouseholdIncomeEconomics.compute(world, firms, hhs, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
       val s4     = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
       val s5     = FirmEconomics.runStep(world, firms, hhs, s1, s2Pre, s3, s4, rng)
-      val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2Pre.employed, s3.hhAgg, rng)
+      val s2Post = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, s5.ioFirms.filter(Firm.isAlive), s5.households)
+      val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, rng)
       val s7     = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(
           world,
           s1.m,
-          s2Pre.newWage,
-          s2Pre.employed,
-          s2Pre.wageGrowth,
+          s2Post.newWage,
+          s2Post.employed,
+          s2Post.wageGrowth,
           s3.domesticCons,
           s4.govPurchases,
           s4.avgDemandMult,
@@ -201,8 +202,8 @@ object LaborDemandProbe:
         ),
         rng,
       )
-      val s8     = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2Pre, s3, s4, s5, s6, s7, rng))
-      val s9     = BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2Pre, s3, s4, s5, s6, s7, s8, rng))
+      val s8     = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, rng))
+      val s9     = BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, s8, rng))
 
       val afterFirm = sectorSnapshots(s5.ioFirms)
       val changes   = sectorChangeSummaries(firms, s5.ioFirms)
@@ -229,7 +230,7 @@ object LaborDemandProbe:
           sectorCap = s4.sectorCap,
           laggedInvestDemand = s4.laggedInvestDemand,
           fiscalRuleStatus = s4.fiscalRuleStatus,
-          laborOutput = s2Pre,
+          laborOutput = s2Post,
           hhOutput = s3,
           firmOutput = s5,
           hhFinancialOutput = s6,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
@@ -37,6 +37,12 @@ object LaborEconomics:
       avgFirmWorkers: Int,
   )
 
+  private case class ClearedLaborMarket(
+      wage: PLN,
+      employed: Int,
+      regionalWages: Map[Region, PLN],
+  )
+
   /** Bridge type — same fields as the deleted LaborDemographicsStep.Output. */
   case class Output(
       newWage: PLN,
@@ -63,61 +69,29 @@ object LaborEconomics:
       households: Vector[Household.State],
       s1: FiscalConstraintEconomics.Output,
   )(using p: SimParams): Result =
-    import ComputationBoundary.toDouble
-    val living      = firms.filter(Firm.isAlive)
-    val laborDemand = living.map(f => Firm.workerCount(f)).sum
-
-    // Regional clearing: 6 independent Phillips curves → national aggregate
-    val (rawWage, rawEmployed, regWages) =
-      if p.flags.regionalLabor then
-        val rc          = RegionalClearing.clear(w.regionalWages, s1.resWage, laborDemand, w.totalPopulation)
-        val natEmployed = LaborMarket.employmentAtWage(rc.nationalWage, s1.resWage, laborDemand, w.totalPopulation)
-        (toDouble(rc.nationalWage), natEmployed, rc.regionalWages)
-      else
-        val wageResult = LaborMarket.updateLaborMarket(w.hhAgg.marketWage, s1.resWage, laborDemand, w.totalPopulation)
-        (toDouble(wageResult.wage), wageResult.employed, w.regionalWages)
-
-    // Channel 1: Expectations-augmented wage Phillips curve
-    val wageAfterExp = if p.flags.expectations then
-      val target          = toDouble(p.monetary.targetInfl)
-      val expWagePressure = toDouble(p.labor.expWagePassthrough) *
-        Math.max(0.0, toDouble(w.mechanisms.expectations.expectedInflation) - target) / 12.0
-      Math.max(toDouble(s1.resWage), rawWage * (1.0 + expWagePressure))
-    else rawWage
-
-    // Union downward wage rigidity
-    val newWage = if p.flags.unions && wageAfterExp < toDouble(w.hhAgg.marketWage) then
-      val aggDensity =
-        p.sectorDefs.zipWithIndex.map((s, i) => toDouble(s.share) * toDouble(p.labor.unionDensity(i))).sum
-      val decline    = toDouble(w.hhAgg.marketWage) - wageAfterExp
-      Math.max(toDouble(s1.resWage), wageAfterExp + decline * toDouble(p.labor.unionRigidity) * aggDensity)
-    else wageAfterExp
-
-    // Demographics caps employment
-    val employed =
-      if p.flags.demographics then Math.min(rawEmployed, w.social.demographics.workingAgePop)
-      else rawEmployed
-
-    val availableLabor       = LaborMarket.laborSupplyAtWage(PLN(newWage), s1.resWage, w.totalPopulation)
+    val living               = firms.filter(Firm.isAlive)
+    val laborDemand          = living.map(f => Firm.workerCount(f)).sum
+    val cleared              = clearLaborMarket(w, s1.resWage, laborDemand)
+    val availableLabor       = LaborMarket.laborSupplyAtWage(cleared.wage, s1.resWage, w.totalPopulation)
     val aggregateHiringSlack = aggregateHiringSlackFactor(laborDemand, availableLabor)
 
     // Immigration
-    val unempRateForImmig = 1.0 - employed.toDouble / w.totalPopulation
-    val newImmig          = Immigration.step(w.external.immigration, households, PLN(newWage), unempRateForImmig)
+    val unempRateForImmig = 1.0 - cleared.employed.toDouble / w.totalPopulation
+    val newImmig          = Immigration.step(w.external.immigration, households, cleared.wage, unempRateForImmig)
     val netMigration      = newImmig.monthlyInflow - newImmig.monthlyOutflow
 
     // Demographics
-    val newDemographics = SocialSecurity.demographicsStep(w.social.demographics, employed, netMigration)
+    val newDemographics = SocialSecurity.demographicsStep(w.social.demographics, cleared.employed, netMigration)
 
     // Wage growth
-    val wageGrowth = if toDouble(w.hhAgg.marketWage) > 0 then newWage / toDouble(w.hhAgg.marketWage) - 1.0 else 0.0
+    val wageGrowth = wageGrowthFrom(w.hhAgg.marketWage, cleared.wage)
 
     val nBankrupt  = firms.length - living.length
     val avgWorkers = if living.nonEmpty then laborDemand / living.length else 0
 
     Result(
-      wage = PLN(newWage),
-      employed = employed,
+      wage = cleared.wage,
+      employed = cleared.employed,
       laborDemand = laborDemand,
       wageGrowth = Coefficient(wageGrowth),
       aggregateHiringSlack = aggregateHiringSlack,
@@ -125,7 +99,81 @@ object LaborEconomics:
       immigration = newImmig,
       netMigration = netMigration,
       living = living,
-      regionalWages = regWages,
+      regionalWages = cleared.regionalWages,
       nBankruptFirms = nBankrupt,
       avgFirmWorkers = avgWorkers,
     )
+
+  /** Reconcile labor outputs after firm-side separations and matching so
+    * downstream blocks use effective post-firm labor demand rather than stale
+    * inherited headcount.
+    */
+  @boundaryEscape
+  def reconcilePostFirmStep(
+      w: World,
+      s1: FiscalConstraintEconomics.Output,
+      pre: Output,
+      postLiving: Vector[Firm.State],
+      postHouseholds: Vector[Household.State],
+  )(using p: SimParams): Output =
+    val postLaborDemand    = postLiving.map(Firm.workerCount).sum
+    val cleared            = clearLaborMarket(w, s1.resWage, postLaborDemand)
+    val realizedEmployment = postHouseholds.count:
+      _.status match
+        case HhStatus.Employed(_, _, _) => true
+        case _                          => false
+    val employedCap        =
+      if p.flags.demographics then Math.min(realizedEmployment, pre.newDemographics.workingAgePop)
+      else realizedEmployment
+    val postAvailableLabor = LaborMarket.laborSupplyAtWage(cleared.wage, s1.resWage, w.totalPopulation)
+    pre.copy(
+      newWage = cleared.wage,
+      employed = employedCap,
+      laborDemand = postLaborDemand,
+      wageGrowth = Coefficient(wageGrowthFrom(w.hhAgg.marketWage, cleared.wage)),
+      aggregateHiringSlack = aggregateHiringSlackFactor(postLaborDemand, postAvailableLabor),
+      living = postLiving,
+      regionalWages = cleared.regionalWages,
+    )
+
+  @boundaryEscape
+  private def clearLaborMarket(
+      w: World,
+      resWage: PLN,
+      laborDemand: Int,
+  )(using p: SimParams): ClearedLaborMarket =
+    import ComputationBoundary.toDouble
+    val (rawWage, rawEmployed, regWages) =
+      if p.flags.regionalLabor then
+        val rc          = RegionalClearing.clear(w.regionalWages, resWage, laborDemand, w.totalPopulation)
+        val natEmployed = LaborMarket.employmentAtWage(rc.nationalWage, resWage, laborDemand, w.totalPopulation)
+        (toDouble(rc.nationalWage), natEmployed, rc.regionalWages)
+      else
+        val wageResult = LaborMarket.updateLaborMarket(w.hhAgg.marketWage, resWage, laborDemand, w.totalPopulation)
+        (toDouble(wageResult.wage), wageResult.employed, w.regionalWages)
+
+    val wageAfterExp =
+      if p.flags.expectations then
+        val target          = toDouble(p.monetary.targetInfl)
+        val expWagePressure = toDouble(p.labor.expWagePassthrough) *
+          Math.max(0.0, toDouble(w.mechanisms.expectations.expectedInflation) - target) / 12.0
+        Math.max(toDouble(resWage), rawWage * (1.0 + expWagePressure))
+      else rawWage
+
+    val newWage =
+      if p.flags.unions && wageAfterExp < toDouble(w.hhAgg.marketWage) then
+        val aggDensity =
+          p.sectorDefs.zipWithIndex.map((s, i) => toDouble(s.share) * toDouble(p.labor.unionDensity(i))).sum
+        val decline    = toDouble(w.hhAgg.marketWage) - wageAfterExp
+        Math.max(toDouble(resWage), wageAfterExp + decline * toDouble(p.labor.unionRigidity) * aggDensity)
+      else wageAfterExp
+
+    val employed =
+      if p.flags.demographics then Math.min(rawEmployed, w.social.demographics.workingAgePop)
+      else rawEmployed
+
+    ClearedLaborMarket(PLN(newWage), employed, regWages)
+
+  private def wageGrowthFrom(prevWage: PLN, newWage: PLN): Double =
+    import ComputationBoundary.toDouble
+    if toDouble(prevWage) > 0 then toDouble(newWage) / toDouble(prevWage) - 1.0 else 0.0

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -4,7 +4,6 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -260,10 +259,10 @@ object FlowSimulation:
       households: Vector[Household.State],
       rng: Random,
   )(using p: SimParams): FullComputation =
-    val fiscal             = FiscalConstraintEconomics.compute(w)
-    val s1                 = FiscalConstraintEconomics.toOutput(fiscal)
-    val labor              = LaborEconomics.compute(w, firms, households, s1)
-    val s2Pre              = LaborEconomics.Output(
+    val fiscal          = FiscalConstraintEconomics.compute(w)
+    val s1              = FiscalConstraintEconomics.toOutput(fiscal)
+    val labor           = LaborEconomics.compute(w, firms, households, s1)
+    val s2Pre           = LaborEconomics.Output(
       labor.wage,
       labor.employed,
       labor.laborDemand,
@@ -280,24 +279,13 @@ object FlowSimulation:
       labor.living,
       labor.regionalWages,
     )
-    val s3                 = HouseholdIncomeEconomics.compute(w, firms, households, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
-    val s4                 = DemandEconomics.compute(DemandEconomics.Input(w, s2Pre.employed, s2Pre.living, s3.domesticCons))
-    val s5                 = FirmEconomics.runStep(w, firms, households, s1, s2Pre, s3, s4, rng)
-    val postLivingFirms    = s5.ioFirms.filter(Firm.isAlive)
-    val postLaborDemand    = postLivingFirms.map(Firm.workerCount).sum
-    val postAvailableLabor = LaborMarket.laborSupplyAtWage(s2Pre.newWage, s1.resWage, w.totalPopulation)
-    val s2                 = s2Pre.copy(
-      employed = s5.households.count(hh =>
-        hh.status match
-          case HhStatus.Employed(_, _, _) => true
-          case _                          => false,
-      ),
-      laborDemand = postLaborDemand,
-      aggregateHiringSlack = LaborEconomics.aggregateHiringSlackFactor(postLaborDemand, postAvailableLabor),
-      living = postLivingFirms,
-    )
-    val s6                 = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, rng)
-    val s7                 = PriceEquityEconomics.compute(
+    val s3              = HouseholdIncomeEconomics.compute(w, firms, households, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
+    val s4              = DemandEconomics.compute(DemandEconomics.Input(w, s2Pre.employed, s2Pre.living, s3.domesticCons))
+    val s5              = FirmEconomics.runStep(w, firms, households, s1, s2Pre, s3, s4, rng)
+    val postLivingFirms = s5.ioFirms.filter(Firm.isAlive)
+    val s2              = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
+    val s6              = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, rng)
+    val s7              = PriceEquityEconomics.compute(
       PriceEquityEconomics.Input(
         w,
         s1.m,
@@ -312,7 +300,7 @@ object FlowSimulation:
       ),
       rng,
     )
-    val openEcon           = OpenEconEconomics.compute(
+    val openEcon        = OpenEconEconomics.compute(
       OpenEconEconomics.Input(
         w = w,
         employed = s2.employed,
@@ -343,8 +331,8 @@ object FlowSimulation:
         commodityRng = rng,
       ),
     )
-    val s8                 = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, rng))
-    val banking            = BankingEconomics.compute(
+    val s8              = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, rng))
+    val banking         = BankingEconomics.compute(
       BankingEconomics.Input(
         w = w,
         month = fiscal.month,
@@ -371,11 +359,11 @@ object FlowSimulation:
         depositRng = rng,
       ),
     )
-    val s9                 = BankingEconomics.runStep(BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, rng))
-    val agg                = s3.hhAgg
-    val eq                 = w.financial.equity
-    val h                  = w.real.housing
-    val calc               = MonthlyCalculus(
+    val s9              = BankingEconomics.runStep(BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, rng))
+    val agg             = s3.hhAgg
+    val eq              = w.financial.equity
+    val h               = w.real.housing
+    val calc            = MonthlyCalculus(
       month = fiscal.month,
       resWage = fiscal.resWage,
       lendingBaseRate = fiscal.lendingBaseRate,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.economics
 
+import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
 import com.boombustgroup.amorfati.types.*
@@ -50,4 +51,33 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
 
   it should "leave hiring plans unchanged when labor demand fits available labor" in {
     LaborEconomics.aggregateHiringSlackFactor(laborDemand = 60000, availableLabor = 80000) shouldBe (1.0 +- 1e-9)
+  }
+
+  it should "reconcile post-firm labor demand and realized employment from post-step state" in {
+    val pre   = LaborEconomics.compute(world, firms, world.households, s1)
+    val s2Pre = LaborEconomics.Output(
+      pre.wage,
+      pre.employed,
+      pre.laborDemand,
+      pre.wageGrowth,
+      pre.aggregateHiringSlack,
+      pre.immigration,
+      pre.netMigration,
+      pre.demographics,
+      SocialSecurity.ZusState.zero,
+      SocialSecurity.NfzState.zero,
+      SocialSecurity.PpkState.zero,
+      PLN.Zero,
+      EarmarkedFunds.State.zero,
+      pre.living,
+      pre.regionalWages,
+    )
+
+    val postLiving = firms.take(10).filter(Firm.isAlive)
+    val postHh     = world.households.map(_.copy(status = HhStatus.Unemployed(0)))
+    val post       = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, postLiving, postHh)
+
+    post.laborDemand shouldBe postLiving.map(Firm.workerCount).sum
+    post.employed shouldBe 0
+    ComputationBoundary.toDouble(post.newWage) should be >= ComputationBoundary.toDouble(s1.resWage)
   }


### PR DESCRIPTION
## Summary

This PR makes the labor block reconcile its aggregate outputs after firm-side employment changes instead of continuing to propagate stale pre-firm labor-demand/employment values.

Concretely:
- `LaborEconomics` now exposes a post-firm reconciliation step
- `FlowSimulation` and diagnostics use reconciled labor outputs after `FirmEconomics`
- a regression test covers post-firm reconciliation of labor demand and realized employment

## Why

Issue #198 started from a timing mismatch: macro labor outputs were being computed before firm-side separations/matching and then reused downstream after the firm block had already changed employment.

This PR fixes that sequencing mismatch so downstream blocks consume a labor snapshot aligned with post-firm state.

## Notes

The refactor improved internal consistency, but diagnostics show the dominant remaining employment collapse now comes from runaway household bankruptcies, tracked separately in #199.

## Verification

- `sbt scalafmtAll`
- `sbt 'testOnly *LaborEconomicsSpec* *FlowSimulationSpec* *FullMonthFlowSpec*'`

Fixes #198
