### PR TITLE
Remove legacy FlowSimulation step surface

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -17,7 +17,7 @@ object BankruptcyProbe:
     given SimParams = SimParams.defaults
 
     val init  = WorldInit.initialize(seed)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     println(s"seed=$seed months=$months")
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -25,7 +25,7 @@ object BankruptcyProbe:
       val rng          = new Random(seed * 1000 + month)
       val prevById     = state.firms.map(f => f.id -> f).toMap
       val result       = FlowSimulation.step(state, rng)
-      val newBankrupts = result.newFirms.flatMap: f =>
+      val newBankrupts = result.nextState.firms.flatMap: f =>
         bankruptReason(f).flatMap: reason =>
           prevById.get(f.id).flatMap(bankruptReason) match
             case Some(_) => None
@@ -33,8 +33,8 @@ object BankruptcyProbe:
 
       val byReason    = newBankrupts.groupMapReduce(_._1)(_ => 1)(_ + _).toVector.sortBy(-_._2)
       val bySector    = newBankrupts.groupMapReduce(_._2)(_ => 1)(_ + _).toVector.sortBy(_._1)
-      val unemp       = result.householdAggregates.unemploymentRate(result.newWorld.derivedTotalPopulation)
-      val demandMults = result.newWorld.pipeline.sectorDemandMult
+      val unemp       = result.nextState.householdAggregates.unemploymentRate(result.nextState.world.derivedTotalPopulation)
+      val demandMults = result.nextState.world.pipeline.sectorDemandMult
 
       println(
         s"month=$month unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -50,9 +50,6 @@ Read it as a month transition:
 - `trace` is the emitted audit artifact for month `t`.
 - `nextState` is the typed month `t+1` boundary state.
 
-The old `step(world, firms, households, banks, rng)` entry point remains only as
-a compatibility wrapper around `step(state, rng)`.
-
 ## economics/
 
 The 9-stage computation pipeline, executed in fixed order each month. Each

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -35,6 +35,10 @@ object FlowSimulation:
       householdAggregates: Household.Aggregates,
   )
 
