### PR TITLE
Use labor-force denominator for unemployment ratios

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -35,6 +35,12 @@ case class World(
   def derivedTotalPopulation: Int =
     social.demographics.workingAgePop + social.demographics.retirees
 
+  def laborForcePopulation: Int =
+    social.demographics.workingAgePop.max(1)
+
+  def unemploymentRate(employed: Int): Share =
+    Share.One - Share.fraction(employed, laborForcePopulation)
+
   def cachedMonthlyGdpProxy: PLN = flows.monthlyGdpProxy
 
   def updateSocial(f: SocialState => SocialState): World                        = copy(social = f(social))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -396,8 +396,7 @@ object BankingEconomics:
 
   /** Housing market: price step, origination, mortgage flows. */
   private def computeHousingFlows(in: StepInput)(using p: SimParams): HousingResult =
-    val population             = in.w.derivedTotalPopulation.max(1)
-    val unempRate              = 1.0 - in.s2.employed.toDouble / population
+    val unempRate              = in.w.unemploymentRate(in.s2.employed)
     val prevMortgageRate       = in.w.real.housing.avgMortgageRate
     val mortgageBaseRate: Rate =
       if p.flags.interbankTermStructure then
@@ -425,7 +424,7 @@ object BankingEconomics:
     )
     val housingAfterOrig       =
       HousingMarket.processOrigination(housingAfterPrice, in.s3.totalIncome, mortgageRate, true)
-    val mortgageFlows          = HousingMarket.processMortgageFlows(housingAfterOrig, mortgageRate, Share(unempRate))
+    val mortgageFlows          = HousingMarket.processMortgageFlows(housingAfterOrig, mortgageRate, unempRate)
     val housingAfterFlows      = HousingMarket.applyFlows(housingAfterOrig, mortgageFlows)
 
     HousingResult(housingAfterFlows = housingAfterFlows, mortgageFlows = mortgageFlows)
@@ -584,7 +583,7 @@ object BankingEconomics:
     )
 
     // IFRS 9 ECL staging: provision change hits capital
-    val unemployment = Share.One - Share.fraction(in.s2.employed, in.w.derivedTotalPopulation.max(1))
+    val unemployment = in.w.unemploymentRate(in.s2.employed)
     val prevGdp      = in.w.cachedMonthlyGdpProxy
     val gdpGrowth    =
       if prevGdp > PLN.Zero then ComputationBoundary.toDouble(in.s7.gdp - prevGdp) / ComputationBoundary.toDouble(prevGdp) else 0.0

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -53,7 +53,7 @@ object HouseholdFinancialEconomics:
       val base          = toDouble(p.remittance.perCapita) * wap.toDouble
       val erAdj         = Math.pow(w.forex.exchangeRate / p.forex.baseExRate, toDouble(p.remittance.erElasticity))
       val trendAdj      = Math.pow(1.0 + toDouble(p.remittance.growthRate) / 12.0, month.toDouble)
-      val unempForRemit = 1.0 - employed.toDouble / w.derivedTotalPopulation
+      val unempForRemit = toDouble(w.unemploymentRate(employed))
       val cyclicalAdj   = 1.0 + toDouble(p.remittance.cyclicalSens) * Math.max(0.0, unempForRemit - DiasporaUnempThreshold)
       PLN(base * erAdj * trendAdj * cyclicalAdj)
     else PLN.Zero

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -220,8 +220,8 @@ object OpenEconEconomics:
 
     // 4. Monetary policy (Taylor rule + expectations)
     val exRateChg   = Coefficient((forex.exchangeRate / in.w.forex.exchangeRate) - 1.0)
-    val newRefRate  = Nbp.updateRate(in.w.nbp.referenceRate, in.newInflation, exRateChg, in.employed, in.w.derivedTotalPopulation)
-    val unempForExp = 1.0 - in.employed.toDouble / in.w.derivedTotalPopulation
+    val newRefRate  = Nbp.updateRate(in.w.nbp.referenceRate, in.newInflation, exRateChg, in.employed, in.w.laborForcePopulation)
+    val unempForExp = toDouble(in.w.unemploymentRate(in.employed))
     val newExp      =
       if p.flags.expectations then Expectations.step(in.w.mechanisms.expectations, toDouble(in.newInflation), toDouble(newRefRate), unempForExp)
       else in.w.mechanisms.expectations
@@ -273,7 +273,7 @@ object OpenEconEconomics:
     val corpDefaults  = CorporateBondMarket.processDefaults(in.w.financial.corporateBonds, in.totalBondDefault)
 
     // 8. Insurance
