### PR TITLE
Clarify NBP QE stock semantics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbp.scala
@@ -32,8 +32,8 @@ object Nbp:
   )
 
   case class BalanceState(
-      govBondHoldings: PLN, // NBP bond portfolio (QE + open market)
-      qeCumulative: PLN,    // cumulative QE purchases since activation
+      govBondHoldings: PLN, // current NBP government bond position (QE + open market), i.e. the ledger-coverable stock
+      qeCumulative: PLN,    // cumulative purchases executed under the QE regime; accounting/policy metric, not a separate ledger asset
       fxReserves: PLN,      // EUR-equivalent total reserves (multi-currency)
   )
 
@@ -213,6 +213,10 @@ object Nbp:
   /** Compute QE purchase request. Does NOT update govBondHoldings — the bond
     * waterfall in BankingEconomics handles the actual transfer so that SFC
     * clears by construction (actualSold from banks = actualSold to NBP).
+    *
+    * `qeCumulative` is intentionally distinct from current `govBondHoldings`:
+    * it tracks purchases attributed to the QE regime, not the full NBP bond
+    * stock.
     */
   def executeQe(nbp: State, bankBondHoldings: PLN, annualGdp: PLN, inflation: Rate, expectedInflation: Rate)(using p: SimParams): QeRequest =
     if !nbp.qeActive then QeRequest(nbp, PLN.Zero)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -143,7 +143,7 @@ object LedgerStateAdapter:
   )
 
   case class UnsupportedNbpBalances(
-      qeCumulative: PLN,
+      qeCumulativePurchases: PLN,
   )
 
   case class UnsupportedQuasiFiscalBalances(
@@ -321,7 +321,7 @@ object LedgerStateAdapter:
         fiscalCumulativeDebt = sim.world.gov.cumulativeDebt,
       ),
       nbp = UnsupportedNbpBalances(
-        qeCumulative = sim.world.nbp.qeCumulative,
+        qeCumulativePurchases = sim.world.nbp.qeCumulative,
       ),
       social = UnsupportedSocialBalances(
         jstDeposits = sim.world.social.jst.deposits,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -44,7 +44,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     w.gov.domesticBudgetOutlays should be >= w.gov.domesticBudgetDemand
   }
 
-  it should "overwrite only supported financial slice from ledger snapshot" in {
+  it should "overwrite only supported financial slice from ledger snapshot while preserving unsupported QE metrics" in {
     val init      = WorldInit.initialize(42L)
     val base      = init.world.copy(
       gov = init.world.gov.copy(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -180,7 +180,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     val unsupported = LedgerStateAdapter.unsupportedSnapshot(runtime)
 
     unsupported.government.fiscalCumulativeDebt shouldBe runtime.world.gov.cumulativeDebt
-    unsupported.nbp.qeCumulative shouldBe PLN(89e6)
+    unsupported.nbp.qeCumulativePurchases shouldBe PLN(89e6)
     unsupported.social.jstDeposits shouldBe PLN(10e6)
     unsupported.corporateBonds.outstanding shouldBe PLN(32e6)
     unsupported.quasiFiscal.bankHoldings shouldBe PLN(29e6)


### PR DESCRIPTION
Fixes #230

This PR clarifies NBP QE stock semantics without introducing a pseudo-asset for cumulative QE purchases.

What changes:
- clarifies that the ledger-covered NBP slice is the current government bond position (`govBondHoldings`) plus reserves (`fxReserves`)
- clarifies that `qeCumulative` is a QE-regime purchase metric, not a separate holder-tracked ledger asset
- renames the unsupported adapter field to `qeCumulativePurchases`
- makes the world-assembly regression test explicit that supported NBP balances come from ledger while the QE purchase metric remains unsupported/manual

What it does not do:
- does not add any new `AssetType` for QE cumulative purchases
- does not expand ledger coverage beyond the already supported NBP balance slice

Validation:
- `sbt scalafmtAll`
- `sbt 'testOnly *LedgerStateAdapterSpec* *WorldAssemblyEconomicsSpec* *CentralBankSpec* *OpenEconEconomicsSpec*'`
