### PR TITLE
Extract typed MonthOutcome boundary inside FlowSimulation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
@@ -1,0 +1,54 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation.{PostMonth, StageOutputs}
+
+/** Tiny type-level timeline for one monthly engine step.
+  *
+  * `At[A, P]` is intentionally zero-cost at runtime: it only tags values with a
+  * phase so internal boundaries in [[FlowSimulation]] stay explicit.
+  */
+object MonthSemantics:
+
+  /** Marker hierarchy for the coarse month timeline. */
+  sealed trait Phase
+
+  /** Persisted decision surface visible at the start of month `t`. */
+  sealed trait Pre extends Phase
+
+  /** Same-month artifacts used during the execution of month `t`. */
+  sealed trait SameMonth extends Phase
+
+  /** Post-assembly state after month `t` has been realized, before reuse as
+    * input.
+    */
+  sealed trait Post extends Phase
+
+  /** Extracted seed that becomes the `pre` surface for month `t+1`. */
+  sealed trait NextPre extends Phase
+
+  /** Zero-cost phase tag. The underlying runtime representation stays `A`. */
+  opaque type At[+A, P <: Phase] = A
+
+  object At:
+    /** Constructor is kept engine-internal so phase tags are introduced
+      * deliberately.
+      */
+    private[engine] inline def apply[A, P <: Phase](value: A): At[A, P] = value
+
+    /** Explicit unwrap used at phase boundaries. */
+    extension [A, P <: Phase](staged: At[A, P]) private[engine] inline def value: A = staged
+
+  /** Start-of-month seed consumed by timing-sensitive blocks. */
+  type SeedIn = At[DecisionSignals, Pre]
+
+  /** Same-month operational signal surface derived inside the step. */
+  type Operational = At[OperationalSignals, SameMonth]
+
+  /** Same-month stage bag kept internal to [[FlowSimulation]]. */
+  type StageView = At[StageOutputs, SameMonth]
+
+  /** Realized post-month assembly before extracting the next seed. */
+  type PostAssembly = At[PostMonth, Post]
+
+  /** Extracted next-month seed plus provenance. */
+  type SeedOut = At[SignalExtraction.Output, NextPre]

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -20,6 +20,7 @@ engine/
 | File | Responsibility |
 |------|----------------|
 | `World.scala` | Case class holding all macro state, decomposed into 7 nested types: `SocialState`, `FinancialMarketsState`, `ExternalState`, `RealState`, `MechanismsState`, `MonetaryPlumbingState`, `FlowState`. |
+| `MonthSemantics.scala` | Tiny typed phase markers for the internal month step: pre-seed, same-month operational state, post-assembly state, and next pre-seed extraction. |
 | `OperationalSignals.scala` | Explicit same-month signal surface for month-`t` operational execution, kept distinct from persisted start-of-month `DecisionSignals`. |
 | `SignalExtraction.scala` | Explicit post-to-pre boundary: derives next-month `DecisionSignals` and typed seed provenance from realized month-`t` outcomes. |
 | `MonthTrace.scala` | Boundary-focused audit artifact with a stable month core (`boundary`, `seedTransition`, validations) plus extensible typed timing envelopes. |
@@ -30,6 +31,7 @@ The top-level engine shape is now explicit:
 
 ```scala
 case class SimState(...)
+case class MonthOutcome(...)
 case class StepOutput(
   stateIn: SimState,
   operationalSignals: OperationalSignals,
@@ -45,6 +47,7 @@ def step(state: SimState, rng: Random): StepOutput
 Read it as a month transition:
 
 - `stateIn.world.seedIn` is the persisted `pre` input surface.
+- `MonthOutcome` is the internal bridge from same-month computation to post-month assembly.
 - `operationalSignals` is the explicit same-month surface created inside the step.
 - `signalExtraction` is the dedicated `post -> pre` boundary.
 - `trace` is the emitted audit artifact for month `t`.
@@ -77,9 +80,9 @@ against 13 accounting identities each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point. `step(state, rng)` is the explicit month boundary: it runs `computeAll()`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point. `step(state, rng)` is the explicit month boundary: it computes typed `StageOutputs`, narrows them into `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `FirmWages`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
-| `StateAdapter.scala` | Bridges computation outputs to flow inputs: extracts ZUS, NFZ, PPK, earmarked, HH, insurance, and firm flow parameters from `FullComputation`. |
+| `StateAdapter.scala` | Legacy bridge from economics/world state into specific flow inputs. Kept only as transitional adapter code around the newer pipeline. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |
 | `NfzFlows.scala` | NFZ (National Health Fund): 9% składka zdrowotna, healthcare spending, gov subvention |
 | `PpkFlows.scala` | PPK (Pracownicze Plany Kapitałowe): employee + employer contributions, bond purchases |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/SignalExtraction.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/SignalExtraction.scala
@@ -65,6 +65,36 @@ object SignalExtraction:
       demand: DemandOutcomes,
   )
 
+  /** Canonical builder used by both world assembly and typed month-boundary
+    * code so seed extraction always reads the same realized fields.
+    */
+  private[engine] def inputFromRealizedOutcomes(
+      unemploymentRate: Share,
+      laggedHiringSlack: Share,
+      startupAbsorptionRate: Share,
+      inflation: Rate,
+      expectedInflation: Rate,
+      sectorDemandMult: Vector[Multiplier],
+      sectorDemandPressure: Vector[Multiplier],
+      sectorHiringSignal: Vector[Multiplier],
+  ): Input =
+    Input(
+      labor = LaborOutcomes(
+        unemploymentRate = unemploymentRate,
+        laggedHiringSlack = laggedHiringSlack,
+        startupAbsorptionRate = startupAbsorptionRate,
+      ),
+      nominal = NominalOutcomes(
+        inflation = inflation,
+        expectedInflation = expectedInflation,
+      ),
+      demand = DemandOutcomes(
+        sectorDemandMult = sectorDemandMult,
+        sectorDemandPressure = sectorDemandPressure,
+        sectorHiringSignal = sectorHiringSignal,
+      ),
+    )
+
   /** Extraction result: persisted seed plus typed provenance for audit/trace.
     */
   case class Output(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -135,6 +135,13 @@ object WorldAssemblyEconomics:
       startupAbsorptionRate: Share,
   )
 
+  private case class SignalExtractionInput(
+      operationalHiringSlack: Share,
+      sectorDemandMult: Vector[Multiplier],
+      sectorDemandPressure: Vector[Multiplier],
+      sectorHiringSignal: Vector[Multiplier],
+  )
+
   private def buildStepInput(in: Input): StepInput =
     val s1 = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
 
@@ -154,8 +161,16 @@ object WorldAssemblyEconomics:
       in.bankOutput,
     )
 
+  private def buildSignalExtractionInput(in: StepInput): SignalExtractionInput =
+    SignalExtractionInput(
+      operationalHiringSlack = in.s2.operationalHiringSlack,
+      sectorDemandMult = in.s4.sectorMults,
+      sectorDemandPressure = in.s4.sectorDemandPressure,
+      sectorHiringSignal = in.s4.sectorHiringSignal,
+    )
+
   private def extractSignalExtraction(
-      in: StepInput,
+      signalInput: SignalExtractionInput,
       post: PostResult,
   ): SignalExtraction.Output =
     val employedHouseholds = Household.countEmployed(post.households)
@@ -163,13 +178,13 @@ object WorldAssemblyEconomics:
     SignalExtraction.compute(
       SignalExtraction.inputFromRealizedOutcomes(
         unemploymentRate = post.world.unemploymentRate(employedHouseholds),
-        laggedHiringSlack = in.s2.operationalHiringSlack,
+        laggedHiringSlack = signalInput.operationalHiringSlack,
         startupAbsorptionRate = post.startupAbsorptionRate,
         inflation = post.world.inflation,
         expectedInflation = post.world.mechanisms.expectations.expectedInflation,
-        sectorDemandMult = in.s4.sectorMults,
-        sectorDemandPressure = in.s4.sectorDemandPressure,
-        sectorHiringSignal = in.s4.sectorHiringSignal,
+        sectorDemandMult = signalInput.sectorDemandMult,
+        sectorDemandPressure = signalInput.sectorDemandPressure,
+        sectorHiringSignal = signalInput.sectorHiringSignal,
       ),
     )
 
