### PR TITLE
Add JST deposits to supported ledger slice

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Jst.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Jst.scala
@@ -4,7 +4,9 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
 /** Local government (JST / samorządy). JST receives PIT/CIT shares, property
-  * tax, subventions/dotacje. JST deposits sit in commercial banks.
+  * tax, subventions/dotacje. JST deposits sit in commercial banks and are
+  * ledger-coverable cash balances; JST debt remains a cumulative fiscal metric
+  * in the current model.
   */
 object Jst:
 
@@ -12,8 +14,8 @@ object Jst:
   private val FallbackPitRate = 0.12
 
   case class State(
-      deposits: PLN, // JST deposits in commercial banks
-      debt: PLN,     // cumulative JST debt
+      deposits: PLN, // JST deposits in commercial banks (ledger-coverable cash balance)
+      debt: PLN,     // cumulative JST debt metric (not yet represented as a holder-tracked instrument)
       revenue: PLN,  // this month's revenue
       spending: PLN, // this month's spending
       deficit: PLN,  // spending − revenue (positive = deficit)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -493,6 +493,7 @@ object WorldAssemblyEconomics:
         fpCash = in.s2.newEarmarked.fpBalance,
         pfronCash = in.s2.newEarmarked.pfronBalance,
         fgspCash = in.s2.newEarmarked.fgspBalance,
+        jstCash = in.s9.newJst.deposits,
         nbfi = LedgerStateAdapter.NbfiFundBalances(
           tfiUnit = in.s9.finalNbfi.tfiAum,
           govBondHoldings = in.s9.finalNbfi.tfiGovBondHoldings,
@@ -528,6 +529,7 @@ object WorldAssemblyEconomics:
         ),
       ),
       social = world.social.copy(
+        jst = world.social.jst.copy(deposits = supported.funds.jstCash),
         zus = world.social.zus.copy(fusBalance = supported.funds.zusCash),
         nfz = world.social.nfz.copy(balance = supported.funds.nfzCash),
         ppk = world.social.ppk.copy(bondHoldings = supported.funds.ppkGovBondHoldings),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -24,10 +24,11 @@ object LedgerStateAdapter:
     val Fp: Int          = 3
     val Pfron: Int       = 4
     val Fgsp: Int        = 5
-    val Nbfi: Int        = 6
-    val QuasiFiscal: Int = 7
+    val Jst: Int         = 6
+    val Nbfi: Int        = 7
+    val QuasiFiscal: Int = 8
 
-    val Count: Int = 8
+    val Count: Int = 9
 
   private val SingletonSectorSize = 1
   private val ForeignSectorSize   = 1
@@ -114,6 +115,7 @@ object LedgerStateAdapter:
       fpCash: PLN,
       pfronCash: PLN,
       fgspCash: PLN,
+      jstCash: PLN,
       nbfi: NbfiFundBalances,
       quasiFiscal: QuasiFiscalBalances,
   )
@@ -156,8 +158,7 @@ object LedgerStateAdapter:
       otherHoldings: PLN,
   )
 
-  case class UnsupportedSocialBalances(
-      jstDeposits: PLN,
+  case class UnsupportedJstBalances(
       jstDebt: PLN,
   )
 
@@ -165,7 +166,7 @@ object LedgerStateAdapter:
       banks: Vector[UnsupportedBankBalances],
       government: UnsupportedGovernmentBalances,
       nbp: UnsupportedNbpBalances,
-      social: UnsupportedSocialBalances,
+      jst: UnsupportedJstBalances,
       corporateBonds: UnsupportedCorporateBondBalances,
       quasiFiscal: UnsupportedQuasiFiscalBalances,
   )
@@ -285,6 +286,7 @@ object LedgerStateAdapter:
         fpCash = sim.world.social.earmarked.fpBalance,
         pfronCash = sim.world.social.earmarked.pfronBalance,
         fgspCash = sim.world.social.earmarked.fgspBalance,
+        jstCash = sim.world.social.jst.deposits,
         nbfi = NbfiFundBalances(
           tfiUnit = sim.world.financial.nbfi.tfiAum,
           govBondHoldings = sim.world.financial.nbfi.tfiGovBondHoldings,
@@ -323,8 +325,7 @@ object LedgerStateAdapter:
       nbp = UnsupportedNbpBalances(
         qeCumulativePurchases = sim.world.nbp.qeCumulative,
       ),
-      social = UnsupportedSocialBalances(
-        jstDeposits = sim.world.social.jst.deposits,
+      jst = UnsupportedJstBalances(
         jstDebt = sim.world.social.jst.debt,
       ),
       corporateBonds = UnsupportedCorporateBondBalances(
@@ -411,6 +412,7 @@ object LedgerStateAdapter:
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp, supported.funds.fpCash)
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron, supported.funds.pfronCash)
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp, supported.funds.fgspCash)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst, supported.funds.jstCash)
     set(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi, supported.funds.nbfi.tfiUnit)
     set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi, supported.funds.nbfi.govBondHoldings)
     set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi, supported.funds.nbfi.corpBondHoldings)
@@ -478,6 +480,7 @@ object LedgerStateAdapter:
         fpCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp),
         pfronCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron),
         fgspCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp),
