### PR TITLE
Narrow the stock-only SFC API

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -74,12 +74,12 @@ object Sfc:
       banks: Vector[Banking.BankState],
   )
 
-  /** Point-in-time stock state for SFC validation.
+  /** Point-in-time stock state for stock-side diagnostics and exactness checks.
     *
     * Captured twice per month (before and after Simulation.step) so that
-    * validate can compute Δstock = curr - prev for each identity. Fields
-    * corresponding to disabled mechanisms are simply zero — the identity holds
-    * trivially in that case.
+    * stock-side validation can compute Δstock = curr - prev for each identity.
+    * Some fields remain here only for legacy diagnostics; they are not part of
+    * the narrowed exact stock-only contract.
     */
   case class StockState(
       hhSavings: PLN,                // Σ household savings (individual mode only, 0 in aggregate)
@@ -186,9 +186,10 @@ object Sfc:
   )
 
   /** Enumeration of exact runtime identities plus legacy diagnostic metric
-    * identities. The public-sector metric identities remain here so callers can
-    * inspect them explicitly, but they are no longer part of the exact core
-    * validation path.
+    * identities. The stock-only exact API is deliberately narrower than this
+    * full set: runtime public cash identities and legacy public-sector metric
+    * identities remain available for explicit callers, but they are not part of
+    * the narrowed stock-only exact validation surface.
     */
   enum SfcIdentity:
     case BankCapital, BankDeposits, GovDebt, GovBudgetCash, JstCash, ZusCash,
@@ -314,7 +315,7 @@ object Sfc:
     */
   private case class IdentitySpec(id: SfcIdentity, msg: String, expected: PLN, actual: PLN, tolerance: PLN)
 
-  def validate(
+  def validateStockExactness(
       prev: StockState,               // stocks at the beginning of the month (before Simulation.step)
       curr: StockState,               // stocks at the end of the month (after Simulation.step)
       flows: SemanticFlows,           // all flows that occurred during the month
@@ -491,7 +492,7 @@ object Sfc:
     // execution; public-sector metric identities are available separately via
     // `metricDiagnostics`.
     val baseErrors    =
-      validate(snapshot(prev), snapshot(curr), flows.copy(fofResidual = PLN.Zero), tolerance, nfaTolerance).left.toOption.getOrElse(Vector.empty)
+      validateStockExactness(snapshot(prev), snapshot(curr), flows.copy(fofResidual = PLN.Zero), tolerance, nfaTolerance).left.toOption.getOrElse(Vector.empty)
     val runtimeErrors = runtimeIdentityErrors(batches, executionSnapshot, totalWealth)
     merge(baseErrors ++ runtimeErrors)
 

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/BopSfcSpec.scala
@@ -115,8 +115,8 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 4: NFA ----
 
-  "Sfc.validate (NFA)" should "pass trivially when OPEN_ECON is off (all zeros)" in {
-    val result = Sfc.validate(baseSnap, baseSnap, zeroFlows)
+  "Sfc.validateStockExactness (NFA)" should "pass trivially when OPEN_ECON is off (all zeros)" in {
+    val result = Sfc.validateStockExactness(baseSnap, baseSnap, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -126,7 +126,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     val prev      = baseSnap.copy(nfa = PLN(100000.0))
     val curr      = baseSnap.copy(nfa = PLN(100000.0) + ca + valuation)
     val flows     = zeroFlows.copy(currentAccount = ca, valuationEffect = valuation)
-    val result    = Sfc.validate(prev, curr, flows)
+    val result    = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -135,7 +135,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     // Bug: NFA unchanged despite positive CA
     val curr   = baseSnap.copy(nfa = PLN(100000.0))
     val flows  = zeroFlows.copy(currentAccount = PLN(25000.0), valuationEffect = PLN(0.0))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.Nfa) shouldBe -25000.0 +- 0.01
   }
@@ -144,7 +144,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     val prev   = baseSnap.copy(nfa = PLN(100000.0))
     val curr   = baseSnap.copy(nfa = PLN(70000.0))
     val flows  = zeroFlows.copy(currentAccount = PLN(-30000.0), valuationEffect = PLN(0.0))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -153,7 +153,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     // CA=-10000, valuation=+15000 → expected ΔNFA = +5000
     val curr   = baseSnap.copy(nfa = PLN(105000.0))
     val flows  = zeroFlows.copy(currentAccount = PLN(-10000.0), valuationEffect = PLN(15000.0))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -161,7 +161,7 @@ class BopSfcSpec extends AnyFlatSpec with Matchers:
     val prev   = baseSnap.copy(nfa = PLN(100000.0))
     // NFA jumps by 50000 but CA+valuation = 0 → error on identity 4 only
     val curr   = baseSnap.copy(nfa = PLN(150000.0))
-    val result = Sfc.validate(prev, curr, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, curr, zeroFlows)
     result shouldBe a[Left[?, ?]]
     result.swap.getOrElse(Vector.empty).map(_.identity) should contain only Sfc.SfcIdentity.Nfa
     errorDelta(result, Sfc.SfcIdentity.Nfa) shouldBe 50000.0 +- 0.01

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
@@ -22,10 +22,10 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
 
   // --- Consistent flows always pass ---
 
-  "Sfc.validate" should "pass when flows are consistent with snapshots" in
+  "Sfc.validateStockExactness" should "pass when flows are consistent with snapshots" in
     forAll(genConsistentFlowsAndSnapshots) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows)) =>
       val (prev, curr, flows) = triple
-      val result              = Sfc.validate(prev, curr, flows)
+      val result              = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }
 
