### PR TITLE
Split pipeline signals from derived flow outputs

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -303,8 +303,8 @@ object Firm:
   private def desiredWorkers(f: State, w: World)(using p: SimParams): Int =
     if isInStartup(f) then return Math.max(workerCount(f), f.startupTargetWorkers)
     import ComputationBoundary.toDouble
-    val sectorDemand = w.flows.sectorDemandMult(f.sector.toInt)
-    val hiringSignal = w.flows.sectorHiringSignal(f.sector.toInt)
+    val sectorDemand = w.pipeline.sectorDemandMult(f.sector.toInt)
+    val hiringSignal = w.pipeline.sectorHiringSignal(f.sector.toInt)
     val demandMult   = sectorDemand + (hiringSignal - sectorDemand).max(0.0) * HiringPressureBlend
     val price        = w.priceLevel
     val wage         = toDouble(w.hhAgg.marketWage) * toDouble(effectiveWageMult(f.sector))
@@ -319,7 +319,7 @@ object Firm:
       val capPrev = computeCapacity(f.copy(tech = TechState.Traditional(mid - 1)))
       val mr      = toDouble(capMid - capPrev) * demandMult * price
       if mr > wage then lo = mid else hi = mid - 1
-    applyAggregateHiringSlack(lo, minW, w.flows.aggregateHiringSlack)
+    applyAggregateHiringSlack(lo, minW, w.pipeline.aggregateHiringSlack)
 
   private def monthlyHiringHeadroom(workers: Int): Int =
     if workers <= 5 then 1
@@ -455,7 +455,7 @@ object Firm:
     val r1       = applyGreenInvestment(r0a)
     val r2       = applyInvestment(r1)
     val r3       = applyDigitalDrift(r2)
-    val r4       = applyInventory(r3, sectorDemandMult = w.flows.sectorDemandMult(firm.sector.toInt))
+    val r4       = applyInventory(r3, sectorDemandMult = w.pipeline.sectorDemandMult(firm.sector.toInt))
     val r5       = applyFdiFlows(r4)
     applyInformalCitEvasion(r5, w.mechanisms.informalCyclicalAdj)
 
