### PR TITLE
Deduplicate informal tax shadow-share calculation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.markets.{EquityMarket, LaborMarket}
-import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, SectoralMobility}
+import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, InformalEconomy, SectoralMobility}
 import com.boombustgroup.amorfati.types.*
 
 import scala.util.Random
@@ -269,12 +269,7 @@ object WorldAssemblyEconomics:
     val cyclicalAdj = in.w.mechanisms.informalCyclicalAdj * toDouble(p.informal.smoothing) +
       target * (1.0 - toDouble(p.informal.smoothing))
 
-    val effectiveShadowShare =
-      p.fiscal.fofConsWeights
-        .map(toDouble(_))
-        .zip(p.informal.sectorShares.map(toDouble(_)))
-        .map((cw, ss) => cw * Math.min(1.0, ss + cyclicalAdj))
-        .sum: Double
+    val effectiveShadowShare = toDouble(InformalEconomy.aggregateTaxShadowShare(Share(cyclicalAdj)))
 
     InformalResult(taxEvasionLoss, informalEmployed, cyclicalAdj, effectiveShadowShare)
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/InformalEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/InformalEconomy.scala
@@ -1,0 +1,18 @@
+package com.boombustgroup.amorfati.engine.mechanisms
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+
+/** Shared helpers for aggregate tax-side informal-economy semantics. */
+object InformalEconomy:
+
+  /** Consumption-weighted aggregate shadow-economy share used by the current
+    * aggregate tax channels (VAT, PIT, excise).
+    */
+  def aggregateTaxShadowShare(cyclicalAdj: Share)(using p: SimParams): Share =
+    if !p.flags.informal then Share.Zero
+    else
+      p.fiscal.fofConsWeights
+        .zip(p.informal.sectorShares)
+        .map((cw, ss) => cw * (ss + cyclicalAdj).min(Share.One))
+        .foldLeft(Share.Zero)(_ + _)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
@@ -31,9 +31,11 @@ object TaxRevenue:
   @boundaryEscape
   def compute(in: Input)(using p: SimParams): Output =
     import ComputationBoundary.toDouble
-    val weights  = p.fiscal.fofConsWeights.map(toDouble(_))
-    val vatRates = p.fiscal.vatRates.map(toDouble(_))
-    val excRates = p.fiscal.exciseRates.map(toDouble(_))
+    val weights              = p.fiscal.fofConsWeights.map(toDouble(_))
+    val vatRates             = p.fiscal.vatRates.map(toDouble(_))
+    val excRates             = p.fiscal.exciseRates.map(toDouble(_))
+    val effectiveShadowShare = InformalEconomy.aggregateTaxShadowShare(Share(in.informalCyclicalAdj))
+    val effectiveShadowFrac  = toDouble(effectiveShadowShare)
 
     val vat = in.consumption * weights.zip(vatRates).map((w, r) => w * r).sum
 
@@ -42,25 +44,15 @@ object TaxRevenue:
     val customsDutyRevenue =
       in.totalImports * toDouble(p.fiscal.customsNonEuShare) * toDouble(p.fiscal.customsDutyRate)
 
-    // Informal economy: aggregate tax evasion
-    val effectiveShadowShare =
-      if p.flags.informal then
-        val sectorShares = p.informal.sectorShares.map(toDouble(_))
-        weights
-          .zip(sectorShares)
-          .map((cw, ss) => cw * Math.min(1.0, ss + in.informalCyclicalAdj))
-          .sum
-      else 0.0
-
     val vatAfterEvasion =
-      if p.flags.informal then vat * (1.0 - effectiveShadowShare * toDouble(p.informal.vatEvasion)) else vat
+      if p.flags.informal then vat * (1.0 - effectiveShadowFrac * toDouble(p.informal.vatEvasion)) else vat
 
     val exciseAfterEvasion =
-      if p.flags.informal then exciseRevenue * (1.0 - effectiveShadowShare * toDouble(p.informal.exciseEvasion))
+      if p.flags.informal then exciseRevenue * (1.0 - effectiveShadowFrac * toDouble(p.informal.exciseEvasion))
       else exciseRevenue
 
     val pitAfterEvasion =
-      if p.flags.informal then in.pitRevenue * (1.0 - effectiveShadowShare * toDouble(p.informal.pitEvasion))
+      if p.flags.informal then in.pitRevenue * (1.0 - effectiveShadowFrac * toDouble(p.informal.pitEvasion))
       else in.pitRevenue
 
     Output(
@@ -70,5 +62,5 @@ object TaxRevenue:
       exciseRevenue = exciseRevenue,
       exciseAfterEvasion = exciseAfterEvasion,
       customsDutyRevenue = customsDutyRevenue,
-      effectiveShadowShare = effectiveShadowShare,
+      effectiveShadowShare = effectiveShadowFrac,
     )


### PR DESCRIPTION
Fixes #273

This PR extracts one canonical helper for the aggregate tax-side shadow share used by the informal-economy mechanism.

What changes:
- add InformalEconomy.aggregateTaxShadowShare(...) as the single source of truth for the aggregate tax-side shadow-share formula
- make the helper typed on Share instead of using Double internally
- route both TaxRevenue and WorldAssemblyEconomics through the same implementation

Why this matters:
- removes duplicated formula logic
- prevents future semantic drift between tax computation and reported observables
- keeps the refactor low-risk: this PR does not change the model contract yet, it only canonicalizes the existing aggregate tax-side calculation