@@ -194,9 +209,10 @@ object WorldAssemblyEconomics:
     computePostMonth(buildStepInput(in), in.rng, in.migRng)
 
   def compute(in: Input)(using SimParams): Result =
-    val step = buildStepInput(in)
-    val post = computePostMonth(step, in.rng, in.migRng)
-    val seed = extractSignalExtraction(step, post)
+    val step        = buildStepInput(in)
+    val signalInput = buildSignalExtractionInput(step)
+    val post        = computePostMonth(step, in.rng, in.migRng)
+    val seed        = extractSignalExtraction(signalInput, post)
     Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)
 
   // ---------------------------------------------------------------------------
@@ -204,8 +220,9 @@ object WorldAssemblyEconomics:
   // ---------------------------------------------------------------------------
 
   def runStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): StepOutput =
+    val signalInput      = buildSignalExtractionInput(in)
     val post             = runPostStep(in, rng, migRng)
-    val signalExtraction = extractSignalExtraction(in, post)
+    val signalExtraction = extractSignalExtraction(signalInput, post)
     StepOutput(
       newWorld = advanceToBoundaryWorld(post.world, signalExtraction.seedOut),
       finalFirms = post.firms,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -47,6 +47,18 @@ object WorldAssemblyEconomics:
       signalExtraction: SignalExtraction.Output,
   )
 
+  /** Internal post-month state before the next-month seed is extracted and
+    * applied to the pipeline boundary.
+    */
+  private[engine] case class PostStepOutput(
+      newWorld: World,
+      finalFirms: Vector[Firm.State],
+      reassignedHouseholds: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+      householdAggregates: Household.Aggregates,
+      startupAbsorptionRate: Share,
+  )
+
   // ---------------------------------------------------------------------------
   // Private intermediate types
   // ---------------------------------------------------------------------------
@@ -125,10 +137,51 @@ object WorldAssemblyEconomics:
       signalExtraction: SignalExtraction.Output,
   )
 
-  def compute(in: Input)(using SimParams): Result =
+  /** Internal post-month result kept distinct from the next-month boundary. */
+  private[engine] case class PostResult(
+      world: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+      householdAggregates: Household.Aggregates,
+      startupAbsorptionRate: Share,
+  )
+
+  private def extractSignalExtraction(
+      in: StepInput,
+      post: PostStepOutput,
+  ): SignalExtraction.Output =
+    val employedHouseholds = Household.countEmployed(post.reassignedHouseholds)
+
+    SignalExtraction.compute(
+      SignalExtraction.Input(
+        labor = SignalExtraction.LaborOutcomes(
+          unemploymentRate = post.newWorld.unemploymentRate(employedHouseholds),
+          laggedHiringSlack = in.s2.operationalHiringSlack,
+          startupAbsorptionRate = post.startupAbsorptionRate,
+        ),
+        nominal = SignalExtraction.NominalOutcomes(
+          inflation = post.newWorld.inflation,
+          expectedInflation = post.newWorld.mechanisms.expectations.expectedInflation,
+        ),
+        demand = SignalExtraction.DemandOutcomes(
+          sectorDemandMult = in.s4.sectorMults,
+          sectorDemandPressure = in.s4.sectorDemandPressure,
+          sectorHiringSignal = in.s4.sectorHiringSignal,
+        ),
+      ),
+    )
+
+  private def advanceToBoundaryWorld(
+      postWorld: World,
+      signals: DecisionSignals,
+  ): World =
+    postWorld.updatePipeline(_.withDecisionSignals(signals))
+
+  private[engine] def computePostMonth(in: Input)(using SimParams): PostResult =
     val s1 = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
 
-    val s10 = runStep(
+    val s10 = runPostStep(
       StepInput(
         in.w,
         in.firms,
@@ -148,13 +201,47 @@ object WorldAssemblyEconomics:
       in.migRng,
     )
 
-    Result(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds, s10.banks, s10.householdAggregates, s10.signalExtraction)
+    PostResult(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds, s10.banks, s10.householdAggregates, s10.startupAbsorptionRate)
+
+  def compute(in: Input)(using SimParams): Result =
+    val post  = computePostMonth(in)
+    val s1    = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
+    val step  = StepInput(
+      in.w,
+      in.firms,
+      in.households,
+      in.banks,
+      s1,
+      in.laborOutput,
+      in.hhOutput,
+      buildDemandOutput(in),
+      in.firmOutput,
+      in.hhFinancialOutput,
+      in.priceEquityOutput,
+      in.openEconOutput,
+      in.bankOutput,
+    )
+    val postS = PostStepOutput(post.world, post.firms, post.households, post.banks, post.householdAggregates, post.startupAbsorptionRate)
+    val seed  = extractSignalExtraction(step, postS)
+    Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)
 
   // ---------------------------------------------------------------------------
   // runStep — migrated from WorldAssemblyStep.run
   // ---------------------------------------------------------------------------
 
   def runStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): StepOutput =
+    val post             = runPostStep(in, rng, migRng)
+    val signalExtraction = extractSignalExtraction(in, post)
+    StepOutput(
+      newWorld = advanceToBoundaryWorld(post.newWorld, signalExtraction.seedOut),
+      finalFirms = post.finalFirms,
+      reassignedHouseholds = post.reassignedHouseholds,
+      banks = post.banks,
+      householdAggregates = post.householdAggregates,
+      signalExtraction = signalExtraction,
+    )
+
+  private[engine] def runPostStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): PostStepOutput =
     val equityAfterStep = finalizeEquity(in)
     val fofResidual     = computeFofResidual(in)
     val informal        = computeInformalEconomy(in)
@@ -177,30 +264,10 @@ object WorldAssemblyEconomics:
     val startupStaffing = applyStartupStaffing(in, entryStep.firms, in.s9.reassignedHouseholds, rng)
 
     // Regional migration: unemployed HH may relocate between NUTS-1 regions
-    val postMigHh          = RegionalMigration(startupStaffing.households, in.s2.regionalWages, migRng).households
-    val finalFirms         = syncStartupStaffing(startupStaffing.firms, postMigHh)
-    val employedHouseholds = Household.countEmployed(postMigHh)
-    val signalExtraction   = SignalExtraction.compute(
-      SignalExtraction.Input(
-        labor = SignalExtraction.LaborOutcomes(
-          unemploymentRate = newW.unemploymentRate(employedHouseholds),
-          laggedHiringSlack = in.s2.operationalHiringSlack,
-          startupAbsorptionRate = startupStaffing.startupAbsorptionRate,
-        ),
-        nominal = SignalExtraction.NominalOutcomes(
-          inflation = newW.inflation,
-          expectedInflation = newW.mechanisms.expectations.expectedInflation,
-        ),
-        demand = SignalExtraction.DemandOutcomes(
-          sectorDemandMult = in.s4.sectorMults,
-          sectorDemandPressure = in.s4.sectorDemandPressure,
-          sectorHiringSignal = in.s4.sectorHiringSignal,
-        ),
-      ),
-    )
-
-    val finalW = newW
-      .updatePipeline(_ => buildPipelineState(in, signalExtraction.seedOut))
+    val postMigHh  = RegionalMigration(startupStaffing.households, in.s2.regionalWages, migRng).households
+    val finalFirms = syncStartupStaffing(startupStaffing.firms, postMigHh)
+    val finalW     = newW
+      .updatePipeline(_ => buildPostMonthPipelineState(in))
       .updateFlows(_.copy(firmBirths = entryStep.firmBirths, firmDeaths = in.s5.firmDeaths, netFirmBirths = entryStep.netBirths))
       .updateReal: r =>
         r.copy(
@@ -209,7 +276,7 @@ object WorldAssemblyEconomics:
           ),
         )
       .copy(regionalWages = in.s2.regionalWages)
-    StepOutput(finalW, finalFirms, postMigHh, in.s9.banks, startupStaffing.hhAgg, signalExtraction)
+    PostStepOutput(finalW, finalFirms, postMigHh, in.s9.banks, startupStaffing.hhAgg, startupStaffing.startupAbsorptionRate)
 
   // ---------------------------------------------------------------------------
   // Private helpers — migrated from WorldAssemblyStep
