### PR TITLE
Tag heavy test suites for faster local runs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,4 +38,17 @@ lazy val root = project
       "dev.zio"           %% "zio-test-sbt"    % "2.1.16"   % Test,
       "com.github.lalyos"  % "jfiglet"         % "0.0.9",
     ),
+    Test / testOptions ++= {
+      val heavyTag         = "com.boombustgroup.amorfati.tags.Heavy"
+      // Local `sbt test` skips @Heavy suites by default.
+      // Run the full suite locally with: `sbt -DamorFati.includeHeavyTests=true test`
+      val includeHeavy     = sys.props.get("amorFati.includeHeavyTests").exists { value =>
+        val normalized = value.trim.toLowerCase
+        normalized == "true" || normalized == "1" || normalized == "yes"
+      }
+      val runningOnCi      = sys.env.get("CI").contains("true") || sys.env.get("GITHUB_ACTIONS").contains("true")
+      val excludeHeavyByDefault = !includeHeavy && !runningOnCi
+      if (excludeHeavyByDefault) Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", heavyTag))
+      else Nil
+    },
   )

--- a/src/test/java/com/boombustgroup/amorfati/tags/Heavy.java
+++ b/src/test/java/com/boombustgroup/amorfati/tags/Heavy.java
@@ -1,0 +1,18 @@
+package com.boombustgroup.amorfati.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Marks expensive suites that are skipped by default in local `sbt test`.
+ * CI still runs them unless explicitly disabled.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface Heavy {}

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -4,10 +4,12 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.montecarlo.McRunner.runSingle
 import com.boombustgroup.amorfati.montecarlo.SimOutput
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
+import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+@Heavy
 class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   given SimParams      = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
 import com.boombustgroup.amorfati.fp.ComputationBoundary
+import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -11,6 +12,7 @@ import org.scalatest.matchers.should.Matchers
   * No old Simulation.step() in the loop. FlowSimulation produces new World,
   * which feeds into next month's FlowSimulation.step().
   */
+@Heavy
 class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,6 +13,7 @@ import org.scalatest.matchers.should.Matchers
   * emitAllBatches → batch bridge → Interpreter) closes at SFC == 0L when fed
   * with real simulation data.
   */
+@Heavy
 class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -2,10 +2,12 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.ledger.{ImperativeInterpreter, Interpreter}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+@Heavy
 class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -5,6 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,6 +14,7 @@ import org.scalatest.matchers.should.Matchers
 /** Full month: run pipeline via Economics objects, extract flows from every
   * step, verify SFC == 0L.
   */
+@Heavy
 class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,6 +11,7 @@ import org.scalatest.matchers.should.Matchers
   *
   * Runs 120 months via FlowSimulation.step(). At each month verifies SFC == 0L.
   */
+@Heavy
 class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,6 +12,7 @@ import org.scalatest.matchers.should.Matchers
   * Acceptance test for the pipeline. Proves SFC == 0L and economic sanity
   * across diverse random trajectories.
   */
+@Heavy
 class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults


### PR DESCRIPTION
## Summary
- add a Heavy ScalaTest tag for the most expensive integration suites
- skip Heavy suites by default in local sbt test
- keep running them on CI, and allow full local runs via sbt -DamorFati.includeHeavyTests=true test

## Notes
- this shortens the default local feedback loop without weakening CI coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Implemented test categorization for resource-intensive test suites with automatic exclusion during local development
  * CI environments include all tests automatically
  * System property allows manual override of test filtering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->