### PR TITLE
Introduce batched-flow emission contract

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
@@ -1,0 +1,121 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.ledger.*
+
+/** Aggregate batched-flow contract for the current pre-agent runtime path.
+  *
+  * The main simulation still emits aggregate mechanism totals, not per-agent
+  * flows. To use the public BatchedFlow API without pretending we already have
+  * per-agent sender/receiver vectors, each mechanism writes against a small set
+  * of explicit aggregate nodes inside each ledger sector.
+  *
+  * This contract is intentionally separate from the real runtime
+  * LedgerStateAdapter sector sizing. It is an emission-layer bridge only.
+  */
+object AggregateBatchContract:
+
+  object HouseholdIndex:
+    val Aggregate  = 0
+    val Landlords  = 1
+    val Depositors = 2
+    val Investors  = 3
+
+  object FirmIndex:
+    val Aggregate      = 0
+    val Services       = 1
+    val CapitalGoods   = 2
+    val IoCounterparty = 3
+    val DomesticDemand = 4
+
+  object BankIndex:
+    val Aggregate = 0
+
+  object GovernmentIndex:
+    val Budget       = 0
+    val TaxpayerPool = 1
+
+  object NbpIndex:
+    val Aggregate = 0
+
+  object InsuranceIndex:
+    val Aggregate = 0
+
+  object FundIndex:
+    val Zus         = 0
+    val Nfz         = 1
+    val Ppk         = 2
+    val Fp          = 3
+    val Pfron       = 4
+    val Fgsp        = 5
+    val Jst         = 6
+    val Bondholders = 7
+    val BondMarket  = 8
+    val Markets     = 9
+    val Healthcare  = 10
+
+  object ForeignIndex:
+    val Aggregate = 0
+
+  val sectorSizes: Map[EntitySector, Int] = Map(
+    EntitySector.Households -> 4,
+    EntitySector.Firms      -> 5,
+    EntitySector.Banks      -> 1,
+    EntitySector.Government -> 2,
+    EntitySector.NBP        -> 1,
+    EntitySector.Insurance  -> 1,
+    EntitySector.Funds      -> 11,
+    EntitySector.Foreign    -> 1,
+  )
+
+  private val sectorOrder: Vector[EntitySector] = Vector(
+    EntitySector.Households,
+    EntitySector.Firms,
+    EntitySector.Banks,
+    EntitySector.Government,
+    EntitySector.NBP,
+    EntitySector.Insurance,
+    EntitySector.Funds,
+    EntitySector.Foreign,
+  )
+
+  val offsets: Map[EntitySector, Int] =
+    sectorOrder
+      .foldLeft((Map.empty[EntitySector, Int], 0)):
+        case ((acc, next), sector) => (acc.updated(sector, next), next + sectorSizes(sector))
+      ._1
+
+  def toLegacyFlows(batches: Vector[BatchedFlow]): Vector[Flow] =
+    batches.flatMap(toLegacyFlows)
+
+  def totalTransferred(batches: Vector[BatchedFlow]): Long =
+    batches.iterator.map(totalTransferred).sum
+
+  def totalTransferred(batch: BatchedFlow): Long =
+    batch match
+      case scatter: BatchedFlow.Scatter     => scatter.amounts.iterator.sum
+      case broadcast: BatchedFlow.Broadcast => broadcast.amounts.iterator.sum
+
+  private def toLegacyFlows(batch: BatchedFlow): Vector[Flow] =
+    batch match
+      case scatter: BatchedFlow.Scatter     =>
+        val fromOffset = offsets(scatter.from)
+        val toOffset   = offsets(scatter.to)
+        scatter.amounts.indices
+          .flatMap: i =>
+            val amount = scatter.amounts(i)
+            val fromId = fromOffset + i
+            val toId   = toOffset + scatter.targetIndices(i)
+            if amount != 0L && fromId != toId then Some(Flow(fromId, toId, amount, scatter.mechanism.toInt)) else None
+          .toVector
+      case broadcast: BatchedFlow.Broadcast =>
+        val fromOffset = offsets(broadcast.from)
+        val toOffset   = offsets(broadcast.to)
+        broadcast.amounts.indices
+          .flatMap: i =>
+            val amount = broadcast.amounts(i)
+            val fromId = fromOffset + broadcast.fromIndex
+            val toId   = toOffset + broadcast.targetIndices(i)
+            if amount != 0L && fromId != toId then Some(Flow(fromId, toId, amount, broadcast.mechanism.toInt)) else None
+          .toVector
+
+end AggregateBatchContract

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchedEmission.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchedEmission.scala
@@ -1,0 +1,19 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.PLN
+import com.boombustgroup.ledger.*
+
+/** Helper for aggregate one-sender / one-receiver batching. */
+object AggregateBatchedEmission:
+
+  def transfer(
+      from: EntitySector,
+      fromIndex: Int,
+      to: EntitySector,
+      toIndex: Int,
+      amount: PLN,
+      asset: AssetType,
+      mechanism: MechanismId,
+  ): Vector[BatchedFlow] =
+    if amount > PLN.Zero then Vector(BatchedFlow.Broadcast(from, fromIndex, to, Array(amount.toLong), Array(toIndex), asset, mechanism))
+    else Vector.empty

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/BankingFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/BankingFlows.scala
@@ -34,6 +34,95 @@ object BankingFlows:
       nbpRemittance: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.govBondIncome,