@@ -572,9 +639,8 @@ object WorldAssemblyEconomics:
       ),
     )
 
-  private def buildPipelineState(in: StepInput, signals: DecisionSignals): PipelineState =
+  private def buildPostMonthPipelineState(in: StepInput): PipelineState =
     in.w.pipeline
-      .withDecisionSignals(signals)
       .copy(
         operationalHiringSlack = in.s2.operationalHiringSlack,
         fiscalRuleSeverity = in.s4.fiscalRuleStatus.bindingRule,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -147,66 +147,10 @@ object WorldAssemblyEconomics:
       startupAbsorptionRate: Share,
   )
 
-  private def extractSignalExtraction(
-      in: StepInput,
-      post: PostStepOutput,
-  ): SignalExtraction.Output =
-    val employedHouseholds = Household.countEmployed(post.reassignedHouseholds)
-
-    SignalExtraction.compute(
-      SignalExtraction.Input(
-        labor = SignalExtraction.LaborOutcomes(
-          unemploymentRate = post.newWorld.unemploymentRate(employedHouseholds),
-          laggedHiringSlack = in.s2.operationalHiringSlack,
-          startupAbsorptionRate = post.startupAbsorptionRate,
-        ),
-        nominal = SignalExtraction.NominalOutcomes(
-          inflation = post.newWorld.inflation,
-          expectedInflation = post.newWorld.mechanisms.expectations.expectedInflation,
-        ),
-        demand = SignalExtraction.DemandOutcomes(
-          sectorDemandMult = in.s4.sectorMults,
-          sectorDemandPressure = in.s4.sectorDemandPressure,
-          sectorHiringSignal = in.s4.sectorHiringSignal,
-        ),
-      ),
-    )
-
-  private def advanceToBoundaryWorld(
-      postWorld: World,
-      signals: DecisionSignals,
-  ): World =
-    postWorld.updatePipeline(_.withDecisionSignals(signals))
-
-  private[engine] def computePostMonth(in: Input)(using SimParams): PostResult =
+  private def buildStepInput(in: Input): StepInput =
     val s1 = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
 
-    val s10 = runPostStep(
-      StepInput(
-        in.w,
-        in.firms,
-        in.households,
-        in.banks,
-        s1,
-        in.laborOutput,
-        in.hhOutput,
-        buildDemandOutput(in),
-        in.firmOutput,
-        in.hhFinancialOutput,
-        in.priceEquityOutput,
-        in.openEconOutput,
-        in.bankOutput,
-      ),
-      in.rng,
-      in.migRng,
-    )
-
-    PostResult(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds, s10.banks, s10.householdAggregates, s10.startupAbsorptionRate)
-
-  def compute(in: Input)(using SimParams): Result =
-    val post  = computePostMonth(in)
-    val s1    = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
-    val step  = StepInput(
+    StepInput(
       in.w,
       in.firms,
       in.households,
@@ -221,6 +165,51 @@ object WorldAssemblyEconomics:
       in.openEconOutput,
       in.bankOutput,
     )
+
+  private def extractSignalExtraction(
+      in: StepInput,
+      post: PostStepOutput,
+  ): SignalExtraction.Output =
+    val employedHouseholds = Household.countEmployed(post.reassignedHouseholds)
+
+    SignalExtraction.compute(
+      SignalExtraction.inputFromRealizedOutcomes(
+        unemploymentRate = post.newWorld.unemploymentRate(employedHouseholds),
+        laggedHiringSlack = in.s2.operationalHiringSlack,
+        startupAbsorptionRate = post.startupAbsorptionRate,
+        inflation = post.newWorld.inflation,
+        expectedInflation = post.newWorld.mechanisms.expectations.expectedInflation,
+        sectorDemandMult = in.s4.sectorMults,
+        sectorDemandPressure = in.s4.sectorDemandPressure,
+        sectorHiringSignal = in.s4.sectorHiringSignal,
+      ),
+    )
+
+  private def advanceToBoundaryWorld(
+      postWorld: World,
+      signals: DecisionSignals,
+  ): World =
+    postWorld.updatePipeline(_.withDecisionSignals(signals))
+
+  private[engine] def computePostMonth(
+      step: StepInput,
+      rng: Random,
+      migRng: Random,
+  )(using SimParams): PostResult =
+    val s10 = runPostStep(
+      step,
+      rng,
+      migRng,
+    )
+
+    PostResult(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds, s10.banks, s10.householdAggregates, s10.startupAbsorptionRate)
+
+  private[engine] def computePostMonth(in: Input)(using SimParams): PostResult =
+    computePostMonth(buildStepInput(in), in.rng, in.migRng)
+
+  def compute(in: Input)(using SimParams): Result =
+    val step  = buildStepInput(in)
+    val post  = computePostMonth(step, in.rng, in.migRng)
     val postS = PostStepOutput(post.world, post.firms, post.households, post.banks, post.householdAggregates, post.startupAbsorptionRate)
     val seed  = extractSignalExtraction(step, postS)
     Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -47,18 +47,6 @@ object WorldAssemblyEconomics:
       signalExtraction: SignalExtraction.Output,
   )
 
-  /** Internal post-month state before the next-month seed is extracted and
-    * applied to the pipeline boundary.
-    */
-  private[engine] case class PostStepOutput(
-      newWorld: World,
-      finalFirms: Vector[Firm.State],
-      reassignedHouseholds: Vector[Household.State],
-      banks: Vector[Banking.BankState],
-      householdAggregates: Household.Aggregates,
-      startupAbsorptionRate: Share,
-  )
-
   // ---------------------------------------------------------------------------
   // Private intermediate types
   // ---------------------------------------------------------------------------
@@ -168,17 +156,17 @@ object WorldAssemblyEconomics:
 
   private def extractSignalExtraction(
       in: StepInput,
-      post: PostStepOutput,
+      post: PostResult,
   ): SignalExtraction.Output =
-    val employedHouseholds = Household.countEmployed(post.reassignedHouseholds)
+    val employedHouseholds = Household.countEmployed(post.households)
 
     SignalExtraction.compute(
       SignalExtraction.inputFromRealizedOutcomes(
-        unemploymentRate = post.newWorld.unemploymentRate(employedHouseholds),
+        unemploymentRate = post.world.unemploymentRate(employedHouseholds),
         laggedHiringSlack = in.s2.operationalHiringSlack,
         startupAbsorptionRate = post.startupAbsorptionRate,
-        inflation = post.newWorld.inflation,
-        expectedInflation = post.newWorld.mechanisms.expectations.expectedInflation,
+        inflation = post.world.inflation,
+        expectedInflation = post.world.mechanisms.expectations.expectedInflation,
         sectorDemandMult = in.s4.sectorMults,
         sectorDemandPressure = in.s4.sectorDemandPressure,
         sectorHiringSignal = in.s4.sectorHiringSignal,
@@ -196,22 +184,19 @@ object WorldAssemblyEconomics:
       rng: Random,
       migRng: Random,
   )(using SimParams): PostResult =
-    val s10 = runPostStep(
+    runPostStep(
       step,
       rng,
       migRng,
     )
 
-    PostResult(s10.newWorld, s10.finalFirms, s10.reassignedHouseholds, s10.banks, s10.householdAggregates, s10.startupAbsorptionRate)
-
   private[engine] def computePostMonth(in: Input)(using SimParams): PostResult =
     computePostMonth(buildStepInput(in), in.rng, in.migRng)
 
   def compute(in: Input)(using SimParams): Result =
-    val step  = buildStepInput(in)
-    val post  = computePostMonth(step, in.rng, in.migRng)
-    val postS = PostStepOutput(post.world, post.firms, post.households, post.banks, post.householdAggregates, post.startupAbsorptionRate)
-    val seed  = extractSignalExtraction(step, postS)
+    val step = buildStepInput(in)
+    val post = computePostMonth(step, in.rng, in.migRng)
+    val seed = extractSignalExtraction(step, post)
     Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)
 
   // ---------------------------------------------------------------------------
@@ -222,15 +207,15 @@ object WorldAssemblyEconomics:
     val post             = runPostStep(in, rng, migRng)
     val signalExtraction = extractSignalExtraction(in, post)
     StepOutput(
-      newWorld = advanceToBoundaryWorld(post.newWorld, signalExtraction.seedOut),
-      finalFirms = post.finalFirms,
-      reassignedHouseholds = post.reassignedHouseholds,
+      newWorld = advanceToBoundaryWorld(post.world, signalExtraction.seedOut),
+      finalFirms = post.firms,
+      reassignedHouseholds = post.households,
       banks = post.banks,
       householdAggregates = post.householdAggregates,
       signalExtraction = signalExtraction,
     )
 
-  private[engine] def runPostStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): PostStepOutput =
+  private[engine] def runPostStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): PostResult =
     val equityAfterStep = finalizeEquity(in)
     val fofResidual     = computeFofResidual(in)
     val informal        = computeInformalEconomy(in)