+  object SimState:
+    def fromInit(init: com.boombustgroup.amorfati.init.WorldInit.InitResult): SimState =
+      SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+
   case class ExecutionResult(
       snapshot: Map[(EntitySector, AssetType, Int), Long],
       totalWealth: Long,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -466,18 +466,6 @@ object FlowSimulation:
   def computeCalculus(state: SimState, rng: Random)(using p: SimParams): MonthlyCalculus =
     computeAll(state.world, state.firms, state.households, state.banks, rng).calculus
 
-  def computeCalculus(
-      w: World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      banks: Vector[Banking.BankState],
-      rng: Random,
-  )(using p: SimParams): MonthlyCalculus =
-    computeCalculus(
-      legacyInputState(w, firms, households, banks),
-      rng,
-    )
-
   /** Full month-step contract.
     *
     * `stateIn -> StepOutput(nextState, trace)` is the explicit monthly
@@ -496,41 +484,7 @@ object FlowSimulation:
       trace: MonthTrace,
       nextState: SimState,
   ):
-    def monthTrace: MonthTrace                    = trace
-    def newWorld: World                           = nextState.world
-    def newFirms: Vector[Firm.State]              = nextState.firms
-    def newHouseholds: Vector[Household.State]    = nextState.households
-    def newBanks: Vector[Banking.BankState]       = nextState.banks
-    def householdAggregates: Household.Aggregates = nextState.householdAggregates
-    def transition: (MonthTrace, SimState)        = (trace, nextState)
-
-  object StepOutput:
-    def apply(
-        stateIn: SimState,
-        calculus: MonthlyCalculus,
-        operationalSignals: OperationalSignals,
-        signalExtraction: SignalExtraction.Output,
-        flows: Vector[BatchedFlow],
-        execution: ExecutionResult,
-        sfcResult: Sfc.SfcResult,
-        trace: MonthTrace,
-        nextWorld: World,
-        nextFirms: Vector[Firm.State],
-        nextHouseholds: Vector[Household.State],
-        nextBanks: Vector[Banking.BankState],
-        nextHouseholdAggregates: Household.Aggregates,
-    ): StepOutput =
-      StepOutput(
-        stateIn = stateIn,
-        calculus = calculus,
-        operationalSignals = operationalSignals,
-        signalExtraction = signalExtraction,
-        flows = flows,
-        execution = execution,
-        sfcResult = sfcResult,
-        trace = trace,
-        nextState = SimState(nextWorld, nextFirms, nextHouseholds, nextBanks, nextHouseholdAggregates),
-      )
+    def transition: (MonthTrace, SimState) = (trace, nextState)
 
   private def executeBatches(flows: Vector[BatchedFlow]): Either[String, ExecutionResult] =
     val state = AggregateBatchContract.emptyExecutionState()
@@ -731,30 +685,6 @@ object FlowSimulation:
       validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
     )
 
-  private def inferBoundaryAggregates(world: World, households: Vector[Household.State])(using p: SimParams): Household.Aggregates =
-    Household.computeAggregates(
-      households,
-      marketWage = world.householdMarket.marketWage,
-      reservationWage = world.householdMarket.reservationWage,
-      importAdj = p.forex.importPropensity,
-      retrainingAttempts = 0,
-      retrainingSuccesses = 0,
-    )
-
-  private def legacyInputState(
-      w: World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      banks: Vector[Banking.BankState],
-  )(using p: SimParams): SimState =
-    SimState(
-      world = w,
-      firms = firms,
-      households = households,
-      banks = banks,
-      householdAggregates = inferBoundaryAggregates(w, households),
-    )
-
   /** Full step: compute calculus → emit flows → assemble new World.
     *
     * This is the pipeline entry point. Runs s1–s9 exactly once via
@@ -835,12 +765,4 @@ object FlowSimulation:
       sfcResult,
       trace = monthTrace,
       nextState = nextState,
-    )
-
-  def step(w: World, firms: Vector[Firm.State], households: Vector[Household.State], banks: Vector[Banking.BankState], rng: Random)(using
-      p: SimParams,
-  ): StepOutput =
-    step(
-      legacyInputState(w, firms, households, banks),
-      rng,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -488,7 +488,7 @@ object FlowSimulation:
       trace: MonthTrace,
       nextState: SimState,
   ):
-    def transition: (MonthTrace, SimState) = (trace, nextState)
+    def transition: (SimState, MonthTrace) = (nextState, trace)
 
   private def executeBatches(flows: Vector[BatchedFlow]): Either[String, ExecutionResult] =
     val state = AggregateBatchContract.emptyExecutionState()

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -73,7 +73,7 @@ object McRunner:
     val runtime = Sfc.RuntimeState(init.world, init.firms, init.households, init.banks)
     val errors  = InitCheck.validate(runtime)
     if errors.nonEmpty then Left(SimError.Init(errors))
-    else Right(FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates))
+    else Right(FlowSimulation.SimState.fromInit(init))
 
   private def stepMonth(state: FlowSimulation.SimState, seed: Long, month: Int)(using p: SimParams) =
     val rng    = new scala.util.Random(seed * 10000 + month)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -330,25 +330,19 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
 
   "Informal calibration" should "keep default runtime ratios in a plausible envelope over 12 months" in {
     val init  = WorldInit.initialize(42L)
-    var w     = init.world
-    var firms = init.firms
-    var hh    = init.households
-    var banks = init.banks
+    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
     val realizedShares = collection.mutable.ArrayBuffer.empty[Share]
     val evasionRatios  = collection.mutable.ArrayBuffer.empty[Share]
 
     (1 to 12).foreach: month =>
-      val result     = FlowSimulation.step(w, firms, hh, banks, new scala.util.Random(42L * 1000 + month))
-      realizedShares += Share(result.newWorld.flows.realizedTaxShadowShare)
-      val monthlyGdp = result.newWorld.cachedMonthlyGdpProxy
+      val result     = FlowSimulation.step(state, new scala.util.Random(42L * 1000 + month))
+      realizedShares += Share(result.nextState.world.flows.realizedTaxShadowShare)
+      val monthlyGdp = result.nextState.world.cachedMonthlyGdpProxy
       val ratio      =
-        if monthlyGdp > PLN.Zero then Share(td.toDouble(result.newWorld.flows.taxEvasionLoss) / td.toDouble(monthlyGdp)) else Share.Zero
+        if monthlyGdp > PLN.Zero then Share(td.toDouble(result.nextState.world.flows.taxEvasionLoss) / td.toDouble(monthlyGdp)) else Share.Zero
       evasionRatios += ratio
-      w = result.newWorld
-      firms = result.newFirms
-      hh = result.newHouseholds
-      banks = result.newBanks
+      state = result.nextState
 
     val avgShare = Share(realizedShares.map(td.toDouble).sum / realizedShares.size)
     val avgRatio = Share(evasionRatios.map(td.toDouble).sum / evasionRatios.size)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -330,7 +330,7 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
 
   "Informal calibration" should "keep default runtime ratios in a plausible envelope over 12 months" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     val realizedShares = collection.mutable.ArrayBuffer.empty[Share]
     val evasionRatios  = collection.mutable.ArrayBuffer.empty[Share]

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -14,21 +14,23 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
 
   "WorldAssemblyEconomics (own Input)" should "produce valid world after simulation step" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val w      = result.newWorld
+    val result = FlowSimulation.step(state, rng)
+    val w      = result.nextState.world
 
     w.month.shouldBe(1)
     w.derivedTotalPopulation should be > 0
-    result.householdAggregates.employed should be > 0
+    result.nextState.householdAggregates.employed should be > 0
     w.external.tourismSeasonalFactor should not be 0.0
   }
 
   it should "preserve public-spending semantic aggregates on the assembled world" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val w      = result.newWorld
+    val result = FlowSimulation.step(state, rng)
+    val w      = result.nextState.world
 
     w.gov.domesticBudgetDemand shouldBe (w.gov.govCurrentSpend + w.gov.govCapitalSpend)
     w.gov.domesticBudgetOutlays shouldBe (

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -14,7 +14,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
 
   "WorldAssemblyEconomics (own Input)" should "produce valid world after simulation step" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     val w      = result.nextState.world
@@ -27,7 +27,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
 
   it should "preserve public-spending semantic aggregates on the assembled world" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     val w      = result.nextState.world

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -20,7 +20,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
 
   "FlowSimulation (autonomous)" should "run 12 months with SFC == 0L" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
@@ -36,7 +36,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
 
   it should "produce evolving economy (GDP changes)" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
     val gdps  = scala.collection.mutable.ArrayBuffer[Double]()
 
     (1 to 12).foreach { month =>
@@ -52,7 +52,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
 
   it should "maintain positive employment throughout" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 /** Autonomous pipeline: FlowSimulation.step() drives its own state.
   *
-  * No old Simulation.step() in the loop. FlowSimulation produces new World,
+  * No old Simulation.step() in the loop. FlowSimulation produces nextState,
   * which feeds into next month's FlowSimulation.step().
   */
 @Heavy
@@ -60,7 +60,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
       state = result.nextState
 
       withClue(s"Month $month: ") {
-        result.householdAggregates.employed should be > 0
+        result.nextState.householdAggregates.employed should be > 0
       }
     }
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -132,7 +132,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
 
   it should "drive FlowSimulation main path through BatchedFlow" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42L)
     val result = FlowSimulation.step(state, rng)
     val legacy = AggregateBatchContract.toLegacyFlows(result.flows)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -132,8 +132,9 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
 
   it should "drive FlowSimulation main path through BatchedFlow" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val result = FlowSimulation.step(state, rng)
     val legacy = AggregateBatchContract.toLegacyFlows(result.flows)
 
     result.flows should not be empty

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -20,7 +20,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   "FlowSimulation.emitAllBatches" should "preserve SFC at 0L" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
@@ -31,7 +31,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   it should "preserve SFC across 12 months" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
@@ -49,7 +49,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   it should "emit 30+ mechanism IDs" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -20,8 +20,9 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   "FlowSimulation.emitAllBatches" should "preserve SFC at 0L" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val result = FlowSimulation.step(state, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
     result.execution.totalWealth shouldBe 0L
@@ -30,14 +31,11 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   it should "preserve SFC across 12 months" in {
     val init  = WorldInit.initialize(42L)
-    var w     = init.world
-    var firms = init.firms
-    var hh    = init.households
-    var banks = init.banks
+    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(w, firms, hh, banks, rng)
+      val result = FlowSimulation.step(state, rng)
       val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
       withClue(s"Month $month: ") {
@@ -45,17 +43,15 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
         AggregateBatchContract.totalTransferred(flows) should be > 0L
       }
 
-      w = result.newWorld
-      firms = result.newFirms
-      hh = result.newHouseholds
-      banks = result.newBanks
+      state = result.nextState
     }
   }
 
   it should "emit 30+ mechanism IDs" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val result = FlowSimulation.step(state, rng)
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
     result.execution.totalWealth shouldBe 0L

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -34,7 +34,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.calculus.employed should be > 0
   }
 