+        AssetType.Cash,
+        FlowMechanism.BankGovBondIncome,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.NBP,
+        NbpIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.reserveInterest,
+        AssetType.Cash,
+        FlowMechanism.BankReserveInterest,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.NBP,
+        NbpIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.standingFacilityIncome,
+        AssetType.Cash,
+        FlowMechanism.BankStandingFacility,
+      ),
+      if input.interbankInterest > PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.NBP,
+          NbpIndex.Aggregate,
+          EntitySector.Banks,
+          BankIndex.Aggregate,
+          input.interbankInterest,
+          AssetType.Cash,
+          FlowMechanism.BankInterbankInterest,
+        )
+      else if input.interbankInterest < PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.Banks,
+          BankIndex.Aggregate,
+          EntitySector.NBP,
+          NbpIndex.Aggregate,
+          -input.interbankInterest,
+          AssetType.Cash,
+          FlowMechanism.BankInterbankInterest,
+        )
+      else Vector.empty,
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.bfgLevy,
+        AssetType.Cash,
+        FlowMechanism.BankBfgLevy,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.unrealizedBondLoss,
+        AssetType.Cash,
+        FlowMechanism.BankUnrealizedLoss,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Depositors,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.bailInLoss,
+        AssetType.DemandDeposit,
+        FlowMechanism.BankBailIn,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.nbpRemittance,
+        AssetType.Cash,
+        FlowMechanism.BankNbpRemittance,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/CorpBondFlows.scala
@@ -22,6 +22,47 @@ object CorpBondFlows:
       amortization: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Funds,
+        FundIndex.Bondholders,
+        input.coupon,
+        AssetType.Cash,
+        FlowMechanism.CorpBondCoupon,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Funds,
+        FundIndex.Bondholders,
+        input.defaultLoss,
+        AssetType.CorpBond,
+        FlowMechanism.CorpBondDefault,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        FundIndex.BondMarket,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.issuance,
+        AssetType.CorpBond,
+        FlowMechanism.CorpBondIssuance,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Funds,
+        FundIndex.Bondholders,
+        input.amortization,
+        AssetType.CorpBond,
+        FlowMechanism.CorpBondAmortization,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
     if input.coupon > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HOLDER_ACCOUNT, input.coupon.toLong, FlowMechanism.CorpBondCoupon.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
@@ -28,6 +28,69 @@ object EarmarkedFlows:
       avgFirmWorkers: Int,
   )
 
+  def emitBatches(input: Input)(using p: SimParams): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    val fpContrib = input.employed * (input.wage * p.earmarked.fpRate)
+    val fpSpend   = input.unempBenefitSpend + input.employed * p.earmarked.fpAlmpSpendPerWorker
+    val fpDeficit = fpSpend - fpContrib
+
+    val pfronContrib = p.earmarked.pfronMonthlyRevenue
+    val pfronSpend   = p.earmarked.pfronMonthlySpending
+    val pfronDeficit = pfronSpend - pfronContrib
+
+    val fgspContrib = input.employed * (input.wage * p.earmarked.fgspRate)
+    val fgspSpend   = (input.nBankruptFirms * input.avgFirmWorkers) * p.earmarked.fgspPayoutPerWorker
+    val fgspDeficit = fgspSpend - fgspContrib
+
+    Vector.concat(
+      AggregateBatchedEmission
+        .transfer(EntitySector.Households, HouseholdIndex.Aggregate, EntitySector.Funds, FundIndex.Fp, fpContrib, AssetType.Cash, FlowMechanism.FpContribution),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Funds, FundIndex.Fp, EntitySector.Firms, FirmIndex.Services, fpSpend, AssetType.Cash, FlowMechanism.FpSpending),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Government, GovernmentIndex.Budget, EntitySector.Funds, FundIndex.Fp, fpDeficit, AssetType.Cash, FlowMechanism.FpGovSubvention),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        FundIndex.Pfron,
+        pfronContrib,
+        AssetType.Cash,
+        FlowMechanism.PfronContribution,
+      ),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Funds, FundIndex.Pfron, EntitySector.Firms, FirmIndex.Services, pfronSpend, AssetType.Cash, FlowMechanism.PfronSpending),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Funds,
+        FundIndex.Pfron,
+        pfronDeficit,
+        AssetType.Cash,
+        FlowMechanism.PfronGovSubvention,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        FundIndex.Fgsp,
+        fgspContrib,
+        AssetType.Cash,
+        FlowMechanism.FgspContribution,
+      ),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Funds, FundIndex.Fgsp, EntitySector.Firms, FirmIndex.Services, fgspSpend, AssetType.Cash, FlowMechanism.FgspSpending),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Funds,
+        FundIndex.Fgsp,
+        fgspDeficit,
+        AssetType.Cash,
+        FlowMechanism.FgspGovSubvention,
+      ),
+    )
+
   def emit(input: Input)(using p: SimParams): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -24,6 +24,47 @@ object EquityFlows:
       issuance: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Investors,