@@ -265,7 +250,7 @@ object WorldAssemblyEconomics:
           ),
         )
       .copy(regionalWages = in.s2.regionalWages)
-    PostStepOutput(finalW, finalFirms, postMigHh, in.s9.banks, startupStaffing.hhAgg, startupStaffing.startupAbsorptionRate)
+    PostResult(finalW, finalFirms, postMigHh, in.s9.banks, startupStaffing.hhAgg, startupStaffing.startupAbsorptionRate)
 
   // ---------------------------------------------------------------------------
   // Private helpers — migrated from WorldAssemblyStep

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.MonthSemantics.At.*
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -241,21 +242,45 @@ object FlowSimulation:
   def emitAllFlows(c: MonthlyCalculus)(using p: SimParams): Vector[Flow] =
     AggregateBatchContract.toLegacyFlows(emitAllBatches(c))
 
-  /** All intermediate step outputs needed for both MonthlyCalculus and
-    * WorldAssembly. Computed once per step — eliminates the double-computation
-    * bug where s1–s9 ran twice with diverging RNG state.
+  /** Typed month-`t` boundary input used internally by [[step]]. */
+  case class StepInput(
+      stateIn: SimState,
+      seedIn: MonthSemantics.SeedIn,
+  )
+
+  /** Same-month stage outputs computed exactly once and reused by every
+    * downstream boundary.
     */
-  private case class FullComputation(
-      calculus: MonthlyCalculus,
+  case class StageOutputs(
       fiscal: FiscalConstraintEconomics.Result,
-      s2: LaborEconomics.Output,
-      s3: HouseholdIncomeEconomics.Output,
-      s4: DemandEconomics.Output,
-      s5: FirmEconomics.StepOutput,
-      s6: HouseholdFinancialEconomics.Output,
-      s7: PriceEquityEconomics.Output,
-      s8: OpenEconEconomics.StepOutput,
-      s9: BankingEconomics.StepOutput,
+      labor: LaborEconomics.Output,
+      hhIncome: HouseholdIncomeEconomics.Output,
+      demand: DemandEconomics.Output,
+      firms: FirmEconomics.StepOutput,
+      hhFinancial: HouseholdFinancialEconomics.Output,
+      prices: PriceEquityEconomics.Output,
+      openEcon: OpenEconEconomics.StepOutput,
+      banking: BankingEconomics.StepOutput,
+      calculus: MonthlyCalculus,
+  )
+
+  case class TraceInputs(
+      labor: MonthTimingPayload.LaborSignals,
+      demand: MonthTimingPayload.DemandSignals,
+      nominal: MonthTimingPayload.NominalSignals,
+      firmDynamics: MonthTimingPayload.FirmDynamics,
+  )
+
+  case class PostMonth(
+      assembled: WorldAssemblyEconomics.PostResult,
+      traceInputs: TraceInputs,
+  )
+
+  case class MonthOutcome(
+      operational: MonthSemantics.Operational,
+      stages: MonthSemantics.StageView,
+      post: MonthSemantics.PostAssembly,
+      seedOut: MonthSemantics.SeedOut,
   )
 
   /** Compute MonthlyCalculus by chaining all Economics. Uses old pipeline steps
@@ -264,16 +289,18 @@ object FlowSimulation:
     * once, then derives both the aggregate banking result and the step output
     * used by WorldAssembly from that single execution.
     *
-    * Returns FullComputation with both calculus AND step outputs for
-    * WorldAssembly.
+    * Returns typed [[StageOutputs]] so later boundaries do not depend on one
+    * broad transport bag.
     */
-  private def computeAll(
-      w: World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      banks: Vector[Banking.BankState],
+  private def computeStageOutputs(
+      input: StepInput,
       rng: Random,
-  )(using p: SimParams): FullComputation =
+  )(using p: SimParams): StageOutputs =
+    val stateIn         = input.stateIn
+    val w               = stateIn.world
+    val firms           = stateIn.firms
+    val households      = stateIn.households
+    val banks           = stateIn.banks
     val fiscal          = FiscalConstraintEconomics.compute(w, banks)
     val s1              = FiscalConstraintEconomics.toOutput(fiscal)
     val labor           = LaborEconomics.compute(w, firms, households, s1)
@@ -349,7 +376,7 @@ object FlowSimulation:
       ),
     )
     val s8              = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, banks, rng))
-    val operational     = extractOperationalSignals(s2, s4)
+    val operational     = operationalSignals(s2, s4)
     val bankingInput    = BankingEconomics.Input(
       w = w,
       month = fiscal.month,
@@ -463,12 +490,18 @@ object FlowSimulation:
       govBondYield = openEcon.newBondYield,
       corpBondYield = openEcon.corpBondYield,
     )
-    FullComputation(calc, fiscal, s2, s3, s4, s5, s6, s7, s8, s9)
+    StageOutputs(fiscal, s2, s3, s4, s5, s6, s7, s8, s9, calc)
 
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
   def computeCalculus(state: SimState, rng: Random)(using p: SimParams): MonthlyCalculus =