@@ -98,7 +98,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         htmRealizedLoss = PLN.Zero,
         eclProvisionChange = PLN.Zero,
       )
-      val result    = Sfc.validate(snap, snap, zeroFlows)
+      val result    = Sfc.validateStockExactness(snap, snap, zeroFlows)
       result shouldBe Right(())
     }
 
@@ -108,7 +108,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(bankCapital = curr.bankCapital + PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BankCapital) shouldBe true
     }
 
@@ -116,7 +116,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(bankDeposits = curr.bankDeposits + PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BankDeposits) shouldBe true
     }
 
@@ -132,7 +132,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(nfa = curr.nfa + PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.Nfa) shouldBe true
     }
 
@@ -142,8 +142,8 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(0.01, 5.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(bankCapital = curr.bankCapital + PLN(perturbation))
-      val strictResult        = Sfc.validate(prev, perturbed, flows, tolerance = PLN(perturbation))
-      val looseResult         = Sfc.validate(prev, perturbed, flows, tolerance = PLN(perturbation * 10))
+      val strictResult        = Sfc.validateStockExactness(prev, perturbed, flows, tolerance = PLN(perturbation))
+      val looseResult         = Sfc.validateStockExactness(prev, perturbed, flows, tolerance = PLN(perturbation * 10))
       if strictResult.isRight then looseResult shouldBe Right(())
     }
 
@@ -153,7 +153,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), delta: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(bankCapital = curr.bankCapital + PLN(delta))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe (delta +- 1.0)
     }
 
@@ -174,7 +174,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
   it should "pass bond clearing when bankBonds + nbpBonds = bondsOutstanding" in
     forAll(genConsistentFlowsAndSnapshots) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows)) =>
       val (prev, curr, flows) = triple
-      val result              = Sfc.validate(prev, curr, flows)
+      val result              = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }
 
@@ -182,7 +182,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(bankBondHoldings = curr.bankBondHoldings + PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BondClearing) shouldBe true
     }
 
@@ -191,7 +191,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
   it should "pass interbank netting when interbankNetSum is zero" in
     forAll(genConsistentFlowsAndSnapshots) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows)) =>
       val (prev, curr, flows) = triple
-      val result              = Sfc.validate(prev, curr, flows)
+      val result              = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }
 
@@ -199,7 +199,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(interbankNetSum = PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.InterbankNetting) shouldBe true
     }
 