-  it should "expose the month boundary as SimState -> StepOutput -> (trace, nextState)" in {
+  it should "expose the month boundary as SimState -> StepOutput -> (nextState, trace)" in {
     val init        = WorldInit.initialize(42L)
     val state       = FlowSimulation.SimState.fromInit(init)
     val stateRng    = new scala.util.Random(42L)
@@ -43,7 +43,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val repeated    = FlowSimulation.step(state, rerunRng)
 
     stateResult.stateIn shouldBe state
-    stateResult.transition shouldBe ((stateResult.trace, stateResult.nextState))
+    stateResult.transition shouldBe ((stateResult.nextState, stateResult.trace))
     stateResult.nextState.world shouldBe repeated.nextState.world
     stateResult.nextState.firms shouldBe repeated.nextState.firms
     canonicalHouseholds(stateResult.nextState.households) shouldBe canonicalHouseholds(repeated.nextState.households)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -17,8 +17,9 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   "FlowSimulation.step" should "produce SFC == 0L on real World" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val result = FlowSimulation.step(state, rng)
     result.execution.totalWealth shouldBe 0L
     result.sfcResult shouldBe Right(())
     result.calculus.employed should be > 0
@@ -28,38 +29,32 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val init        = WorldInit.initialize(42L)
     val state       = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val stateRng    = new scala.util.Random(42L)
-    val legacyRng   = new scala.util.Random(42L)
+    val rerunRng    = new scala.util.Random(42L)
     val stateResult = FlowSimulation.step(state, stateRng)
-    val legacy      = FlowSimulation.step(init.world, init.firms, init.households, init.banks, legacyRng)
+    val repeated    = FlowSimulation.step(state, rerunRng)
 
     stateResult.stateIn shouldBe state
-    stateResult.transition shouldBe ((stateResult.monthTrace, stateResult.nextState))
-    stateResult.nextState.world shouldBe legacy.newWorld
-    stateResult.nextState.firms shouldBe legacy.newFirms
-    stateResult.nextState.households.map(_.status) shouldBe legacy.newHouseholds.map(_.status)
-    stateResult.nextState.banks shouldBe legacy.newBanks
-    stateResult.nextState.householdAggregates shouldBe legacy.householdAggregates
-    stateResult.monthTrace shouldBe legacy.monthTrace
+    stateResult.transition shouldBe ((stateResult.trace, stateResult.nextState))
+    stateResult.nextState.world shouldBe repeated.nextState.world
+    stateResult.nextState.firms shouldBe repeated.nextState.firms
+    stateResult.nextState.households.map(_.status) shouldBe repeated.nextState.households.map(_.status)
+    stateResult.nextState.banks shouldBe repeated.nextState.banks
+    stateResult.nextState.householdAggregates shouldBe repeated.nextState.householdAggregates
+    stateResult.trace shouldBe repeated.trace
   }
 
   it should "produce SFC == 0L across 12 months (autonomous driving)" in {
     val init  = WorldInit.initialize(42L)
-    var w     = init.world
-    var firms = init.firms
-    var hh    = init.households
-    var banks = init.banks
+    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(w, firms, hh, banks, rng)
+      val result = FlowSimulation.step(state, rng)
       withClue(s"Month $month: ") {
         result.execution.totalWealth shouldBe 0L
         result.sfcResult shouldBe Right(())
       }
-      w = result.newWorld
-      firms = result.newFirms
-      hh = result.newHouseholds
-      banks = result.newBanks
+      state = result.nextState
     }
   }
 