+        input.netDomesticDividends,
+        AssetType.Cash,
+        FlowMechanism.EquityDomDividend,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.foreignDividends,
+        AssetType.Cash,
+        FlowMechanism.EquityForDividend,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Investors,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.dividendTax,
+        AssetType.Cash,
+        FlowMechanism.EquityDividendTax,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Investors,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.issuance,
+        AssetType.Equity,
+        FlowMechanism.EquityIssuance,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
     if input.netDomesticDividends > PLN.Zero then

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
@@ -37,6 +37,114 @@ object FirmFlows:
       grossInvestment: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.wages,
+        AssetType.Cash,
+        FlowMechanism.FirmWages,
+      ),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Firms, FirmIndex.Aggregate, EntitySector.Government, GovernmentIndex.Budget, input.cit, AssetType.Cash, FlowMechanism.FirmCit),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.loanRepayment,
+        AssetType.FirmLoan,
+        FlowMechanism.FirmLoanRepayment,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.newLoans,
+        AssetType.FirmLoan,
+        FlowMechanism.FirmNewLoan,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.interestPaid,
+        AssetType.Cash,
+        FlowMechanism.FirmInterestPaid,
+      ),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Firms, FirmIndex.Aggregate, EntitySector.Firms, FirmIndex.CapitalGoods, input.capex, AssetType.Cash, FlowMechanism.FirmCapex),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Investors,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.equityIssuance,
+        AssetType.Equity,
+        FlowMechanism.FirmEquityIssuance,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        FundIndex.BondMarket,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.bondIssuance,
+        AssetType.CorpBond,
+        FlowMechanism.FirmBondIssuance,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.IoCounterparty,
+        input.ioPayments,
+        AssetType.Cash,
+        FlowMechanism.FirmIoPayment,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.nplDefault,
+        AssetType.FirmLoan,
+        FlowMechanism.FirmNplDefault,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.profitShifting,
+        AssetType.Cash,
+        FlowMechanism.FirmProfitShifting,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.fdiRepatriation,
+        AssetType.Cash,
+        FlowMechanism.FirmFdiRepatriation,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.CapitalGoods,
+        input.grossInvestment,
+        AssetType.Cash,
+        FlowMechanism.FirmGrossInvestment,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -135,16 +135,16 @@ object FlowSimulation:
   /** Emit ALL flows from calculus results. Pure translation — no economics
     * here.
     */
-  def emitAllFlows(c: MonthlyCalculus)(using p: SimParams): Vector[Flow] =
+  def emitAllBatches(c: MonthlyCalculus)(using p: SimParams): Vector[BatchedFlow] =
     Vector.concat(
       // Tier 1: Social funds
-      ZusFlows.emit(ZusFlows.ZusInput(c.employed, c.wage, c.retirees)),
-      NfzFlows.emit(NfzFlows.NfzInput(c.employed, c.wage, c.workingAgePop, c.retirees)),
-      PpkFlows.emit(PpkFlows.PpkInput(c.employed, c.wage)),
-      EarmarkedFlows.emit(EarmarkedFlows.Input(c.employed, c.wage, c.totalUnempBenefits, c.nBankruptFirms, c.avgFirmWorkers)),
-      JstFlows.emit(JstFlows.Input(c.govTaxRevenue, c.totalIncome, c.gdp, c.laborDemand, c.totalPit)),
+      ZusFlows.emitBatches(ZusFlows.ZusInput(c.employed, c.wage, c.retirees)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput(c.employed, c.wage, c.workingAgePop, c.retirees)),
+      PpkFlows.emitBatches(PpkFlows.PpkInput(c.employed, c.wage)),
+      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.employed, c.wage, c.totalUnempBenefits, c.nBankruptFirms, c.avgFirmWorkers)),
+      JstFlows.emitBatches(JstFlows.Input(c.govTaxRevenue, c.totalIncome, c.gdp, c.laborDemand, c.totalPit)),
       // Tier 2: Agents
