### PR TITLE
Remove World household duplication

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -8,8 +8,8 @@ import com.boombustgroup.amorfati.types.*
 
 /** Immutable snapshot of the entire simulation state at the end of one month.
   *
-  * Fields with defaults (`hhAgg`, `households`, `monetaryAgg`, `bop`) are
-  * populated during the step pipeline and do not need to be provided at init.
+  * Fields with defaults (`hhAgg`, `monetaryAgg`, `bop`) are populated during
+  * the step pipeline and do not need to be provided at init.
   */
 case class World(
     month: Int,                                             // simulation month (1-indexed)
@@ -25,7 +25,6 @@ case class World(
     forex: OpenEconomy.ForexState,                          // EUR/PLN, exports, imports, trade balance
     bop: OpenEconomy.BopState = OpenEconomy.BopState.zero,  // balance of payments: NFA, CA, KA, FDI
     hhAgg: Household.Aggregates,                            // household aggregates (employment, wages, consumption)
-    households: Vector[Household.State] = Vector.empty,     // individual household states
     monetaryAgg: Option[Banking.MonetaryAggregates] = None, // M1, monetary base, credit multiplier (CREDIT_DIAGNOSTICS)
     social: SocialState,                                    // JST, ZUS, PPK, demographics
     financial: FinancialMarketsState,                       // equity, corporate bonds, insurance, TFI

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -211,7 +211,7 @@ object WorldAssemblyEconomics:
             crossSectorHires = r.sectoralMobility.crossSectorHires + startupStaffing.crossSectorHires,
           ),
         )
-      .copy(hhAgg = startupStaffing.hhAgg, households = postMigHh)
+      .copy(hhAgg = startupStaffing.hhAgg)
       .copy(regionalWages = in.s2.regionalWages)
     StepOutput(finalW, finalFirms, postMigHh, sfcResult)
 
@@ -387,7 +387,6 @@ object WorldAssemblyEconomics:
       forex = in.s8.external.newForex,
       bop = in.s8.external.newBop,
       hhAgg = in.s9.finalHhAgg,
-      households = in.s9.reassignedHouseholds,
       monetaryAgg = in.s9.monAgg,
       social = SocialState(
         jst = in.s9.newJst,
@@ -470,7 +469,7 @@ object WorldAssemblyEconomics:
 
   /** Run SFC validation against previous and current snapshots. */
   private def validateSfc(in: StepInput, newW: World, fofResidual: PLN)(using p: SimParams): Sfc.SfcResult =
-    val prevSnap = Sfc.snapshot(in.w, in.firms, in.w.households)
+    val prevSnap = Sfc.snapshot(in.w, in.firms, in.households)
     val currSnap = Sfc.snapshot(newW, in.s9.reassignedFirms, in.s9.reassignedHouseholds)
     val flows    = buildMonthlyFlows(in, fofResidual)
     Sfc.validate(prevSnap, currSnap, flows)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
@@ -15,6 +15,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
   private val initResult = WorldInit.initialize(42L)
   private val world      = initResult.world
   private val firms      = initResult.firms
+  private val households = initResult.households
 
   private val s1 = FiscalConstraintEconomics.Output(
     m = 1,
@@ -25,22 +26,22 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
   )
 
   "LaborEconomics.compute" should "produce positive wage" in {
-    val result = LaborEconomics.compute(world, firms, world.households, s1)
+    val result = LaborEconomics.compute(world, firms, households, s1)
     ComputationBoundary.toDouble(result.wage) should be > 0.0
   }
 
   it should "produce positive employment" in {
-    val result = LaborEconomics.compute(world, firms, world.households, s1)
+    val result = LaborEconomics.compute(world, firms, households, s1)
     result.employed should be > 0
   }
 
   it should "produce demographics with positive working-age pop" in {
-    val result = LaborEconomics.compute(world, firms, world.households, s1)
+    val result = LaborEconomics.compute(world, firms, households, s1)
     result.demographics.workingAgePop should be > 0
   }
 
   it should "produce consistent wage growth" in {
-    val result = LaborEconomics.compute(world, firms, world.households, s1)
+    val result = LaborEconomics.compute(world, firms, households, s1)
     // Wage growth should be a finite number
     ComputationBoundary.toDouble(result.wageGrowth).isNaN shouldBe false
   }
@@ -54,7 +55,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "reconcile post-firm labor demand and realized employment from post-step state" in {
-    val pre   = LaborEconomics.compute(world, firms, world.households, s1)
+    val pre   = LaborEconomics.compute(world, firms, households, s1)
     val s2Pre = LaborEconomics.Output(
       pre.wage,
       pre.employed,
@@ -74,7 +75,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
     )
 
     val postLiving = firms.take(10).filter(Firm.isAlive)
-    val postHh     = world.households.map(_.copy(status = HhStatus.Unemployed(0)))
+    val postHh     = households.map(_.copy(status = HhStatus.Unemployed(0)))
     val post       = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, postLiving, postHh)
 
     post.laborDemand shouldBe postLiving.map(Firm.workerCount).sum


### PR DESCRIPTION
Fixes #207

## Summary
- remove the duplicate `World.households` runtime field
- pass the standalone household vector into `Sfc.snapshot(...)`
- update labor/world-assembly tests to stop reading households from `World`

## Validation
- `sbt scalafmtAll`
- `sbt 'testOnly *LaborEconomicsSpec* *WorldAssemblyEconomicsSpec* *InitCheckSpec*'`