### PR TITLE
Require persistent distress before household bankruptcy

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -96,6 +96,7 @@ object Household:
       education: Int,                                      // education level: 0=Primary, 1=Vocational, 2=Secondary, 3=Tertiary
       taskRoutineness: Share,                              // how routine is this worker's task bundle [0,1] (Acemoglu & Restrepo 2020)
       wageScar: Share,                                     // persistent wage penalty from unemployment spell (Jacobson et al. 1993)
+      financialDistressMonths: Int = 0,                    // consecutive months of deep financial distress
       contractType: ContractType = ContractType.Permanent, // employment contract type (Kodeks Pracy / umowa zlecenie / B2B)
       region: Region = Region.Central,                     // NUTS-1 macroregion (geographic labor market)
   )
@@ -538,6 +539,10 @@ object Household:
       neighborDistress: Share,
   )
 
+  private def bankruptcyFloor(f: MonthlyFlows)(using p: SimParams): PLN =
+    val essentialOutflows = (f.hh.monthlyRent + f.debtService + f.credit.debtService).max(f.hh.monthlyRent)
+    essentialOutflows * Multiplier(p.household.bankruptcyThreshold)
+
   /** Per-HH monthly pipeline: income → tax → credit → consumption → equity. */
   private def computeMonthlyFlows(
       hh: State,
@@ -622,12 +627,14 @@ object Household:
       sectorVacancies: Option[Vector[Int]],
       distressedIds: java.util.BitSet,
   )(using p: SimParams): HhMonthlyResult =
-    val f = computeMonthlyFlows(hh, world, rng, bankRates, equityIndexReturn, distressedIds)
-    if f.newSavings < hh.monthlyRent * Multiplier(p.household.bankruptcyThreshold) then resolveBankruptcy(f)
-    else resolveSurvival(f, sectorWages, sectorVacancies, rng)
+    val f              = computeMonthlyFlows(hh, world, rng, bankRates, equityIndexReturn, distressedIds)
+    val distressMonths =
+      if f.newSavings < bankruptcyFloor(f) then hh.financialDistressMonths + 1 else 0
+    if distressMonths >= p.household.bankruptcyDistressMonths then resolveBankruptcy(f, distressMonths)
+    else resolveSurvival(f, sectorWages, sectorVacancies, rng, distressMonths)
 
   /** Bankruptcy branch: write off consumer debt, zero equity. */
-  private def resolveBankruptcy(f: MonthlyFlows)(using p: SimParams): HhMonthlyResult =
+  private def resolveBankruptcy(f: MonthlyFlows, distressMonths: Int)(using p: SimParams): HhMonthlyResult =
     val ccDefaultAmt  = f.hh.consumerDebt * (Rate(1.0) - p.household.ccAmortRate) + f.credit.newLoan
     val creditWithDef = f.credit.copy(defaultAmt = ccDefaultAmt, updatedDebt = PLN.Zero)
     HhMonthlyResult(
@@ -637,6 +644,7 @@ object Household:
         consumerDebt = PLN.Zero,
         status = HhStatus.Bankrupt,
         equityWealth = PLN.Zero,
+        financialDistressMonths = distressMonths,
       ),
       income = f.income,
       benefit = f.benefit,
@@ -660,6 +668,7 @@ object Household:
       sectorWages: Option[Vector[PLN]],
       sectorVacancies: Option[Vector[Int]],
       rng: Random,
+      distressMonths: Int,
   )(using p: SimParams): HhMonthlyResult =
     val afterSkill    = applySkillDecay(f.hh, f.newStatus)
     val afterHealth   = applyHealthScarring(f.hh, f.newStatus)
@@ -689,6 +698,7 @@ object Household:
         mpc = afterMpc,
         status = finalStatus,
         equityWealth = f.newEquityWealth,
+        financialDistressMonths = distressMonths,
       ),
       income = f.income,
       benefit = f.benefit,

--- a/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HouseholdConfig.scala
@@ -133,6 +133,7 @@ case class HouseholdConfig(
     retrainingEnabled: Boolean = true,
     // Bankruptcy
     bankruptcyThreshold: Double = -3.0,
+    bankruptcyDistressMonths: Int = 3,
     // Social network
     socialK: Int = 10,
     socialP: Share = Share(0.15),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -130,11 +130,37 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
     updated(0).healthPenalty should be > Share.Zero
   }
 
-  it should "bankrupt household when savings fall below threshold" in {
+  it should "not bankrupt household after a single month of deep distress" in {
     val rng             = new Random(42)
     val hh              = mkHousehold(0, HhStatus.Unemployed(1), savings = PLN(-10000.0), rent = PLN(1800.0))
     val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), 0.4, rng)
+    updated(0).status should not be HhStatus.Bankrupt
+    updated(0).financialDistressMonths shouldBe 1
+  }
+
+  it should "bankrupt household after persistent deep distress" in {
+    val rng             = new Random(42)
+    val hh              = mkHousehold(
+      0,
+      HhStatus.Unemployed(1),
+      savings = PLN(-10000.0),
+      rent = PLN(1800.0),
+    ).copy(financialDistressMonths = p.household.bankruptcyDistressMonths - 1)
+    val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), 0.4, rng)
     updated(0).status shouldBe HhStatus.Bankrupt
+  }
+
+  it should "reset financial distress months after recovery" in {
+    val rng             = new Random(42)
+    val hh              = mkHousehold(
+      0,
+      HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)),
+      savings = PLN(20000.0),
+      rent = PLN(1800.0),
+    ).copy(financialDistressMonths = 2)
+    val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), 0.4, rng)
+    updated(0).status shouldBe a[HhStatus.Employed]
+    updated(0).financialDistressMonths shouldBe 0
   }
 
   it should "return None for perBankHhFlows when bankRates not provided" in {


### PR DESCRIPTION
## Summary

This PR makes household bankruptcy depend on persistent deep financial distress instead of a single bad month.

Concretely:
- adds `bankruptcyDistressMonths` to `HouseholdConfig`
- tracks consecutive months of deep household distress
- evaluates bankruptcy against full essential monthly outflows, not rent alone
- only transitions to `HhStatus.Bankrupt` after distress persists for the configured number of months
- adds regression tests for single-month distress, persistent distress, and distress reset after recovery

## Why

Issue #199 came out of the labor-collapse audit. The dominant remaining employment failure mode was not firm-side labor demand, but a runaway increase in household bankruptcies removing people from the active population too early.

Diagnostics before this change showed:
- very large `HhStatus.Bankrupt` counts by `m10-m12`
- employment collapsing well below post-firm labor demand
- early deflation emerging as a downstream consequence

## Verification

- `sbt scalafmtAll`
- `sbt 'testOnly *HouseholdSpec* *BufferStockMpcSpec* *ConsumerCreditSpec*'`
- `sbt 'testOnly *HouseholdSpec*'`
- `sbt 'runMain com.boombustgroup.amorfati.diagnostics.runInflationProbe 1 12'`
- `sbt 'runMain com.boombustgroup.amorfati.diagnostics.runInflationProbe 1 24'`

## Diagnostic impact

Relative to the pre-fix baseline on the labor-timing investigation branch:
- `m11` inflation moved from about `0.35%` to `4.69%`
- `m12` inflation moved from about `-2.34%` to `4.35%`
- the model no longer falls into early deflation during the first year

Later-horizon deflation still remains, so this fixes the household-bankruptcy runaway but does not yet fully stabilize the macro path.

Fixes #199
