### PR TITLE
Add corporate bond residual holder to supported slice

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -494,6 +494,7 @@ object WorldAssemblyEconomics:
         pfronCash = in.s2.newEarmarked.pfronBalance,
         fgspCash = in.s2.newEarmarked.fgspBalance,
         jstCash = in.s9.newJst.deposits,
+        corpBondOtherHoldings = in.s8.corpBonds.newCorpBonds.otherHoldings,
         nbfi = LedgerStateAdapter.NbfiFundBalances(
           tfiUnit = in.s9.finalNbfi.tfiAum,
           govBondHoldings = in.s9.finalNbfi.tfiGovBondHoldings,
@@ -513,8 +514,7 @@ object WorldAssemblyEconomics:
       world: World,
       supported: LedgerStateAdapter.SupportedFinancialSnapshot,
   ): World =
-    val bankCorpBondHoldings = supported.banks.foldLeft(PLN.Zero): (acc, bank) =>
-      acc + bank.corpBond
+    val corpBonds = LedgerStateAdapter.corporateBondCircuit(supported)
     world.copy(
       gov = world.gov.copy(
         financial = world.gov.financial.copy(
@@ -541,8 +541,10 @@ object WorldAssemblyEconomics:
       ),
       financial = world.financial.copy(
         corporateBonds = world.financial.corporateBonds.copy(
-          bankHoldings = bankCorpBondHoldings,
-          ppkHoldings = supported.funds.ppkCorpBondHoldings,
+          outstanding = corpBonds.outstanding,
+          bankHoldings = corpBonds.bankHoldings,
+          ppkHoldings = corpBonds.ppkHoldings,
+          otherHoldings = corpBonds.otherHoldings,
         ),
         insurance = world.financial.insurance.copy(
           reserves = world.financial.insurance.reserves.copy(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -18,17 +18,18 @@ import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
 object LedgerStateAdapter:
 
   object FundIndex:
-    val Zus: Int         = 0
-    val Nfz: Int         = 1
-    val Ppk: Int         = 2
-    val Fp: Int          = 3
-    val Pfron: Int       = 4
-    val Fgsp: Int        = 5
-    val Jst: Int         = 6
-    val Nbfi: Int        = 7
-    val QuasiFiscal: Int = 8
+    val Zus: Int           = 0
+    val Nfz: Int           = 1
+    val Ppk: Int           = 2
+    val Fp: Int            = 3
+    val Pfron: Int         = 4
+    val Fgsp: Int          = 5
+    val Jst: Int           = 6
+    val CorpBondOther: Int = 7
+    val Nbfi: Int          = 8
+    val QuasiFiscal: Int   = 9
 
-    val Count: Int = 9
+    val Count: Int = 10
 
   private val SingletonSectorSize = 1
   private val ForeignSectorSize   = 1
@@ -76,6 +77,17 @@ object LedgerStateAdapter:
     def totalHoldings: PLN =
       bankHoldings + foreignHoldings + nbpHoldings + insuranceHoldings + ppkHoldings + tfiHoldings
 
+  case class CorporateBondCircuit(
+      outstanding: PLN,
+      bankHoldings: PLN,
+      ppkHoldings: PLN,
+      insuranceHoldings: PLN,
+      tfiHoldings: PLN,
+      otherHoldings: PLN,
+  ):
+    def totalHoldings: PLN =
+      bankHoldings + ppkHoldings + insuranceHoldings + tfiHoldings + otherHoldings
+
   case class ForeignBalances(
       govBondHoldings: PLN,
   )
@@ -116,6 +128,7 @@ object LedgerStateAdapter:
       pfronCash: PLN,
       fgspCash: PLN,
       jstCash: PLN,
+      corpBondOtherHoldings: PLN,
       nbfi: NbfiFundBalances,
       quasiFiscal: QuasiFiscalBalances,
   )
@@ -153,11 +166,6 @@ object LedgerStateAdapter:
       nbpHoldings: PLN,
   )
 
-  case class UnsupportedCorporateBondBalances(
-      outstanding: PLN,
-      otherHoldings: PLN,
-  )
-
   case class UnsupportedJstBalances(
       jstDebt: PLN,
   )
@@ -167,7 +175,6 @@ object LedgerStateAdapter:
       government: UnsupportedGovernmentBalances,
       nbp: UnsupportedNbpBalances,
       jst: UnsupportedJstBalances,
-      corporateBonds: UnsupportedCorporateBondBalances,
       quasiFiscal: UnsupportedQuasiFiscalBalances,
   )
 
@@ -255,6 +262,34 @@ object LedgerStateAdapter:
       tfiHoldings = supported.funds.nbfi.govBondHoldings,
     )
 
+  def corporateBondCircuit(
+      world: World,
+      firms: Vector[Firm.State],
+      banks: Vector[Banking.BankState],
+  ): CorporateBondCircuit =
+    val bankAgg = Banking.aggregateFromBanks(banks)
+    CorporateBondCircuit(
+      outstanding = PLN.fromRaw(firms.map(_.bondDebt.toLong).sum),
+      bankHoldings = bankAgg.corpBondHoldings,
+      ppkHoldings = world.financial.corporateBonds.ppkHoldings,
+      insuranceHoldings = world.financial.insurance.corpBondHoldings,
+      tfiHoldings = world.financial.nbfi.tfiCorpBondHoldings,
+      otherHoldings = world.financial.corporateBonds.otherHoldings,
+    )
+
+  def corporateBondCircuit(
+      supported: SupportedFinancialSnapshot,
+  ): CorporateBondCircuit =
+    val bankCorpBondHoldings = supported.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
+    CorporateBondCircuit(
+      outstanding = PLN.fromRaw(supported.firms.map(_.corpBond.toLong).sum),
+      bankHoldings = bankCorpBondHoldings,
+      ppkHoldings = supported.funds.ppkCorpBondHoldings,
+      insuranceHoldings = supported.insurance.corpBondHoldings,
+      tfiHoldings = supported.funds.nbfi.corpBondHoldings,
+      otherHoldings = supported.funds.corpBondOtherHoldings,
+    )
+
   /** Pure supported-slice read from runtime state. */
   def supportedSnapshot(sim: FlowSimulation.SimState): SupportedFinancialSnapshot =
     SupportedFinancialSnapshot(
@@ -287,6 +322,7 @@ object LedgerStateAdapter:
         pfronCash = sim.world.social.earmarked.pfronBalance,
         fgspCash = sim.world.social.earmarked.fgspBalance,
         jstCash = sim.world.social.jst.deposits,
+        corpBondOtherHoldings = sim.world.financial.corporateBonds.otherHoldings,
         nbfi = NbfiFundBalances(
           tfiUnit = sim.world.financial.nbfi.tfiAum,
           govBondHoldings = sim.world.financial.nbfi.tfiGovBondHoldings,
@@ -327,10 +363,6 @@ object LedgerStateAdapter:
       ),
       jst = UnsupportedJstBalances(
         jstDebt = sim.world.social.jst.debt,
-      ),
-      corporateBonds = UnsupportedCorporateBondBalances(
-        outstanding = sim.world.financial.corporateBonds.outstanding,
-        otherHoldings = sim.world.financial.corporateBonds.otherHoldings,
       ),
       quasiFiscal = UnsupportedQuasiFiscalBalances(
         bankHoldings = sim.world.financial.quasiFiscal.bankHoldings,
@@ -413,6 +445,7 @@ object LedgerStateAdapter:
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron, supported.funds.pfronCash)
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp, supported.funds.fgspCash)
     set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst, supported.funds.jstCash)
