### PR TITLE
Downgrade derived banking fields from World state

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -193,20 +193,21 @@ object Sfc:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
   ): Snapshot =
-    val hhS   = PLN.fromRaw(households.map(_.savings.toLong).sum)
-    val hhD   = PLN.fromRaw(households.map(_.debt.toLong).sum)
-    val ibNet = PLN.fromRaw(banks.map(_.interbankNet.toLong).sum)
+    val hhS     = PLN.fromRaw(households.map(_.savings.toLong).sum)
+    val hhD     = PLN.fromRaw(households.map(_.debt.toLong).sum)
+    val ibNet   = PLN.fromRaw(banks.map(_.interbankNet.toLong).sum)
+    val bankAgg = Banking.aggregateFromBanks(banks)
     Snapshot(
       hhSavings = hhS,
       hhDebt = hhD,
       firmCash = PLN.fromRaw(firms.map(_.cash.toLong).sum),
       firmDebt = PLN.fromRaw(firms.map(_.debt.toLong).sum),
-      bankCapital = w.bank.capital,
-      bankDeposits = w.bank.deposits,
-      bankLoans = w.bank.totalLoans,
+      bankCapital = bankAgg.capital,
+      bankDeposits = bankAgg.deposits,
+      bankLoans = bankAgg.totalLoans,
       govDebt = w.gov.cumulativeDebt,
       nfa = w.bop.nfa,
-      bankBondHoldings = w.bank.govBondHoldings,
+      bankBondHoldings = bankAgg.govBondHoldings,
       nbpBondHoldings = w.nbp.govBondHoldings,
       bondsOutstanding = w.gov.bondsOutstanding,
       interbankNetSum = ibNet,
@@ -217,7 +218,7 @@ object Sfc:
       foreignBondHoldings = w.gov.foreignBondHoldings,
       ppkBondHoldings = w.social.ppk.bondHoldings,
       mortgageStock = w.real.housing.mortgageStock,
-      consumerLoans = w.bank.consumerLoans,
+      consumerLoans = bankAgg.consumerLoans,
       corpBondsOutstanding = w.financial.corporateBonds.outstanding,
       insuranceGovBondHoldings = w.financial.insurance.govBondHoldings,
       tfiGovBondHoldings = w.financial.nbfi.tfiGovBondHoldings,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -73,7 +73,7 @@ object InflationProbe:
 
     (1 to months).foreach: month =>
       val rng               = new Random(seed * 1000 + month)
-      val fiscal            = FiscalConstraintEconomics.compute(world)
+      val fiscal            = FiscalConstraintEconomics.compute(world, banks)
       val s1                = FiscalConstraintEconomics.toOutput(fiscal)
       val labor             = LaborEconomics.compute(world, firms, hhs, s1)
       val prevWage          = toDouble(world.hhAgg.marketWage)

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -163,7 +163,7 @@ object LaborDemandProbe:
       val beforeAll = sectorSnapshots(firms)
       val hiring    = hiringSummaries(world, firms)
 
-      val fiscal = FiscalConstraintEconomics.compute(world)
+      val fiscal = FiscalConstraintEconomics.compute(world, banks)
       val s1     = FiscalConstraintEconomics.toOutput(fiscal)
       val labor  = LaborEconomics.compute(world, firms, hhs, s1)
       val s2Pre  = LaborEconomics.Output(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -8,32 +8,30 @@ import com.boombustgroup.amorfati.types.*
 
 /** Immutable snapshot of the entire simulation state at the end of one month.
   *
-  * Fields with defaults (`monetaryAgg`, `bop`) are populated during the step
-  * pipeline and do not need to be provided at init.
+  * Fields with defaults (`bop`) are populated during the step pipeline and do
+  * not need to be provided at init.
   */
 case class World(
-    month: Int,                                             // simulation month (1-indexed)
-    inflation: Rate,                                        // CPI YoY inflation
-    priceLevel: Double,                                     // cumulative CPI index (base = 1.0)
-    gdpProxy: Double,                                       // monthly GDP proxy
-    currentSigmas: Vector[Sigma],                           // per-sector σ (Arthur increasing returns)
-    totalPopulation: Int,                                   // employed + immigrants + retirees
-    gov: FiscalBudget.GovState,                             // government budget & debt
-    nbp: Nbp.State,                                         // central bank: rate, bonds, FX, QE
-    bank: Banking.Aggregate,                                // consolidated banking balance sheet
-    bankingSector: Banking.MarketState,                     // banking macro state: interbank conditions, configs, term structure
-    forex: OpenEconomy.ForexState,                          // EUR/PLN, exports, imports, trade balance
-    bop: OpenEconomy.BopState = OpenEconomy.BopState.zero,  // balance of payments: NFA, CA, KA, FDI
-    hhAgg: Household.Aggregates,                            // household aggregates (employment, wages, consumption)
-    monetaryAgg: Option[Banking.MonetaryAggregates] = None, // M1, monetary base, credit multiplier (CREDIT_DIAGNOSTICS)
-    social: SocialState,                                    // JST, ZUS, PPK, demographics
-    financial: FinancialMarketsState,                       // equity, corporate bonds, insurance, TFI
-    external: ExternalState,                                // GVC, immigration, tourism
-    real: RealState,                                        // housing, mobility, investment, energy, automation
-    mechanisms: MechanismsState,                            // macropru, expectations, BFG, informal economy
-    plumbing: MonetaryPlumbingState,                        // reserve corridor, standing facilities, interbank
-    flows: FlowState,                                       // single-step flows → SFC identities
-    regionalWages: Map[Region, PLN] = Map.empty,            // per-region wage levels (NUTS-1)
+    month: Int,                                            // simulation month (1-indexed)
+    inflation: Rate,                                       // CPI YoY inflation
+    priceLevel: Double,                                    // cumulative CPI index (base = 1.0)
+    gdpProxy: Double,                                      // monthly GDP proxy
+    currentSigmas: Vector[Sigma],                          // per-sector σ (Arthur increasing returns)
+    totalPopulation: Int,                                  // employed + immigrants + retirees
+    gov: FiscalBudget.GovState,                            // government budget & debt
+    nbp: Nbp.State,                                        // central bank: rate, bonds, FX, QE
+    bankingSector: Banking.MarketState,                    // banking macro state: interbank conditions, configs, term structure
+    forex: OpenEconomy.ForexState,                         // EUR/PLN, exports, imports, trade balance
+    bop: OpenEconomy.BopState = OpenEconomy.BopState.zero, // balance of payments: NFA, CA, KA, FDI
+    hhAgg: Household.Aggregates,                           // household aggregates (employment, wages, consumption)
+    social: SocialState,                                   // JST, ZUS, PPK, demographics
+    financial: FinancialMarketsState,                      // equity, corporate bonds, insurance, TFI
+    external: ExternalState,                               // GVC, immigration, tourism
+    real: RealState,                                       // housing, mobility, investment, energy, automation
+    mechanisms: MechanismsState,                           // macropru, expectations, BFG, informal economy
+    plumbing: MonetaryPlumbingState,                       // reserve corridor, standing facilities, interbank
+    flows: FlowState,                                      // single-step flows → SFC identities
+    regionalWages: Map[Region, PLN] = Map.empty,           // per-region wage levels (NUTS-1)
 ):
   def updateSocial(f: SocialState => SocialState): World                        = copy(social = f(social))
   def updateFinancial(f: FinancialMarketsState => FinancialMarketsState): World = copy(financial = f(financial))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -188,6 +188,7 @@ object BankingEconomics:
   // ---- Public API ----
 
   def runStep(in: StepInput)(using p: SimParams): StepOutput =
+    val prevBankAgg          = Banking.aggregateFromBanks(in.banks)
     val govJst               = computeGovAndJst(in)
     val housing              = computeHousingFlows(in)
     val bfgLevy              =
@@ -249,7 +250,7 @@ object BankingEconomics:
       actualBondChange = multi.actualBondChange,
       unrealizedBondLoss = {
         val yieldChange = in.s8.monetary.newBondYield - in.w.gov.bondYield
-        if yieldChange > Rate.Zero then in.w.bank.afsBonds * yieldChange * Multiplier(p.banking.govBondDuration) else PLN.Zero
+        if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * Multiplier(p.banking.govBondDuration) else PLN.Zero
       },
       htmRealizedLoss = multi.htmRealizedLoss,
       eclProvisionChange = PLN.fromRaw:
@@ -298,8 +299,9 @@ object BankingEconomics:
     toResult(s9, in)
 
   private def toResult(s9: StepOutput, in: Input): Result =
+    val prevBankAgg = Banking.aggregateFromBanks(in.banks)
     Result(
-      govBondIncome = in.w.bank.govBondHoldings * in.openEconOutput.monetary.newBondYield.monthly,
+      govBondIncome = prevBankAgg.govBondHoldings * in.openEconOutput.monetary.newBondYield.monthly,
       reserveInterest = in.openEconOutput.banking.totalReserveInterest,
       standingFacilityIncome = in.openEconOutput.banking.totalStandingFacilityIncome,
       interbankInterest = in.openEconOutput.banking.totalInterbankInterest,
@@ -389,7 +391,7 @@ object BankingEconomics:
         YieldCurve
           .compute(
             in.w.bankingSector.interbankRate,
-            nplRatio = in.w.bank.nplRatio,
+            nplRatio = Banking.aggregateFromBanks(in.banks).nplRatio,
             credibility = exp.credibility,
             expectedInflation = exp.expectedInflation,
             targetInflation = p.monetary.targetInfl,
@@ -641,9 +643,10 @@ object BankingEconomics:
       bs: Banking.State,
       wf: BondWaterfallInputs,
   )(using p: SimParams): MultiBankResult =
+    val prevBankAgg      = Banking.aggregateFromBanks(in.banks)
     val ibRate           = Banking.interbankRate(updatedBanks, in.w.nbp.referenceRate)
     // Liquidity hoarding: reduce interbank lending when system NPL is high
-    val hoarding         = InterbankContagion.hoardingFactor(in.w.bank.nplRatio)
+    val hoarding         = InterbankContagion.hoardingFactor(prevBankAgg.nplRatio)
     val afterInterbank   = Banking.clearInterbank(updatedBanks, bs.configs, hoarding)
     val afterFxInjection = distributeFxInjection(afterInterbank, in.s8.monetary.fxPlnInjection)
     // HTM forced reclassification: LCR-stressed banks reclassify HTM→AFS, realizing hidden losses
@@ -719,7 +722,7 @@ object BankingEconomics:
         Some(
           YieldCurve.compute(
             ibRate,
-            nplRatio = in.w.bank.nplRatio,
+            nplRatio = prevBankAgg.nplRatio,
             credibility = exp.credibility,
             expectedInflation = exp.expectedInflation,
             targetInflation = p.monetary.targetInfl,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -337,7 +337,7 @@ object FirmEconomics:
     import ComputationBoundary.toDouble
     val lending                             = prepareLending(stepIn, rng)
     val fp                                  = processFirms(stepIn.firms, lending, rng)
-    val bonded                              = applyBondAbsorption(fp, stepIn.w)
+    val bonded                              = applyBondAbsorption(fp, stepIn.w, stepIn.banks)
     val (ioFirms, totalIoPaid)              = applyIntermediateMarket(bonded.firms, stepIn)
     // Calvo staggered pricing: per-firm markup update
     val calvoFirms                          = ioFirms.map: f =>
@@ -465,9 +465,11 @@ object FirmEconomics:
   private def applyBondAbsorption(
       result: FirmProcessingResult,
       w: World,
+      banks: Vector[Banking.BankState],
   )(using p: SimParams): BondAbsorptionResult =
+    val bankAgg            = Banking.aggregateFromBanks(banks)
     val absorption         = CorporateBondMarket
-      .computeAbsorption(w.financial.corporateBonds, result.flows.bondIssuance, w.bank.car, p.banking.minCar)
+      .computeAbsorption(w.financial.corporateBonds, result.flows.bondIssuance, bankAgg.car, p.banking.minCar)
     val actualBondIssuance = result.flows.bondIssuance * absorption
     val revertShare        = Share.One - absorption
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.economics
 
+import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.mechanisms.YieldCurve
@@ -36,9 +37,10 @@ object FiscalConstraintEconomics:
     Output(r.month, r.baseMinWage, r.updatedMinWagePriceLevel, r.resWage, r.lendingBaseRate)
 
   @boundaryEscape
-  def compute(w: World)(using p: SimParams): Result =
+  def compute(w: World, banks: Vector[Banking.BankState])(using p: SimParams): Result =
     import ComputationBoundary.toDouble
-    val m = w.month + 1
+    val m       = w.month + 1
+    val bankAgg = Banking.aggregateFromBanks(banks)
 
     val (baseMinWage, updatedMinWagePriceLevel) = if p.flags.minWage then
       val isAdjustMonth = m > 0 && m % p.fiscal.minWageAdjustMonths == 0
@@ -63,7 +65,7 @@ object FiscalConstraintEconomics:
         val exp = w.mechanisms.expectations
         toDouble(
           YieldCurve
-            .compute(w.bankingSector.interbankRate, w.bank.nplRatio, exp.credibility, exp.expectedInflation, p.monetary.targetInfl)
+            .compute(w.bankingSector.interbankRate, bankAgg.nplRatio, exp.credibility, exp.expectedInflation, p.monetary.targetInfl)
             .wibor3m,
         )
       else toDouble(w.nbp.referenceRate)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -165,6 +165,7 @@ object OpenEconEconomics:
   @boundaryEscape
   def compute(in: Input)(using p: SimParams): Result =
     import ComputationBoundary.toDouble
+    val bankAgg = Banking.aggregateFromBanks(in.banks)
 
     // 1. Sector outputs (capacity × demand × price)
     val sectorOutputs = computeSectorOutputs(in)
@@ -245,7 +246,7 @@ object OpenEconEconomics:
       updateWeightedCoupon(in.w.gov.weightedCoupon, marketYield, in.w.gov.bondsOutstanding, in.w.gov.deficit, p.fiscal.govAvgMaturityMonths)
     val rawDebtService    = in.w.gov.bondsOutstanding * newWeightedCoupon.monthly
     val debtService       = rawDebtService.min(PLN(in.w.gdpProxy * MaxDebtServiceGdpShare))
-    val bankBondIncome    = in.w.bank.govBondHoldings * marketYield.monthly
+    val bankBondIncome    = bankAgg.govBondHoldings * marketYield.monthly
     val nbpBondIncome     = in.w.nbp.govBondHoldings * marketYield.monthly
     val nbpRemittance     = nbpBondIncome - reserveInterest - standingFacility
 
@@ -255,7 +256,7 @@ object OpenEconEconomics:
       else if Nbp.shouldTaperQe(in.newInflation, newExp.expectedInflation) then false
       else in.w.nbp.qeActive
     val preQeNbp  = Nbp.State(newRefRate, in.w.nbp.govBondHoldings, qeActive, in.w.nbp.qeCumulative, in.w.nbp.fxReserves, in.w.nbp.lastFxTraded)
-    val qeRequest = Nbp.executeQe(preQeNbp, in.w.bank.govBondHoldings, annualGdp, in.newInflation, newExp.expectedInflation)
+    val qeRequest = Nbp.executeQe(preQeNbp, bankAgg.govBondHoldings, annualGdp, in.newInflation, newExp.expectedInflation)
 
     // 7. Corporate bonds
     val corpBondAmort = CorporateBondMarket.amortization(in.w.financial.corporateBonds)
@@ -263,7 +264,7 @@ object OpenEconEconomics:
       CorporateBondMarket.StepInput(
         in.w.financial.corporateBonds,
         marketYield,
-        in.w.bank.nplRatio,
+        bankAgg.nplRatio,
         in.totalBondDefault,
         in.actualBondIssuance,
       ),
@@ -414,14 +415,15 @@ object OpenEconEconomics:
   private case class NbfiResult(state: Nbfi.State)
 
   def runStep(in: StepInput)(using p: SimParams): StepOutput =
+    val bankAgg       = Banking.aggregateFromBanks(in.banks)
     val sectorOutputs = runStepSectorOutputs(in)
     val external      = runStepExternalSector(in, sectorOutputs)
     val rateAndExp    = runStepRateAndExpectations(in, external.newForex)
     val interbank     = runStepInterbankFlows(in.w, in.banks)
-    val bondQe        = runStepBondYieldAndQe(in, rateAndExp.refRate, rateAndExp.expectations, external.fxIntervention, interbank)
-    val corpBonds     = runStepCorporateBonds(in, bondQe.marketYield)
+    val bondQe        = runStepBondYieldAndQe(in, bankAgg, rateAndExp.refRate, rateAndExp.expectations, external.fxIntervention, interbank)
+    val corpBonds     = runStepCorporateBonds(in, bankAgg, bondQe.marketYield)
     val insurance     = runStepInsurance(in, bondQe.marketYield)
-    val nbfi          = runStepNbfi(in, bondQe.postFxNbp, bondQe.marketYield)
+    val nbfi          = runStepNbfi(in, bankAgg, bondQe.postFxNbp, bondQe.marketYield)
 
     StepOutput(
       monetary = MonetaryPolicy(
@@ -585,6 +587,7 @@ object OpenEconEconomics:
   @boundaryEscape
   private def runStepBondYieldAndQe(
       in: StepInput,
+      bankAgg: Banking.Aggregate,
       newRefRate: Rate,
       newExp: Expectations.State,
       fxResult: Nbp.FxInterventionResult,
@@ -611,7 +614,7 @@ object OpenEconEconomics:
 
     val rawDebtService     = in.w.gov.bondsOutstanding * newWeightedCoupon.monthly
     val monthlyDebtService = rawDebtService.min(PLN(in.w.gdpProxy * MaxDebtServiceGdpShare))
-    val bankBondIncome     = in.w.bank.govBondHoldings * marketYield.monthly
+    val bankBondIncome     = bankAgg.govBondHoldings * marketYield.monthly
     val nbpBondIncome      = in.w.nbp.govBondHoldings * marketYield.monthly
     val nbpRemittance      = nbpBondIncome - interbank.reserveInterest - interbank.standingFacilityIncome
 
@@ -622,20 +625,20 @@ object OpenEconEconomics:
       else if qeTaper then false
       else in.w.nbp.qeActive
     val preQeNbp         = Nbp.State(newRefRate, in.w.nbp.govBondHoldings, qeActive, in.w.nbp.qeCumulative, in.w.nbp.fxReserves, in.w.nbp.lastFxTraded)
-    val qeRequest        = Nbp.executeQe(preQeNbp, in.w.bank.govBondHoldings, annualGdpForBonds, in.s7.newInfl, newExp.expectedInflation)
+    val qeRequest        = Nbp.executeQe(preQeNbp, bankAgg.govBondHoldings, annualGdpForBonds, in.s7.newInfl, newExp.expectedInflation)
     val qePurchaseAmount = qeRequest.requestedPurchase
     val postFxNbp        = qeRequest.nbpState.copy(fxReserves = fxResult.newReserves, lastFxTraded = fxResult.eurTraded)
 
     BondQeResult(marketYield, newWeightedCoupon, bankBondIncome, nbpRemittance, monthlyDebtService, qePurchaseAmount, postFxNbp)
 
-  private def runStepCorporateBonds(in: StepInput, newBondYield: Rate)(using SimParams): CorporateBonds =
+  private def runStepCorporateBonds(in: StepInput, bankAgg: Banking.Aggregate, newBondYield: Rate)(using SimParams): CorporateBonds =
     val corpBondAmort    = CorporateBondMarket.amortization(in.w.financial.corporateBonds)
     val newCorpBonds     = CorporateBondMarket
       .step(
         CorporateBondMarket.StepInput(
           prev = in.w.financial.corporateBonds,
           govBondYield = newBondYield,
-          nplRatio = in.w.bank.nplRatio,
+          nplRatio = bankAgg.nplRatio,
           totalBondDefault = in.s5.totalBondDefault,
           totalBondIssuance = in.s5.actualBondIssuance,
         ),
@@ -667,7 +670,7 @@ object OpenEconEconomics:
       else in.w.financial.insurance
     InsuranceResult(newInsurance)
 
-  private def runStepNbfi(in: StepInput, postFxNbp: Nbp.State, newBondYield: Rate)(using p: SimParams): NbfiResult =
+  private def runStepNbfi(in: StepInput, bankAgg: Banking.Aggregate, postFxNbp: Nbp.State, newBondYield: Rate)(using p: SimParams): NbfiResult =
     val nbfiDepositRate = (postFxNbp.referenceRate - Rate(NbfiDepositRateSpread)).max(Rate.Zero)
     val nbfiUnempRate   = Share.One - Share.fraction(in.s2.employed, in.w.totalPopulation)
     val newNbfi         =
@@ -678,7 +681,7 @@ object OpenEconEconomics:
           in.s2.newWage,
           in.w.priceLevel,
           nbfiUnempRate,
-          in.w.bank.nplRatio,
+          bankAgg.nplRatio,
           newBondYield,
           in.w.financial.corporateBonds.corpBondYield,
           in.w.financial.equity.monthlyReturn,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -387,12 +387,10 @@ object WorldAssemblyEconomics:
         minWagePriceLevel = in.s1.updatedMinWagePriceLevel,
       ),
       nbp = in.s9.finalNbp,
-      bank = in.s9.resolvedBank,
       bankingSector = in.s9.bankingMarket,
       forex = in.s8.external.newForex,
       bop = in.s8.external.newBop,
       hhAgg = in.s9.finalHhAgg,
-      monetaryAgg = in.s9.monAgg,
       social = SocialState(
         jst = in.s9.newJst,
         zus = in.s2.newZus,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -261,7 +261,7 @@ object FlowSimulation:
       banks: Vector[Banking.BankState],
       rng: Random,
   )(using p: SimParams): FullComputation =
-    val fiscal          = FiscalConstraintEconomics.compute(w)
+    val fiscal          = FiscalConstraintEconomics.compute(w, banks)
     val s1              = FiscalConstraintEconomics.toOutput(fiscal)
     val labor           = LaborEconomics.compute(w, firms, households, s1)
     val s2Pre           = LaborEconomics.Output(

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -79,7 +79,6 @@ object WorldInit:
         fxReserves = p.monetary.fxReserves,
         lastFxTraded = PLN.Zero,
       ),
-      bank = initBankingSector.aggregate,
       bankingSector = initBankingSector.marketState,
       forex = OpenEconomy.ForexState(
         exchangeRate = p.forex.baseExRate,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -36,8 +36,12 @@ object SimOutput:
       val aliveBanks: Vector[Banking.BankState],
       val p: SimParams,
   ):
-    given SimParams                         = p
-    lazy val sectorAuto: IndexedSeq[Double] = p.sectorDefs.indices.map { s =>
+    given SimParams                                          = p
+    lazy val bankAgg: Banking.Aggregate                      = Banking.aggregateFromBanks(banks)
+    lazy val monetaryAgg: Option[Banking.MonetaryAggregates] =
+      if p.flags.creditDiagnostics then Some(Banking.MonetaryAggregates.compute(banks, world.financial.nbfi.tfiAum, world.financial.corporateBonds.outstanding))
+      else None
+    lazy val sectorAuto: IndexedSeq[Double]                  = p.sectorDefs.indices.map { s =>
       val secFirms = living.filter(_.sector.toInt == s)
       if secFirms.isEmpty then 0.0
       else
@@ -80,7 +84,7 @@ object SimOutput:
     ColumnDef("ExRate", ctx => ctx.world.forex.exchangeRate),
     ColumnDef("MarketWage", ctx => td.toDouble(ctx.world.hhAgg.marketWage)),
     ColumnDef("GovDebt", ctx => td.toDouble(ctx.world.gov.cumulativeDebt)),
-    ColumnDef("NPL", ctx => td.toDouble(ctx.world.bank.nplRatio)),
+    ColumnDef("NPL", ctx => td.toDouble(ctx.bankAgg.nplRatio)),
     ColumnDef("RefRate", ctx => td.toDouble(ctx.world.nbp.referenceRate)),
     ColumnDef("PriceLevel", ctx => ctx.world.priceLevel),
     ColumnDef("AutoRatio", ctx => td.toDouble(ctx.world.real.automationRatio)),
@@ -201,7 +205,7 @@ object SimOutput:
     ColumnDef("BondYield", ctx => td.toDouble(ctx.world.gov.bondYield)),
     ColumnDef("WeightedCoupon", ctx => td.toDouble(ctx.world.gov.weightedCoupon)),
     ColumnDef("BondsOutstanding", ctx => td.toDouble(ctx.world.gov.bondsOutstanding)),
-    ColumnDef("BankBondHoldings", ctx => td.toDouble(ctx.world.bank.govBondHoldings)),
+    ColumnDef("BankBondHoldings", ctx => td.toDouble(ctx.bankAgg.govBondHoldings)),
     ColumnDef("ForeignBondHoldings", ctx => td.toDouble(ctx.world.gov.foreignBondHoldings)),
     ColumnDef("NbpBondHoldings", ctx => td.toDouble(ctx.world.nbp.govBondHoldings)),
     ColumnDef("QeActive", ctx => if ctx.world.nbp.qeActive then 1.0 else 0.0),
@@ -213,11 +217,11 @@ object SimOutput:
     ColumnDef("DepositFacilityUsage", ctx => td.toDouble(ctx.world.plumbing.depositFacilityUsage)),
     ColumnDef("InterbankInterestNet", ctx => td.toDouble(ctx.world.plumbing.interbankInterestNet)),
     // Monetary aggregates
-    ColumnDef("M0", ctx => ctx.world.monetaryAgg.map(a => td.toDouble(a.m0)).getOrElse(0.0)),
-    ColumnDef("M1", ctx => ctx.world.monetaryAgg.map(a => td.toDouble(a.m1)).getOrElse(td.toDouble(ctx.world.bank.deposits))),
-    ColumnDef("M2", ctx => ctx.world.monetaryAgg.map(a => td.toDouble(a.m2)).getOrElse(td.toDouble(ctx.world.bank.deposits))),
-    ColumnDef("M3", ctx => ctx.world.monetaryAgg.map(a => td.toDouble(a.m3)).getOrElse(td.toDouble(ctx.world.bank.deposits))),
-    ColumnDef("CreditMultiplier", ctx => ctx.world.monetaryAgg.map(_.creditMultiplier).getOrElse(0.0)),
+    ColumnDef("M0", ctx => ctx.monetaryAgg.map(a => td.toDouble(a.m0)).getOrElse(0.0)),
+    ColumnDef("M1", ctx => ctx.monetaryAgg.map(a => td.toDouble(a.m1)).getOrElse(td.toDouble(ctx.bankAgg.deposits))),
+    ColumnDef("M2", ctx => ctx.monetaryAgg.map(a => td.toDouble(a.m2)).getOrElse(td.toDouble(ctx.bankAgg.deposits))),
+    ColumnDef("M3", ctx => ctx.monetaryAgg.map(a => td.toDouble(a.m3)).getOrElse(td.toDouble(ctx.bankAgg.deposits))),
+    ColumnDef("CreditMultiplier", ctx => ctx.monetaryAgg.map(_.creditMultiplier).getOrElse(0.0)),
     ColumnDef("FofResidual", ctx => td.toDouble(ctx.world.plumbing.fofResidual)),
   )
 
@@ -247,11 +251,11 @@ object SimOutput:
     ColumnDef("WIBOR_3M", ctx => ctx.world.bankingSector.interbankCurve.map(c => td.toDouble(c.wibor3m)).getOrElse(0.0)),
     ColumnDef("WIBOR_6M", ctx => ctx.world.bankingSector.interbankCurve.map(c => td.toDouble(c.wibor6m)).getOrElse(0.0)),
     // Consumer Credit
-    ColumnDef("ConsumerLoans", ctx => td.toDouble(ctx.world.bank.consumerLoans)),
+    ColumnDef("ConsumerLoans", ctx => td.toDouble(ctx.bankAgg.consumerLoans)),
     ColumnDef(
       "ConsumerNplRatio",
       ctx =>
-        if ctx.world.bank.consumerLoans > PLN.Zero then ctx.world.bank.consumerNpl / ctx.world.bank.consumerLoans
+        if ctx.bankAgg.consumerLoans > PLN.Zero then ctx.bankAgg.consumerNpl / ctx.bankAgg.consumerLoans
         else 0.0,
     ),
     ColumnDef("ConsumerOrigination", ctx => td.toDouble(ctx.world.hhAgg.totalConsumerOrigination)),
@@ -314,8 +318,8 @@ object SimOutput:
     ),
     ColumnDef("NbfiDepositDrain", ctx => td.toDouble(ctx.world.financial.nbfi.lastDepositDrain)),
     // AFS/HTM bond portfolio split
-    ColumnDef("BankAfsBonds", ctx => td.toDouble(ctx.world.bank.afsBonds)),
-    ColumnDef("BankHtmBonds", ctx => td.toDouble(ctx.world.bank.htmBonds)),
+    ColumnDef("BankAfsBonds", ctx => td.toDouble(ctx.bankAgg.afsBonds)),
+    ColumnDef("BankHtmBonds", ctx => td.toDouble(ctx.bankAgg.htmBonds)),
     // IFRS 9 ECL staging (aggregate across banks)
     ColumnDef("EclStage1", ctx => ctx.banks.map(b => td.toDouble(b.eclStaging.stage1)).sum),
     ColumnDef("EclStage2", ctx => ctx.banks.map(b => td.toDouble(b.eclStaging.stage2)).sum),

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -305,7 +305,6 @@ object Generators:
     price    <- genPrice
     gov      <- genGovState
     rate     <- genRate
-    bank     <- genBankingAggregate
     forex    <- genForexState
     employed <- Gen.choose(0, p.pop.firmsCount * p.pop.workersPerFirm)
     wage     <- genWage
@@ -322,7 +321,6 @@ object Generators:
     totalPopulation = employed,
     gov = gov,
     nbp = Nbp.State(Rate(rate), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-    bank = bank,
     bankingSector = testBankingSector().marketState,
     forex = forex,
     hhAgg = Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -29,10 +29,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     result.swap.getOrElse(Vector.empty).find(_.identity == id).map(e => td.toDouble(e.actual - e.expected)).getOrElse(0.0)
 
   private def makeWorld(
-      bankCapital: Double = 500000.0,
-      bankDeposits: Double = 1000000.0,
-      bankLoans: Double = 0.0,
-      bankNpl: Double = 0.0,
       govDebt: Double = 0.0,
   ): World =
     World(
@@ -44,7 +40,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN(govDebt), PLN.Zero),
       nbp = Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN(bankLoans), PLN(bankNpl), PLN(bankCapital), PLN(bankDeposits), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       hhAgg = Household.Aggregates(
@@ -269,10 +264,33 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     snap.hhDebt shouldBe PLN.Zero
   }
 
-  it should "capture bank state from World" in {
-    val w     = makeWorld(bankCapital = 123456.0, bankDeposits = 789012.0, bankLoans = 50000.0, govDebt = 100000.0)
+  it should "capture bank state from explicit banks" in {
+    val w     = makeWorld(govDebt = 100000.0)
     val firms = makeFirms(1)
-    val snap  = Sfc.snapshot(w, firms, Vector.empty, Vector.empty)
+    val banks = Vector(
+      Banking.BankState(
+        id = BankId(0),
+        loans = PLN(50000.0),
+        nplAmount = PLN.Zero,
+        capital = PLN(123456.0),
+        deposits = PLN(789012.0),
+        afsBonds = PLN.Zero,
+        htmBonds = PLN.Zero,
+        htmBookYield = Rate.Zero,
+        reservesAtNbp = PLN.Zero,
+        interbankNet = PLN.Zero,
+        status = Banking.BankStatus.Active(0),
+        demandDeposits = PLN(789012.0),
+        termDeposits = PLN.Zero,
+        loansShort = PLN(50000.0),
+        loansMedium = PLN.Zero,
+        loansLong = PLN.Zero,
+        consumerLoans = PLN.Zero,
+        consumerNpl = PLN.Zero,
+        corpBondHoldings = PLN.Zero,
+      ),
+    )
+    val snap  = Sfc.snapshot(w, firms, Vector.empty, banks)
     snap.bankCapital shouldBe PLN(123456.0)
     snap.bankDeposits shouldBe PLN(789012.0)
     snap.bankLoans shouldBe PLN(50000.0)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -322,7 +322,6 @@ class FirmSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100000,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN(1000000), PLN(10000), PLN(500000), PLN(1000000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN(190000000), PLN.Zero, PLN.Zero),
       hhAgg = Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -438,7 +438,6 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100000,
       gov = FiscalBudget.GovState(PLN(0.0), PLN(0.0), PLN(0.0), PLN(0.0)),
       nbp = Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN(1000000), PLN(10000), PLN(500000), PLN(1000000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN(0.0), PLN(190000000), PLN(0.0), PLN(0.0)),
       hhAgg = Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
@@ -48,7 +48,6 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100000,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN(1000000), PLN(10000), PLN(500000), PLN(1000000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN(190000000), PLN.Zero, PLN.Zero),
       hhAgg = Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
@@ -3,7 +3,6 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
-import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
@@ -207,7 +206,6 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(100), PLN(1000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
-import com.boombustgroup.amorfati.agents.{Banking, BankruptReason, Firm, TechState}
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.types.*
 
 class EnergyClimateSpec extends AnyFlatSpec with Matchers:
@@ -178,7 +178,6 @@ class EnergyClimateSpec extends AnyFlatSpec with Matchers:
     totalPopulation = 100000,
     gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-    bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(500000000.0), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     bankingSector = Generators.testBankingSector().marketState,
     forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
@@ -169,7 +169,6 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100000,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = Nbp.State(Rate(0.0575), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN(1000000), PLN(10000), PLN(500000), PLN(1000000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN(190000000), PLN.Zero, PLN.Zero),
       hhAgg = Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
-import com.boombustgroup.amorfati.agents.{Banking, BankruptReason, Firm, TechState}
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.mechanisms.FirmEntry
 import com.boombustgroup.amorfati.types.*
@@ -75,7 +75,6 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
     totalPopulation = 100,
     gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-    bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(1e9), PLN(1e9), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     bankingSector = Generators.testBankingSector().marketState,
     forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
-import com.boombustgroup.amorfati.agents.{Banking, BankruptReason, Firm, TechState}
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.types.*
 
 class InformalEconomySpec extends AnyFlatSpec with Matchers:
@@ -77,7 +77,6 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
     totalPopulation = 100,
     gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-    bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(1e9), PLN(1e9), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     bankingSector = Generators.testBankingSector().marketState,
     forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
-import com.boombustgroup.amorfati.agents.{Banking, BankruptReason, Firm, TechState}
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
 
@@ -85,7 +85,6 @@ class InventorySpec extends AnyFlatSpec with Matchers:
     totalPopulation = 100,
     gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-    bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(1e9), PLN(1e9), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     bankingSector = Generators.testBankingSector().marketState,
     forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
     hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -207,7 +207,6 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(100000), PLN(500000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(4.33, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
@@ -3,7 +3,6 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
-import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
 
@@ -251,7 +250,6 @@ class TourismSpec extends AnyFlatSpec with Matchers:
       totalPopulation = 100,
       gov = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       nbp = com.boombustgroup.amorfati.agents.Nbp.State(Rate(0.05), PLN.Zero, false, PLN.Zero, PLN.Zero, PLN.Zero),
-      bank = Banking.Aggregate(PLN.Zero, PLN.Zero, PLN(100), PLN(1000), PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       bankingSector = Generators.testBankingSector().marketState,
       forex = OpenEconomy.ForexState(p.forex.baseExRate, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero),
       hhAgg = com.boombustgroup.amorfati.agents.Household.Aggregates(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -18,7 +18,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     val w    = init.world
     val rng  = new scala.util.Random(42)
 
-    val fiscal = FiscalConstraintEconomics.compute(w)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
     val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
     val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -17,7 +17,7 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private val w    = init.world
   private val rng  = new scala.util.Random(42)
 
-  private val fiscal = FiscalConstraintEconomics.compute(w)
+  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
   private val s1     = FiscalConstraintEconomics.toOutput(fiscal)
   private val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
   private val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
@@ -10,10 +10,11 @@ class FiscalConstraintEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val world = WorldInit.initialize(42L).world
+  private val init  = WorldInit.initialize(42L)
+  private val world = init.world
 
   "FiscalConstraintEconomics.compute" should "produce consistent result and output" in {
-    val result = FiscalConstraintEconomics.compute(world)
+    val result = FiscalConstraintEconomics.compute(world, init.banks)
     val output = FiscalConstraintEconomics.toOutput(result)
 
     output.m shouldBe result.month
@@ -24,6 +25,6 @@ class FiscalConstraintEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "advance month by 1" in {
-    val result = FiscalConstraintEconomics.compute(world)
+    val result = FiscalConstraintEconomics.compute(world, init.banks)
     result.month shouldBe world.month + 1
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -19,7 +19,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
   private val rng  = new scala.util.Random(42)
 
   // Run pipeline through Economics objects
-  private val fiscal = FiscalConstraintEconomics.compute(w)
+  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
   private val s1     = FiscalConstraintEconomics.toOutput(fiscal)
   private val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
   private val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -22,7 +22,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
     */
   private def runOneMonth: (Map[Int, Long], LaborEconomics.Result) =
     // Step 1: Fiscal constraints (pure calculus)
-    val fiscal = FiscalConstraintEconomics.compute(w)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
 
     // Step 2: Labor economics (pure calculus)
     val s1    = FiscalConstraintEconomics.toOutput(fiscal)
@@ -59,7 +59,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "emit non-trivial fund flows" in {
-    val fiscal = FiscalConstraintEconomics.compute(w)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
     val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -23,7 +23,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =
-    val fiscal             = FiscalConstraintEconomics.compute(w)
+    val fiscal             = FiscalConstraintEconomics.compute(w, initResult.banks)
     val s1                 = FiscalConstraintEconomics.toOutput(fiscal)
     val labor              = LaborEconomics.compute(w, initResult.firms, initResult.households, s1)
     val s2                 = LaborEconomics.Output(


### PR DESCRIPTION
## Summary
- remove derived banking aggregate fields from `World`
- derive banking aggregate and monetary aggregates from the explicit bank population where they are actually needed
- thread explicit banks into fiscal-constraint consumers and update fixtures/tests to the thinner `World` contract

## Validation
- `sbt compile Test/compile`
- `sbt scalafmtAll`
- `sbt 'testOnly *SfcSpec* *FiscalConstraintEconomicsSpec* *BankingEconomicsSpec* *OpenEconEconomicsSpec* *FirmEconomicsSpec* *FlowSimulationStepSpec*'`

Fixes #209