-    computeAll(state.world, state.firms, state.households, state.banks, rng).calculus
+    computeStageOutputs(
+      StepInput(
+        stateIn = state,
+        seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
+      ),
+      rng,
+    ).calculus
 
   /** Full month-step contract.
     *
@@ -546,41 +579,42 @@ object FlowSimulation:
 
       ExecutedBatchEvidence(totals, signedTotals)
 
-  private def buildSfcFlows(full: FullComputation, batches: Vector[BatchedFlow], fofResidual: PLN)(using p: SimParams): Sfc.SemanticFlows =
+  private def buildSfcFlows(stageView: MonthSemantics.StageView, batches: Vector[BatchedFlow], fofResidual: PLN)(using p: SimParams): Sfc.SemanticFlows =
+    val stages   = stageView.value
     val evidence = ExecutedBatchEvidence.from(batches)
     Sfc.SemanticFlows(
       govSpending =
-        full.s9.newGovWithYield.domesticBudgetOutlays + full.s2.newZus.govSubvention + full.s2.newNfz.govSubvention + full.s2.newEarmarked.totalGovSubvention,
+        stages.banking.newGovWithYield.domesticBudgetOutlays + stages.labor.newZus.govSubvention + stages.labor.newNfz.govSubvention + stages.labor.newEarmarked.totalGovSubvention,
       govRevenue =
-        full.s5.sumTax + full.s7.dividendTax + full.s9.pitAfterEvasion + full.s9.vatAfterEvasion + full.s8.banking.nbpRemittance + full.s9.exciseAfterEvasion + full.s9.customsDutyRevenue,
-      nplLoss = full.s5.nplLoss,
+        stages.firms.sumTax + stages.prices.dividendTax + stages.banking.pitAfterEvasion + stages.banking.vatAfterEvasion + stages.openEcon.banking.nbpRemittance + stages.banking.exciseAfterEvasion + stages.banking.customsDutyRevenue,
+      nplLoss = stages.firms.nplLoss,
       interestIncome = evidence.amount(FlowMechanism.FirmInterestPaid),
       hhDebtService = evidence.amount(FlowMechanism.HhDebtService),
-      totalIncome = full.s3.totalIncome,
+      totalIncome = stages.hhIncome.totalIncome,
       totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
       newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
-      nplRecovery = full.s5.nplNew * p.banking.loanRecovery,
-      currentAccount = full.s8.external.newBop.currentAccount,
-      valuationEffect = full.s8.external.oeValuationEffect,
+      nplRecovery = stages.firms.nplNew * p.banking.loanRecovery,
+      currentAccount = stages.openEcon.external.newBop.currentAccount,
+      valuationEffect = stages.openEcon.external.oeValuationEffect,
       bankBondIncome = evidence.amount(FlowMechanism.BankGovBondIncome),
-      qePurchase = full.s8.monetary.qePurchaseAmount,
-      newBondIssuance = full.s9.actualBondChange,
+      qePurchase = stages.openEcon.monetary.qePurchaseAmount,
+      newBondIssuance = stages.banking.actualBondChange,
       depositInterestPaid = evidence.amount(FlowMechanism.HhDepositInterest),
       reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
       standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
       interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
-      jstDepositChange = full.s9.jstDepositChange,
-      jstSpending = full.s9.newJst.spending,
-      jstRevenue = full.s9.newJst.revenue,
-      zusContributions = full.s2.newZus.contributions,
-      zusPensionPayments = full.s2.newZus.pensionPayments,
-      zusGovSubvention = full.s2.newZus.govSubvention,
-      nfzContributions = full.s2.newNfz.contributions,
-      nfzSpending = full.s2.newNfz.spending,
-      nfzGovSubvention = full.s2.newNfz.govSubvention,
-      dividendIncome = full.s7.netDomesticDividends,
-      foreignDividendOutflow = full.s7.foreignDividendOutflow,
-      dividendTax = full.s7.dividendTax,
+      jstDepositChange = stages.banking.jstDepositChange,
+      jstSpending = stages.banking.newJst.spending,
+      jstRevenue = stages.banking.newJst.revenue,
+      zusContributions = stages.labor.newZus.contributions,
+      zusPensionPayments = stages.labor.newZus.pensionPayments,
+      zusGovSubvention = stages.labor.newZus.govSubvention,
+      nfzContributions = stages.labor.newNfz.contributions,
+      nfzSpending = stages.labor.newNfz.spending,
+      nfzGovSubvention = stages.labor.newNfz.govSubvention,
+      dividendIncome = stages.prices.netDomesticDividends,
+      foreignDividendOutflow = stages.prices.foreignDividendOutflow,
+      dividendTax = stages.prices.dividendTax,
       mortgageInterestIncome = evidence.amount(FlowMechanism.MortgageInterest),
       mortgageNplLoss = evidence.amount(FlowMechanism.MortgageDefault) * (Share.One - p.housing.mortgageRecovery),
       mortgageOrigination = evidence.amount(FlowMechanism.MortgageOrigination),
@@ -589,20 +623,20 @@ object FlowSimulation:
       remittanceOutflow = evidence.amount(FlowMechanism.HhRemittance),
       fofResidual = fofResidual,
       consumerDebtService = evidence.amount(FlowMechanism.HhCcDebtService),
-      consumerNplLoss = full.s6.consumerNplLoss,
+      consumerNplLoss = stages.hhFinancial.consumerNplLoss,
       consumerOrigination = evidence.amount(FlowMechanism.HhCcOrigination),
-      consumerPrincipalRepaid = full.s6.consumerPrincipal,
+      consumerPrincipalRepaid = stages.hhFinancial.consumerPrincipal,
       consumerDefaultAmount = evidence.amount(FlowMechanism.HhCcDefault),
       corpBondCouponIncome = evidence.amount(FlowMechanism.CorpBondCoupon),
       corpBondDefaultLoss = evidence.amount(FlowMechanism.CorpBondDefault),
       corpBondIssuance = evidence.amount(FlowMechanism.CorpBondIssuance),
       corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
       corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
-      insNetDepositChange = full.s8.nonBank.insNetDepositChange,
-      nbfiDepositDrain = full.s8.nonBank.nbfiDepositDrain,
-      nbfiOrigination = full.s9.finalNbfi.lastNbfiOrigination,
-      nbfiRepayment = full.s9.finalNbfi.lastNbfiRepayment,
-      nbfiDefaultAmount = full.s9.finalNbfi.lastNbfiDefaultAmount,
+      insNetDepositChange = stages.openEcon.nonBank.insNetDepositChange,
+      nbfiDepositDrain = stages.openEcon.nonBank.nbfiDepositDrain,
+      nbfiOrigination = stages.banking.finalNbfi.lastNbfiOrigination,
+      nbfiRepayment = stages.banking.finalNbfi.lastNbfiRepayment,
+      nbfiDefaultAmount = stages.banking.finalNbfi.lastNbfiDefaultAmount,
       fdiProfitShifting = evidence.amount(FlowMechanism.FirmProfitShifting),
       fdiRepatriation = evidence.amount(FlowMechanism.FirmFdiRepatriation),
       diasporaInflow = evidence.amount(FlowMechanism.DiasporaInflow),
@@ -610,79 +644,186 @@ object FlowSimulation:
       tourismImport = evidence.amount(FlowMechanism.TourismImport),
       bfgLevy = evidence.amount(FlowMechanism.BankBfgLevy),
       bailInLoss = evidence.amount(FlowMechanism.BankBailIn),
-      bankCapitalDestruction = full.s9.multiCapDestruction,
-      investNetDepositFlow = full.s9.investNetDepositFlow,
+      bankCapitalDestruction = stages.banking.multiCapDestruction,
+      investNetDepositFlow = stages.banking.investNetDepositFlow,
       firmPrincipalRepaid = evidence.amount(FlowMechanism.FirmLoanRepayment),
       unrealizedBondLoss = evidence.amount(FlowMechanism.BankUnrealizedLoss),
-      htmRealizedLoss = full.s9.htmRealizedLoss,
-      eclProvisionChange = full.s9.eclProvisionChange,
+      htmRealizedLoss = stages.banking.htmRealizedLoss,
+      eclProvisionChange = stages.banking.eclProvisionChange,
     )
 
-  private def extractOperationalSignals(
-      s2: LaborEconomics.Output,
-      s4: DemandEconomics.Output,
+  private def operationalSignals(
+      labor: LaborEconomics.Output,
+      demand: DemandEconomics.Output,
   ): OperationalSignals =
     OperationalSignals(
-      sectorDemandMult = s4.sectorMults,
-      sectorDemandPressure = s4.sectorDemandPressure,
-      sectorHiringSignal = s4.sectorHiringSignal,
-      operationalHiringSlack = s2.operationalHiringSlack,
+      sectorDemandMult = demand.sectorMults,
+      sectorDemandPressure = demand.sectorDemandPressure,
+      sectorHiringSignal = demand.sectorHiringSignal,
+      operationalHiringSlack = labor.operationalHiringSlack,
     )
 
-  private def extractOperationalSignals(full: FullComputation): OperationalSignals =
-    extractOperationalSignals(full.s2, full.s4)
+  private def buildOperationalSignals(stageView: MonthSemantics.StageView): MonthSemantics.Operational =
+    val stages = stageView.value
+    MonthSemantics.At[OperationalSignals, MonthSemantics.SameMonth](operationalSignals(stages.labor, stages.demand))
+
+  private def buildTraceInputs(
+      stageView: MonthSemantics.StageView,
+      assembled: WorldAssemblyEconomics.PostResult,
+  ): TraceInputs =
+    val stages = stageView.value
+    TraceInputs(
+      labor = MonthTimingPayload.LaborSignals(
+        operationalHiringSlack = stages.labor.operationalHiringSlack,
+      ),
+      demand = MonthTimingPayload.DemandSignals(
+        sectorDemandMult = stages.demand.sectorMults,
+        sectorDemandPressure = stages.demand.sectorDemandPressure,
+        sectorHiringSignal = stages.demand.sectorHiringSignal,
+      ),
+      nominal = MonthTimingPayload.NominalSignals(
+        realizedInflation = stages.prices.newInfl,
+        expectedInflation = stages.openEcon.monetary.newExp.expectedInflation,
+      ),
+      firmDynamics = MonthTimingPayload.FirmDynamics(
+        startupAbsorptionRate = assembled.startupAbsorptionRate,
+        firmBirths = assembled.world.flows.firmBirths,
+        firmDeaths = assembled.world.flows.firmDeaths,
+        netFirmBirths = assembled.world.flows.netFirmBirths,
+      ),
+    )
+
+  private def assemblePostMonth(
+      input: StepInput,
+      stageView: MonthSemantics.StageView,
+      rng: Random,
+  )(using p: SimParams): MonthSemantics.PostAssembly =
+    val stages    = stageView.value
+    val assembled = WorldAssemblyEconomics.computePostMonth(
+      WorldAssemblyEconomics.Input(
+        w = input.stateIn.world,
+        firms = input.stateIn.firms,
+        households = input.stateIn.households,
+        month = stages.fiscal.month,
+        lendingBaseRate = stages.fiscal.lendingBaseRate,
+        resWage = stages.fiscal.resWage,
+        baseMinWage = stages.fiscal.baseMinWage,
+        minWagePriceLevel = stages.fiscal.updatedMinWagePriceLevel,
+        govPurchases = stages.demand.govPurchases,
+        sectorMults = stages.demand.sectorMults,
+        sectorDemandPressure = stages.demand.sectorDemandPressure,
+        sectorHiringSignal = stages.demand.sectorHiringSignal,
+        avgDemandMult = stages.demand.avgDemandMult,
+        sectorCapReal = stages.demand.sectorCapReal,
+        laggedInvestDemand = stages.demand.laggedInvestDemand,
+        fiscalRuleStatus = stages.demand.fiscalRuleStatus,
+        laborOutput = stages.labor,
+        hhOutput = stages.hhIncome,
+        firmOutput = stages.firms,
+        hhFinancialOutput = stages.hhFinancial,
+        priceEquityOutput = stages.prices,
+        openEconOutput = stages.openEcon,
+        bankOutput = stages.banking,
+        banks = input.stateIn.banks,
+        rng = rng,
+        migRng = rng,
+      ),
+    )
+    MonthSemantics.At[PostMonth, MonthSemantics.Post](PostMonth(assembled, buildTraceInputs(stageView, assembled)))
+
+  private def extractSeedOut(
+      stageView: MonthSemantics.StageView,
+      post: MonthSemantics.PostAssembly,
+  ): MonthSemantics.SeedOut =
+    val assembled = post.value.assembled
+    val trace     = post.value.traceInputs
+    val employed  = Household.countEmployed(assembled.households)
+    val stages    = stageView.value
+
+    MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
+      SignalExtraction.compute(
+        SignalExtraction.Input(
+          labor = SignalExtraction.LaborOutcomes(
+            unemploymentRate = assembled.world.unemploymentRate(employed),
+            laggedHiringSlack = stages.labor.operationalHiringSlack,
+            startupAbsorptionRate = trace.firmDynamics.startupAbsorptionRate,
+          ),
+          nominal = SignalExtraction.NominalOutcomes(
+            inflation = stages.prices.newInfl,
+            expectedInflation = stages.openEcon.monetary.newExp.expectedInflation,
+          ),
+          demand = SignalExtraction.DemandOutcomes(
+            sectorDemandMult = stages.demand.sectorMults,
+            sectorDemandPressure = stages.demand.sectorDemandPressure,
+            sectorHiringSignal = stages.demand.sectorHiringSignal,
+          ),
+        ),
+      ),
+    )
+
+  private def computeMonthOutcome(
+      input: StepInput,
+      rng: Random,
+  )(using p: SimParams): MonthOutcome =
+    val stageView   = MonthSemantics.At[StageOutputs, MonthSemantics.SameMonth](computeStageOutputs(input, rng))
+    val operational = buildOperationalSignals(stageView)
+    val post        = assemblePostMonth(input, stageView, rng)
+    val seedOut     = extractSeedOut(stageView, post)
+
+    MonthOutcome(
+      operational = operational,
+      stages = stageView,
+      post = post,
+      seedOut = seedOut,
+    )
+
+  private def advanceState(
+      input: StepInput,
+      post: MonthSemantics.PostAssembly,
+      seedOut: MonthSemantics.SeedOut,
+  ): SimState =
+    val assembled = post.value.assembled
+    val nextSeed  = seedOut.value.seedOut
+    val nextWorld = assembled.world.updatePipeline(_.withDecisionSignals(nextSeed))
+
+    require(input.seedIn.value == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
+    require(assembled.world.seedIn == input.seedIn.value, "PostMonth world must remain on the pre-step seed until advanceState runs")
+    require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")
+
+    SimState(
+      world = nextWorld,
+      firms = assembled.firms,
+      households = assembled.households,
+      banks = assembled.banks,
+      householdAggregates = assembled.householdAggregates,
+    )
 
   private def buildMonthTrace(
-      stateIn: SimState,
-      full: FullComputation,
+      input: StepInput,
+      outcome: MonthOutcome,
       nextState: SimState,
       executedFlows: Sfc.SemanticFlows,
       sfcResult: Sfc.SfcResult,
-      signalExtraction: SignalExtraction.Output,
   ): MonthTrace =
+    val traceInputs = outcome.post.value.traceInputs
+    val seedOut     = outcome.seedOut.value
     MonthTrace(
       month = nextState.world.month,
       boundary = MonthBoundaryTrace(
-        startSnapshot = MonthBoundarySnapshot.capture(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
+        startSnapshot = MonthBoundarySnapshot.capture(input.stateIn.world, input.stateIn.firms, input.stateIn.households, input.stateIn.banks),
         endSnapshot = MonthBoundarySnapshot.capture(nextState.world, nextState.firms, nextState.households, nextState.banks),
       ),
       seedTransition = SeedTransitionTrace(
-        seedIn = stateIn.world.seedIn,
-        seedOut = signalExtraction.seedOut,
-        provenance = signalExtraction.provenance,
+        seedIn = input.seedIn.value,
+        seedOut = seedOut.seedOut,
+        provenance = seedOut.provenance,
       ),
       timing = MonthTimingTrace(
         Vector(
-          MonthTrace.timingEnvelope(
-            MonthTimingEnvelopeKey.LaborSignals,
-            MonthTimingPayload.LaborSignals(
-              operationalHiringSlack = full.s2.operationalHiringSlack,
-            ),
-          ),
-          MonthTrace.timingEnvelope(
-            MonthTimingEnvelopeKey.DemandSignals,
-            MonthTimingPayload.DemandSignals(
-              sectorDemandMult = full.s4.sectorMults,
-              sectorDemandPressure = full.s4.sectorDemandPressure,
-              sectorHiringSignal = full.s4.sectorHiringSignal,
-            ),
-          ),
-          MonthTrace.timingEnvelope(
-            MonthTimingEnvelopeKey.NominalSignals,
-            MonthTimingPayload.NominalSignals(
-              realizedInflation = full.s7.newInfl,
-              expectedInflation = full.s8.monetary.newExp.expectedInflation,
-            ),
-          ),
-          MonthTrace.timingEnvelope(
-            MonthTimingEnvelopeKey.FirmDynamics,
-            MonthTimingPayload.FirmDynamics(
-              startupAbsorptionRate = signalExtraction.seedOut.startupAbsorptionRate,
-              firmBirths = nextState.world.flows.firmBirths,
-              firmDeaths = nextState.world.flows.firmDeaths,
-              netFirmBirths = nextState.world.flows.netFirmBirths,
-            ),
-          ),
+          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.LaborSignals, traceInputs.labor),
+          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.DemandSignals, traceInputs.demand),
+          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.NominalSignals, traceInputs.nominal),
+          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.FirmDynamics, traceInputs.firmDynamics),
         ),
       ),
       executedFlows = executedFlows,
@@ -691,79 +832,40 @@ object FlowSimulation:
 
   /** Full step: compute calculus → emit flows → assemble new World.
     *
-    * This is the pipeline entry point. Runs s1–s9 exactly once via
-    * computeAll(), then feeds both MonthlyCalculus (for flows) and step outputs
-    * (for WorldAssembly) from that single computation.
+    * The internal month-step shape is now explicit:
+    * `stateIn -> StepInput -> MonthOutcome -> nextState`.
     */
   def step(stateIn: SimState, rng: Random)(using p: SimParams): StepOutput =
