### PR TITLE
Type immigration sampling and sector allocation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -1,7 +1,6 @@
 package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.config.SocialConfig
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
 
@@ -49,16 +48,16 @@ object Immigration:
     * immigrant wages × remittance rate.
     */
   def computeRemittances(immigrantHH: Iterable[Household.State])(using p: SimParams): PLN =
-    immigrantHH
-      .filter(_.isImmigrant)
-      .foldLeft(PLN.Zero): (acc, h) =>
+    immigrantHH.foldLeft(PLN.Zero): (acc, h) =>
+      if !h.isImmigrant then acc
+      else
         h.status match
           case HhStatus.Employed(_, _, wage) => acc + (wage * p.immigration.remitRate)
           case _                             => acc
 
   /** Choose sector for new immigrant (weighted by sectorShares). */
   def chooseSector(rng: Random)(using p: SimParams): SectorIdx =
-    SectorIdx(SocialConfig.cdfSample(p.immigration.sectorShares, rng))
+    SectorIdx(Distributions.cdfSample(p.immigration.sectorShares, rng))
 
   /** Spawn new immigrant households. Start as Unemployed(0) — matched in next
     * jobSearch round.

--- a/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.config
 
 import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.amorfati.util.Distributions
 
 /** Social security, pensions, demographics, and education.
   *
@@ -95,11 +96,11 @@ case class SocialConfig(
   /** Draw education tier for a worker in given sector using CDF sampling. */
   def drawEducation(sectorIdx: Int, rng: scala.util.Random): Int =
     val shares = eduSectorShares.getOrElse(defaultEduSectorShares)(sectorIdx.max(0).min(5))
-    SocialConfig.cdfSample(shares.map(Share(_)), rng)
+    Distributions.cdfSample(shares.map(Share(_)), rng)
 
   /** Draw education tier for an immigrant worker. */
   def drawImmigrantEducation(rng: scala.util.Random): Int =
-    SocialConfig.cdfSample(eduImmigShares, rng)
+    Distributions.cdfSample(eduImmigShares, rng)
 
   /** Wage premium multiplier for given education tier (0-3). */
   def eduWagePremium(education: Int): Multiplier =
@@ -114,21 +115,4 @@ case class SocialConfig(
     val idx = education.max(0).min(3)
     (eduSkillFloors(idx), eduSkillCeilings(idx))
 
-object SocialConfig:
-
-  /** Sample a categorical index from a probability vector using the inverse CDF
-    * method.
-    *
-    * Builds a cumulative distribution from `shares`, draws a uniform random
-    * number, and returns the first index whose cumulative probability exceeds
-    * the draw. The last category absorbs any fixed-point residual.
-    */
-  private[amorfati] def cdfSample(shares: Vector[Share], rng: scala.util.Random): Int =
-    val draw       = Share.random(rng)
-    var cumulative = Share.Zero
-    var i          = 0
-    while i < shares.length - 1 do
-      cumulative = cumulative + shares(i)
-      if draw < cumulative then return i
-      i += 1
-    shares.length - 1
+object SocialConfig

--- a/src/main/scala/com/boombustgroup/amorfati/util/Distributions.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/util/Distributions.scala
@@ -7,6 +7,22 @@ import scala.util.Random
 /** Sampling helpers for standard distributions (Poisson, Beta, Gamma). */
 object Distributions:
 
+  /** Sample a categorical index from non-negative fixed-point weights. */
+  private[amorfati] def cdfSample(shares: Vector[Share], rng: Random): Int =
+    require(shares.nonEmpty, "shares must be non-empty")
+    require(shares.forall(_ >= Share.Zero), s"shares must be non-negative: $shares")
+    val total = shares.foldLeft(Share.Zero)(_ + _)
+    require(total > Share.Zero, s"shares must contain at least one positive weight: $shares")
+
+    val draw       = Share.random(rng) * total
+    var cumulative = Share.Zero
+    var i          = 0
+    while i < shares.length - 1 do
+      cumulative = cumulative + shares(i)
+      if draw < cumulative then return i
+      i += 1
+    shares.length - 1
+
   /** Sample from Poisson(lambda) using Knuth algorithm (small λ). */
   def poissonSample(lambda: Double, rng: Random): Int =
     if lambda <= 0 then 0


### PR DESCRIPTION
## Summary
- remove Double, toDouble, toLong and boundaryEscape from Immigration.scala
- use typed fixed-point sampling helpers for immigrant skill, MPC, savings and rent
- consolidate SocialConfig categorical sampling on a typed cdfSample(Vector[Share], rng)

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.ImmigrationSpec com.boombustgroup.amorfati.agents.ImmigrationPropertySpec com.boombustgroup.amorfati.agents.EducationSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified sampling and randomization logic for immigration, education, sector choice, savings and rent initialization.
  * Switched to higher-precision fixed-point routines for numerical consistency.

* **New Features**
  * More robust and consistent stochastic draws for immigrants (education, sector, skill, savings, rent), reducing edge-case bias and improving simulation stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->