### PR TITLE
Separate realized and next-period informal tax semantics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -187,7 +187,7 @@ case class MechanismsState(
     expectations: Expectations.State,  // inflation forecast, credibility, forward guidance
     bfgFundBalance: PLN = PLN.Zero,    // cumulative BFG resolution fund
     informalCyclicalAdj: Double = 0.0, // smoothed cyclical shadow-economy adjustment
-    effectiveShadowShare: Double = 0.0, // consumption-weighted shadow share
+    nextTaxShadowShare: Double = 0.0,  // next-period smoothed tax-side shadow share
 )
 object MechanismsState:
   def zero(using SimParams): MechanismsState = MechanismsState(
@@ -240,6 +240,7 @@ case class FlowState(
     firmDeaths: Int = 0,                      // firms bankrupt this step
     netFirmBirths: Int = 0,                   // net new firms appended to vector
     taxEvasionLoss: PLN = PLN.Zero,           // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
+    realizedTaxShadowShare: Double = 0.0,     // current-period realized aggregate tax-side shadow share
     informalEmployed: Double = 0.0,           // estimated informal employment count
     bailInLoss: PLN = PLN.Zero,               // bail-in capital loss on bank creditors
     bfgLevyTotal: Double = 0.0,               // BFG resolution levy from all banks

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -66,7 +66,7 @@ object BankingEconomics:
       exciseRevenue: PLN,                            // gross excise revenue
       exciseAfterEvasion: PLN,                       // excise after informal evasion
       customsDutyRevenue: PLN,                       // customs duty revenue
-      effectiveShadowShare: Share,                   // effective shadow economy share
+      realizedTaxShadowShare: Share,                 // current-period realized aggregate tax-side shadow share
       mortgageInterestIncome: PLN,                   // mortgage interest income (bank share)
       mortgagePrincipal: PLN,                        // mortgage principal repaid
       mortgageDefaultLoss: PLN,                      // mortgage default loss (bank share)
@@ -183,7 +183,7 @@ object BankingEconomics:
       mortgageDefaultLoss: PLN,
       mortgageDefaultAmount: PLN,
       // Non-monetary outputs needed by WorldAssembly
-      effectiveShadowShare: Share,
+      realizedTaxShadowShare: Share,
       jstDepositChange: PLN,
       investNetDepositFlow: PLN,
       actualBondChange: PLN,
@@ -248,7 +248,7 @@ object BankingEconomics:
       exciseRevenue = PLN(govJst.tax.exciseRevenue),
       exciseAfterEvasion = PLN(govJst.tax.exciseAfterEvasion),
       customsDutyRevenue = PLN(govJst.tax.customsDutyRevenue),
-      effectiveShadowShare = Share(govJst.tax.effectiveShadowShare),
+      realizedTaxShadowShare = Share(govJst.tax.realizedTaxShadowShare),
       mortgageInterestIncome = housing.mortgageFlows.interest,
       mortgagePrincipal = housing.mortgageFlows.principal,
       mortgageDefaultLoss = housing.mortgageFlows.defaultLoss,
@@ -321,7 +321,7 @@ object BankingEconomics:
       mortgagePrincipal = s9.mortgagePrincipal,
       mortgageDefaultLoss = s9.mortgageDefaultLoss,
       mortgageDefaultAmount = s9.mortgageDefaultAmount,
-      effectiveShadowShare = s9.effectiveShadowShare,
+      realizedTaxShadowShare = s9.realizedTaxShadowShare,
       jstDepositChange = s9.jstDepositChange,
       investNetDepositFlow = s9.investNetDepositFlow,
       actualBondChange = s9.actualBondChange,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -53,9 +53,10 @@ object WorldAssemblyEconomics:
   /** Intermediate result for informal economy computations. */
   private case class InformalResult(
       taxEvasionLoss: PLN,
+      realizedTaxShadowShare: Double,
       informalEmployed: Double,
       cyclicalAdj: Double,
-      effectiveShadowShare: Double,
+      nextTaxShadowShare: Double,
   )
 
   /** Intermediate result for observable values surfaced on World. */
@@ -255,23 +256,24 @@ object WorldAssemblyEconomics:
   @boundaryEscape
   private def computeInformalEconomy(in: StepInput)(using p: SimParams): InformalResult =
     import ComputationBoundary.toDouble
-    if !p.flags.informal then return InformalResult(PLN.Zero, 0.0, 0.0, 0.0)
+    if !p.flags.informal then return InformalResult(PLN.Zero, 0.0, 0.0, 0.0, 0.0)
 
     val taxEvasionLoss =
       in.s5.sumCitEvasion + (in.s9.vat - in.s9.vatAfterEvasion) +
         (in.s3.pitRevenue - in.s9.pitAfterEvasion) +
         (in.s9.exciseRevenue - in.s9.exciseAfterEvasion)
 
-    val informalEmployed = in.s2.employed.toDouble * toDouble(in.s9.effectiveShadowShare)
+    val realizedTaxShadowShare = toDouble(in.s9.realizedTaxShadowShare)
+    val informalEmployed       = in.s2.employed.toDouble * realizedTaxShadowShare
 
     val unemp       = 1.0 - in.s2.employed.toDouble / in.w.derivedTotalPopulation.max(1)
     val target      = Math.max(0.0, unemp - toDouble(p.informal.unempThreshold)) * toDouble(p.informal.cyclicalSens)
     val cyclicalAdj = in.w.mechanisms.informalCyclicalAdj * toDouble(p.informal.smoothing) +
       target * (1.0 - toDouble(p.informal.smoothing))
 
-    val effectiveShadowShare = toDouble(InformalEconomy.aggregateTaxShadowShare(Share(cyclicalAdj)))
+    val nextTaxShadowShare = toDouble(InformalEconomy.aggregateTaxShadowShare(Share(cyclicalAdj)))
 
-    InformalResult(taxEvasionLoss, informalEmployed, cyclicalAdj, effectiveShadowShare)
+    InformalResult(taxEvasionLoss, realizedTaxShadowShare, informalEmployed, cyclicalAdj, nextTaxShadowShare)
 
   /** Pre-compute observable values surfaced on World for SimOutput. */
   @boundaryEscape
@@ -441,7 +443,7 @@ object WorldAssemblyEconomics:
         expectations = in.s8.monetary.newExp,
         bfgFundBalance = in.w.mechanisms.bfgFundBalance + in.s9.bfgLevy,
         informalCyclicalAdj = informal.cyclicalAdj,
-        effectiveShadowShare = informal.effectiveShadowShare,
+        nextTaxShadowShare = informal.nextTaxShadowShare,
       ),
       plumbing = MonetaryPlumbingState(
         reserveInterestTotal = in.s8.banking.totalReserveInterest,
@@ -596,6 +598,7 @@ object WorldAssemblyEconomics:
       firmBirths = 0,
       firmDeaths = 0,
       taxEvasionLoss = informal.taxEvasionLoss,
+      realizedTaxShadowShare = informal.realizedTaxShadowShare,
       informalEmployed = informal.informalEmployed,
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = toDouble(in.s9.bfgLevy),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/TaxRevenue.scala
@@ -19,23 +19,23 @@ object TaxRevenue:
   )
 
   case class Output(
-      vat: Double,                 // gross VAT revenue (sector-weighted effective rates)
-      vatAfterEvasion: Double,     // net VAT revenue after informal economy evasion
-      pitAfterEvasion: Double,     // net PIT revenue after informal economy evasion
-      exciseRevenue: Double,       // gross excise tax revenue (sector-weighted rates)
-      exciseAfterEvasion: Double,  // net excise revenue after informal economy evasion
-      customsDutyRevenue: Double,  // customs duty on non-EU imports
-      effectiveShadowShare: Double, // consumption-weighted aggregate shadow economy share
+      vat: Double,                   // gross VAT revenue (sector-weighted effective rates)
+      vatAfterEvasion: Double,       // net VAT revenue after informal economy evasion
+      pitAfterEvasion: Double,       // net PIT revenue after informal economy evasion
+      exciseRevenue: Double,         // gross excise tax revenue (sector-weighted rates)
+      exciseAfterEvasion: Double,    // net excise revenue after informal economy evasion
+      customsDutyRevenue: Double,    // customs duty on non-EU imports
+      realizedTaxShadowShare: Double, // current-period realized aggregate tax-side shadow share
   )
 
   @boundaryEscape
   def compute(in: Input)(using p: SimParams): Output =
     import ComputationBoundary.toDouble
-    val weights              = p.fiscal.fofConsWeights.map(toDouble(_))
-    val vatRates             = p.fiscal.vatRates.map(toDouble(_))
-    val excRates             = p.fiscal.exciseRates.map(toDouble(_))
-    val effectiveShadowShare = InformalEconomy.aggregateTaxShadowShare(Share(in.informalCyclicalAdj))
-    val effectiveShadowFrac  = toDouble(effectiveShadowShare)
+    val weights                = p.fiscal.fofConsWeights.map(toDouble(_))
+    val vatRates               = p.fiscal.vatRates.map(toDouble(_))
+    val excRates               = p.fiscal.exciseRates.map(toDouble(_))
+    val realizedTaxShadowShare = InformalEconomy.aggregateTaxShadowShare(Share(in.informalCyclicalAdj))
+    val realizedTaxShadowFrac  = toDouble(realizedTaxShadowShare)
 
     val vat = in.consumption * weights.zip(vatRates).map((w, r) => w * r).sum
 
@@ -45,14 +45,14 @@ object TaxRevenue:
       in.totalImports * toDouble(p.fiscal.customsNonEuShare) * toDouble(p.fiscal.customsDutyRate)
 
     val vatAfterEvasion =
-      if p.flags.informal then vat * (1.0 - effectiveShadowFrac * toDouble(p.informal.vatEvasion)) else vat
+      if p.flags.informal then vat * (1.0 - realizedTaxShadowFrac * toDouble(p.informal.vatEvasion)) else vat
 
     val exciseAfterEvasion =
-      if p.flags.informal then exciseRevenue * (1.0 - effectiveShadowFrac * toDouble(p.informal.exciseEvasion))
+      if p.flags.informal then exciseRevenue * (1.0 - realizedTaxShadowFrac * toDouble(p.informal.exciseEvasion))
       else exciseRevenue
 
     val pitAfterEvasion =
-      if p.flags.informal then in.pitRevenue * (1.0 - effectiveShadowFrac * toDouble(p.informal.pitEvasion))
+      if p.flags.informal then in.pitRevenue * (1.0 - realizedTaxShadowFrac * toDouble(p.informal.pitEvasion))
       else in.pitRevenue
 
     Output(
@@ -62,5 +62,5 @@ object TaxRevenue:
       exciseRevenue = exciseRevenue,
       exciseAfterEvasion = exciseAfterEvasion,
       customsDutyRevenue = customsDutyRevenue,
-      effectiveShadowShare = effectiveShadowFrac,
+      realizedTaxShadowShare = realizedTaxShadowFrac,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -463,7 +463,8 @@ object SimOutput:
     ColumnDef("NetFirmBirths", ctx => ctx.world.flows.netFirmBirths.toDouble),
     ColumnDef("TotalFirmCount", ctx => ctx.firms.length.toDouble),
     // Informal Economy
-    ColumnDef("EffectiveShadowShare", ctx => ctx.world.mechanisms.effectiveShadowShare),
+    ColumnDef("RealizedTaxShadowShare", ctx => ctx.world.flows.realizedTaxShadowShare),
+    ColumnDef("NextTaxShadowShare", ctx => ctx.world.mechanisms.nextTaxShadowShare),
     ColumnDef("TaxEvasionLoss", ctx => td.toDouble(ctx.world.flows.taxEvasionLoss)),
     ColumnDef("InformalEmployment", ctx => ctx.world.flows.informalEmployed),
     ColumnDef(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -134,9 +134,19 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
     w.mechanisms.informalCyclicalAdj shouldBe 0.0
   }
 
+  it should "have nextTaxShadowShare defaulting to 0.0" in {
+    val w = mkMinimalWorld()
+    w.mechanisms.nextTaxShadowShare shouldBe 0.0
+  }
+
   it should "have taxEvasionLoss defaulting to 0.0" in {
     val w = mkMinimalWorld()
     w.flows.taxEvasionLoss shouldBe PLN.Zero
+  }
+
+  it should "have realizedTaxShadowShare defaulting to 0.0" in {
+    val w = mkMinimalWorld()
+    w.flows.realizedTaxShadowShare shouldBe 0.0
   }
 
   it should "have informalEmployed defaulting to 0.0" in {


### PR DESCRIPTION
Fixes #267

This PR separates current-period realized tax-side informality from the next-period smoothed shadow-economy state.

What changes:
- add realizedTaxShadowShare as the current-period aggregate tax-side shadow share surfaced on FlowState
- add nextTaxShadowShare as the next-period smoothed shadow share carried on MechanismsState
- stop reusing one field for both realized tax outputs and next-period state
- update WorldAssemblyEconomics, BankingEconomics, and SimOutput to use the explicit split
- replace the old single output column with two explicit columns: RealizedTaxShadowShare and NextTaxShadowShare

Why this matters:
- a single monthly snapshot no longer mixes current-period tax evasion semantics with next-period smoothed state
- TaxEvasionLoss and the reported tax-side shadow-share output now describe the same realized period
- the next-period carried mechanism state remains explicit instead of being conflated with a realized observable