@@ -223,7 +223,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows)) =>
       val (prev, curr, flows) = triple
       // genMonthlyFlows generates non-zero dividend fields — verify all 8 identities hold
-      val result              = Sfc.validate(prev, curr, flows)
+      val result              = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }
 
@@ -232,7 +232,7 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
       val (prev, curr, flows) = triple
       // Perturb dividendIncome without updating deposits → Identity 2 fails
       val badFlows            = flows.copy(dividendIncome = flows.dividendIncome + PLN(perturbation))
-      val result              = Sfc.validate(prev, curr, badFlows)
+      val result              = Sfc.validateStockExactness(prev, curr, badFlows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BankDeposits) shouldBe true
     }
 
@@ -242,13 +242,13 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 50000.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
       val (prev, curr, flows) = triple
       val perturbed           = curr.copy(mortgageStock = curr.mortgageStock + PLN(perturbation))
-      val result              = Sfc.validate(prev, perturbed, flows)
+      val result              = Sfc.validateStockExactness(prev, perturbed, flows)
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.MortgageStock) shouldBe true
     }
 
   it should "pass mortgage stock identity in consistent snapshots" in
     forAll(genConsistentFlowsAndSnapshots) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows)) =>
       val (prev, curr, flows) = triple
-      val result              = Sfc.validate(prev, curr, flows)
+      val result              = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -303,14 +303,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 1: Bank capital ----
 