-    val full               = computeAll(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, rng)
-    val flows              = emitAllBatches(full.calculus)
-    val execution          = executeBatches(flows).fold(
+    val input      = StepInput(stateIn, MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn))
+    val outcome    = computeMonthOutcome(input, rng)
+    val flows      = emitAllBatches(outcome.stages.value.calculus)
+    val execution  = executeBatches(flows).fold(
       err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
       identity,
     )
-    val operationalSignals = extractOperationalSignals(full)
-
-    val assembled  = WorldAssemblyEconomics.compute(
-      WorldAssemblyEconomics.Input(
-        w = stateIn.world,
-        firms = stateIn.firms,
-        households = stateIn.households,
-        month = full.fiscal.month,
-        lendingBaseRate = full.fiscal.lendingBaseRate,
-        resWage = full.fiscal.resWage,
-        baseMinWage = full.fiscal.baseMinWage,
-        minWagePriceLevel = full.fiscal.updatedMinWagePriceLevel,
-        govPurchases = full.s4.govPurchases,
-        sectorMults = full.s4.sectorMults,
-        sectorDemandPressure = full.s4.sectorDemandPressure,
-        sectorHiringSignal = full.s4.sectorHiringSignal,
-        avgDemandMult = full.s4.avgDemandMult,
-        sectorCapReal = full.s4.sectorCapReal,
-        laggedInvestDemand = full.s4.laggedInvestDemand,
-        fiscalRuleStatus = full.s4.fiscalRuleStatus,
-        laborOutput = full.s2,
-        hhOutput = full.s3,
-        firmOutput = full.s5,
-        hhFinancialOutput = full.s6,
-        priceEquityOutput = full.s7,
-        openEconOutput = full.s8,
-        bankOutput = full.s9,
-        banks = stateIn.banks,
-        rng = rng,
-        migRng = rng,
-      ),
-    )
-    val nextState  = SimState(
-      world = assembled.world,
-      firms = assembled.firms,
-      households = assembled.households,
-      banks = assembled.banks,
-      householdAggregates = assembled.householdAggregates,
-    )
-    val sfcFlows   = buildSfcFlows(full, flows, nextState.world.plumbing.fofResidual)
+    val nextState  = advanceState(input, outcome.post, outcome.seedOut)
+    val sfcFlows   = buildSfcFlows(outcome.stages, flows, nextState.world.plumbing.fofResidual)
     val sfcResult  = Sfc.validate(
       prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
-      curr = runtimeState(assembled.world, assembled.firms, assembled.households, assembled.banks),
+      curr = runtimeState(nextState.world, nextState.firms, nextState.households, nextState.banks),
       flows = sfcFlows,
       batches = flows,
       executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
       totalWealth = execution.totalWealth,
     )
     val monthTrace = buildMonthTrace(
-      stateIn = stateIn,
-      full = full,
+      input = input,
+      outcome = outcome,
       nextState = nextState,
       executedFlows = sfcFlows,
       sfcResult = sfcResult,
-      signalExtraction = assembled.signalExtraction,
     )
 
     StepOutput(
       stateIn = stateIn,
-      calculus = full.calculus,
-      operationalSignals = operationalSignals,
-      signalExtraction = assembled.signalExtraction,
+      calculus = outcome.stages.value.calculus,
+      operationalSignals = outcome.operational.value,
+      signalExtraction = outcome.seedOut.value,
       flows,
       execution,
       sfcResult,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -271,11 +271,18 @@ object FlowSimulation:
       firmDynamics: MonthTimingPayload.FirmDynamics,
   )
 