@@ -578,7 +578,7 @@ object Firm:
     val pnl = computePnL(
       firm,
       w.hhAgg.marketWage,
-      w.flows.sectorDemandMult(firm.sector.toInt),
+      w.pipeline.sectorDemandMult(firm.sector.toInt),
       PriceIndex(w.priceLevel),
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,
@@ -604,7 +604,7 @@ object Firm:
     val pnl    = computePnL(
       firm,
       w.hhAgg.marketWage,
-      w.flows.sectorDemandMult(firm.sector.toInt),
+      w.pipeline.sectorDemandMult(firm.sector.toInt),
       PriceIndex(w.priceLevel),
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,
@@ -880,7 +880,7 @@ object Firm:
     val pnl           = computePnL(
       firm,
       w.hhAgg.marketWage,
-      w.flows.sectorDemandMult(firm.sector.toInt),
+      w.pipeline.sectorDemandMult(firm.sector.toInt),
       PriceIndex(w.priceLevel),
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -37,7 +37,7 @@ object BankruptcyProbe:
       val byReason    = newBankrupts.groupMapReduce(_._1)(_ => 1)(_ + _).toVector.sortBy(-_._2)
       val bySector    = newBankrupts.groupMapReduce(_._2)(_ => 1)(_ + _).toVector.sortBy(_._1)
       val unemp       = result.newWorld.hhAgg.unemploymentRate(result.newWorld.totalPopulation)
-      val demandMults = result.newWorld.flows.sectorDemandMult
+      val demandMults = result.newWorld.pipeline.sectorDemandMult
 
       println(
         s"month=$month unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -30,7 +30,8 @@ case class World(
     real: RealState,                                       // housing, mobility, investment, energy, automation
     mechanisms: MechanismsState,                           // macropru, expectations, BFG, informal economy
     plumbing: MonetaryPlumbingState,                       // reserve corridor, standing facilities, interbank
-    flows: FlowState,                                      // single-step flows → SFC identities
+    pipeline: PipelineState = PipelineState.zero,          // inter-step demand / hiring / fiscal signals
+    flows: FlowState,                                      // single-step derived flow outputs → SFC identities
     regionalWages: Map[Region, PLN] = Map.empty,           // per-region wage levels (NUTS-1)
 ):
   def updateSocial(f: SocialState => SocialState): World                        = copy(social = f(social))
@@ -39,6 +40,7 @@ case class World(
   def updateReal(f: RealState => RealState): World                              = copy(real = f(real))
   def updateMechanisms(f: MechanismsState => MechanismsState): World            = copy(mechanisms = f(mechanisms))
   def updatePlumbing(f: MonetaryPlumbingState => MonetaryPlumbingState): World  = copy(plumbing = f(plumbing))
+  def updatePipeline(f: PipelineState => PipelineState): World                  = copy(pipeline = f(pipeline))
   def updateFlows(f: FlowState => FlowState): World                             = copy(flows = f(flows))
 
 // ---------------------------------------------------------------------------
@@ -139,27 +141,8 @@ case class MonetaryPlumbingState(
 object MonetaryPlumbingState:
   val zero: MonetaryPlumbingState = MonetaryPlumbingState()
 
-/** Single-step flow outputs — recomputed each step, zero at init. Feed into SFC
-  * identities.
-  */
-case class FlowState(
-    ioFlows: PLN = PLN.Zero,                                                                     // I-O intermediate payments between sectors
-    fdiProfitShifting: PLN = PLN.Zero,                                                           // intangible imports booked abroad (profit shifting)
-    fdiRepatriation: PLN = PLN.Zero,                                                             // dividend repatriation by foreign-owned firms
-    fdiCitLoss: PLN = PLN.Zero,                                                                  // CIT lost to profit shifting
-    diasporaRemittanceInflow: PLN = PLN.Zero,                                                    // diaspora remittance inflow
-    tourismExport: PLN = PLN.Zero,                                                               // inbound tourism services export
-    tourismImport: PLN = PLN.Zero,                                                               // outbound tourism services import
-    aggInventoryStock: PLN = PLN.Zero,                                                           // aggregate firm inventory stock
-    aggInventoryChange: PLN = PLN.Zero,                                                          // ΔInventories (enters GDP)
-    aggEnergyCost: PLN = PLN.Zero,                                                               // aggregate energy + CO₂ costs
-    firmBirths: Int = 0,                                                                         // new firms (recycled + net new)
-    firmDeaths: Int = 0,                                                                         // firms bankrupt this step
-    netFirmBirths: Int = 0,                                                                      // net new firms appended to vector
-    taxEvasionLoss: PLN = PLN.Zero,                                                              // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
-    informalEmployed: Double = 0.0,                                                              // estimated informal employment count
-    bailInLoss: PLN = PLN.Zero,                                                                  // bail-in capital loss on bank creditors
-    bfgLevyTotal: Double = 0.0,                                                                  // BFG resolution levy from all banks
+/** Inter-step pipeline signals carried into the next month. */
+case class PipelineState(
     sectorDemandMult: Vector[Double] = Vector.fill(SimParams.DefaultSectorDefs.length)(1.0),     // per-sector demand multipliers from S4
     sectorDemandPressure: Vector[Double] = Vector.fill(SimParams.DefaultSectorDefs.length)(1.0), // uncapped demand/capacity ratios for hiring
     sectorHiringSignal: Vector[Double] = Vector.fill(SimParams.DefaultSectorDefs.length)(1.0),   // smoothed sector hiring signal used by firm labor planning
@@ -167,6 +150,31 @@ case class FlowState(
     govSpendingCutRatio: Share = Share.Zero,                                                     // fraction of raw spending cut by fiscal rules
     aggregateHiringSlack: Double = 1.0,                                                          // economy-wide compression of firm labor targets when plans exceed supply
     startupAbsorptionRate: Double = 1.0,                                                         // share of startup hiring targets filled across active startup firms
+)
+object PipelineState:
+  val zero: PipelineState = PipelineState()
+
+/** Single-step derived flow outputs — recomputed each step, zero at init. Feed
+  * into SFC identities and output columns.
+  */
+case class FlowState(
+    ioFlows: PLN = PLN.Zero,                  // I-O intermediate payments between sectors
+    fdiProfitShifting: PLN = PLN.Zero,        // intangible imports booked abroad (profit shifting)
+    fdiRepatriation: PLN = PLN.Zero,          // dividend repatriation by foreign-owned firms
+    fdiCitLoss: PLN = PLN.Zero,               // CIT lost to profit shifting
+    diasporaRemittanceInflow: PLN = PLN.Zero, // diaspora remittance inflow
+    tourismExport: PLN = PLN.Zero,            // inbound tourism services export
+    tourismImport: PLN = PLN.Zero,            // outbound tourism services import
+    aggInventoryStock: PLN = PLN.Zero,        // aggregate firm inventory stock
+    aggInventoryChange: PLN = PLN.Zero,       // ΔInventories (enters GDP)
+    aggEnergyCost: PLN = PLN.Zero,            // aggregate energy + CO₂ costs
+    firmBirths: Int = 0,                      // new firms (recycled + net new)
+    firmDeaths: Int = 0,                      // firms bankrupt this step
+    netFirmBirths: Int = 0,                   // net new firms appended to vector
+    taxEvasionLoss: PLN = PLN.Zero,           // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
+    informalEmployed: Double = 0.0,           // estimated informal employment count
+    bailInLoss: PLN = PLN.Zero,               // bail-in capital loss on bank creditors
+    bfgLevyTotal: Double = 0.0,               // BFG resolution levy from all banks
 )
 object FlowState:
   val zero: FlowState = FlowState()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -272,8 +272,8 @@ object BankingEconomics:
     val s4 = DemandEconomics.Output(
       in.govPurchases,
       in.sectorMults,
-      in.w.flows.sectorDemandPressure,
-      in.w.flows.sectorHiringSignal,
+      in.w.pipeline.sectorDemandPressure,
+      in.w.pipeline.sectorHiringSignal,
       in.avgDemandMult,
       in.sectorCap,
       in.laggedInvestDemand,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
@@ -51,7 +51,7 @@ object DemandEconomics:
     val sectorDemand       = computeSectorDemand(in, govPurchases, sectorExports, laggedInvestDemand)
     val rawPressure        = computeRawDemandPressure(sectorDemand, sectorCap, in.w.priceLevel)
     val sectorPressure     = stabilizeDemandPressure(rawPressure)
-    val sectorHiringSignal = smoothHiringSignal(in.w.flows.sectorHiringSignal, sectorPressure)
+    val sectorHiringSignal = smoothHiringSignal(in.w.pipeline.sectorHiringSignal, sectorPressure)
     val sectorMults        = applySpillover(rawPressure, sectorCap, in.w.priceLevel)
     val avgDemandMult      = computeAvgDemandMult(sectorMults, sectorCap, in)
     Output(govPurchases, sectorMults, sectorPressure, sectorHiringSignal, avgDemandMult, sectorCap, laggedInvestDemand, fiscalResult.status)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -304,7 +304,7 @@ object FirmEconomics:
       in.employed,
       in.laborDemand,
       in.wageGrowth,
-      in.w.flows.aggregateHiringSlack,
+      in.w.pipeline.aggregateHiringSlack,
       in.immigration,
       in.netMigration,
       in.demographics,
@@ -319,8 +319,8 @@ object FirmEconomics:
     val s4 = DemandEconomics.Output(
       in.govPurchases,
       in.sectorMults,
-      in.w.flows.sectorDemandPressure,
-      in.w.flows.sectorHiringSignal,
+      in.w.pipeline.sectorDemandPressure,
+      in.w.pipeline.sectorHiringSignal,
       in.avgDemandMult,
       in.sectorCap,
       in.laggedInvestDemand,
@@ -377,7 +377,7 @@ object FirmEconomics:
     val canLend = (bankId: Int, amt: PLN) => Banking.canLend(in.banks(bankId), amt, rng, ccyb)
     val world   = in.w.copy(
       month = in.s1.m,
-      flows = in.w.flows.copy(
+      pipeline = in.w.pipeline.copy(
         sectorDemandMult = in.s4.sectorMults,
         sectorDemandPressure = in.s4.sectorDemandPressure,
         aggregateHiringSlack = in.s2.aggregateHiringSlack,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -127,8 +127,8 @@ object WorldAssemblyEconomics:
     val s4 = DemandEconomics.Output(
       in.govPurchases,
       in.sectorMults,
-      in.w.flows.sectorDemandPressure,
-      in.w.flows.sectorHiringSignal,
+      in.w.pipeline.sectorDemandPressure,
+      in.w.pipeline.sectorHiringSignal,
       in.avgDemandMult,
       in.sectorCap,
       in.laggedInvestDemand,
@@ -187,7 +187,7 @@ object WorldAssemblyEconomics:
           in.s2.aggregateHiringSlack,
           newW.inflation,
           newW.mechanisms.expectations.expectedInflation,
-          in.w.flows.startupAbsorptionRate,
+          in.w.pipeline.startupAbsorptionRate,
           rng,
         )
         EntryStepResult(r.firms, r.births, r.netBirths, r.entrantIds)
@@ -202,14 +202,8 @@ object WorldAssemblyEconomics:
     val finalFirms = syncStartupStaffing(startupStaffing.firms, postMigHh)
 
     val finalW = newW
-      .updateFlows(
-        _.copy(
-          firmBirths = entryStep.firmBirths,
-          firmDeaths = in.s5.firmDeaths,
-          netFirmBirths = entryStep.netBirths,
-          startupAbsorptionRate = startupStaffing.startupAbsorptionRate,
-        ),
-      )
+      .updateFlows(_.copy(firmBirths = entryStep.firmBirths, firmDeaths = in.s5.firmDeaths, netFirmBirths = entryStep.netBirths))
+      .updatePipeline(_.copy(startupAbsorptionRate = startupStaffing.startupAbsorptionRate))
       .updateReal: r =>
         r.copy(
           sectoralMobility = r.sectoralMobility.copy(
@@ -439,7 +433,18 @@ object WorldAssemblyEconomics:
         depositFacilityUsage = obs.depositFacilityUsage,
         fofResidual = fofResidual,
       ),
+      pipeline = buildPipelineState(in),
       flows = buildFlowState(in, informal),
+    )
+
+  private def buildPipelineState(in: StepInput): PipelineState =
+    PipelineState(
+      sectorDemandMult = in.s4.sectorMults,
+      sectorDemandPressure = in.s4.sectorDemandPressure,
+      sectorHiringSignal = in.s4.sectorHiringSignal,
+      fiscalRuleSeverity = in.s4.fiscalRuleStatus.bindingRule,
+      govSpendingCutRatio = in.s4.fiscalRuleStatus.spendingCutRatio,
+      aggregateHiringSlack = in.s2.aggregateHiringSlack,
     )
 
   /** Construct the FlowState for this step. */
@@ -463,11 +468,6 @@ object WorldAssemblyEconomics:
       informalEmployed = informal.informalEmployed,
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = toDouble(in.s9.bfgLevy),
-      sectorDemandMult = in.s4.sectorMults,
-      sectorDemandPressure = in.s4.sectorDemandPressure,
-      sectorHiringSignal = in.s4.sectorHiringSignal,
-      fiscalRuleSeverity = in.s4.fiscalRuleStatus.bindingRule,
-      govSpendingCutRatio = in.s4.fiscalRuleStatus.spendingCutRatio,
     )
 
   /** Run SFC validation against previous and current snapshots. */

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -160,6 +160,7 @@ object WorldInit:
         expectations = ExpectationsInit.create(),
       ),
       plumbing = MonetaryPlumbingState.zero,
+      pipeline = PipelineState.zero,
       flows = FlowState.zero,
       regionalWages = Region.all.map(r => r -> (p.household.baseWage * Region.normalizedWageMultiplier(r))).toMap,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -196,8 +196,8 @@ object SimOutput:
       "DeficitToGdp",
       ctx => if ctx.world.gdpProxy > 0 then td.toDouble(ctx.world.gov.deficit) / (ctx.world.gdpProxy * 12.0) else 0.0,
     ),
-    ColumnDef("FiscalRuleBinding", ctx => ctx.world.flows.fiscalRuleSeverity.toDouble),
-    ColumnDef("GovSpendingCutRatio", ctx => td.toDouble(ctx.world.flows.govSpendingCutRatio)),
+    ColumnDef("FiscalRuleBinding", ctx => ctx.world.pipeline.fiscalRuleSeverity.toDouble),
+    ColumnDef("GovSpendingCutRatio", ctx => td.toDouble(ctx.world.pipeline.govSpendingCutRatio)),
   )
 
   private def monetaryGroup: Vector[ColumnDef] = Vector(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -64,12 +64,13 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   "Firm.hiringDiagnostics" should "delay non-micro hiring until demand persists" in {
     val world       = mkWorld().copy(
-      flows = FlowState.zero.copy(
+      pipeline = PipelineState(
         sectorDemandMult = Vector.fill(p.sectorDefs.length)(1.0),
         sectorDemandPressure = Vector.fill(p.sectorDefs.length)(1.75),
         sectorHiringSignal = Vector.fill(p.sectorDefs.length)(1.75),
         aggregateHiringSlack = 1.0,
       ),
+      flows = FlowState.zero,
     )
     val firstSignal = Firm.hiringDiagnostics(mkFirm(TechState.Traditional(8), sector = 3), world)
     firstSignal.desiredWorkers should be > firstSignal.workers
@@ -85,12 +86,13 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   it should "allow micro firms to react on the first sustained positive gap" in {
     val world = mkWorld().copy(
-      flows = FlowState.zero.copy(
+      pipeline = PipelineState(
         sectorDemandMult = Vector.fill(p.sectorDefs.length)(1.0),
         sectorDemandPressure = Vector.fill(p.sectorDefs.length)(1.75),
         sectorHiringSignal = Vector.fill(p.sectorDefs.length)(1.75),
         aggregateHiringSlack = 1.0,
       ),
+      flows = FlowState.zero,
     )
     val diag  = Firm.hiringDiagnostics(mkFirm(TechState.Traditional(4), sector = 3), world)
     diag.desiredWorkers should be > diag.workers
@@ -100,12 +102,13 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   it should "keep startup firms on their startup staffing target even under weak demand" in {
     val world   = mkWorld().copy(
-      flows = FlowState.zero.copy(
+      pipeline = PipelineState(
         sectorDemandMult = Vector.fill(p.sectorDefs.length)(0.8),
         sectorDemandPressure = Vector.fill(p.sectorDefs.length)(0.8),
         sectorHiringSignal = Vector.fill(p.sectorDefs.length)(0.8),
         aggregateHiringSlack = 1.0,
       ),
+      flows = FlowState.zero,
     )
     val startup = mkFirm(TechState.Traditional(1), sector = 3).copy(startupMonthsLeft = 4, startupTargetWorkers = 3)
     val diag    = Firm.hiringDiagnostics(startup, world)
@@ -261,7 +264,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
   it should "bankrupt an Automated firm with negative cash when P&L is negative" in {
     // Very low cash + high price level = deep losses → bankrupt
     val f      = mkFirm(TechState.Automated(0.1)).copy(cash = PLN(-500000.0), debt = PLN(5000000.0))
-    val w      = mkWorld().copy(priceLevel = 0.3, flows = mkWorld().flows.copy(sectorDemandMult = Vector.fill(6)(0.1)))
+    val w      = mkWorld().copy(priceLevel = 0.3, pipeline = mkWorld().pipeline.copy(sectorDemandMult = Vector.fill(6)(0.1)))
     val result = Firm.process(f, w, Rate(0.20), _ => true, Vector(f), new Random(42))
     result.firm.tech shouldBe a[TechState.Bankrupt]
   }


### PR DESCRIPTION
## Summary
- introduce `PipelineState` for inter-step demand, hiring, and fiscal signals
- keep `FlowState` for derived step outputs used by SFC and output columns
- rewire world assembly, firm/banking consumers, and fixtures to use the split state model

## Validation
- `sbt compile Test/compile`
- `sbt scalafmtAll`
- `sbt 'testOnly *WorldAssemblyEconomicsSpec* *FlowSimulationStepSpec* *FirmEconomicsSpec* *BankingEconomicsSpec* *DemandEconomicsSpec* *FirmSpec*'`

Fixes #210