-      HouseholdFlows.emit(
+      HouseholdFlows.emitBatches(
         HouseholdFlows.Input(
           c.consumption,
           c.totalRent,
@@ -157,7 +157,7 @@ object FlowSimulation:
           c.totalCcDefault,
         ),
       ),
-      FirmFlows.emit(
+      FirmFlows.emitBatches(
         FirmFlows.Input(
           c.totalIncome,
           c.firmTax,
@@ -174,7 +174,7 @@ object FlowSimulation:
           c.firmGrossInvestment,
         ),
       ),
-      GovBudgetFlows.emit(
+      GovBudgetFlows.emitBatches(
         GovBudgetFlows.Input(
           c.govTaxRevenue,
           c.govPurchases,
@@ -185,7 +185,7 @@ object FlowSimulation:
           c.govCapitalSpend,
         ),
       ),
-      InsuranceFlows.emit(
+      InsuranceFlows.emitBatches(
         InsuranceFlows.Input(
           c.employed,
           c.wage,
@@ -199,10 +199,10 @@ object FlowSimulation:
         ),
       ),
       // Tier 3: Financial markets
-      EquityFlows.emit(EquityFlows.Input(c.equityDomDividends, c.equityForDividends, c.equityDivTax, c.equityIssuance)),
-      CorpBondFlows.emit(CorpBondFlows.Input(c.corpBondCoupon, c.corpBondDefaultLoss, c.corpBondIssuance, c.corpBondAmortization)),
-      MortgageFlows.emit(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
-      OpenEconFlows.emit(
+      EquityFlows.emitBatches(EquityFlows.Input(c.equityDomDividends, c.equityForDividends, c.equityDivTax, c.equityIssuance)),
+      CorpBondFlows.emitBatches(CorpBondFlows.Input(c.corpBondCoupon, c.corpBondDefaultLoss, c.corpBondIssuance, c.corpBondAmortization)),
+      MortgageFlows.emitBatches(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
+      OpenEconFlows.emitBatches(
         OpenEconFlows.Input(
           c.exports,
           c.totalImports,
@@ -216,7 +216,7 @@ object FlowSimulation:
           PLN.Zero,
         ),
       ),
-      BankingFlows.emit(
+      BankingFlows.emitBatches(
         BankingFlows.Input(
           c.bankGovBondIncome,
           c.bankReserveInterest,
@@ -229,6 +229,9 @@ object FlowSimulation:
         ),
       ),
     )
+
+  def emitAllFlows(c: MonthlyCalculus)(using p: SimParams): Vector[Flow] =
+    AggregateBatchContract.toLegacyFlows(emitAllBatches(c))
 
   /** All intermediate step outputs needed for both MonthlyCalculus and
     * WorldAssembly. Computed once per step — eliminates the double-computation
@@ -466,7 +469,7 @@ object FlowSimulation:
 
   case class StepResult(
       calculus: MonthlyCalculus,
-      flows: Vector[Flow],
+      flows: Vector[BatchedFlow],
       newWorld: World,
       newFirms: Vector[Firm.State],
       newHouseholds: Vector[Household.State],
@@ -484,7 +487,7 @@ object FlowSimulation:
       p: SimParams,
   ): StepResult =
     val full  = computeAll(w, firms, households, banks, rng)
-    val flows = emitAllFlows(full.calculus)
+    val flows = emitAllBatches(full.calculus)
 
     val assembled = WorldAssemblyEconomics.compute(
       WorldAssemblyEconomics.Input(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
@@ -37,6 +37,74 @@ object GovBudgetFlows:
       govCapitalSpend: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.TaxpayerPool,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.taxRevenue,
+        AssetType.Cash,
+        FlowMechanism.GovTaxRevenue,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.govPurchases,
+        AssetType.Cash,
+        FlowMechanism.GovPurchases,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Funds,
+        FundIndex.Bondholders,
+        input.debtService,
+        AssetType.Cash,
+        FlowMechanism.GovDebtService,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.unempBenefitSpend,
+        AssetType.Cash,
+        FlowMechanism.GovUnempBenefit,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.socialTransferSpend,
+        AssetType.Cash,
+        FlowMechanism.GovSocialTransfer,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Firms,
+        FirmIndex.CapitalGoods,
+        input.euCofinancing,
+        AssetType.Cash,
+        FlowMechanism.GovEuCofin,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        EntitySector.Firms,
+        FirmIndex.CapitalGoods,
+        input.govCapitalSpend,
+        AssetType.Cash,
+        FlowMechanism.GovCapitalInvestment,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
@@ -37,6 +37,92 @@ object HouseholdFlows:
       ccDefault: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        input.consumption,
+        AssetType.Cash,
+        FlowMechanism.HhConsumption,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Landlords,
+        input.rent,
+        AssetType.Cash,
+        FlowMechanism.HhRent,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.pit,
+        AssetType.Cash,
+        FlowMechanism.HhPit,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.debtService,
+        AssetType.Cash,
+        FlowMechanism.HhDebtService,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.depositInterest,
+        AssetType.Cash,
+        FlowMechanism.HhDepositInterest,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.remittances,
+        AssetType.Cash,
+        FlowMechanism.HhRemittance,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.ccOrigination,
+        AssetType.ConsumerLoan,
+        FlowMechanism.HhCcOrigination,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.ccDebtService,
+        AssetType.ConsumerLoan,
+        FlowMechanism.HhCcDebtService,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.ccDefault,
+        AssetType.ConsumerLoan,
+        FlowMechanism.HhCcDefault,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
@@ -31,6 +31,69 @@ object InsuranceFlows:
       equityReturn: Rate,
   )
 
+  def emitBatches(input: Input)(using p: SimParams): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    val lifePrem    = input.employed * (input.wage * p.ins.lifePremiumRate)
+    val nonLifePrem = input.employed * (input.wage * p.ins.nonLifePremiumRate)
+
+    val lifeCl      = lifePrem * p.ins.lifeLossRatio
+    val nonLifeBase = nonLifePrem * p.ins.nonLifeLossRatio
+    val stressGap   = (input.unempRate - Share(NonLifeUnempThreshold)).max(Share.Zero)
+    val stressAdj   = (stressGap * p.ins.nonLifeUnempSens).toMultiplier
+    val nonLifeCl   = nonLifeBase * (Multiplier.One + stressAdj)
+
+    val invIncome = input.prevGovBondHoldings * input.govBondYield.monthly +
+      input.prevCorpBondHoldings * input.corpBondYield.monthly +
+      input.prevEquityHoldings * input.equityReturn
+
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Insurance,
+        InsuranceIndex.Aggregate,
+        lifePrem,
+        AssetType.LifeReserve,
+        FlowMechanism.InsLifePremium,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Insurance,
+        InsuranceIndex.Aggregate,
+        nonLifePrem,
+        AssetType.NonLifeReserve,
+        FlowMechanism.InsNonLifePremium,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Insurance,
+        InsuranceIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        lifeCl,
+        AssetType.LifeReserve,
+        FlowMechanism.InsLifeClaim,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Insurance,
+        InsuranceIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        nonLifeCl,
+        AssetType.NonLifeReserve,
+        FlowMechanism.InsNonLifeClaim,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        FundIndex.Markets,
+        EntitySector.Insurance,
+        InsuranceIndex.Aggregate,
+        invIncome,
+        AssetType.Cash,
+        FlowMechanism.InsInvestmentIncome,
+      ),
+    )
+
   def emit(input: Input)(using p: SimParams): Vector[Flow] =
     val lifePrem    = input.employed * (input.wage * p.ins.lifePremiumRate)
     val nonLifePrem = input.employed * (input.wage * p.ins.nonLifePremiumRate)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
@@ -25,6 +25,40 @@ object JstFlows:
       pitRevenue: PLN,
   )
 
+  def emitBatches(input: Input)(using p: SimParams): Vector[BatchedFlow] =
+    if !p.flags.jst then Vector.empty
+    else
+      import AggregateBatchContract.*
+      val jstPitIncome  =
+        if p.flags.pit && input.pitRevenue > PLN.Zero then input.pitRevenue * p.fiscal.jstPitShare
+        else input.totalWageIncome * (Share(FallbackPitRate) * p.fiscal.jstPitShare)
+      val citRevenue    = input.govTaxRevenue * p.fiscal.jstCitShare
+      val propertyTax   = input.nFirms * p.fiscal.jstPropertyTax / 12L
+      val subvention    = input.gdp * p.fiscal.jstSubventionShare / 12L
+      val dotacje       = input.gdp * p.fiscal.jstDotacjeShare / 12L
+      val totalRevenue  = jstPitIncome + citRevenue + propertyTax + subvention + dotacje
+      val totalSpending = totalRevenue * p.fiscal.jstSpendingMult
+      Vector.concat(
+        AggregateBatchedEmission.transfer(
+          EntitySector.Government,
+          GovernmentIndex.TaxpayerPool,
+          EntitySector.Funds,
+          FundIndex.Jst,
+          totalRevenue,
+          AssetType.Cash,
+          FlowMechanism.JstRevenue,
+        ),
+        AggregateBatchedEmission.transfer(
+          EntitySector.Funds,
+          FundIndex.Jst,
+          EntitySector.Firms,
+          FirmIndex.Services,
+          totalSpending,
+          AssetType.Cash,
+          FlowMechanism.JstSpending,
+        ),
+      )
+
   def emit(input: Input)(using p: SimParams): Vector[Flow] =
     if !p.flags.jst then Vector.empty
     else

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MortgageFlows.scala
@@ -22,6 +22,47 @@ object MortgageFlows:
       defaultAmount: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.origination,
+        AssetType.MortgageLoan,
+        FlowMechanism.MortgageOrigination,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.principalRepayment,
+        AssetType.MortgageLoan,
+        FlowMechanism.MortgageRepayment,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.interest,
+        AssetType.Cash,
+        FlowMechanism.MortgageInterest,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        EntitySector.Banks,
+        BankIndex.Aggregate,
+        input.defaultAmount,
+        AssetType.MortgageLoan,
+        FlowMechanism.MortgageDefault,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
     if input.origination > PLN.Zero then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.origination.toLong, FlowMechanism.MortgageOrigination.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
@@ -26,6 +26,38 @@ object NfzFlows:
       nRetirees: Int,
   )
 
+  def emitBatches(input: NfzInput)(using p: SimParams): Vector[BatchedFlow] =
+    if !p.flags.nfz then Vector.empty
+    else
+      import AggregateBatchContract.*
+      val contributions = input.employed * (input.wage * p.social.nfzContribRate)
+      val spending      =
+        input.workingAge * p.social.nfzPerCapitaCost +
+          input.nRetirees * (p.social.nfzPerCapitaCost * p.social.nfzAgingElasticity)
+      val deficit       = spending - contributions
+      Vector.concat(
+        AggregateBatchedEmission.transfer(
+          EntitySector.Households,
+          HouseholdIndex.Aggregate,
+          EntitySector.Funds,
+          FundIndex.Nfz,
+          contributions,
+          AssetType.Cash,
+          FlowMechanism.NfzContribution,
+        ),
+        AggregateBatchedEmission
+          .transfer(EntitySector.Funds, FundIndex.Nfz, EntitySector.Firms, FirmIndex.Services, spending, AssetType.Cash, FlowMechanism.NfzSpending),
+        AggregateBatchedEmission.transfer(
+          EntitySector.Government,
+          GovernmentIndex.Budget,
+          EntitySector.Funds,
+          FundIndex.Nfz,
+          deficit,
+          AssetType.Cash,
+          FlowMechanism.NfzGovSubvention,
+        ),
+      )
+
   def emit(input: NfzInput)(using p: SimParams): Vector[Flow] =
     if !p.flags.nfz then Vector.empty
     else

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
@@ -31,6 +31,118 @@ object OpenEconFlows:
       capitalFlightOutflow: PLN,
   )
 
+  def emitBatches(input: Input): Vector[BatchedFlow] =
+    import AggregateBatchContract.*
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.DomesticDemand,
+        input.exports,
+        AssetType.Cash,
+        FlowMechanism.TradeExports,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.DomesticDemand,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.imports,
+        AssetType.Cash,
+        FlowMechanism.TradeImports,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        EntitySector.Firms,
+        FirmIndex.DomesticDemand,
+        input.tourismExport,
+        AssetType.Cash,
+        FlowMechanism.TourismExport,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.DomesticDemand,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.tourismImport,
+        AssetType.Cash,
+        FlowMechanism.TourismImport,
+      ),
+      AggregateBatchedEmission
+        .transfer(EntitySector.Foreign, ForeignIndex.Aggregate, EntitySector.Firms, FirmIndex.Aggregate, input.fdi, AssetType.Cash, FlowMechanism.Fdi),
+      if input.portfolioFlows > PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.Foreign,
+          ForeignIndex.Aggregate,
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          input.portfolioFlows,
+          AssetType.Cash,
+          FlowMechanism.PortfolioFlow,
+        )
+      else if input.portfolioFlows < PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          EntitySector.Foreign,
+          ForeignIndex.Aggregate,
+          -input.portfolioFlows,
+          AssetType.Cash,
+          FlowMechanism.PortfolioFlow,
+        )
+      else Vector.empty,
+      if input.primaryIncome > PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.Foreign,
+          ForeignIndex.Aggregate,
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          input.primaryIncome,
+          AssetType.Cash,
+          FlowMechanism.PrimaryIncome,
+        )
+      else if input.primaryIncome < PLN.Zero then
+        AggregateBatchedEmission.transfer(
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          EntitySector.Foreign,
+          ForeignIndex.Aggregate,
+          -input.primaryIncome,
+          AssetType.Cash,
+          FlowMechanism.PrimaryIncome,
+        )
+      else Vector.empty,
+      AggregateBatchedEmission.transfer(
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.euFunds,
+        AssetType.Cash,
+        FlowMechanism.EuFunds,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        EntitySector.Households,
+        HouseholdIndex.Aggregate,
+        input.diasporaInflow,
+        AssetType.Cash,
+        FlowMechanism.DiasporaInflow,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Foreign,
+        ForeignIndex.Aggregate,
+        input.capitalFlightOutflow,
+        AssetType.Cash,
+        FlowMechanism.CapitalFlight,
+      ),
+    )
+
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
@@ -19,6 +19,33 @@ object PpkFlows:
 
   case class PpkInput(employed: Int, wage: PLN)
 
+  def emitBatches(input: PpkInput)(using p: SimParams): Vector[BatchedFlow] =
+    if !p.flags.ppk then Vector.empty
+    else
+      import AggregateBatchContract.*
+      val contributions = input.employed * (input.wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
+      val bondPurchase  = contributions * p.social.ppkBondAlloc
+      Vector.concat(
+        AggregateBatchedEmission.transfer(
+          EntitySector.Households,
+          HouseholdIndex.Aggregate,
+          EntitySector.Funds,
+          FundIndex.Ppk,
+          contributions,
+          AssetType.Cash,
+          FlowMechanism.PpkContribution,
+        ),
+        AggregateBatchedEmission.transfer(
+          EntitySector.Funds,
+          FundIndex.Ppk,
+          EntitySector.Funds,
+          FundIndex.BondMarket,
+          bondPurchase,
+          AssetType.GovBondHTM,
+          FlowMechanism.PpkBondPurchase,
+        ),
+      )
+
   def emit(input: PpkInput)(using p: SimParams): Vector[Flow] =
     if !p.flags.ppk then Vector.empty
     else

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
@@ -29,6 +29,36 @@ object ZusFlows:
       nRetirees: Int,
   )
 
+  def emitBatches(input: ZusInput)(using p: SimParams): Vector[BatchedFlow] =
+    if !p.flags.zus then Vector.empty
+    else
+      import AggregateBatchContract.*
+      val contributions = input.employed * (input.wage * p.social.zusContribRate * p.social.zusScale)
+      val pensions      = input.nRetirees * p.social.zusBasePension
+      val deficit       = pensions - contributions
+      Vector.concat(
+        AggregateBatchedEmission.transfer(
+          EntitySector.Households,
+          HouseholdIndex.Aggregate,
+          EntitySector.Funds,
+          FundIndex.Zus,
+          contributions,
+          AssetType.Cash,
+          FlowMechanism.ZusContribution,
+        ),
+        AggregateBatchedEmission
+          .transfer(EntitySector.Funds, FundIndex.Zus, EntitySector.Households, HouseholdIndex.Aggregate, pensions, AssetType.Cash, FlowMechanism.ZusPension),
+        AggregateBatchedEmission.transfer(
+          EntitySector.Government,
+          GovernmentIndex.Budget,
+          EntitySector.Funds,
+          FundIndex.Zus,
+          deficit,
+          AssetType.Cash,
+          FlowMechanism.ZusGovSubvention,
+        ),
+      )
+
   def emit(input: ZusInput)(using p: SimParams): Vector[Flow] =
     if !p.flags.zus then Vector.empty
     else

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -80,7 +80,7 @@ object McRunner:
     val result = engine.flows.FlowSimulation.step(state.world, state.firms, state.households, state.banks, rng)
     // SFC verification: flows through verified interpreter should always be 0L
     val wealth = com.boombustgroup.ledger.Interpreter.totalWealth(
-      com.boombustgroup.ledger.Interpreter.applyAll(Map.empty[Int, Long], result.flows),
+      com.boombustgroup.ledger.Interpreter.applyAll(Map.empty[Int, Long], engine.flows.AggregateBatchContract.toLegacyFlows(result.flows)),
     )
     if wealth != 0L then
       val err = Sfc.SfcIdentityError(Sfc.SfcIdentity.FlowOfFunds, s"Flow SFC: totalWealth=$wealth", PLN.fromRaw(wealth), PLN.Zero)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -25,7 +25,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], result.flows))
+      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
 
       withClue(s"Month $month: ") {
         wealth.shouldBe(0L)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -1,0 +1,143 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
+
+  private given SimParams = SimParams.defaults
+
+  private def legacyMechanismTotals(flows: Vector[Flow]): Map[Int, Long] =
+    flows.groupMapReduce(_.mechanism)(_.amount)(_ + _)
+
+  private def batchedMechanismTotals(batches: Vector[BatchedFlow]): Map[Int, Long] =
+    batches.groupMapReduce(_.mechanism.toInt)(AggregateBatchContract.totalTransferred)(_ + _)
+
+  "emitBatches" should "preserve mechanism totals across migrated emitters" in {
+    val legacyFlows = Vector.concat(
+      ZusFlows.emit(ZusFlows.ZusInput(80000, PLN(7000.0), 1000)),
+      NfzFlows.emit(NfzFlows.NfzInput(80000, PLN(7000.0), 90000, 1000)),
+      PpkFlows.emit(PpkFlows.PpkInput(80000, PLN(7000.0))),
+      EarmarkedFlows.emit(EarmarkedFlows.Input(80000, PLN(7000.0), PLN(1000000.0), 10, 15)),
+      JstFlows.emit(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),
+      HouseholdFlows.emit(
+        HouseholdFlows
+          .Input(PLN(40000000.0), PLN(8000000.0), PLN(5000000.0), PLN(3000000.0), PLN(1000000.0), PLN(500000.0), PLN(2000000.0), PLN(1500000.0), PLN(200000.0)),
+      ),
+      FirmFlows.emit(
+        FirmFlows.Input(
+          PLN(50000000.0),
+          PLN(8000000.0),
+          PLN(4000000.0),
+          PLN(6000000.0),
+          PLN(3000000.0),
+          PLN(5000000.0),
+          PLN(1000000.0),
+          PLN(2000000.0),
+          PLN(7000000.0),
+          PLN(300000.0),
+          PLN(800000.0),
+          PLN(600000.0),
+          PLN(5000000.0),
+        ),
+      ),
+      GovBudgetFlows.emit(
+        GovBudgetFlows.Input(PLN(15000000.0), PLN(10000000.0), PLN(4000000.0), PLN(2000000.0), PLN(3000000.0), PLN(1500000.0), PLN(2500000.0)),
+      ),
+      InsuranceFlows.emit(
+        InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
+      ),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))),
+      CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
+      MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
+      OpenEconFlows.emit(
+        OpenEconFlows.Input(
+          PLN(1000000.0),
+          PLN(700000.0),
+          PLN(250000.0),
+          PLN(200000.0),
+          PLN(300000.0),
+          PLN(50000.0),
+          PLN(-20000.0),
+          PLN(400000.0),
+          PLN(100000.0),
+          PLN(150000.0),
+        ),
+      ),
+      BankingFlows.emit(BankingFlows.Input(PLN(600000.0), PLN(200000.0), PLN(100000.0), PLN(-50000.0), PLN(80000.0), PLN(40000.0), PLN(30000.0), PLN(50000.0))),
+    )
+
+    val batchedFlows = Vector.concat(
+      ZusFlows.emitBatches(ZusFlows.ZusInput(80000, PLN(7000.0), 1000)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput(80000, PLN(7000.0), 90000, 1000)),
+      PpkFlows.emitBatches(PpkFlows.PpkInput(80000, PLN(7000.0))),
+      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(80000, PLN(7000.0), PLN(1000000.0), 10, 15)),
+      JstFlows.emitBatches(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),
+      HouseholdFlows.emitBatches(
+        HouseholdFlows
+          .Input(PLN(40000000.0), PLN(8000000.0), PLN(5000000.0), PLN(3000000.0), PLN(1000000.0), PLN(500000.0), PLN(2000000.0), PLN(1500000.0), PLN(200000.0)),
+      ),
+      FirmFlows.emitBatches(
+        FirmFlows.Input(
+          PLN(50000000.0),
+          PLN(8000000.0),
+          PLN(4000000.0),
+          PLN(6000000.0),
+          PLN(3000000.0),
+          PLN(5000000.0),
+          PLN(1000000.0),
+          PLN(2000000.0),
+          PLN(7000000.0),
+          PLN(300000.0),
+          PLN(800000.0),
+          PLN(600000.0),
+          PLN(5000000.0),
+        ),
+      ),
+      GovBudgetFlows.emitBatches(
+        GovBudgetFlows.Input(PLN(15000000.0), PLN(10000000.0), PLN(4000000.0), PLN(2000000.0), PLN(3000000.0), PLN(1500000.0), PLN(2500000.0)),
+      ),
+      InsuranceFlows.emitBatches(
+        InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
+      ),
+      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))),
+      CorpBondFlows.emitBatches(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
+      MortgageFlows.emitBatches(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
+      OpenEconFlows.emitBatches(
+        OpenEconFlows.Input(
+          PLN(1000000.0),
+          PLN(700000.0),
+          PLN(250000.0),
+          PLN(200000.0),
+          PLN(300000.0),
+          PLN(50000.0),
+          PLN(-20000.0),
+          PLN(400000.0),
+          PLN(100000.0),
+          PLN(150000.0),
+        ),
+      ),
+      BankingFlows.emitBatches(
+        BankingFlows.Input(PLN(600000.0), PLN(200000.0), PLN(100000.0), PLN(-50000.0), PLN(80000.0), PLN(40000.0), PLN(30000.0), PLN(50000.0)),
+      ),
+    )
+
+    batchedMechanismTotals(batchedFlows) shouldBe legacyMechanismTotals(legacyFlows)
+    batchedFlows.foreach(_ shouldBe a[BatchedFlow.Broadcast])
+  }
+
+  it should "drive FlowSimulation main path through BatchedFlow" in {
+    val init   = WorldInit.initialize(42L)
+    val rng    = new scala.util.Random(42L)
+    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val legacy = AggregateBatchContract.toLegacyFlows(result.flows)
+
+    result.flows should not be empty
+    result.flows.forall(_.isInstanceOf[BatchedFlow]) shouldBe true
+    batchedMechanismTotals(result.flows) shouldBe legacyMechanismTotals(legacy)
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], legacy)) shouldBe 0L
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -6,24 +6,24 @@ import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/** Tests FlowSimulation.emitAllFlows with MonthlyCalculus from
+/** Tests FlowSimulation.emitAllBatches with MonthlyCalculus from
   * FlowSimulation.computeCalculus.
   *
   * Proves that the Contract-First pipeline design (MonthlyCalculus →
-  * emitAllFlows → Interpreter) closes at SFC == 0L when fed with real
-  * simulation data.
+  * emitAllBatches → batch bridge → Interpreter) closes at SFC == 0L when fed
+  * with real simulation data.
   */
 class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  "FlowSimulation.emitAllFlows" should "preserve SFC at 0L" in {
+  "FlowSimulation.emitAllBatches" should "preserve SFC at 0L" in {
     val init   = WorldInit.initialize(42L)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val flows  = FlowSimulation.emitAllFlows(result.calculus)
+    val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
-    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(flows))) shouldBe 0L
   }
 
   it should "preserve SFC across 12 months" in {
@@ -36,10 +36,10 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      val flows  = FlowSimulation.emitAllFlows(result.calculus)
+      val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
       withClue(s"Month $month: ") {
-        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
+        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(flows))) shouldBe 0L
       }
 
       w = result.newWorld
@@ -53,7 +53,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     val init   = WorldInit.initialize(42L)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val flows  = FlowSimulation.emitAllFlows(result.calculus)
+    val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
     flows.map(_.mechanism).toSet.size should be > 30
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -14,7 +14,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val init   = WorldInit.initialize(42L)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], result.flows)).shouldBe(0L)
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows))).shouldBe(0L)
     result.calculus.employed should be > 0
   }
 
