### PR TITLE
Introduce minimal MonthTrace audit artifact

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -1,0 +1,132 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.accounting.Sfc
+import com.boombustgroup.amorfati.agents.{Banking, Firm, HhStatus, Household}
+import com.boombustgroup.amorfati.types.*
+
+/** Minimal month-level audit artifact for timing-sensitive execution.
+  *
+  * The trace is intentionally narrower than event sourcing: it captures the
+  * month boundary, selected same-month outputs, extracted next-month signals,
+  * and validation summaries.
+  */
+case class MonthTrace(
+    month: Int,
+    startSnapshot: MonthBoundarySnapshot,
+    seedIn: DecisionSignals,
+    stages: MonthStageTrace,
+    executedFlows: Sfc.SemanticFlows,
+    endSnapshot: MonthBoundarySnapshot,
+    seedOut: DecisionSignals,
+    seedOutProvenance: SeedOutProvenance,
+    validations: Vector[MonthValidation],
+)
+
+/** Compact boundary snapshot used at the start and end of a month trace. */
+case class MonthBoundarySnapshot(
+    stock: Sfc.StockState,
+    firmCount: Int,
+    livingFirmCount: Int,
+    householdCount: Int,
+    bankCount: Int,
+    activeBankCount: Int,
+    employedHouseholds: Int,
+    unemploymentRate: Share,
+    inflation: Rate,
+    priceLevel: PriceIndex,
+    monthlyGdpProxy: PLN,
+)
+
+object MonthBoundarySnapshot:
+  def capture(
+      world: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+  ): MonthBoundarySnapshot =
+    val employedHouseholds = households.count: hh =>
+      hh.status match
+        case HhStatus.Employed(_, _, _) => true
+        case _                          => false
+
+    MonthBoundarySnapshot(
+      stock = Sfc.snapshot(world, firms, households, banks),
+      firmCount = firms.length,
+      livingFirmCount = firms.count(Firm.isAlive),
+      householdCount = households.length,
+      bankCount = banks.length,
+      activeBankCount = banks.count(b => !b.failed),
+      employedHouseholds = employedHouseholds,
+      unemploymentRate = world.unemploymentRate(employedHouseholds),
+      inflation = world.inflation,
+      priceLevel = world.priceLevel,
+      monthlyGdpProxy = world.flows.monthlyGdpProxy,
+    )
+
+/** Selected same-month outputs that matter for signal timing and FirmEntry. */
+case class MonthStageTrace(
+    operationalHiringSlack: Share,
+    sectorDemandMult: Vector[Multiplier],
+    sectorDemandPressure: Vector[Multiplier],
+    sectorHiringSignal: Vector[Multiplier],
+    realizedInflation: Rate,
+    expectedInflation: Rate,
+    startupAbsorptionRate: Share,
+    firmBirths: Int,
+    firmDeaths: Int,
+    netFirmBirths: Int,
+)
+
+/** Provenance stage tags for the extracted seed-out fields. */
+enum MonthTraceStage:
+  case LaborEconomics
+  case DemandEconomics
+  case PriceEquityEconomics
+  case OpenEconEconomics
+  case WorldAssemblyEconomics
+  case StartupStaffing
+
+/** Typed provenance for one extracted next-month signal. */
+case class SignalProvenance[A](
+    value: A,
+    stage: MonthTraceStage,
+    source: String,
+)
+
+/** Minimal provenance view for the fields persisted into the next month. */
+case class SeedOutProvenance(
+    unemploymentRate: SignalProvenance[Share],
+    inflation: SignalProvenance[Rate],
+    expectedInflation: SignalProvenance[Rate],
+    laggedHiringSlack: SignalProvenance[Share],
+    startupAbsorptionRate: SignalProvenance[Share],
+    sectorDemandMult: SignalProvenance[Vector[Multiplier]],
+    sectorDemandPressure: SignalProvenance[Vector[Multiplier]],
+    sectorHiringSignal: SignalProvenance[Vector[Multiplier]],
+)
+
+enum MonthValidationKind:
+  case Sfc
+
+case class MonthValidationFailure(
+    identity: Sfc.SfcIdentity,
+    message: String,
+    expected: PLN,
+    actual: PLN,
+)
+
+case class MonthValidation(
+    kind: MonthValidationKind,
+    failures: Vector[MonthValidationFailure],
+):
+  def passed: Boolean = failures.isEmpty
+
+object MonthValidation:
+  def fromSfcResult(result: Sfc.SfcResult): MonthValidation =
+    result match
+      case Right(())    => MonthValidation(MonthValidationKind.Sfc, Vector.empty)
+      case Left(errors) =>
+        MonthValidation(
+          MonthValidationKind.Sfc,
+          errors.map(e => MonthValidationFailure(e.identity, e.msg, e.expected, e.actual)),
+        )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -48,7 +48,7 @@ against 13 accounting identities each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point. `step()` runs the 9-stage `computeAll()`, then `emitAllFlows()` to record all monetary flows. Produces `StepResult(world, firms, households)`. |
+| `FlowSimulation.scala` | Sole pipeline entry point. `step()` runs the 9-stage `computeAll()`, then `emitAllFlows()` to record all monetary flows. Produces `StepResult(world, firms, households, monthTrace)` with an inspectable month-boundary audit artifact. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `FirmWages`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `StateAdapter.scala` | Bridges computation outputs to flow inputs: extracts ZUS, NFZ, PPK, earmarked, HH, insurance, and firm flow parameters from `FullComputation`. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -480,6 +480,7 @@ object FlowSimulation:
       newHouseholds: Vector[Household.State],
       newBanks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