-  "Sfc.validate (bank capital)" should "pass when change matches formula exactly" in {
+  "Sfc.validateStockExactness (bank capital)" should "pass when change matches formula exactly" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // nplLoss=7000, intIncome=10000, hhDebtService=2000
     // expected change = -7000 + 10000*0.3 + 2000*0.3 = -7000 + 3000 + 600 = -3400
     val curr   = prev.copy(bankCapital = prev.bankCapital - PLN(3400))
     val flows  = zeroFlows.copy(nplLoss = PLN(7000), interestIncome = PLN(10000), hhDebtService = PLN(2000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -320,7 +320,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: bank capital didn't decrease by nplLoss
     val curr   = prev.copy(bankCapital = prev.bankCapital)
     val flows  = zeroFlows.copy(nplLoss = PLN(5000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe 5000.0 +- 0.01 // actual=0, expected=-5000
   }
@@ -331,7 +331,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: 50% of interest goes to bank instead of 30%
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(10000) * Share(0.5))
     val flows  = zeroFlows.copy(interestIncome = PLN(10000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     // actual change = +5000, expected = +3000, error = 2000
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe 2000.0 +- 0.01
@@ -349,20 +349,20 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: hhDebtService=20000 should add 6000 to bank capital, but bank unchanged
     val curr   = prev.copy(bankCapital = prev.bankCapital)
     val flows  = zeroFlows.copy(hhDebtService = PLN(20000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe -6000.0 +- 0.01 // actual=0, expected=+6000
   }
 
   // ---- Identity 2: Bank deposits ----
 
-  "Sfc.validate (bank deposits)" should "pass when change matches income - consumption" in {
+  "Sfc.validateStockExactness (bank deposits)" should "pass when change matches income - consumption" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // totalIncome=100000, consumption=82000 -> deposit increase = 18000
     val curr   = prev.copy(bankDeposits = prev.bankDeposits + PLN(18000))
     val flows  = zeroFlows.copy(totalIncome = PLN(100000), totalConsumption = PLN(82000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -372,7 +372,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: deposits unchanged despite positive savings
     val curr   = prev.copy(bankDeposits = prev.bankDeposits)
     val flows  = zeroFlows.copy(totalIncome = PLN(100000), totalConsumption = PLN(82000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankDeposits) shouldBe -18000.0 +- 0.01
   }
@@ -427,7 +427,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Zero-flow identity ----
 
-  "Sfc.validate" should "pass with zero flows and no changes" in {
+  "Sfc.validateStockExactness" should "pass with zero flows and no changes" in {
     val snap   =
       zeroSnap.copy(
         hhSavings = PLN(100000),
@@ -438,7 +438,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         bankDeposits = PLN(800000),
         bankLoans = PLN(10000),
       )
-    val result = Sfc.validate(snap, snap, zeroFlows)
+    val result = Sfc.validateStockExactness(snap, snap, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -471,7 +471,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       totalIncome = PLN(50000),
       totalConsumption = PLN(41000),
     )
-    val exactResult  = Sfc.validate(prev, curr, flows)
+    val exactResult  = Sfc.validateStockExactness(prev, curr, flows)
     val metricResult = Sfc.metricDiagnostics(prev, curr, flows)
     exactResult shouldBe Right(())
     metricResult shouldBe Vector.empty
@@ -484,7 +484,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // Bank capital off by 500 (below default tolerance of 1000)
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(500.0))
-    val result = Sfc.validate(prev, curr, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, curr, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -493,7 +493,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // Bank capital off by 5000 (above default tolerance of 1000)
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(5000.0))
-    val result = Sfc.validate(prev, curr, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, curr, zeroFlows)
     result shouldBe a[Left[?, ?]]
   }
 
@@ -502,14 +502,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     val curr = prev.copy(bankCapital = prev.bankCapital + PLN(5000.0))
     // Default tolerance (1000): fails
-    Sfc.validate(prev, curr, zeroFlows) shouldBe a[Left[?, ?]]
+    Sfc.validateStockExactness(prev, curr, zeroFlows) shouldBe a[Left[?, ?]]
     // Loose tolerance (10000): passes
-    Sfc.validate(prev, curr, zeroFlows, tolerance = PLN(10000.0)) shouldBe Right(())
+    Sfc.validateStockExactness(prev, curr, zeroFlows, tolerance = PLN(10000.0)) shouldBe Right(())
   }
 
   // ---- Identity 5: Bond clearing ----
 
-  "Sfc.validate (bond clearing)" should "pass when holdings sum to outstanding" in {
+  "Sfc.validateStockExactness (bond clearing)" should "pass when holdings sum to outstanding" in {
     val prev   = zeroSnap.copy(
       firmCash = PLN(500000),
       bankCapital = PLN(200000),
@@ -518,7 +518,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       nbpBondHoldings = PLN(3000.0),
       bondsOutstanding = PLN(8000.0),
     )
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -531,7 +531,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       nbpBondHoldings = PLN(3000.0),
       bondsOutstanding = PLN(10000.0),
     )
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BondClearing) shouldBe -2000.0 +- 0.01
   }
@@ -539,7 +539,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
   it should "pass trivially when all bond fields are zero" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -553,20 +553,20 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       bondsOutstanding = PLN(10000.0),
       insuranceGovBondHoldings = PLN(2000.0),
     )
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     // 5000 + 3000 + 0 (ppk) + 2000 (insurance) = 10000 = outstanding
     result shouldBe Right(())
   }
 
   // ---- Identity 1 with bond income ----
 
-  "Sfc.validate (bank capital with bond income)" should "include bankBondIncome in Identity 1" in {
+  "Sfc.validateStockExactness (bank capital with bond income)" should "include bankBondIncome in Identity 1" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // bankBondIncome=6000 -> 6000*0.3 = 1800 added to bank capital
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(1800))
     val flows  = zeroFlows.copy(bankBondIncome = PLN(6000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -574,9 +574,9 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 6: Interbank netting ----
 
-  "Sfc.validate (interbank netting)" should "pass when interbankNetSum is zero" in {
+  "Sfc.validateStockExactness (interbank netting)" should "pass when interbankNetSum is zero" in {
     val prev   = zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -584,7 +584,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     val curr   = prev.copy(interbankNetSum = PLN(5000.0))
-    val result = Sfc.validate(prev, curr, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, curr, zeroFlows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.InterbankNetting) shouldBe 5000.0 +- 0.01
   }
@@ -600,20 +600,20 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         bankDeposits = PLN(800000),
         bankLoans = PLN(10000),
       )
-    val result = Sfc.validate(snap, snap, zeroFlows)
+    val result = Sfc.validateStockExactness(snap, snap, zeroFlows)
     result shouldBe Right(())
   }
 
   // ---- Identity 2 with insurance deposit change (#41) ----
 
-  "Sfc.validate (insurance deposits)" should "include insNetDepositChange in Identity 2" in {
+  "Sfc.validateStockExactness (insurance deposits)" should "include insNetDepositChange in Identity 2" in {
     val prev         =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // Insurance premium > claims -> negative deposit change (drain)
     val insDepChange = PLN(-500.0)
     val curr         = prev.copy(bankDeposits = prev.bankDeposits + insDepChange)
     val flows        = zeroFlows.copy(insNetDepositChange = insDepChange)
-    val result       = Sfc.validate(prev, curr, flows)
+    val result       = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -640,13 +640,13 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 1 with deposit interest ----
 
-  "Sfc.validate (bank capital with deposit interest)" should "subtract deposit interest from bank capital" in {
+  "Sfc.validateStockExactness (bank capital with deposit interest)" should "subtract deposit interest from bank capital" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // depositInterestPaid=3000 -> (0 + 0 + 0 - 3000) * 0.3 = -900
     val curr   = prev.copy(bankCapital = prev.bankCapital - PLN(900))
     val flows  = zeroFlows.copy(depositInterestPaid = PLN(3000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -662,7 +662,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       bankBondIncome = PLN(1000),
       depositInterestPaid = PLN(3000),
     )
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -672,7 +672,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: bank capital unchanged despite deposit interest obligation
     val curr   = prev.copy(bankCapital = prev.bankCapital)
     val flows  = zeroFlows.copy(depositInterestPaid = PLN(5000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     // actual=0, expected=-5000*0.3=-1500, error=0-(-1500)=1500
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe 1500.0 +- 0.01
@@ -680,13 +680,13 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 2 with dividend flows ----
 
-  "Sfc.validate (deposits with dividends)" should "pass when dividendIncome added to deposits" in {
+  "Sfc.validateStockExactness (deposits with dividends)" should "pass when dividendIncome added to deposits" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // dividendIncome=5000 -> deposits increase by 5000
     val curr   = prev.copy(bankDeposits = prev.bankDeposits + PLN(5000))
     val flows  = zeroFlows.copy(dividendIncome = PLN(5000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -696,7 +696,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // foreignDividendOutflow=8000 -> deposits decrease by 8000
     val curr   = prev.copy(bankDeposits = prev.bankDeposits - PLN(8000))
     val flows  = zeroFlows.copy(foreignDividendOutflow = PLN(8000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -712,7 +712,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       dividendIncome = PLN(3000),
       foreignDividendOutflow = PLN(7000),
     )
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -722,20 +722,20 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: deposits unchanged despite dividend income
     val curr   = prev.copy(bankDeposits = prev.bankDeposits)
     val flows  = zeroFlows.copy(dividendIncome = PLN(10000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankDeposits) shouldBe -10000.0 +- 0.01
   }
 
   // ---- Identity 1 with mortgage flows ----
 
-  "Sfc.validate (bank capital with mortgage)" should "include mortgage interest in Identity 1" in {
+  "Sfc.validateStockExactness (bank capital with mortgage)" should "include mortgage interest in Identity 1" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // mortgageInterestIncome=9000 -> 9000*0.3 = 2700 added to bank capital
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(2700))
     val flows  = zeroFlows.copy(mortgageInterestIncome = PLN(9000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -745,7 +745,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // mortgageNplLoss=5000 -> bank capital decreases by 5000
     val curr   = prev.copy(bankCapital = prev.bankCapital - PLN(5000))
     val flows  = zeroFlows.copy(mortgageNplLoss = PLN(5000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -755,7 +755,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // mortgageInterest=10000 -> +3000, mortgageNplLoss=2000 -> -2000, net = +1000
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(1000))
     val flows  = zeroFlows.copy(mortgageInterestIncome = PLN(10000), mortgageNplLoss = PLN(2000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -765,7 +765,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: bank capital unchanged despite mortgage interest
     val curr   = prev.copy(bankCapital = prev.bankCapital)
     val flows  = zeroFlows.copy(mortgageInterestIncome = PLN(6000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     // actual=0, expected=+1800, error=-1800
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankCapital) shouldBe -1800.0 +- 0.01
@@ -773,7 +773,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 9: Mortgage stock ----
 
-  "Sfc.validate (mortgage stock)" should "pass when stock change matches flows" in {
+  "Sfc.validateStockExactness (mortgage stock)" should "pass when stock change matches flows" in {
     val prev   = zeroSnap.copy(
       firmCash = PLN(500000),
       bankCapital = PLN(200000),
@@ -787,14 +787,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       mortgagePrincipalRepaid = PLN(3000),
       mortgageDefaultAmount = PLN(1000),
     )
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
   it should "pass trivially when RE disabled (all zeros)" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -808,7 +808,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: stock unchanged despite origination
     val curr   = prev.copy(mortgageStock = PLN(100000.0))
     val flows  = zeroFlows.copy(mortgageOrigination = PLN(15000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.MortgageStock) shouldBe -15000.0 +- 0.01
   }
@@ -827,19 +827,19 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       mortgagePrincipalRepaid = PLN(5000),
       mortgageDefaultAmount = PLN(500),
     )
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
   // ---- Identity 2 with remittance outflow ----
 
-  "Sfc.validate (deposits with remittances)" should "pass when remittance deducted from deposits" in {
+  "Sfc.validateStockExactness (deposits with remittances)" should "pass when remittance deducted from deposits" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // remittanceOutflow=12000 -> deposits decrease by 12000
     val curr   = prev.copy(bankDeposits = prev.bankDeposits - PLN(12000))
     val flows  = zeroFlows.copy(remittanceOutflow = PLN(12000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -850,7 +850,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // expected deposit delta = 80000 - 60000 - 5000 = 15000
     val curr   = prev.copy(bankDeposits = prev.bankDeposits + PLN(15000))
     val flows  = zeroFlows.copy(totalIncome = PLN(80000), totalConsumption = PLN(60000), remittanceOutflow = PLN(5000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -860,7 +860,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: deposits unchanged despite remittance outflow
     val curr   = prev.copy(bankDeposits = prev.bankDeposits)
     val flows  = zeroFlows.copy(remittanceOutflow = PLN(8000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     // actual=0, expected=-8000, error=0-(-8000)=8000
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankDeposits) shouldBe 8000.0 +- 0.01
@@ -869,20 +869,20 @@ class SfcSpec extends AnyFlatSpec with Matchers:
   it should "pass trivially when remittance is zero (immigration disabled)" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
   // ---- Identity 2 with NBFI deposit drain (#42) ----
 
-  "Sfc.validate (NBFI deposit drain)" should "include nbfiDepositDrain in Identity 2" in {
+  "Sfc.validateStockExactness (NBFI deposit drain)" should "include nbfiDepositDrain in Identity 2" in {
     val prev      =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
     // TFI drains deposits: HH buys fund units -> deposit decreases
     val nbfiDrain = PLN(-800.0)
     val curr      = prev.copy(bankDeposits = prev.bankDeposits + nbfiDrain)
     val flows     = zeroFlows.copy(nbfiDepositDrain = nbfiDrain)
-    val result    = Sfc.validate(prev, curr, flows)
+    val result    = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -892,14 +892,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: deposits unchanged despite NBFI drain
     val curr   = prev.copy(bankDeposits = prev.bankDeposits)
     val flows  = zeroFlows.copy(nbfiDepositDrain = PLN(-5000.0))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BankDeposits) shouldBe 5000.0 +- 0.01
   }
 
   // ---- Identity 5 with TFI gov bond holdings (#42) ----
 
-  "Sfc.validate (TFI bonds)" should "include TFI gov bond holdings in bond clearing" in {
+  "Sfc.validateStockExactness (TFI bonds)" should "include TFI gov bond holdings in bond clearing" in {
     val prev   = zeroSnap.copy(
       firmCash = PLN(500000),
       bankCapital = PLN(200000),
@@ -910,7 +910,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       insuranceGovBondHoldings = PLN(2000.0),
       tfiGovBondHoldings = PLN(3000.0),
     )
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     // 4000 + 3000 + 0 (ppk) + 2000 (insurance) + 3000 (TFI) = 12000 = outstanding
     result shouldBe Right(())
   }
@@ -926,7 +926,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       insuranceGovBondHoldings = PLN(2000.0),
       tfiGovBondHoldings = PLN(5000.0),
     )
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     // 4000 + 3000 + 0 + 2000 + 5000 = 14000 vs 10000 = +4000 error
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.BondClearing) shouldBe 4000.0 +- 0.01
@@ -934,7 +934,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   // ---- Identity 13: NBFI credit stock (#42) ----
 
-  "Sfc.validate (NBFI credit stock)" should "pass when stock change matches flows" in {
+  "Sfc.validateStockExactness (NBFI credit stock)" should "pass when stock change matches flows" in {
     val prev   = zeroSnap.copy(
       firmCash = PLN(500000),
       bankCapital = PLN(200000),
@@ -944,14 +944,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // origination=5000, repayment=2000, default=500 -> delta = 5000-2000-500 = 2500
     val curr   = prev.copy(nbfiLoanStock = PLN(102500.0))
     val flows  = zeroFlows.copy(nbfiOrigination = PLN(5000), nbfiRepayment = PLN(2000), nbfiDefaultAmount = PLN(500))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
   it should "pass trivially when NBFI disabled (all zeros)" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val result = Sfc.validate(prev, prev, zeroFlows)
+    val result = Sfc.validateStockExactness(prev, prev, zeroFlows)
     result shouldBe Right(())
   }
 
@@ -965,7 +965,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // Bug: stock unchanged despite origination
     val curr   = prev.copy(nbfiLoanStock = PLN(100000.0))
     val flows  = zeroFlows.copy(nbfiOrigination = PLN(8000))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     errorDelta(result, Sfc.SfcIdentity.NbfiCredit) shouldBe -8000.0 +- 0.01
   }
@@ -980,7 +980,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     // origination=1000, repayment=4000, default=200 -> delta = 1000-4000-200 = -3200
     val curr   = prev.copy(nbfiLoanStock = PLN(96800.0))
     val flows  = zeroFlows.copy(nbfiOrigination = PLN(1000), nbfiRepayment = PLN(4000), nbfiDefaultAmount = PLN(200))
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ConsumerCreditSpec.scala
@@ -324,6 +324,6 @@ class ConsumerCreditSpec extends AnyFlatSpec with Matchers:
   "Sfc" should "pass consumer credit identity with zero flows" in {
     val snap   = zeroSnap.copy(bankCapital = PLN(100.0), bankDeposits = PLN(200.0))
     val flow   = zeroFlows
-    val result = Sfc.validate(snap, snap, flow)
+    val result = Sfc.validateStockExactness(snap, snap, flow)
     result shouldBe Right(())
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FofSpec.scala
@@ -207,14 +207,14 @@ class FofSpec extends AnyFlatSpec with Matchers:
     // All flows zero except fofResidual — all deltas are 0 = 0
     val flows  = zeroFlows
     val snap   = zeroSnap.copy(bankCapital = PLN(500000.0), bankDeposits = PLN(1000000.0))
-    val result = Sfc.validate(snap, snap, flows)
+    val result = Sfc.validateStockExactness(snap, snap, flows)
     result shouldBe Right(())
   }
 
   it should "fail when fofResidual exceeds tolerance" in {
     val flows  = zeroFlows.copy(fofResidual = PLN(5000.0))
     val snap   = zeroSnap.copy(bankCapital = PLN(500000.0), bankDeposits = PLN(1000000.0))
-    val result = Sfc.validate(snap, snap, flows)
+    val result = Sfc.validateStockExactness(snap, snap, flows)
     result shouldBe a[Left[?, ?]]
     td.toDouble(
       result.swap

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingPropertySpec.scala
@@ -110,7 +110,7 @@ class MonetaryPlumbingPropertySpec extends AnyFlatSpec with Matchers with ScalaC
 
   "Sfc with monetary plumbing flows" should "pass for consistent snapshots" in
     forAll(genConsistentFlowsAndSnapshots) { case (prev, curr, flows) =>
-      val result = Sfc.validate(prev, curr, flows)
+      val result = Sfc.validateStockExactness(prev, curr, flows)
       result shouldBe Right(())
     }
 
@@ -118,6 +118,6 @@ class MonetaryPlumbingPropertySpec extends AnyFlatSpec with Matchers with ScalaC
     forAll(genConsistentFlowsAndSnapshots, Gen.choose(5000.0, 1e6)) { case ((prev, curr, flows), delta) =>
       // Add reserve interest to flows but NOT to bank capital → should fail
       val perturbedFlows = flows.copy(reserveInterest = flows.reserveInterest + PLN(delta))
-      val result         = Sfc.validate(prev, curr, perturbedFlows)
+      val result         = Sfc.validateStockExactness(prev, curr, perturbedFlows)
       result shouldBe a[Left[?, ?]]
     }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -270,7 +270,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val expectedCapChange = reserveInt * Share(0.3)
     val curr              = prev.copy(bankCapital = prev.bankCapital + expectedCapChange)
     val flows             = zeroFlows.copy(reserveInterest = reserveInt)
-    val result            = Sfc.validate(prev, curr, flows)
+    val result            = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -280,7 +280,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val expectedCapChange = sfIncome * Share(0.3)
     val curr              = prev.copy(bankCapital = prev.bankCapital + expectedCapChange)
     val flows             = zeroFlows.copy(standingFacilityIncome = sfIncome)
-    val result            = Sfc.validate(prev, curr, flows)
+    val result            = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -290,7 +290,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val ibInt  = PLN.Zero
     val curr   = prev.copy(bankCapital = prev.bankCapital)
     val flows  = zeroFlows.copy(interbankInterest = ibInt)
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -300,7 +300,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val curr       = prev.copy(bankCapital = prev.bankCapital + reserveInt * Share(0.3))
     // Flows do NOT include reserveInterest — should fail
     val flows      = zeroFlows
-    val result     = Sfc.validate(prev, curr, flows)
+    val result     = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BankCapital) shouldBe true
   }
@@ -317,7 +317,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
       standingFacilityIncome = sfInc,
       interbankInterest = ibInt,
     )
-    val result            = Sfc.validate(prev, curr, flows)
+    val result            = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -376,7 +376,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val jstDep = PLN(50000.0) // positive = JST adds to bank deposits
     val curr   = prev.copy(bankDeposits = prev.bankDeposits + jstDep)
     val flows  = zeroFlows.copy(jstDepositChange = jstDep)
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 
@@ -386,7 +386,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
     val curr   = prev.copy(bankDeposits = prev.bankDeposits + jstDep)
     // Flows do NOT include jstDepositChange → should fail
     val flows  = zeroFlows
-    val result = Sfc.validate(prev, curr, flows)
+    val result = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe a[Left[?, ?]]
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.BankDeposits) shouldBe true
   }
@@ -406,7 +406,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
       jstRevenue = jstRev,
       jstDepositChange = depChange,
     )
-    val result    = Sfc.validate(prev, curr, flows)
+    val result    = Sfc.validateStockExactness(prev, curr, flows)
     result shouldBe Right(())
   }
 


### PR DESCRIPTION
Fixes #256
Fixes #250

This PR narrows the stock-only SFC API after the public-sector cash redesign.

What changes:
- the stock-only exact validator is now explicitly named Sfc.validateStockExactness
- runtime Sfc.validate remains the authoritative validation API
- stock-side call sites and legacy tests now use the narrowed exact API
- public-sector metric diagnostics remain separate from stock exactness