@@ -29,7 +29,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
       withClue(s"Month $month: ") {
-        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], result.flows)).shouldBe(0L)
+        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows))).shouldBe(0L)
       }
       w = result.newWorld
       firms = result.newFirms

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -25,7 +25,7 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
     (1 to 120).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], result.flows))
+      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
 
       withClue(s"SFC violated at month $month: ") {
         wealth shouldBe 0L
@@ -49,7 +49,7 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
     (1 to 120).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      volumes = volumes :+ result.flows.map(_.amount).sum
+      volumes = volumes :+ AggregateBatchContract.totalTransferred(result.flows)
 
       w = result.newWorld
       firms = result.newFirms

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -29,7 +29,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
       (1 to months).foreach { month =>
         val rng    = new scala.util.Random(seed * 1000 + month)
         val result = FlowSimulation.step(w, firms, hh, banks, rng)
-        val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], result.flows))
+        val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
         withClue(s"Seed $seed, month $month: ") {
           wealth.shouldBe(0L)
         }


### PR DESCRIPTION
Fixes #203

## Summary
- add an explicit aggregate batched-flow contract for the current pre-agent flow pipeline
- switch `FlowSimulation.step` main path to `Vector[BatchedFlow]` while keeping a legacy `Flow` bridge for validation
- add focused contract tests that compare mechanism totals between legacy emitters and batched emitters

## Validation
- `sbt compile Test/compile`
- `sbt scalafmtAll`
- `sbt 'testOnly *BatchedEmissionContractSpec* *FlowSimulationSpec* *FlowSimulationStepSpec* *AutonomousPipelineSpec*'`\n\n## Notes\n- legacy `emit(...): Vector[Flow]` remains as a compatibility bridge for older flow specs and the pre-#204 validation path\n- the long multi-month / multi-seed flow regressions were not rerun to completion in this PR branch