@@ -67,61 +62,74 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val init          = WorldInit.initialize(42L)
     val lowShadowW    = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highShadowW   = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.4))
-    val lowShadowRun  = FlowSimulation.step(lowShadowW, init.firms, init.households, init.banks, new scala.util.Random(42L))
-    val highShadowRun = FlowSimulation.step(highShadowW, init.firms, init.households, init.banks, new scala.util.Random(42L))
+    val lowShadowRun  = FlowSimulation.step(
+      FlowSimulation.SimState(lowShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      new scala.util.Random(42L),
+    )
+    val highShadowRun = FlowSimulation.step(
+      FlowSimulation.SimState(highShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      new scala.util.Random(42L),
+    )
 
     lowShadowRun.execution.totalWealth shouldBe 0L
     highShadowRun.execution.totalWealth shouldBe 0L
     lowShadowRun.sfcResult shouldBe Right(())
     highShadowRun.sfcResult shouldBe Right(())
 
-    highShadowRun.newWorld.flows.realizedTaxShadowShare should be > lowShadowRun.newWorld.flows.realizedTaxShadowShare
-    highShadowRun.newWorld.flows.taxEvasionLoss should be > lowShadowRun.newWorld.flows.taxEvasionLoss
-    highShadowRun.newWorld.gov.taxRevenue should be < lowShadowRun.newWorld.gov.taxRevenue
-    highShadowRun.newWorld.gov.deficit should be > lowShadowRun.newWorld.gov.deficit
+    highShadowRun.nextState.world.flows.realizedTaxShadowShare should be > lowShadowRun.nextState.world.flows.realizedTaxShadowShare
+    highShadowRun.nextState.world.flows.taxEvasionLoss should be > lowShadowRun.nextState.world.flows.taxEvasionLoss
+    highShadowRun.nextState.world.gov.taxRevenue should be < lowShadowRun.nextState.world.gov.taxRevenue
+    highShadowRun.nextState.world.gov.deficit should be > lowShadowRun.nextState.world.gov.deficit
   }
 
   it should "produce 30+ mechanism IDs" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+    val result = FlowSimulation.step(state, rng)
     result.flows.map(_.mechanism).toSet.size should be > 30
   }
 
   it should "emit a typed MonthTrace with stable boundaries and typed timing envelopes" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val trace  = result.monthTrace
