### PR TITLE
Remove misleading informalEmployed metric

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -241,7 +241,6 @@ case class FlowState(
     netFirmBirths: Int = 0,                   // net new firms appended to vector
     taxEvasionLoss: PLN = PLN.Zero,           // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
     realizedTaxShadowShare: Double = 0.0,     // current-period realized aggregate tax-side shadow share
-    informalEmployed: Double = 0.0,           // estimated informal employment count
     bailInLoss: PLN = PLN.Zero,               // bail-in capital loss on bank creditors
     bfgLevyTotal: Double = 0.0,               // BFG resolution levy from all banks
 )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -54,7 +54,6 @@ object WorldAssemblyEconomics:
   private case class InformalResult(
       taxEvasionLoss: PLN,
       realizedTaxShadowShare: Double,
-      informalEmployed: Double,
       cyclicalAdj: Double,
       nextTaxShadowShare: Double,
   )
@@ -256,7 +255,7 @@ object WorldAssemblyEconomics:
   @boundaryEscape
   private def computeInformalEconomy(in: StepInput)(using p: SimParams): InformalResult =
     import ComputationBoundary.toDouble
-    if !p.flags.informal then return InformalResult(PLN.Zero, 0.0, 0.0, 0.0, 0.0)
+    if !p.flags.informal then return InformalResult(PLN.Zero, 0.0, 0.0, 0.0)
 
     val taxEvasionLoss =
       in.s5.sumCitEvasion + (in.s9.vat - in.s9.vatAfterEvasion) +
@@ -264,7 +263,6 @@ object WorldAssemblyEconomics:
         (in.s9.exciseRevenue - in.s9.exciseAfterEvasion)
 
     val realizedTaxShadowShare = toDouble(in.s9.realizedTaxShadowShare)
-    val informalEmployed       = in.s2.employed.toDouble * realizedTaxShadowShare
 
     val laborPopulation = in.w.social.demographics.workingAgePop.max(1)
     val unemp           = 1.0 - in.s2.employed.toDouble / laborPopulation
@@ -274,7 +272,7 @@ object WorldAssemblyEconomics:
 
     val nextTaxShadowShare = toDouble(InformalEconomy.aggregateTaxShadowShare(Share(cyclicalAdj)))
 
-    InformalResult(taxEvasionLoss, realizedTaxShadowShare, informalEmployed, cyclicalAdj, nextTaxShadowShare)
+    InformalResult(taxEvasionLoss, realizedTaxShadowShare, cyclicalAdj, nextTaxShadowShare)
 
   /** Pre-compute observable values surfaced on World for SimOutput. */
   @boundaryEscape
@@ -600,7 +598,6 @@ object WorldAssemblyEconomics:
       firmDeaths = 0,
       taxEvasionLoss = informal.taxEvasionLoss,
       realizedTaxShadowShare = informal.realizedTaxShadowShare,
-      informalEmployed = informal.informalEmployed,
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = toDouble(in.s9.bfgLevy),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -466,7 +466,6 @@ object SimOutput:
     ColumnDef("RealizedTaxShadowShare", ctx => ctx.world.flows.realizedTaxShadowShare),
     ColumnDef("NextTaxShadowShare", ctx => ctx.world.mechanisms.nextTaxShadowShare),
     ColumnDef("TaxEvasionLoss", ctx => td.toDouble(ctx.world.flows.taxEvasionLoss)),
-    ColumnDef("InformalEmployment", ctx => ctx.world.flows.informalEmployed),
     ColumnDef(
       "EvasionToGdpRatio",
       ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.taxEvasionLoss) / td.toDouble(ctx.monthlyGdp) else 0.0,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -149,11 +149,6 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
     w.flows.realizedTaxShadowShare shouldBe 0.0
   }
 
-  it should "have informalEmployed defaulting to 0.0" in {
-    val w = mkMinimalWorld()
-    w.flows.informalEmployed shouldBe 0.0
-  }
-
   // ==========================================================================
   // Firm.Result citEvasion
   // ==========================================================================


### PR DESCRIPTION
Fixes #272

## Summary
- remove informalEmployed from FlowState
- stop assembling and exporting a fake labor metric derived from tax-side shadow-share semantics
- drop the corresponding default-value spec

## Rationale
informalEmployed was derived from a consumption-weighted tax shadow share, so it looked like a labor-market observable while actually encoding tax-evasion semantics. Removing it is cleaner than continuing to report a misleading metric.