+        jstCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst),
         nbfi = NbfiFundBalances(
           tfiUnit = pln(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi),
           govBondHoldings = pln(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -160,17 +160,18 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
         fpCash = PLN(214),
         pfronCash = PLN(215),
         fgspCash = PLN(216),
+        jstCash = PLN(217),
         nbfi = LedgerStateAdapter.NbfiFundBalances(
-          tfiUnit = PLN(217),
-          govBondHoldings = PLN(218),
-          corpBondHoldings = PLN(219),
-          equityHoldings = PLN(220),
-          cashHoldings = PLN(221),
-          nbfiLoanStock = PLN(222),
+          tfiUnit = PLN(218),
+          govBondHoldings = PLN(219),
+          corpBondHoldings = PLN(220),
+          equityHoldings = PLN(221),
+          cashHoldings = PLN(222),
+          nbfiLoanStock = PLN(223),
         ),
         quasiFiscal = LedgerStateAdapter.QuasiFiscalBalances(
-          bondsOutstanding = PLN(223),
-          loanPortfolio = PLN(224),
+          bondsOutstanding = PLN(224),
+          loanPortfolio = PLN(225),
         ),
       ),
     )
@@ -185,13 +186,13 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     updated.nbp.fxReserves shouldBe PLN(204)
     updated.nbp.qeCumulative shouldBe PLN(105)
 
+    updated.social.jst.deposits shouldBe PLN(217)
     updated.social.zus.fusBalance shouldBe PLN(210)
     updated.social.nfz.balance shouldBe PLN(211)
     updated.social.ppk.bondHoldings shouldBe PLN(212)
     updated.social.earmarked.fpBalance shouldBe PLN(214)
     updated.social.earmarked.pfronBalance shouldBe PLN(215)
     updated.social.earmarked.fgspBalance shouldBe PLN(216)
-    updated.social.jst.deposits shouldBe PLN(107)
     updated.social.jst.debt shouldBe PLN(108)
 
     updated.financial.corporateBonds.bankHoldings shouldBe PLN(18)
@@ -205,15 +206,15 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     updated.financial.insurance.corpBondHoldings shouldBe PLN(208)
     updated.financial.insurance.equityHoldings shouldBe PLN(209)
 
-    updated.financial.nbfi.tfiAum shouldBe PLN(217)
-    updated.financial.nbfi.tfiGovBondHoldings shouldBe PLN(218)
-    updated.financial.nbfi.tfiCorpBondHoldings shouldBe PLN(219)
-    updated.financial.nbfi.tfiEquityHoldings shouldBe PLN(220)
-    updated.financial.nbfi.tfiCashHoldings shouldBe PLN(221)
-    updated.financial.nbfi.nbfiLoanStock shouldBe PLN(222)
+    updated.financial.nbfi.tfiAum shouldBe PLN(218)
+    updated.financial.nbfi.tfiGovBondHoldings shouldBe PLN(219)
+    updated.financial.nbfi.tfiCorpBondHoldings shouldBe PLN(220)
+    updated.financial.nbfi.tfiEquityHoldings shouldBe PLN(221)
+    updated.financial.nbfi.tfiCashHoldings shouldBe PLN(222)
+    updated.financial.nbfi.nbfiLoanStock shouldBe PLN(223)
 
-    updated.financial.quasiFiscal.bondsOutstanding shouldBe PLN(223)
-    updated.financial.quasiFiscal.loanPortfolio shouldBe PLN(224)
+    updated.financial.quasiFiscal.bondsOutstanding shouldBe PLN(224)
+    updated.financial.quasiFiscal.loanPortfolio shouldBe PLN(225)
     updated.financial.quasiFiscal.bankHoldings shouldBe PLN(131)
     updated.financial.quasiFiscal.nbpHoldings shouldBe PLN(132)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -173,6 +173,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     supported.banks.head.demandDeposit + supported.banks.head.termDeposit shouldBe supported.banks.head.totalDeposits
     supported.foreign.govBondHoldings shouldBe PLN(778e6)
     supported.funds.ppkCorpBondHoldings shouldBe PLN(33e6)
+    supported.funds.jstCash shouldBe PLN(10e6)
   }
 
   it should "expose unsupported financial fields explicitly instead of forcing them into the ledger slice" in {
@@ -181,7 +182,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
 
     unsupported.government.fiscalCumulativeDebt shouldBe runtime.world.gov.cumulativeDebt
     unsupported.nbp.qeCumulativePurchases shouldBe PLN(89e6)
-    unsupported.social.jstDeposits shouldBe PLN(10e6)
+    unsupported.jst.jstDebt shouldBe PLN(11e6)
     unsupported.corporateBonds.outstanding shouldBe PLN(32e6)
     unsupported.quasiFiscal.bankHoldings shouldBe PLN(29e6)
     unsupported.banks.head.capital shouldBe PLN(310e6)


### PR DESCRIPTION
Fixes #231

This PR adds JST deposits to the supported ledger-backed slice.

What changes:
- adds JST cash to `LedgerStateAdapter.FundBalances` as `EntitySector.Funds × AssetType.Cash × FundIndex.Jst`
- increases the supported fund-sector size accordingly
- reads JST deposits back from the ledger-backed supported slice in `WorldAssemblyEconomics`
- keeps JST debt explicit as an unsupported/manual fiscal metric
- narrows the unsupported JST snapshot naming so it no longer suggests that JST deposits are still outside ledger coverage

Ontology:
- JST deposits have holder-tracked balance semantics and now belong to the ledger-backed slice
- JST debt remains a cumulative fiscal metric in the current model, not a holder-tracked liability instrument
