### PR TITLE
Execute runtime flow batches via imperative ledger runtime

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
@@ -84,6 +84,15 @@ object AggregateBatchContract:
         case ((acc, next), sector) => (acc.updated(sector, next), next + sectorSizes(sector))
       ._1
 
+  def emptyExecutionState(): MutableWorldState =
+    new MutableWorldState(sectorSizes)
+
+  def totalWealth(snapshot: Map[(EntitySector, AssetType, Int), Long]): Long =
+    snapshot.valuesIterator.sum
+
+  def totalWealth(state: MutableWorldState): Long =
+    totalWealth(state.snapshot)
+
   def toLegacyFlows(batches: Vector[BatchedFlow]): Vector[Flow] =
     batches.flatMap(toLegacyFlows)
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -36,6 +36,11 @@ object FlowSimulation:
       householdAggregates: Household.Aggregates,
   )
 
+  case class ExecutionResult(
+      snapshot: Map[(EntitySector, AssetType, Int), Long],
+      totalWealth: Long,
+  )
+
   /** All calculus results needed to feed flow mechanisms. */
   case class MonthlyCalculus(
       // Stage 1: Fiscal constraint
@@ -470,12 +475,24 @@ object FlowSimulation:
   case class StepResult(
       calculus: MonthlyCalculus,
       flows: Vector[BatchedFlow],
+      execution: ExecutionResult,
       newWorld: World,
       newFirms: Vector[Firm.State],
       newHouseholds: Vector[Household.State],
       newBanks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
   )
+
+  private def executeBatches(flows: Vector[BatchedFlow]): Either[String, ExecutionResult] =
+    val state = AggregateBatchContract.emptyExecutionState()
+    ImperativeInterpreter
+      .planAndApplyAll(state, flows)
+      .map: _ =>
+        val snapshot = state.snapshot
+        ExecutionResult(
+          snapshot = snapshot,
+          totalWealth = AggregateBatchContract.totalWealth(snapshot),
+        )
 
   /** Full step: compute calculus → emit flows → assemble new World.
     *
@@ -486,8 +503,12 @@ object FlowSimulation:
   def step(w: World, firms: Vector[Firm.State], households: Vector[Household.State], banks: Vector[Banking.BankState], rng: Random)(using
       p: SimParams,
   ): StepResult =
-    val full  = computeAll(w, firms, households, banks, rng)
-    val flows = emitAllBatches(full.calculus)
+    val full      = computeAll(w, firms, households, banks, rng)
+    val flows     = emitAllBatches(full.calculus)
+    val execution = executeBatches(flows).fold(
+      err => throw IllegalStateException(s"Ledger batch execution failed: $err"),
+      identity,
+    )
 
     val assembled = WorldAssemblyEconomics.compute(
       WorldAssemblyEconomics.Input(
@@ -518,4 +539,4 @@ object FlowSimulation:
       ),
     )
 
-    StepResult(full.calculus, flows, assembled.world, assembled.firms, assembled.households, assembled.banks, assembled.householdAggregates)
+    StepResult(full.calculus, flows, execution, assembled.world, assembled.firms, assembled.households, assembled.banks, assembled.householdAggregates)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -78,10 +78,7 @@ object McRunner:
   private def stepMonth(state: FlowSimulation.SimState, seed: Long, month: Int)(using p: SimParams) =
     val rng    = new scala.util.Random(seed * 10000 + month)
     val result = engine.flows.FlowSimulation.step(state.world, state.firms, state.households, state.banks, rng)
-    // SFC verification: flows through verified interpreter should always be 0L
-    val wealth = com.boombustgroup.ledger.Interpreter.totalWealth(
-      com.boombustgroup.ledger.Interpreter.applyAll(Map.empty[Int, Long], engine.flows.AggregateBatchContract.toLegacyFlows(result.flows)),
-    )
+    val wealth = result.execution.totalWealth
     if wealth != 0L then
       val err = Sfc.SfcIdentityError(Sfc.SfcIdentity.FlowOfFunds, s"Flow SFC: totalWealth=$wealth", PLN.fromRaw(wealth), PLN.Zero)
       Left(SimError.SfcViolation(month + 1, Vector(err)))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -2,7 +2,6 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
-import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -25,10 +24,9 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
 
       withClue(s"Month $month: ") {
-        wealth.shouldBe(0L)
+        result.execution.totalWealth.shouldBe(0L)
       }
 
       w = result.newWorld

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -139,5 +139,5 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
     result.flows should not be empty
     result.flows.forall(_.isInstanceOf[BatchedFlow]) shouldBe true
     batchedMechanismTotals(result.flows) shouldBe legacyMechanismTotals(legacy)
-    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], legacy)) shouldBe 0L
+    result.execution.totalWealth shouldBe 0L
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -2,7 +2,6 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
-import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -23,7 +22,8 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
-    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(flows))) shouldBe 0L
+    result.execution.totalWealth shouldBe 0L
+    AggregateBatchContract.totalTransferred(flows) should be > 0L
   }
 
   it should "preserve SFC across 12 months" in {
@@ -39,7 +39,8 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
       val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
       withClue(s"Month $month: ") {
-        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(flows))) shouldBe 0L
+        result.execution.totalWealth shouldBe 0L
+        AggregateBatchContract.totalTransferred(flows) should be > 0L
       }
 
       w = result.newWorld
@@ -55,5 +56,6 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
+    result.execution.totalWealth shouldBe 0L
     flows.map(_.mechanism).toSet.size should be > 30
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
-import com.boombustgroup.ledger.*
+import com.boombustgroup.ledger.{ImperativeInterpreter, Interpreter}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -14,7 +14,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val init   = WorldInit.initialize(42L)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows))).shouldBe(0L)
+    result.execution.totalWealth shouldBe 0L
     result.calculus.employed should be > 0
   }
 
@@ -29,7 +29,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
       withClue(s"Month $month: ") {
-        Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows))).shouldBe(0L)
+        result.execution.totalWealth shouldBe 0L
       }
       w = result.newWorld
       firms = result.newFirms
@@ -43,4 +43,16 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
     result.flows.map(_.mechanism).toSet.size should be > 30
+  }
+
+  it should "match the legacy pure interpreter on aggregate execution balances" in {
+    val init   = WorldInit.initialize(42L)
+    val rng    = new scala.util.Random(42L)
+    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val state  = AggregateBatchContract.emptyExecutionState()
+
+    ImperativeInterpreter.planAndApplyAll(state, result.flows) shouldBe Right(())
+    AggregateBatchContract.totalWealth(state) shouldBe Interpreter.totalWealth(
+      Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)),
+    )
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -2,7 +2,6 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
-import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -25,10 +24,9 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
     (1 to 120).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
       val result = FlowSimulation.step(w, firms, hh, banks, rng)
-      val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
 
       withClue(s"SFC violated at month $month: ") {
-        wealth shouldBe 0L
+        result.execution.totalWealth shouldBe 0L
       }
 
       w = result.newWorld

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -2,7 +2,6 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
-import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -29,9 +28,8 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
       (1 to months).foreach { month =>
         val rng    = new scala.util.Random(seed * 1000 + month)
         val result = FlowSimulation.step(w, firms, hh, banks, rng)
-        val wealth = Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)))
         withClue(s"Seed $seed, month $month: ") {
-          wealth.shouldBe(0L)
+          result.execution.totalWealth.shouldBe(0L)
         }
         w = result.newWorld
         firms = result.newFirms


### PR DESCRIPTION
Fixes #204

## Summary
- execute FlowSimulation batched flows through ImperativeInterpreter.planAndApplyAll on an aggregate MutableWorldState main path
- carry explicit execution results on FlowSimulation.StepResult and switch McRunner plus main-path specs from legacy toLegacyFlows + Interpreter checking to runtime ledger execution
- add an aggregate execution helper and a regression test that proves imperative execution matches the legacy pure interpreter on the same emitted batches

## Validation
- sbt scalafmtAll
- sbt compile Test/compile
- sbt testOnly FlowSimulationSpec FlowSimulationStepSpec McRunnerSpec AutonomousPipelineSpec MultiMonthFlowSpec MultiSeedValidationSpec BatchedEmissionContractSpec
