### PR TITLE
Make NFA SFC identity exact

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -316,11 +316,11 @@ object Sfc:
   private case class IdentitySpec(id: SfcIdentity, msg: String, expected: PLN, actual: PLN, tolerance: PLN)
 
   def validateStockExactness(
-      prev: StockState,               // stocks at the beginning of the month (before Simulation.step)
-      curr: StockState,               // stocks at the end of the month (after Simulation.step)
-      flows: SemanticFlows,           // all flows that occurred during the month
-      tolerance: PLN = PLN.Zero,      // Exact stock-flow identities outside explicit exceptions
-      nfaTolerance: PLN = PLN(1000.0), // NFA (BoP valuation + rounding)
+      prev: StockState,            // stocks at the beginning of the month (before Simulation.step)
+      curr: StockState,            // stocks at the end of the month (after Simulation.step)
+      flows: SemanticFlows,        // all flows that occurred during the month
+      tolerance: PLN = PLN.Zero,   // Exact stock-flow identities outside explicit exceptions
+      nfaTolerance: PLN = PLN.Zero, // Probe exact NFA semantics; keep explicit override if needed
   )(using p: SimParams): SfcResult =
     import SfcIdentity.*
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -663,7 +663,7 @@ object FlowSimulation:
       executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
       totalWealth = execution.totalWealth,
       tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
+      nfaTolerance = PLN.Zero,
     )
 
     StepResult(


### PR DESCRIPTION
Fixes #239

This PR removes the last dedicated NFA tolerance from SFC exactness.

What changes:
- stock-only exact SFC validation now uses zero NFA tolerance by default
- runtime FlowSimulation SFC validation also runs with zero NFA tolerance
- the NFA identity now passes exactly in both direct SFC specs and real runtime paths