### PR TITLE
Add earmarked-fund runtime cash identities to SFC

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -191,7 +191,7 @@ object Sfc:
     */
   enum SfcIdentity:
     case BankCapital, BankDeposits, GovDebt, GovBudgetCash, JstCash, ZusCash,
-      NfzCash, Nfa, BondClearing, InterbankNetting, JstDebt, FusBalance,
+      NfzCash, FpCash, PfronCash, FgspCash, Nfa, BondClearing, InterbankNetting, JstDebt, FusBalance,
       NfzBalance, MortgageStock,
       FlowOfFunds, ConsumerCredit, CorpBondStock, NbfiCredit
 
@@ -532,6 +532,27 @@ object Sfc:
           SfcIdentity.NfzCash,
           "NFZ cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Nfz)),
+          batches,
+          executionSnapshot,
+        ) ++
+        runtimeCashIdentity(
+          SfcIdentity.FpCash,
+          "FP cash",
+          AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Fp)),
+          batches,
+          executionSnapshot,
+        ) ++
+        runtimeCashIdentity(
+          SfcIdentity.PfronCash,
+          "PFRON cash",
+          AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Pfron)),
+          batches,
+          executionSnapshot,
+        ) ++
+        runtimeCashIdentity(
+          SfcIdentity.FgspCash,
+          "FGSP cash",
+          AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Fgsp)),
           batches,
           executionSnapshot,
         )

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -1290,3 +1290,180 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     result.shouldBe(a[Left[?, ?]])
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.ZusCash).shouldBe(true)
   }
+
+  it should "pass when earmarked-fund cash balances match executed batches" in {
+    val batches = Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        AggregateBatchContract.HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fp,
+        PLN(100.0),
+        AssetType.Cash,
+        FlowMechanism.FpContribution,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fp,
+        EntitySector.Firms,
+        AggregateBatchContract.FirmIndex.Services,
+        PLN(70.0),
+        AssetType.Cash,
+        FlowMechanism.FpSpending,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        AggregateBatchContract.GovernmentIndex.Budget,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fp,
+        PLN(20.0),
+        AssetType.Cash,
+        FlowMechanism.FpGovSubvention,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        AggregateBatchContract.HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Pfron,
+        PLN(30.0),
+        AssetType.Cash,
+        FlowMechanism.PfronContribution,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Pfron,
+        EntitySector.Firms,
+        AggregateBatchContract.FirmIndex.Services,
+        PLN(40.0),
+        AssetType.Cash,
+        FlowMechanism.PfronSpending,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        AggregateBatchContract.GovernmentIndex.Budget,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Pfron,
+        PLN(15.0),
+        AssetType.Cash,
+        FlowMechanism.PfronGovSubvention,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        AggregateBatchContract.HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        PLN(50.0),
+        AssetType.Cash,
+        FlowMechanism.FgspContribution,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        EntitySector.Firms,
+        AggregateBatchContract.FirmIndex.Services,
+        PLN(60.0),
+        AssetType.Cash,
+        FlowMechanism.FgspSpending,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        AggregateBatchContract.GovernmentIndex.Budget,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        PLN(25.0),
+        AssetType.Cash,
+        FlowMechanism.FgspGovSubvention,
+      ),
+    )
+    val result  = Sfc.validate(
+      prev = zeroRuntime,
+      curr = zeroRuntime,
+      flows = zeroFlows,
+      batches = batches,
+      executionSnapshot = Sfc.ExecutionSnapshot(
+        Map(
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Government,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+          ) -> PLN(-60.0),
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Funds,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.FundIndex.Fp),
+          ) -> PLN(50.0),
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Funds,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.FundIndex.Pfron),
+          ) -> PLN(5.0),
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Funds,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.FundIndex.Fgsp),
+          ) -> PLN(15.0),
+        ),
+      ),
+      totalWealth = 0L,
+      tolerance = PLN(1000.0),
+      nfaTolerance = PLN(1000.0),
+    )
+    result.shouldBe(Right(()))
+  }
+
+  it should "detect mismatch in FGSP runtime cash identity" in {
+    val batches = Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        AggregateBatchContract.HouseholdIndex.Aggregate,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        PLN(50.0),
+        AssetType.Cash,
+        FlowMechanism.FgspContribution,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        EntitySector.Firms,
+        AggregateBatchContract.FirmIndex.Services,
+        PLN(60.0),
+        AssetType.Cash,
+        FlowMechanism.FgspSpending,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        AggregateBatchContract.GovernmentIndex.Budget,
+        EntitySector.Funds,
+        AggregateBatchContract.FundIndex.Fgsp,
+        PLN(25.0),
+        AssetType.Cash,
+        FlowMechanism.FgspGovSubvention,
+      ),
+    )
+    val result  = Sfc.validate(
+      prev = zeroRuntime,
+      curr = zeroRuntime,
+      flows = zeroFlows,
+      batches = batches,
+      executionSnapshot = Sfc.ExecutionSnapshot(
+        Map(
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Government,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+          ) -> PLN(-25.0),
+          Sfc.ExecutionBalanceKey(
+            EntitySector.Funds,
+            AssetType.Cash,
+            Sfc.ExecutionIndex(AggregateBatchContract.FundIndex.Fgsp),
+          ) -> PLN(14.0),
+        ),
+      ),
+      totalWealth = 0L,
+      tolerance = PLN(1000.0),
+      nfaTolerance = PLN(1000.0),
+    )
+    result.shouldBe(a[Left[?, ?]])
+    result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.FgspCash).shouldBe(true)
+  }


### PR DESCRIPTION
Fixes #254
Part of #250

This PR adds runtime public-sector cash exactness for all earmarked funds.

What changes:
- adds runtime FpCash, PfronCash, and FgspCash identities
- derives all three from executed Funds x Cash balances, not from hand-assembled metric state
- adds contract tests for exact earmarked-fund cash balances and explicit mismatch detection

Why:
- earmarked funds are honest public cash accounts in the runtime
- they should participate in runtime SFC exactness on the same footing as budget, JST, ZUS, and NFZ