-    val unempRate    = Share.One - Share.fraction(in.employed, in.w.derivedTotalPopulation)
+    val unempRate    = in.w.unemploymentRate(in.employed)
     val newInsurance =
       if p.flags.insurance then
         Insurance.step(in.w.financial.insurance, in.employed, in.newWage, in.w.priceLevel, unempRate, marketYield, newCorpBonds.corpBondYield, in.equityReturn)
@@ -568,9 +568,9 @@ object OpenEconEconomics:
       in.s7.newInfl,
       exRateChg,
       in.s2.employed,
-      in.w.derivedTotalPopulation,
+      in.w.laborForcePopulation,
     )
-    val unempRateForExp = 1.0 - in.s2.employed.toDouble / in.w.derivedTotalPopulation
+    val unempRateForExp = toDouble(in.w.unemploymentRate(in.s2.employed))
     val newExp          =
       if p.flags.expectations then Expectations.step(in.w.mechanisms.expectations, toDouble(in.s7.newInfl), toDouble(newRefRate), unempRateForExp)
       else in.w.mechanisms.expectations
@@ -657,7 +657,7 @@ object OpenEconEconomics:
     )
 
   private def runStepInsurance(in: StepInput, newBondYield: Rate)(using p: SimParams): InsuranceResult =
-    val unempRate    = Share.One - Share.fraction(in.s2.employed, in.w.derivedTotalPopulation)
+    val unempRate    = in.w.unemploymentRate(in.s2.employed)
     val newInsurance =
       if p.flags.insurance then
         Insurance.step(
@@ -675,7 +675,7 @@ object OpenEconEconomics:
 
   private def runStepNbfi(in: StepInput, bankAgg: Banking.Aggregate, postFxNbp: Nbp.State, newBondYield: Rate)(using p: SimParams): NbfiResult =
     val nbfiDepositRate = (postFxNbp.referenceRate - Rate(NbfiDepositRateSpread)).max(Rate.Zero)
-    val nbfiUnempRate   = Share.One - Share.fraction(in.s2.employed, in.w.derivedTotalPopulation)
+    val nbfiUnempRate   = in.w.unemploymentRate(in.s2.employed)
     val newNbfi         =
       if p.flags.nbfi then
         Nbfi.step(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
@@ -66,7 +66,7 @@ object StateAdapter:
     InsuranceFlows.Input(
       employed = labor.employed,
       wage = labor.wage,
-      unempRate = Share.One - Share.fraction(labor.employed, w.derivedTotalPopulation.max(1)),
+      unempRate = w.unemploymentRate(labor.employed),
       prevGovBondHoldings = ins.govBondHoldings,
       prevCorpBondHoldings = ins.corpBondHoldings,
       prevEquityHoldings = ins.equityHoldings,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -53,7 +53,7 @@ object SimOutput:
           .toDouble / secFirms.length
     }
 
-    inline def unemployPct: Double = hhAgg.unemploymentRate(world.derivedTotalPopulation)
+    inline def unemployPct: Double = td.toDouble(world.unemploymentRate(hhAgg.employed))
 
   // -------------------------------------------------------------------------
   //  Schema groups — composed with ++


### PR DESCRIPTION
Fixes #276

## Summary
- add a `World.laborForcePopulation` / `World.unemploymentRate` helper pair
- switch production unemployment-like ratios from `derivedTotalPopulation` to the working-age denominator where they truly represent labor-market stress
- update output unemployment to use the same labor-force denominator

## Covered by this PR
- remittance cyclicality in HouseholdFinancialEconomics
- expectations / insurance / NBFI / Taylor-rule unemployment inputs in OpenEconEconomics
- housing and ECL unemployment inputs in BankingEconomics
- insurance bridge input in StateAdapter
- exported `Unemployment` metric in SimOutput

## Audit outcome
The remaining `derivedTotalPopulation` call sites are not the same semantic category:
- some are population-level supply or demand approximations (for example in LaborEconomics / DemandEconomics)
- some are diagnostics only
- one is a per-capita housing wealth split, not an unemployment ratio
So this PR fixes the real unemployment-denominator bugs without widening scope into unrelated semantics.

## Validation
- sbt scalafmtAll
- sbt 'testOnly *InformalEconomySpec* *FlowSimulationStepSpec* *OpenEconEconomicsSpec* *BankingEconomicsSpec* *WorldAssemblyEconomicsSpec*'