+    val result = FlowSimulation.step(state, rng)
+    val trace  = result.trace
 
     val demandSignals = trace.timing.requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.DemandSignals)
 
-    trace.month shouldBe result.newWorld.month
+    trace.month shouldBe result.nextState.world.month
     trace.seedTransition.seedIn shouldBe init.world.seedIn
-    trace.seedTransition.seedOut shouldBe result.newWorld.seedIn
+    trace.seedTransition.seedOut shouldBe result.nextState.world.seedIn
     trace.boundary.startSnapshot.stock shouldBe Sfc.snapshot(init.world, init.firms, init.households, init.banks)
-    trace.boundary.endSnapshot.stock shouldBe Sfc.snapshot(result.newWorld, result.newFirms, result.newHouseholds, result.newBanks)
+    trace.boundary.endSnapshot.stock shouldBe Sfc.snapshot(
+      result.nextState.world,
+      result.nextState.firms,
+      result.nextState.households,
+      result.nextState.banks,
+    )
     trace.boundary.startSnapshot.inflation shouldBe init.world.inflation
-    trace.boundary.endSnapshot.inflation shouldBe result.newWorld.inflation
+    trace.boundary.endSnapshot.inflation shouldBe result.nextState.world.inflation
     trace.timing.envelopes.map(_.key).toSet shouldBe Set(
       MonthTimingEnvelopeKey.LaborSignals,
       MonthTimingEnvelopeKey.DemandSignals,
       MonthTimingEnvelopeKey.NominalSignals,
       MonthTimingEnvelopeKey.FirmDynamics,
     )
-    trace.timing.laborSignals.operationalHiringSlack shouldBe result.newWorld.pipeline.operationalHiringSlack
-    demandSignals.sectorDemandMult shouldBe result.newWorld.seedIn.sectorDemandMult
-    demandSignals.sectorDemandPressure shouldBe result.newWorld.seedIn.sectorDemandPressure
-    demandSignals.sectorHiringSignal shouldBe result.newWorld.seedIn.sectorHiringSignal
-    trace.timing.nominalSignals.realizedInflation shouldBe result.newWorld.inflation
-    trace.timing.nominalSignals.expectedInflation shouldBe result.newWorld.mechanisms.expectations.expectedInflation
-    trace.timing.firmDynamics.startupAbsorptionRate shouldBe result.newWorld.seedIn.startupAbsorptionRate
-    trace.timing.firmDynamics.firmBirths shouldBe result.newWorld.flows.firmBirths
-    trace.timing.firmDynamics.firmDeaths shouldBe result.newWorld.flows.firmDeaths
-    trace.timing.firmDynamics.netFirmBirths shouldBe result.newWorld.flows.netFirmBirths
+    trace.timing.laborSignals.operationalHiringSlack shouldBe result.nextState.world.pipeline.operationalHiringSlack
+    demandSignals.sectorDemandMult shouldBe result.nextState.world.seedIn.sectorDemandMult
+    demandSignals.sectorDemandPressure shouldBe result.nextState.world.seedIn.sectorDemandPressure
+    demandSignals.sectorHiringSignal shouldBe result.nextState.world.seedIn.sectorHiringSignal
+    trace.timing.nominalSignals.realizedInflation shouldBe result.nextState.world.inflation
+    trace.timing.nominalSignals.expectedInflation shouldBe result.nextState.world.mechanisms.expectations.expectedInflation
+    trace.timing.firmDynamics.startupAbsorptionRate shouldBe result.nextState.world.seedIn.startupAbsorptionRate
+    trace.timing.firmDynamics.firmBirths shouldBe result.nextState.world.flows.firmBirths
+    trace.timing.firmDynamics.firmDeaths shouldBe result.nextState.world.flows.firmDeaths
+    trace.timing.firmDynamics.netFirmBirths shouldBe result.nextState.world.flows.netFirmBirths
     trace.executedFlows.totalIncome shouldBe result.calculus.totalIncome
