### PR TITLE
Remove SFC tolerance parameters

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -23,7 +23,7 @@ import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
   *      month, using the exact same values that were applied to balance sheet
   *      updates in Simulation.step.
   *   3. '''validate''' — for each of the 13 identities, check that Δstock =
-  *      Σflows within tolerance.
+  *      Σflows exactly.
   *
   * Together these 13 identities cover every financial instrument in the model
   * (deposits, loans, government bonds, corporate bonds, mortgages, consumer
@@ -313,14 +313,12 @@ object Sfc:
     * without updating the corresponding SFC flow projection. Exact global
     * conservation is enforced separately by ledger execution.
     */
-  private case class IdentitySpec(id: SfcIdentity, msg: String, expected: PLN, actual: PLN, tolerance: PLN)
+  private case class IdentitySpec(id: SfcIdentity, msg: String, expected: PLN, actual: PLN)
 
   def validateStockExactness(
-      prev: StockState,            // stocks at the beginning of the month (before Simulation.step)
-      curr: StockState,            // stocks at the end of the month (after Simulation.step)
-      flows: SemanticFlows,        // all flows that occurred during the month
-      tolerance: PLN = PLN.Zero,   // Exact stock-flow identities outside explicit exceptions
-      nfaTolerance: PLN = PLN.Zero, // Probe exact NFA semantics; keep explicit override if needed
+      prev: StockState,    // stocks at the beginning of the month (before Simulation.step)
+      curr: StockState,    // stocks at the end of the month (after Simulation.step)
+      flows: SemanticFlows, // all flows that occurred during the month
   )(using p: SimParams): SfcResult =
     import SfcIdentity.*
 
@@ -341,7 +339,6 @@ object Sfc:
           -losses + grossIncome * p.banking.profitRetention
         },
         actual = curr.bankCapital - prev.bankCapital,
-        tolerance,
       ),
       // 2. Bank deposits: HH income − consumption + all deposit-affecting flows
       //    PLN is Long-based — addition is exact, no Kahan needed
@@ -354,15 +351,13 @@ object Sfc:
           flows.tourismImport - flows.bailInLoss + flows.newLoans - flows.firmPrincipalRepaid +
           flows.consumerOrigination + flows.insNetDepositChange + flows.nbfiDepositDrain,
         actual = curr.bankDeposits - prev.bankDeposits,
-        tolerance,
       ),
-      // 3. NFA: current account + valuation (wider tolerance for FP cancellation)
+      // 3. NFA: current account + valuation
       IdentitySpec(
         Nfa,
         "NFA change (current account + valuation)",
         expected = flows.currentAccount + flows.valuationEffect,
         actual = curr.nfa - prev.nfa,
-        nfaTolerance,
       ),
       // 4. Bond clearing: holders = outstanding (level, not delta)
       IdentitySpec(
@@ -371,7 +366,6 @@ object Sfc:
         expected = curr.bondsOutstanding,
         actual = curr.bankBondHoldings + curr.nbpBondHoldings + curr.foreignBondHoldings +
           curr.ppkBondHoldings + curr.insuranceGovBondHoldings + curr.tfiGovBondHoldings,
-        PLN.Zero,
       ),
       // 5. Interbank netting: Σ net positions = 0
       IdentitySpec(
@@ -379,7 +373,6 @@ object Sfc:
         "interbank netting (should be zero)",
         expected = PLN.Zero,
         actual = curr.interbankNetSum,
-        tolerance,
       ),
       // 6. Mortgage stock: origination − repayment − default
       IdentitySpec(
@@ -387,7 +380,6 @@ object Sfc:
         "mortgage stock change",
         expected = flows.mortgageOrigination - flows.mortgagePrincipalRepaid - flows.mortgageDefaultAmount,
         actual = curr.mortgageStock - prev.mortgageStock,
-        tolerance,
       ),
       // 7. Flow-of-funds: residual = 0 (closes by construction)
       IdentitySpec(
@@ -395,7 +387,6 @@ object Sfc:
         "flow-of-funds residual",
         expected = PLN.Zero,
         actual = flows.fofResidual,
-        tolerance,
       ),
       // 8. Consumer credit: origination − debtService − default (debtSvc = P+I reduces stock)
       IdentitySpec(
@@ -403,7 +394,6 @@ object Sfc:
         "consumer credit stock change",
         expected = flows.consumerOrigination - flows.consumerDebtService - flows.consumerDefaultAmount,
         actual = curr.consumerLoans - prev.consumerLoans,
-        tolerance,
       ),
       // 9. Corporate bond stock: issuance − amortization − default
       IdentitySpec(
@@ -411,7 +401,6 @@ object Sfc:
         "corporate bond stock change",
         expected = flows.corpBondIssuance - flows.corpBondAmortization - flows.corpBondDefaultAmount,
         actual = curr.corpBondsOutstanding - prev.corpBondsOutstanding,
-        tolerance,
       ),
       // 10. NBFI credit: origination − repayment − default
       IdentitySpec(
@@ -419,12 +408,11 @@ object Sfc:
         "NBFI credit stock change",
         expected = flows.nbfiOrigination - flows.nbfiRepayment - flows.nbfiDefaultAmount,
         actual = curr.nbfiLoanStock - prev.nbfiLoanStock,
-        tolerance,
       ),
     )
 
     val errors = identities.collect:
-      case IdentitySpec(id, msg, expected, actual, tol) if (actual - expected).abs > tol =>
+      case IdentitySpec(id, msg, expected, actual) if actual != expected =>
         SfcIdentityError(id, msg, expected, actual)
 
     if errors.isEmpty then Right(()) else Left(errors)
@@ -433,7 +421,6 @@ object Sfc:
       prev: StockState,
       curr: StockState,
       flows: SemanticFlows,
-      tolerance: PLN = PLN(1000.0),
   ): Vector[SfcIdentityError] =
     Vector(
       IdentitySpec(
@@ -441,31 +428,27 @@ object Sfc:
         "government debt change",
         expected = flows.govSpending - flows.govRevenue,
         actual = curr.govDebt - prev.govDebt,
-        tolerance,
       ),
       IdentitySpec(
         SfcIdentity.JstDebt,
         "JST debt change",
         expected = flows.jstSpending - flows.jstRevenue,
         actual = curr.jstDebt - prev.jstDebt,
-        tolerance,
       ),
       IdentitySpec(
         SfcIdentity.FusBalance,
         "FUS balance change (contributions - pensions)",
         expected = flows.zusContributions - flows.zusPensionPayments,
         actual = curr.fusBalance - prev.fusBalance,
-        tolerance,
       ),
       IdentitySpec(
         SfcIdentity.NfzBalance,
         "NFZ balance change (contributions - spending)",
         expected = flows.nfzContributions - flows.nfzSpending,
         actual = curr.nfzBalance - prev.nfzBalance,
-        tolerance,
       ),
     ).collect:
-      case IdentitySpec(id, msg, expected, actual, tol) if (actual - expected).abs > tol =>
+      case IdentitySpec(id, msg, expected, actual) if actual != expected =>
         SfcIdentityError(id, msg, expected, actual)
 
   /** Preferred production API: project stocks from runtime state and combine
@@ -479,8 +462,6 @@ object Sfc:
       batches: Vector[BatchedFlow],
       executionSnapshot: ExecutionSnapshot,
       totalWealth: Long,
-      tolerance: PLN,
-      nfaTolerance: PLN,
   )(using p: SimParams): SfcResult =
     // In the runtime API, Flow-of-Funds is checked from executed ledger
     // batches. Keep the stock-side identities from the legacy oracle, but
@@ -492,7 +473,7 @@ object Sfc:
     // execution; public-sector metric identities are available separately via
     // `metricDiagnostics`.
     val baseErrors    =
-      validateStockExactness(snapshot(prev), snapshot(curr), flows.copy(fofResidual = PLN.Zero), tolerance, nfaTolerance).left.toOption.getOrElse(Vector.empty)
+      validateStockExactness(snapshot(prev), snapshot(curr), flows.copy(fofResidual = PLN.Zero)).left.toOption.getOrElse(Vector.empty)
     val runtimeErrors = runtimeIdentityErrors(batches, executionSnapshot, totalWealth)
     merge(baseErrors ++ runtimeErrors)
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -662,8 +662,6 @@ object FlowSimulation:
       batches = flows,
       executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
       totalWealth = execution.totalWealth,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN.Zero,
     )
 
     StepResult(

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcPropertySpec.scala
@@ -136,17 +136,6 @@ class SfcPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
       result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.Nfa) shouldBe true
     }
 
-  // --- Tolerance monotonicity ---
-
-  it should "have tolerance monotonicity (pass at t implies pass at t' > t)" in
-    forAll(genConsistentFlowsAndSnapshots, Gen.choose(0.01, 5.0)) { (triple: (Sfc.StockState, Sfc.StockState, Sfc.SemanticFlows), perturbation: Double) =>
-      val (prev, curr, flows) = triple
-      val perturbed           = curr.copy(bankCapital = curr.bankCapital + PLN(perturbation))
-      val strictResult        = Sfc.validateStockExactness(prev, perturbed, flows, tolerance = PLN(perturbation))
-      val looseResult         = Sfc.validateStockExactness(prev, perturbed, flows, tolerance = PLN(perturbation * 10))
-      if strictResult.isRight then looseResult shouldBe Right(())
-    }
-
   // --- Error magnitude property ---
 
   it should "have error magnitude = actual change - expected change" in

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -477,34 +477,15 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     metricResult shouldBe Vector.empty
   }
 
-  // ---- Tolerance ----
+  // ---- Exactness ----
 
-  it should "pass when error is below an explicit custom tolerance" in {
+  it should "fail when exact stock-flow identities do not match" in {
     val prev   =
       zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    // Bank capital off by 500; exact path fails, but explicit tolerance can still allow it.
-    val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(500.0))
-    val result = Sfc.validateStockExactness(prev, curr, zeroFlows, tolerance = PLN(1000.0))
-    result shouldBe Right(())
-  }
-
-  it should "fail when error exceeds tolerance" in {
-    val prev   =
-      zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    // Bank capital off by 5000 (above default tolerance of 1000)
+    // Bank capital off by 5000 -> exact path must fail.
     val curr   = prev.copy(bankCapital = prev.bankCapital + PLN(5000.0))
     val result = Sfc.validateStockExactness(prev, curr, zeroFlows)
     result shouldBe a[Left[?, ?]]
-  }
-
-  it should "respect custom tolerance parameter" in {
-    val prev =
-      zeroSnap.copy(firmCash = PLN(500000), bankCapital = PLN(200000), bankDeposits = PLN(1000000))
-    val curr = prev.copy(bankCapital = prev.bankCapital + PLN(5000.0))
-    // Default tolerance (1000): fails
-    Sfc.validateStockExactness(prev, curr, zeroFlows) shouldBe a[Left[?, ?]]
-    // Loose tolerance (10000): passes
-    Sfc.validateStockExactness(prev, curr, zeroFlows, tolerance = PLN(10000.0)) shouldBe Right(())
   }
 
   // ---- Identity 5: Bond clearing ----
@@ -1023,8 +1004,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       batches = batches,
       executionSnapshot = snapshot,
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result shouldBe Right(())
   }
@@ -1065,8 +1044,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result shouldBe a[Left[?, ?]]
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.GovBudgetCash) shouldBe true
@@ -1110,8 +1087,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result shouldBe Right(())
   }
@@ -1221,8 +1196,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result shouldBe Right(())
   }
@@ -1285,8 +1258,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result.shouldBe(a[Left[?, ?]])
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.ZusCash).shouldBe(true)
@@ -1406,8 +1377,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result.shouldBe(Right(()))
   }
@@ -1462,8 +1431,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       totalWealth = 0L,
-      tolerance = PLN.Zero,
-      nfaTolerance = PLN(1000.0),
     )
     result.shouldBe(a[Left[?, ?]])
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.FgspCash).shouldBe(true)


### PR DESCRIPTION
Fixes #238

This makes zero-tolerance the only exactness contract in SFC.

What changed:
- removed tolerance and nfaTolerance from Sfc.validateStockExactness
- removed tolerance and nfaTolerance from runtime Sfc.validate
- removed tolerance from Sfc.metricDiagnostics
- updated exactness/property tests to reflect exact-by-default semantics

This turns the zero-tolerance regression gate into an explicit API contract rather than a convention encoded in call sites.