+  /** Post-assembly view of month `t`: assembled world plus the narrow payload
+    * needed to build [[MonthTrace]].
+    */
   case class PostMonth(
       assembled: WorldAssemblyEconomics.PostResult,
       traceInputs: TraceInputs,
   )
 
+  /** Full typed boundary carried through one step: pre-step seed, same-month
+    * operational view, post-month assembly, then the extracted seed for
+    * `t + 1`.
+    */
   case class MonthOutcome(
       operational: MonthSemantics.Operational,
       stages: MonthSemantics.StageView,
@@ -729,6 +736,7 @@ object FlowSimulation:
         migRng = rng,
       ),
     )
+    // This stays at month `t`: the boundary seed is still `seedIn` here.
     MonthSemantics.At[PostMonth, MonthSemantics.Post](PostMonth(assembled, buildTraceInputs(stageView, assembled)))
 
   private def extractSeedOut(
@@ -743,6 +751,8 @@ object FlowSimulation:
     MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
       SignalExtraction.compute(
         SignalExtraction.Input(
+          // Seed extraction is the only place that derives the next boundary
+          // signal from realized month-`t` outcomes.
           labor = SignalExtraction.LaborOutcomes(
             unemploymentRate = assembled.world.unemploymentRate(employed),
             laggedHiringSlack = stages.labor.operationalHiringSlack,
@@ -765,6 +775,8 @@ object FlowSimulation:
       input: StepInput,
       rng: Random,
   )(using p: SimParams): MonthOutcome =
+    // Keep the month-step pipeline explicit:
+    // `seedIn/pre -> same-month stages -> post-month assembly -> seedOut/next-pre`.
     val stageView   = MonthSemantics.At[StageOutputs, MonthSemantics.SameMonth](computeStageOutputs(input, rng))
     val operational = buildOperationalSignals(stageView)
     val post        = assemblePostMonth(input, stageView, rng)
@@ -786,6 +798,8 @@ object FlowSimulation:
     val nextSeed  = seedOut.value.seedOut
     val nextWorld = assembled.world.updatePipeline(_.withDecisionSignals(nextSeed))
 
+    // `advanceState` is the only legal `post -> next-pre` transition:
+    // post-month assembly still sees the old seed, next state applies `seedOut`.
     require(input.seedIn.value == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
     require(assembled.world.seedIn == input.seedIn.value, "PostMonth world must remain on the pre-step seed until advanceState runs")
     require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -706,6 +706,8 @@ object FlowSimulation:
       rng: Random,
   )(using p: SimParams): MonthSemantics.PostAssembly =
     val stages    = stageView.value
+    // Keep migration draws on an independent RNG stream.
+    val migRng    = new Random(rng.nextLong())
     val assembled = WorldAssemblyEconomics.computePostMonth(
       WorldAssemblyEconomics.Input(
         w = input.stateIn.world,
@@ -733,7 +735,7 @@ object FlowSimulation:
         bankOutput = stages.banking,
         banks = input.stateIn.banks,
         rng = rng,
-        migRng = rng,
+        migRng = migRng,
       ),
     )
     // This stays at month `t`: the boundary seed is still `seedIn` here.
@@ -744,29 +746,22 @@ object FlowSimulation:
       post: MonthSemantics.PostAssembly,
   ): MonthSemantics.SeedOut =
     val assembled = post.value.assembled
-    val trace     = post.value.traceInputs
     val employed  = Household.countEmployed(assembled.households)
     val stages    = stageView.value
 
     MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
       SignalExtraction.compute(
-        SignalExtraction.Input(
-          // Seed extraction is the only place that derives the next boundary
-          // signal from realized month-`t` outcomes.
-          labor = SignalExtraction.LaborOutcomes(
-            unemploymentRate = assembled.world.unemploymentRate(employed),
-            laggedHiringSlack = stages.labor.operationalHiringSlack,
-            startupAbsorptionRate = trace.firmDynamics.startupAbsorptionRate,
-          ),
-          nominal = SignalExtraction.NominalOutcomes(
-            inflation = stages.prices.newInfl,
-            expectedInflation = stages.openEcon.monetary.newExp.expectedInflation,
-          ),
-          demand = SignalExtraction.DemandOutcomes(
-            sectorDemandMult = stages.demand.sectorMults,
-            sectorDemandPressure = stages.demand.sectorDemandPressure,
-            sectorHiringSignal = stages.demand.sectorHiringSignal,
-          ),
+        // Seed extraction is the only place that derives the next boundary
+        // signal from realized month-`t` outcomes.
+        SignalExtraction.inputFromRealizedOutcomes(
+          unemploymentRate = assembled.world.unemploymentRate(employed),
+          laggedHiringSlack = stages.labor.operationalHiringSlack,
+          startupAbsorptionRate = assembled.startupAbsorptionRate,
+          inflation = assembled.world.inflation,
+          expectedInflation = assembled.world.mechanisms.expectations.expectedInflation,
+          sectorDemandMult = stages.demand.sectorMults,
+          sectorDemandPressure = stages.demand.sectorDemandPressure,
+          sectorHiringSignal = stages.demand.sectorHiringSignal,
         ),
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthSemanticsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthSemanticsSpec.scala
@@ -1,0 +1,58 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MonthSemanticsSpec extends AnyFlatSpec with Matchers:
+
+  "MonthSemantics.At" should "preserve typed wrappers for pre, same-month, and next-pre boundaries" in {
+    val signals = DecisionSignals(
+      unemploymentRate = Share(0.08),
+      inflation = Rate(0.03),
+      expectedInflation = Rate(0.025),
+      laggedHiringSlack = Share(0.42),
+      startupAbsorptionRate = Share(0.65),
+      sectorDemandMult = Vector(Multiplier(0.9), Multiplier(1.1)),
+      sectorDemandPressure = Vector(Multiplier(0.8), Multiplier(1.2)),
+      sectorHiringSignal = Vector(Multiplier(0.85), Multiplier(1.15)),
+    )
+
+    val seedIn: MonthSemantics.SeedIn =
+      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](signals)
+
+    val operationalRaw                          = OperationalSignals(
+      sectorDemandMult = signals.sectorDemandMult,
+      sectorDemandPressure = signals.sectorDemandPressure,
+      sectorHiringSignal = signals.sectorHiringSignal,
+      operationalHiringSlack = Share(0.37),
+    )
+    val operational: MonthSemantics.Operational =
+      MonthSemantics.At[OperationalSignals, MonthSemantics.SameMonth](operationalRaw)
+
+    val extracted                       = SignalExtraction.compute(
+      SignalExtraction.Input(
+        labor = SignalExtraction.LaborOutcomes(
+          unemploymentRate = signals.unemploymentRate,
+          laggedHiringSlack = operationalRaw.operationalHiringSlack,
+          startupAbsorptionRate = signals.startupAbsorptionRate,
+        ),
+        nominal = SignalExtraction.NominalOutcomes(
+          inflation = signals.inflation,
+          expectedInflation = signals.expectedInflation,
+        ),
+        demand = SignalExtraction.DemandOutcomes(
+          sectorDemandMult = signals.sectorDemandMult,
+          sectorDemandPressure = signals.sectorDemandPressure,
+          sectorHiringSignal = signals.sectorHiringSignal,
+        ),
+      ),
+    )
+    val seedOut: MonthSemantics.SeedOut =
+      MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](extracted)
+
+    seedIn.value shouldBe signals
+    operational.value shouldBe operationalRaw
+    seedOut.value shouldBe extracted
+    seedOut.value.seedOut.laggedHiringSlack shouldBe operationalRaw.operationalHiringSlack
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -456,10 +456,10 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     val input = entrySensitiveInput.copy(s2 = entrySensitiveInput.s2.copy(operationalHiringSlack = Share(0.21)))
     val post  = WorldAssemblyEconomics.runPostStep(input, new scala.util.Random(1234L), new scala.util.Random(5678L))
 
-    post.newWorld.pipeline.operationalHiringSlack shouldBe Share(0.21)
-    post.newWorld.seedIn shouldBe input.w.seedIn
-    post.newWorld.pipeline.sectorDemandPressure shouldBe input.w.pipeline.sectorDemandPressure
-    post.newWorld.pipeline.sectorHiringSignal shouldBe input.w.pipeline.sectorHiringSignal
+    post.world.pipeline.operationalHiringSlack shouldBe Share(0.21)
+    post.world.seedIn shouldBe input.w.seedIn
+    post.world.pipeline.sectorDemandPressure shouldBe input.w.pipeline.sectorDemandPressure
+    post.world.pipeline.sectorHiringSignal shouldBe input.w.pipeline.sectorHiringSignal
   }
 
   it should "keep explicit OperationalSignals aligned with post-reconcile labor slack" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -458,6 +458,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
 
     post.world.pipeline.operationalHiringSlack shouldBe Share(0.21)
     post.world.seedIn shouldBe input.w.seedIn
+    post.world.pipeline.sectorDemandMult shouldBe input.w.pipeline.sectorDemandMult
     post.world.pipeline.sectorDemandPressure shouldBe input.w.pipeline.sectorDemandPressure
     post.world.pipeline.sectorHiringSignal shouldBe input.w.pipeline.sectorHiringSignal
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -452,6 +452,16 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     result.newWorld.seedIn.laggedHiringSlack shouldBe Share(0.21)
   }
 
+  it should "keep post-month assembly distinct from the next-month seed boundary" in {
+    val input = entrySensitiveInput.copy(s2 = entrySensitiveInput.s2.copy(operationalHiringSlack = Share(0.21)))
+    val post  = WorldAssemblyEconomics.runPostStep(input, new scala.util.Random(1234L), new scala.util.Random(5678L))
+
+    post.newWorld.pipeline.operationalHiringSlack shouldBe Share(0.21)
+    post.newWorld.seedIn shouldBe input.w.seedIn
+    post.newWorld.pipeline.sectorDemandPressure shouldBe input.w.pipeline.sectorDemandPressure
+    post.newWorld.pipeline.sectorHiringSignal shouldBe input.w.pipeline.sectorHiringSignal
+  }
+
   it should "keep explicit OperationalSignals aligned with post-reconcile labor slack" in {
     baseOperationalSignals.operationalHiringSlack shouldBe baseline.s2.operationalHiringSlack
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
+import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthSemantics, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
 import com.boombustgroup.amorfati.init.WorldInit
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
@@ -50,6 +50,20 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     stateResult.nextState.banks shouldBe repeated.nextState.banks
     stateResult.nextState.householdAggregates shouldBe repeated.nextState.householdAggregates
     stateResult.trace shouldBe repeated.trace
+  }
+
+  it should "keep explicit pre and next-pre seed wrappers aligned with step outputs" in {
+    val init    = WorldInit.initialize(42L)
+    val state   = FlowSimulation.SimState.fromInit(init)
+    val seedIn  = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn)
+    val result  = FlowSimulation.step(state, new scala.util.Random(42L))
+    val seedOut = MonthSemantics.At[com.boombustgroup.amorfati.engine.SignalExtraction.Output, MonthSemantics.NextPre](result.signalExtraction)
+
+    seedIn.value shouldBe state.world.seedIn
+    seedOut.value shouldBe result.signalExtraction
+    seedOut.value.seedOut shouldBe result.nextState.world.seedIn
+    result.trace.seedTransition.seedIn shouldBe seedIn.value
+    result.trace.seedTransition.seedOut shouldBe seedOut.value.seedOut
   }
 
   it should "produce SFC == 0L across 12 months (autonomous driving)" in {


### PR DESCRIPTION
Closes #317
Part of #315.

## Summary
- add `MonthSemantics` phase markers and typed boundary aliases for pre, same-month, post, and next-pre
- refactor `FlowSimulation.step` around `StepInput`, `StageOutputs`, `PostMonth`, and `MonthOutcome`
- separate post-month assembly from next-month seed application so `advanceState` is the explicit `post -> next-pre` transition
- derive trace and seed-transition data from the typed month outcome boundary instead of a broad internal transport bag
- add tests covering the new phase wrappers and the post-month vs next-boundary split

## Follow-ups
- #322
- #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced explicit month-boundary typing for simulation signals and outputs to make boundary payloads and seed provenance explicit.

* **Refactor**
  * Reworked the monthly pipeline to compute stage outputs once, split post-month assembly, and centralize seed application for clearer, type-safe state transitions.

* **Documentation**
  * Updated engine step docs to describe the new month-transition outcome and boundary behavior.

* **Tests**
  * Added and updated tests verifying phase-tagged signals and preservation/isolation of seed/provenance across month boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->