-    trace.executedFlows.currentAccount shouldBe result.newWorld.bop.currentAccount
-    trace.executedFlows.fofResidual shouldBe result.newWorld.plumbing.fofResidual
+    trace.executedFlows.currentAccount shouldBe result.nextState.world.bop.currentAccount
+    trace.executedFlows.fofResidual shouldBe result.nextState.world.plumbing.fofResidual
     trace.seedTransition.provenance.unemploymentRate.stage shouldBe MonthTraceStage.WorldAssemblyEconomics
     trace.seedTransition.provenance.inflation.stage shouldBe MonthTraceStage.PriceEquityEconomics
     trace.seedTransition.provenance.expectedInflation.stage shouldBe MonthTraceStage.OpenEconEconomics
@@ -130,8 +138,8 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     trace.seedTransition.provenance.sectorDemandMult.stage shouldBe MonthTraceStage.DemandEconomics
     trace.seedTransition.provenance.sectorDemandPressure.stage shouldBe MonthTraceStage.DemandEconomics
     trace.seedTransition.provenance.sectorHiringSignal.stage shouldBe MonthTraceStage.DemandEconomics
-    trace.seedTransition.provenance.laggedHiringSlack.value shouldBe result.newWorld.seedIn.laggedHiringSlack
-    trace.seedTransition.provenance.startupAbsorptionRate.value shouldBe result.newWorld.seedIn.startupAbsorptionRate
+    trace.seedTransition.provenance.laggedHiringSlack.value shouldBe result.nextState.world.seedIn.laggedHiringSlack
+    trace.seedTransition.provenance.startupAbsorptionRate.value shouldBe result.nextState.world.seedIn.startupAbsorptionRate
     trace.validations should have size 1
     trace.validations.head.passed shouldBe true
     trace.validations.head.failures shouldBe empty