+      monthTrace: MonthTrace,
   )
 
   private def executeBatches(flows: Vector[BatchedFlow]): Either[String, ExecutionResult] =
@@ -500,6 +501,50 @@ object FlowSimulation:
       banks: Vector[Banking.BankState],
   ): Sfc.RuntimeState =
     Sfc.RuntimeState(w, firms, households, banks)
+
+  private def buildSeedOutProvenance(seedOut: DecisionSignals): SeedOutProvenance =
+    SeedOutProvenance(
+      unemploymentRate = SignalProvenance(
+        seedOut.unemploymentRate,
+        MonthTraceStage.WorldAssemblyEconomics,
+        "finalHouseholds employment count -> assembledWorld.unemploymentRate",
+      ),
+      inflation = SignalProvenance(
+        seedOut.inflation,
+        MonthTraceStage.PriceEquityEconomics,
+        "s7.newInfl -> assembledWorld.inflation",
+      ),
+      expectedInflation = SignalProvenance(
+        seedOut.expectedInflation,
+        MonthTraceStage.OpenEconEconomics,
+        "s8.monetary.newExp.expectedInflation -> assembledWorld.mechanisms.expectations.expectedInflation",
+      ),
+      laggedHiringSlack = SignalProvenance(
+        seedOut.laggedHiringSlack,
+        MonthTraceStage.LaborEconomics,
+        "s2.operationalHiringSlack",
+      ),
+      startupAbsorptionRate = SignalProvenance(
+        seedOut.startupAbsorptionRate,
+        MonthTraceStage.StartupStaffing,
+        "WorldAssemblyEconomics.applyStartupStaffing.startupAbsorptionRate",
+      ),
+      sectorDemandMult = SignalProvenance(
+        seedOut.sectorDemandMult,
+        MonthTraceStage.DemandEconomics,
+        "s4.sectorMults",
+      ),
+      sectorDemandPressure = SignalProvenance(
+        seedOut.sectorDemandPressure,
+        MonthTraceStage.DemandEconomics,
+        "s4.sectorDemandPressure",
+      ),
+      sectorHiringSignal = SignalProvenance(
+        seedOut.sectorHiringSignal,
+        MonthTraceStage.DemandEconomics,
+        "s4.sectorHiringSignal",
+      ),
+    )
 
   private case class ExecutedBatchEvidence(
       totals: Map[MechanismId, Long],
@@ -626,7 +671,7 @@ object FlowSimulation:
       identity,
     )
 