+    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther, supported.funds.corpBondOtherHoldings)
     set(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi, supported.funds.nbfi.tfiUnit)
     set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi, supported.funds.nbfi.govBondHoldings)
     set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi, supported.funds.nbfi.corpBondHoldings)
@@ -481,6 +514,7 @@ object LedgerStateAdapter:
         pfronCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron),
         fgspCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp),
         jstCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst),
+        corpBondOtherHoldings = pln(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther),
         nbfi = NbfiFundBalances(
           tfiUnit = pln(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi),
           govBondHoldings = pln(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -112,7 +112,20 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     )
     val supported = LedgerStateAdapter.SupportedFinancialSnapshot(
       households = Vector.empty,
-      firms = Vector.empty,
+      firms = Vector(
+        LedgerStateAdapter.FirmBalances(
+          cash = PLN.Zero,
+          firmLoan = PLN.Zero,
+          corpBond = PLN(301),
+          equity = PLN.Zero,
+        ),
+        LedgerStateAdapter.FirmBalances(
+          cash = PLN.Zero,
+          firmLoan = PLN.Zero,
+          corpBond = PLN(302),
+          equity = PLN.Zero,
+        ),
+      ),
       banks = Vector(
         LedgerStateAdapter.BankBalances(
           totalDeposits = PLN.Zero,
@@ -161,17 +174,18 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
         pfronCash = PLN(215),
         fgspCash = PLN(216),
         jstCash = PLN(217),
+        corpBondOtherHoldings = PLN(218),
         nbfi = LedgerStateAdapter.NbfiFundBalances(
-          tfiUnit = PLN(218),
-          govBondHoldings = PLN(219),
-          corpBondHoldings = PLN(220),
-          equityHoldings = PLN(221),
-          cashHoldings = PLN(222),
-          nbfiLoanStock = PLN(223),
+          tfiUnit = PLN(219),
+          govBondHoldings = PLN(220),
+          corpBondHoldings = PLN(221),
+          equityHoldings = PLN(222),
+          cashHoldings = PLN(223),
+          nbfiLoanStock = PLN(224),
         ),
         quasiFiscal = LedgerStateAdapter.QuasiFiscalBalances(
-          bondsOutstanding = PLN(224),
-          loanPortfolio = PLN(225),
+          bondsOutstanding = PLN(225),
+          loanPortfolio = PLN(226),
         ),
       ),
     )
@@ -197,8 +211,8 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
 
     updated.financial.corporateBonds.bankHoldings shouldBe PLN(18)
     updated.financial.corporateBonds.ppkHoldings shouldBe PLN(213)
-    updated.financial.corporateBonds.outstanding shouldBe PLN(115)
-    updated.financial.corporateBonds.otherHoldings shouldBe PLN(118)
+    updated.financial.corporateBonds.outstanding shouldBe PLN(603)
+    updated.financial.corporateBonds.otherHoldings shouldBe PLN(218)
 
     updated.financial.insurance.lifeReserves shouldBe PLN(205)
     updated.financial.insurance.nonLifeReserves shouldBe PLN(206)
@@ -206,15 +220,15 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     updated.financial.insurance.corpBondHoldings shouldBe PLN(208)
     updated.financial.insurance.equityHoldings shouldBe PLN(209)
 
-    updated.financial.nbfi.tfiAum shouldBe PLN(218)
-    updated.financial.nbfi.tfiGovBondHoldings shouldBe PLN(219)
-    updated.financial.nbfi.tfiCorpBondHoldings shouldBe PLN(220)
-    updated.financial.nbfi.tfiEquityHoldings shouldBe PLN(221)
-    updated.financial.nbfi.tfiCashHoldings shouldBe PLN(222)
-    updated.financial.nbfi.nbfiLoanStock shouldBe PLN(223)
+    updated.financial.nbfi.tfiAum shouldBe PLN(219)
+    updated.financial.nbfi.tfiGovBondHoldings shouldBe PLN(220)
+    updated.financial.nbfi.tfiCorpBondHoldings shouldBe PLN(221)
+    updated.financial.nbfi.tfiEquityHoldings shouldBe PLN(222)
+    updated.financial.nbfi.tfiCashHoldings shouldBe PLN(223)
+    updated.financial.nbfi.nbfiLoanStock shouldBe PLN(224)
 
-    updated.financial.quasiFiscal.bondsOutstanding shouldBe PLN(224)
-    updated.financial.quasiFiscal.loanPortfolio shouldBe PLN(225)
+    updated.financial.quasiFiscal.bondsOutstanding shouldBe PLN(225)
+    updated.financial.quasiFiscal.loanPortfolio shouldBe PLN(226)
     updated.financial.quasiFiscal.bankHoldings shouldBe PLN(131)
     updated.financial.quasiFiscal.nbpHoldings shouldBe PLN(132)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -173,6 +173,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     supported.banks.head.demandDeposit + supported.banks.head.termDeposit shouldBe supported.banks.head.totalDeposits
     supported.foreign.govBondHoldings shouldBe PLN(778e6)
     supported.funds.ppkCorpBondHoldings shouldBe PLN(33e6)
+    supported.funds.corpBondOtherHoldings shouldBe PLN(34e6)
     supported.funds.jstCash shouldBe PLN(10e6)
   }
 
@@ -183,7 +184,6 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     unsupported.government.fiscalCumulativeDebt shouldBe runtime.world.gov.cumulativeDebt
     unsupported.nbp.qeCumulativePurchases shouldBe PLN(89e6)
     unsupported.jst.jstDebt shouldBe PLN(11e6)
-    unsupported.corporateBonds.outstanding shouldBe PLN(32e6)
     unsupported.quasiFiscal.bankHoldings shouldBe PLN(29e6)
     unsupported.banks.head.capital shouldBe PLN(310e6)
   }


### PR DESCRIPTION
Fixes #232

This PR completes the missing corporate-bond coverage in the ledger-backed slice without introducing a pseudo-asset for outstanding stock.

What changes:
- adds the residual non-bank corporate-bond holder class to the supported fund slice as `EntitySector.Funds × AssetType.CorpBond × FundIndex.CorpBondOther`
- derives corporate-bond `outstanding` from firm bond liabilities (`EntitySector.Firms × AssetType.CorpBond`) instead of treating it as a separate unsupported stock field
- introduces a canonical corporate bond circuit helper for supported snapshots
- removes manual fallback for `otherHoldings` and `outstanding` in world assembly for the covered slice

Ontology:
- firm bond debt remains the liability side of the instrument
- bank/PPK/insurance/TFI/other holdings are the holder side of the instrument
- `outstanding` is derived from the liability circuit, not stored as a separate ledger asset