@@ -140,9 +148,10 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "keep MonthTrace seed transitions consistent with timing envelopes and end-of-month boundary data" in {
     val init   = WorldInit.initialize(42L)
+    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
     val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val trace  = result.monthTrace
+    val result = FlowSimulation.step(state, rng)
+    val trace  = result.trace
 
     trace.seedTransition.seedOut shouldBe DecisionSignals(
       unemploymentRate = trace.boundary.endSnapshot.unemploymentRate,
@@ -165,10 +174,11 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "match the legacy pure interpreter on aggregate execution balances" in {
-    val init   = WorldInit.initialize(42L)
-    val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
-    val state  = AggregateBatchContract.emptyExecutionState()
+    val init      = WorldInit.initialize(42L)
+    val initState = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val rng       = new scala.util.Random(42L)
+    val result    = FlowSimulation.step(initState, rng)
+    val state     = AggregateBatchContract.emptyExecutionState()
 
     ImperativeInterpreter.planAndApplyAll(state, result.flows) shouldBe Right(())
     AggregateBatchContract.totalWealth(state) shouldBe Interpreter.totalWealth(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.accounting.Sfc
+import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
 import com.boombustgroup.amorfati.init.WorldInit
@@ -15,9 +16,17 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
+  private def canonicalHouseholds(households: Vector[Household.State]): Vector[Vector[Any]] =
+    households.map: hh =>
+      hh.productIterator
+        .map:
+          case arr: Array[?] => arr.toIndexedSeq
+          case value         => value
+        .toVector
+
   "FlowSimulation.step" should "produce SFC == 0L on real World" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     result.execution.totalWealth shouldBe 0L
@@ -27,7 +36,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "expose the month boundary as SimState -> StepOutput -> (trace, nextState)" in {
     val init        = WorldInit.initialize(42L)
-    val state       = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state       = FlowSimulation.SimState.fromInit(init)
     val stateRng    = new scala.util.Random(42L)
     val rerunRng    = new scala.util.Random(42L)
     val stateResult = FlowSimulation.step(state, stateRng)
@@ -37,7 +46,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     stateResult.transition shouldBe ((stateResult.trace, stateResult.nextState))
     stateResult.nextState.world shouldBe repeated.nextState.world
     stateResult.nextState.firms shouldBe repeated.nextState.firms
-    stateResult.nextState.households.map(_.status) shouldBe repeated.nextState.households.map(_.status)
+    canonicalHouseholds(stateResult.nextState.households) shouldBe canonicalHouseholds(repeated.nextState.households)
     stateResult.nextState.banks shouldBe repeated.nextState.banks
     stateResult.nextState.householdAggregates shouldBe repeated.nextState.householdAggregates
     stateResult.trace shouldBe repeated.trace
@@ -45,7 +54,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "produce SFC == 0L across 12 months (autonomous driving)" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
@@ -84,7 +93,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "produce 30+ mechanism IDs" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42)
     val result = FlowSimulation.step(state, rng)
     result.flows.map(_.mechanism).toSet.size should be > 30
@@ -92,7 +101,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "emit a typed MonthTrace with stable boundaries and typed timing envelopes" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42L)
     val result = FlowSimulation.step(state, rng)
     val trace  = result.trace
@@ -148,7 +157,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "keep MonthTrace seed transitions consistent with timing envelopes and end-of-month boundary data" in {
     val init   = WorldInit.initialize(42L)
-    val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val state  = FlowSimulation.SimState.fromInit(init)
     val rng    = new scala.util.Random(42L)
     val result = FlowSimulation.step(state, rng)
     val trace  = result.trace
@@ -175,7 +184,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   it should "match the legacy pure interpreter on aggregate execution balances" in {
     val init      = WorldInit.initialize(42L)
-    val initState = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    val initState = FlowSimulation.SimState.fromInit(init)
     val rng       = new scala.util.Random(42L)
     val result    = FlowSimulation.step(initState, rng)
     val state     = AggregateBatchContract.emptyExecutionState()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -18,7 +18,7 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   "Multi-month flow verification (120 months)" should "preserve SFC at 0L every month" in {
     val init  = WorldInit.initialize(42L)
-    var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 120).foreach { month =>
       val rng    = new scala.util.Random(42L * 1000 + month)
@@ -34,7 +34,7 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   it should "produce increasing total flow volume over time" in {
     val init    = WorldInit.initialize(42L)
-    var state   = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    var state   = FlowSimulation.SimState.fromInit(init)
     var volumes = Vector.empty[Long]
 
     (1 to 120).foreach { month =>

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -23,7 +23,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   "FlowSimulation.step (multi-seed)" should "produce SFC == 0L for all seeds × months" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      var state = FlowSimulation.SimState.fromInit(init)
 
       (1 to months).foreach { month =>
         val rng    = new scala.util.Random(seed * 1000 + month)
@@ -38,7 +38,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   it should "produce realistic employment (3-97%) for all seeds at month 12" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      var state = FlowSimulation.SimState.fromInit(init)
       (1 to months).foreach { m =>
         val rng    = new scala.util.Random(seed * 1000 + m)
         val result = FlowSimulation.step(state, rng)
@@ -56,7 +56,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   it should "produce positive GDP for all seeds" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      var state = FlowSimulation.SimState.fromInit(init)
       (1 to months).foreach { m =>
         val rng    = new scala.util.Random(seed * 1000 + m)
         val result = FlowSimulation.step(state, rng)
@@ -71,7 +71,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   it should "emit 30+ mechanism IDs for all seeds" in
     seeds.foreach { seed =>
       val init   = WorldInit.initialize(seed)
-      val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      val state  = FlowSimulation.SimState.fromInit(init)
       val rng    = new scala.util.Random(seed)
       val result = FlowSimulation.step(state, rng)
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -23,42 +23,30 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   "FlowSimulation.step (multi-seed)" should "produce SFC == 0L for all seeds × months" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var w     = init.world
-      var firms = init.firms
-      var hh    = init.households
-      var banks = init.banks
+      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
       (1 to months).foreach { month =>
         val rng    = new scala.util.Random(seed * 1000 + month)
-        val result = FlowSimulation.step(w, firms, hh, banks, rng)
+        val result = FlowSimulation.step(state, rng)
         withClue(s"Seed $seed, month $month: ") {
           result.execution.totalWealth.shouldBe(0L)
         }
-        w = result.newWorld
-        firms = result.newFirms
-        hh = result.newHouseholds
-        banks = result.newBanks
+        state = result.nextState
       }
     }
 
   it should "produce realistic employment (3-97%) for all seeds at month 12" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var w     = init.world
-      var firms = init.firms
-      var hh    = init.households
-      var banks = init.banks
+      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
       (1 to months).foreach { m =>
         val rng    = new scala.util.Random(seed * 1000 + m)
-        val result = FlowSimulation.step(w, firms, hh, banks, rng)
-        w = result.newWorld
-        firms = result.newFirms
-        hh = result.newHouseholds
-        banks = result.newBanks
+        val result = FlowSimulation.step(state, rng)
+        state = result.nextState
       }
 
-      val employed = hh.count(_.status.isInstanceOf[com.boombustgroup.amorfati.agents.HhStatus.Employed])
-      val unemp    = if w.derivedTotalPopulation > 0 then 1.0 - employed.toDouble / w.derivedTotalPopulation else 0.0
+      val employed = state.households.count(_.status.isInstanceOf[com.boombustgroup.amorfati.agents.HhStatus.Employed])
+      val unemp    = if state.world.derivedTotalPopulation > 0 then 1.0 - employed.toDouble / state.world.derivedTotalPopulation else 0.0
       withClue(s"Seed $seed unemployment=$unemp: ") {
         unemp should be >= 0.03
         unemp should be <= 0.97
@@ -68,29 +56,24 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
   it should "produce positive GDP for all seeds" in
     seeds.foreach { seed =>
       val init  = WorldInit.initialize(seed)
-      var w     = init.world
-      var firms = init.firms
-      var hh    = init.households
-      var banks = init.banks
+      var state = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
       (1 to months).foreach { m =>
         val rng    = new scala.util.Random(seed * 1000 + m)
-        val result = FlowSimulation.step(w, firms, hh, banks, rng)
-        w = result.newWorld
-        firms = result.newFirms
-        hh = result.newHouseholds
-        banks = result.newBanks
+        val result = FlowSimulation.step(state, rng)
+        state = result.nextState
       }
 
       withClue(s"Seed $seed GDP: ") {
-        (w.cachedMonthlyGdpProxy > PLN.Zero) shouldBe true
+        (state.world.cachedMonthlyGdpProxy > PLN.Zero) shouldBe true
       }
     }
 
   it should "emit 30+ mechanism IDs for all seeds" in
     seeds.foreach { seed =>
       val init   = WorldInit.initialize(seed)
+      val state  = FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
       val rng    = new scala.util.Random(seed)
-      val result = FlowSimulation.step(init.world, init.firms, init.households, init.banks, rng)
+      val result = FlowSimulation.step(state, rng)
 
       withClue(s"Seed $seed mechanisms: ") {
         result.flows.map(_.mechanism).toSet.size should be > 30

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -15,7 +15,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
 
   private def simState(seed: Long = 42L): FlowSimulation.SimState =
     val init = WorldInit.initialize(seed)
-    FlowSimulation.SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+    FlowSimulation.SimState.fromInit(init)
 
   private def enrichedSimState(): FlowSimulation.SimState =
     val base  = simState()


### PR DESCRIPTION
## Summary
- remove the legacy split-argument `FlowSimulation.step` compatibility surface
- migrate diagnostics and tests to the canonical `SimState -> StepOutput -> nextState` contract
- update engine docs to present the state-based month boundary as the only supported API


Closes #316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the simulation around a single aggregated state and a single state-based step API for simpler, more consistent progression
  * Simplified step output to emphasize trace and next-state transitions, removing legacy per-component outputs

* **Documentation**
  * README updated to present the new month-transition API and remove mention of the legacy wrapper

* **Tests**
  * Test suite updated to build and exercise the unified state-based workflow across scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->