-    val assembled = WorldAssemblyEconomics.compute(
+    val assembled  = WorldAssemblyEconomics.compute(
       WorldAssemblyEconomics.Input(
         w = w,
         firms = firms,
@@ -656,8 +701,8 @@ object FlowSimulation:
         migRng = rng,
       ),
     )
-    val sfcFlows  = buildSfcFlows(full, flows, assembled.world.plumbing.fofResidual)
-    val sfcResult = Sfc.validate(
+    val sfcFlows   = buildSfcFlows(full, flows, assembled.world.plumbing.fofResidual)
+    val sfcResult  = Sfc.validate(
       prev = runtimeState(w, firms, households, banks),
       curr = runtimeState(assembled.world, assembled.firms, assembled.households, assembled.banks),
       flows = sfcFlows,
@@ -665,6 +710,30 @@ object FlowSimulation:
       executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
       totalWealth = execution.totalWealth,
     )
+    val seedOut    = assembled.world.seedIn
+    val monthTrace =
+      MonthTrace(
+        month = assembled.world.month,
+        startSnapshot = MonthBoundarySnapshot.capture(w, firms, households, banks),
+        seedIn = w.seedIn,
+        stages = MonthStageTrace(
+          operationalHiringSlack = full.s2.operationalHiringSlack,
+          sectorDemandMult = full.s4.sectorMults,
+          sectorDemandPressure = full.s4.sectorDemandPressure,
+          sectorHiringSignal = full.s4.sectorHiringSignal,
+          realizedInflation = full.s7.newInfl,
+          expectedInflation = full.s8.monetary.newExp.expectedInflation,
+          startupAbsorptionRate = seedOut.startupAbsorptionRate,
+          firmBirths = assembled.world.flows.firmBirths,
+          firmDeaths = assembled.world.flows.firmDeaths,
+          netFirmBirths = assembled.world.flows.netFirmBirths,
+        ),
+        executedFlows = sfcFlows,
+        endSnapshot = MonthBoundarySnapshot.capture(assembled.world, assembled.firms, assembled.households, assembled.banks),
+        seedOut = seedOut,
+        seedOutProvenance = buildSeedOutProvenance(seedOut),
+        validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
+      )
 
     StepResult(
       full.calculus,
@@ -676,4 +745,5 @@ object FlowSimulation:
       assembled.households,
       assembled.banks,
       assembled.householdAggregates,
+      monthTrace,
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -1,8 +1,11 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthTraceStage
 import com.boombustgroup.amorfati.init.WorldInit
 import com.boombustgroup.amorfati.tags.Heavy
+import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{ImperativeInterpreter, Interpreter}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -65,6 +68,48 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
     result.flows.map(_.mechanism).toSet.size should be > 30
+  }
+
+  it should "emit a typed MonthTrace with boundary snapshots, stage outputs, and seed provenance" in {
+    val init   = WorldInit.initialize(42L)
+    val rng    = new scala.util.Random(42L)
+    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val trace  = result.monthTrace
+
+    trace.month shouldBe result.newWorld.month
+    trace.seedIn shouldBe init.world.seedIn
+    trace.seedOut shouldBe result.newWorld.seedIn
+    trace.startSnapshot.stock shouldBe Sfc.snapshot(init.world, init.firms, init.households, init.banks)
+    trace.endSnapshot.stock shouldBe Sfc.snapshot(result.newWorld, result.newFirms, result.newHouseholds, result.newBanks)
+    trace.startSnapshot.inflation shouldBe init.world.inflation
+    trace.endSnapshot.inflation shouldBe result.newWorld.inflation
+    trace.stages.operationalHiringSlack shouldBe result.newWorld.pipeline.operationalHiringSlack
+    trace.stages.sectorDemandMult shouldBe result.newWorld.seedIn.sectorDemandMult
+    trace.stages.sectorDemandPressure shouldBe result.newWorld.seedIn.sectorDemandPressure
+    trace.stages.sectorHiringSignal shouldBe result.newWorld.seedIn.sectorHiringSignal
+    trace.stages.realizedInflation shouldBe result.newWorld.inflation
+    trace.stages.expectedInflation shouldBe result.newWorld.mechanisms.expectations.expectedInflation
+    trace.stages.startupAbsorptionRate shouldBe result.newWorld.seedIn.startupAbsorptionRate
+    trace.stages.firmBirths shouldBe result.newWorld.flows.firmBirths
+    trace.stages.firmDeaths shouldBe result.newWorld.flows.firmDeaths
+    trace.stages.netFirmBirths shouldBe result.newWorld.flows.netFirmBirths
+    trace.executedFlows.totalIncome shouldBe result.calculus.totalIncome
+    trace.executedFlows.currentAccount shouldBe result.newWorld.bop.currentAccount
+    trace.executedFlows.fofResidual shouldBe result.newWorld.plumbing.fofResidual
+    trace.seedOutProvenance.unemploymentRate.stage shouldBe MonthTraceStage.WorldAssemblyEconomics
+    trace.seedOutProvenance.inflation.stage shouldBe MonthTraceStage.PriceEquityEconomics
+    trace.seedOutProvenance.expectedInflation.stage shouldBe MonthTraceStage.OpenEconEconomics
+    trace.seedOutProvenance.laggedHiringSlack.stage shouldBe MonthTraceStage.LaborEconomics
+    trace.seedOutProvenance.startupAbsorptionRate.stage shouldBe MonthTraceStage.StartupStaffing
+    trace.seedOutProvenance.sectorDemandMult.stage shouldBe MonthTraceStage.DemandEconomics
+    trace.seedOutProvenance.sectorDemandPressure.stage shouldBe MonthTraceStage.DemandEconomics
+    trace.seedOutProvenance.sectorHiringSignal.stage shouldBe MonthTraceStage.DemandEconomics
+    trace.seedOutProvenance.laggedHiringSlack.value shouldBe result.newWorld.seedIn.laggedHiringSlack
+    trace.seedOutProvenance.startupAbsorptionRate.value shouldBe result.newWorld.seedIn.startupAbsorptionRate
+    trace.validations should have size 1
+    trace.validations.head.passed shouldBe true
+    trace.validations.head.failures shouldBe empty
+    result.sfcResult shouldBe Right(())
   }
 
   it should "match the legacy pure interpreter on aggregate execution balances" in {


### PR DESCRIPTION
## Summary
- add a minimal typed MonthTrace artifact for month-boundary auditability
- emit monthTrace from FlowSimulation.step with boundary snapshots, stage outputs, executed-flow summary, seedIn, seedOut, provenance, and validation summaries
- cover the new trace in FlowSimulationStepSpec and keep engine docs aligned

## Testing
- sbt testOnly com.boombustgroup.amorfati.engine.economics.SignalTimingRegressionSpec
- sbt -DamorFati.includeHeavyTests=true testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Simulation now captures detailed monthly audit traces, including boundary snapshots of key economic indicators, stage execution details, and validation results for improved observability.

* **Documentation**
  * Updated step results documentation to reflect inclusion of monthly trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->