### PR TITLE
Unify randomness contracts across init and month step

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.mechanisms.{Macroprudential, YieldCurve}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 object Banking:
 
@@ -319,7 +319,7 @@ object Banking:
   // ---------------------------------------------------------------------------
 
   /** Assign a firm to a bank based on sector affinity and market share. */
-  def assignBank(firmSector: SectorIdx, configs: Vector[Config], rng: Random): BankId =
+  def assignBank(firmSector: SectorIdx, configs: Vector[Config], rng: RandomStream): BankId =
     val weights = configs.map(c => c.sectorAffinity(firmSector.toInt) * c.initMarketShare) // Share * Share → Share
     val total   = weights.map(_.toLong).sum
     if total <= 0L then BankId(0)
@@ -397,7 +397,7 @@ object Banking:
     * the bank approaches full reserve utilisation, rather than a hard block
     * (banks can temporarily fund via interbank market).
     */
-  def canLend(bank: BankState, amount: PLN, rng: Random, ccyb: Multiplier)(using p: SimParams): Boolean =
+  def canLend(bank: BankState, amount: PLN, rng: RandomStream, ccyb: Multiplier)(using p: SimParams): Boolean =
     if bank.failed then false
     else
       val projectedRwa = bank.loans + bank.consumerLoans + bank.corpBondHoldings * CorpBondRiskWeight + amount

--- a/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.agents
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Deposit mobility: endogenous deposit flight and bank runs.
   *
@@ -68,7 +68,7 @@ object DepositMobility:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       anyBankFailed: Boolean,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Result =
     val healthiest = Banking.healthiestBankId(banks)
     val carByBank  = banks.map(b => b.id.toInt -> b.car).toMap

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.engine.{OperationalSignals, World}
 import com.boombustgroup.amorfati.fp.FixedPointBase.bankerRound
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 // ---- Domain types ----
 
@@ -460,7 +460,7 @@ object Firm:
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Result =
     val decision = decide(firm, w, operationalSignals, lendRate, bankCanLend, allFirms, rng)
     val r0       = updateHiringSignalState(execute(firm, decision), firm, w, operationalSignals)
@@ -478,13 +478,14 @@ object Firm:
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Result =
     process(firm, w, OperationalSignals.fromBridgedWorld(w), lendRate, bankCanLend, allFirms, rng)
 
-  // ---- Decide (all match logic + Random rolls) ----
+  // ---- Decide (all match logic + RandomStream rolls) ----
 
-  /** Dispatch to tech-specific decision logic. Contains all Random calls. */
+  /** Dispatch to tech-specific decision logic. Contains all RandomStream calls.
+    */
   private def decide(
       firm: State,
       w: World,
@@ -492,7 +493,7 @@ object Firm:
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Decision =
     firm.tech match
       case _: TechState.Bankrupt         => Decision.StayBankrupt
@@ -619,7 +620,7 @@ object Firm:
       bankCanLend: PLN => Boolean,
       workers: Int,
       aiEff: Multiplier,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Decision =
     val pnl    = computePnL(
       firm,
@@ -798,7 +799,7 @@ object Firm:
   /** Roll for full-AI upgrade: success (with random efficiency) or
     * implementation failure.
     */
-  private def rollFullAiUpgrade(firm: State, pnl: PnL, ai: UpgradeCandidate, rng: Random): Decision =
+  private def rollFullAiUpgrade(firm: State, pnl: PnL, ai: UpgradeCandidate, rng: RandomStream): Decision =
     val failRate = Share(FullAiBaseFailRate) + (Share.One - firm.digitalReadiness) * Share(FullAiFailDrSens)
     if failRate.sampleBelow(rng) then
       Decision.UpgradeFailed(pnl, BankruptReason.AiImplFailure, ai.capex * Share(FailCapexFrac), ai.loan * Share(FailLoanFrac), ai.down * Share(FailDownFrac))
@@ -809,7 +810,7 @@ object Firm:
   /** Roll for hybrid upgrade: catastrophic failure, partial failure (bad
     * efficiency), or success (good efficiency).
     */
-  private def rollHybridUpgrade(firm: State, pnl: PnL, hyb: UpgradeCandidate, hWkrs: Int, rng: Random): Decision =
+  private def rollHybridUpgrade(firm: State, pnl: PnL, hyb: UpgradeCandidate, hWkrs: Int, rng: RandomStream): Decision =
     val failRate = Share(HybridBaseFailRate) + (Share.One - firm.digitalReadiness) * Share(HybridFailDrSens)
     val draw     = Share.random(rng)
     if draw < failRate * Share(CatastrophicFailFrac) then
@@ -838,7 +839,7 @@ object Firm:
       w: World,
       operationalSignals: OperationalSignals,
       workers: Int,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Decision =
     val nc            = firm.cash + pnl.netAfterTax
     // Firms now distinguish between a one-period desired workforce target,
@@ -909,7 +910,7 @@ object Firm:
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
       workers: Int,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Decision =
     val pnl           = computePnL(
       firm,
@@ -931,9 +932,9 @@ object Firm:
     else if roll < pFull + pHyb then rollHybridUpgrade(firm, pnl, hyb, hWkrs, rng)
     else fallbackDecision(firm, pnl, w, operationalSignals, workers, rng)
 
-  // ---- Execute (pure dispatch, zero Random calls) ----
+  // ---- Execute (pure dispatch, zero RandomStream calls) ----
 
-  /** Pure dispatch: map `Decision` → `Result`. No Random calls, no side
+  /** Pure dispatch: map `Decision` → `Result`. No RandomStream calls, no side
     * effects.
     */
   private def execute(firm: State, d: Decision)(using p: SimParams): Result =

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -3,11 +3,11 @@ package com.boombustgroup.amorfati.agents
 import com.boombustgroup.amorfati.config.*
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.mechanisms.SectoralMobility
+import com.boombustgroup.amorfati.init.InitRandomness
 import com.boombustgroup.amorfati.networks.Network
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
-
-import scala.util.Random
 
 import com.boombustgroup.amorfati.fp.FixedPointBase.bankerRound
 
@@ -179,10 +179,10 @@ object Household:
       * NAIRU-fraction of households start as Unemployed(0) so the economy
       * initializes near steady state rather than overheated.
       */
-    def create(rng: Random, firms: Vector[Firm.State])(using p: SimParams): Vector[State] =
+    def create(randomness: InitRandomness.HouseholdStreams, firms: Vector[Firm.State])(using p: SimParams): Vector[State] =
       val hhCount     = firms.map(Firm.workerCount).sum
-      val hhNetwork   = Network.wattsStrogatz(hhCount, p.household.socialK, p.household.socialP, rng)
-      val hhs         = initialize(hhCount, firms, hhNetwork, rng)
+      val hhNetwork   = Network.wattsStrogatz(hhCount, p.household.socialK, p.household.socialP, randomness.network)
+      val hhs         = initialize(hhCount, firms, hhNetwork, randomness.attributes)
       // Assign households to same bank as their employer
       val banked      = hhs.map: h =>
         h.status match
@@ -190,7 +190,7 @@ object Household:
           case _                                                        => h
       // Set NAIRU fraction as unemployed — prevents overheated init
       val nUnemployed = p.monetary.nairu.applyTo(hhCount)
-      val toUnemploy  = rng.shuffle(banked.indices.toVector).take(nUnemployed).toSet
+      val toUnemploy  = randomness.initialUnemployment.shuffle(banked.indices.toVector).take(nUnemployed).toSet
       banked.zipWithIndex.map: (h, i) =>
         if toUnemploy.contains(i) then
           h.status match
@@ -205,7 +205,7 @@ object Household:
         nHouseholds: Int,
         firms: Vector[Firm.State],
         socialNetwork: Array[Array[Int]],
-        rng: Random,
+        rng: RandomStream,
     )(using p: SimParams): Vector[State] =
       // Expand alive firms into (firm, sectorIdx) per worker slot, capped at nHouseholds
       val assignments: Vector[(Firm.State, SectorIdx)] =
@@ -224,7 +224,7 @@ object Household:
         firm: Firm.State,
         sectorIdx: SectorIdx,
         socialNetwork: Array[Array[Int]],
-        rng: Random,
+        rng: RandomStream,
     )(using p: SimParams): State =
       import ComputationBoundary.toDouble
       val savings: PLN  = Distributions.lognormalPln(toDouble(p.household.savingsMu), toDouble(p.household.savingsSigma), rng)
@@ -264,7 +264,7 @@ object Household:
       )
 
     /** Sample education level and skill for a sector, clamped to edu range. */
-    private def sampleEducationAndSkill(sectorIdx: SectorIdx, rng: Random)(using p: SimParams): (Int, Share) =
+    private def sampleEducationAndSkill(sectorIdx: SectorIdx, rng: RandomStream)(using p: SimParams): (Int, Share) =
       val edu                          = p.social.drawEducation(sectorIdx.toInt, rng)
       val (skillFloorS, skillCeilingS) = p.social.eduSkillRange(edu)
       val baseSkill                    = Distributions.randomShareBetween(skillFloorS, skillCeilingS, rng)
@@ -280,7 +280,7 @@ object Household:
       *
       * routineness = base(edu) + σ-bonus, clamped to [0.05, 0.95], with noise.
       */
-    private[agents] def sampleTaskRoutineness(edu: Int, sectorIdx: SectorIdx, rng: Random)(using p: SimParams): Share =
+    private[agents] def sampleTaskRoutineness(edu: Int, sectorIdx: SectorIdx, rng: RandomStream)(using p: SimParams): Share =
       val eduBase  = p.labor.sbtcEduRoutineness(edu)
       val sigmaAdj = (Scalar(0.05) * p.sectorDefs(sectorIdx.toInt).sigma.toScalar.log10).toShare
       val noise    = Scalar.randomBetween(Scalar(-0.025), Scalar(0.025), rng).toShare
@@ -427,7 +427,7 @@ object Household:
       status: HhStatus.Employed,
       sectorWages: Vector[PLN],
       sectorVacancies: Vector[Int],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): (HhStatus, Int) =
     if !p.labor.voluntarySearchProb.sampleBelow(rng) then return (status, 0)
     val targetSector      =
@@ -449,7 +449,7 @@ object Household:
       neighborDistress: Share,
       sectorWages: Option[Vector[PLN]],
       sectorVacancies: Option[Vector[Int]],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): (HhStatus, Int, Int) =
     status match
       case HhStatus.Unemployed(months) if months > UnemploymentRetrainingThreshold && p.household.retrainingEnabled =>
@@ -496,7 +496,7 @@ object Household:
       debtService: PLN,
       world: World,
       bankRates: Option[BankRates],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): CreditResult =
     val consumerRate: Rate = bankRates match
       case Some(br) => br.lendingRates(hh.bankId.toInt) + p.household.ccSpread
@@ -556,7 +556,7 @@ object Household:
   private def computeMonthlyFlows(
       hh: State,
       world: World,
-      rng: Random,
+      rng: RandomStream,
       bankRates: Option[BankRates],
       equityIndexReturn: Rate,
       distressedIds: java.util.BitSet,
@@ -629,7 +629,7 @@ object Household:
   private def processHousehold(
       hh: State,
       world: World,
-      rng: Random,
+      rng: RandomStream,
       bankRates: Option[BankRates],
       equityIndexReturn: Rate,
       sectorWages: Option[Vector[PLN]],
@@ -676,7 +676,7 @@ object Household:
       f: MonthlyFlows,
       sectorWages: Option[Vector[PLN]],
       sectorVacancies: Option[Vector[Int]],
-      rng: Random,
+      rng: RandomStream,
       distressMonths: Int,
   )(using p: SimParams): HhMonthlyResult =
     val afterSkill    = applySkillDecay(f.hh, f.newStatus)
@@ -732,7 +732,7 @@ object Household:
       marketWage: PLN,
       reservationWage: PLN,
       importAdj: Share,
-      rng: Random,
+      rng: RandomStream,
       nBanks: Int = 1,
       bankRates: Option[BankRates] = None,
       equityIndexReturn: Rate = Rate.Zero,

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Immigration: tracks immigrant stock, flows, remittances, spawning/removal.
   */
@@ -56,13 +56,13 @@ object Immigration:
           case _                             => acc
 
   /** Choose sector for new immigrant (weighted by sectorShares). */
-  def chooseSector(rng: Random)(using p: SimParams): SectorIdx =
+  def chooseSector(rng: RandomStream)(using p: SimParams): SectorIdx =
     SectorIdx(Distributions.cdfSample(p.immigration.sectorShares, rng))
 
   /** Spawn new immigrant households. Start as Unemployed(0) — matched in next
     * jobSearch round.
     */
-  def spawnImmigrants(count: Int, startId: Int, rng: Random)(using p: SimParams): Vector[Household.State] =
+  def spawnImmigrants(count: Int, startId: Int, rng: RandomStream)(using p: SimParams): Vector[Household.State] =
     import ComputationBoundary.toDouble
     (0 until count).map { i =>
       val sector                       = chooseSector(rng)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Region.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Region.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.agents
 
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
 
@@ -75,7 +76,7 @@ object Region:
     region.wageMultiplier.ratioTo(weightedMeanWageMultiplier).toMultiplier
 
   /** Sample a region from population share CDF (inverse transform). */
-  def cdfSample(rng: scala.util.Random): Region =
+  def cdfSample(rng: RandomStream): Region =
     all(Distributions.cdfSample(all.map(_.populationShare), rng))
 
   /** Migration friction matrix: `friction(from)(to)` ∈ [0,1]. 0 = no friction

--- a/src/main/scala/com/boombustgroup/amorfati/agents/RegionalMigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/RegionalMigration.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.agents
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Internal migration between NUTS-1 macroregions.
   *
@@ -30,13 +30,13 @@ object RegionalMigration:
   /** Monthly migration step: unemployed HH may relocate to a better region.
     * Employed workers are tied to their firm's region and do not migrate.
     */
-  def apply(households: Vector[Household.State], regionalWages: Map[Region, PLN], rng: Random)(using p: SimParams): Result =
+  def apply(households: Vector[Household.State], regionalWages: Map[Region, PLN], rng: RandomStream)(using p: SimParams): Result =
     Result(households.map(considerMigration(_, regionalWages, rng)))
 
   /** Evaluate migration for a single household. Only unemployed workers
     * consider relocation.
     */
-  private def considerMigration(hh: Household.State, regionalWages: Map[Region, PLN], rng: Random)(using p: SimParams) =
+  private def considerMigration(hh: Household.State, regionalWages: Map[Region, PLN], rng: RandomStream)(using p: SimParams) =
     hh.status match
       case HhStatus.Unemployed(_) => tryRelocate(hh, regionalWages, rng)
       case _                      => hh
@@ -45,7 +45,7 @@ object RegionalMigration:
     * region (highest migration probability), then rolls the dice to decide
     * whether to move.
     */
-  private def tryRelocate(hh: Household.State, regionalWages: Map[Region, PLN], rng: Random)(using p: SimParams) =
+  private def tryRelocate(hh: Household.State, regionalWages: Map[Region, PLN], rng: RandomStream)(using p: SimParams) =
     val currentWage = regionalWages.getOrElse(hh.region, PLN.Zero)
     findBestTarget(hh.region, currentWage, regionalWages).fold(hh): (target, targetScore) =>
       val moveProbability = targetScore * p.regional.baseMigrationRate

--- a/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
@@ -195,9 +195,9 @@ object SimParams:
   * data.
   */
 object FirmSizeDistribution:
-  import scala.util.Random
+  import com.boombustgroup.amorfati.random.RandomStream
 
-  def draw(rng: Random)(using p: SimParams): Int =
+  def draw(rng: RandomStream)(using p: SimParams): Int =
     p.pop.firmSizeDist match
       case FirmSizeDist.Gus     =>
         val micro    = p.pop.firmSizeMicroShare.toLong

--- a/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SocialConfig.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.config
 
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
 
@@ -94,12 +95,12 @@ case class SocialConfig(
   )
 
   /** Draw education tier for a worker in given sector using CDF sampling. */
-  def drawEducation(sectorIdx: Int, rng: scala.util.Random): Int =
+  def drawEducation(sectorIdx: Int, rng: RandomStream): Int =
     val shares = eduSectorShares.getOrElse(defaultEduSectorShares)(sectorIdx.max(0).min(5))
     Distributions.cdfSample(shares, rng)
 
   /** Draw education tier for an immigrant worker. */
-  def drawImmigrantEducation(rng: scala.util.Random): Int =
+  def drawImmigrantEducation(rng: RandomStream): Int =
     Distributions.cdfSample(eduImmigShares, rng)
 
   /** Wage premium multiplier for given education tier (0-3). */

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -2,10 +2,9 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.init.WorldInit
-
-import scala.util.Random
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 
 object BankruptcyProbe:
 
@@ -16,15 +15,14 @@ object BankruptcyProbe:
   @main def runBankruptcyProbe(seed: Long = 1L, months: Int = 12): Unit =
     given SimParams = SimParams.defaults
 
-    val init  = WorldInit.initialize(seed)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
     var state = FlowSimulation.SimState.fromInit(init)
 
     println(s"seed=$seed months=$months")
 
     (1 to months).foreach: month =>
-      val rng          = new Random(seed * 1000 + month)
       val prevById     = state.firms.map(f => f.id -> f).toMap
-      val result       = FlowSimulation.step(state, rng)
+      val result       = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + month))
       val newBankrupts = result.nextState.firms.flatMap: f =>
         bankruptReason(f).flatMap: reason =>
           prevById.get(f.id).flatMap(bankruptReason) match

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -2,13 +2,12 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.RegionalClearing
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
-
-import scala.util.Random
 
 object InflationProbe:
 
@@ -63,7 +62,7 @@ object InflationProbe:
     given SimParams = SimParams.defaults
     import ComputationBoundary.toDouble
 
-    val init  = WorldInit.initialize(seed)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
     var world = init.world
     var firms = init.firms
     var hhs   = init.households
@@ -73,7 +72,7 @@ object InflationProbe:
 
     (1 to months).foreach: month =>
       val population        = world.derivedTotalPopulation.max(1)
-      val rng               = new Random(seed * 1000 + month)
+      val contract          = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
       val fiscal            = FiscalConstraintEconomics.compute(world, banks)
       val s1                = FiscalConstraintEconomics.toOutput(fiscal)
       val labor             = LaborEconomics.compute(world, firms, hhs, s1)
@@ -115,12 +114,23 @@ object InflationProbe:
         labor.living,
         labor.regionalWages,
       )
-      val s3                = HouseholdIncomeEconomics.compute(world, firms, hhs, banks, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
+      val s3                =
+        HouseholdIncomeEconomics.compute(
+          world,
+          firms,
+          hhs,
+          banks,
+          s1.lendingBaseRate,
+          s1.resWage,
+          s2Pre.newWage,
+          contract.stages.householdIncomeEconomics.newStream(),
+        )
       val s4                = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
-      val s5                = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, rng)
+      val s5                = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
       val living            = s5.ioFirms.filter(Firm.isAlive)
       val s2                = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
-      val s6                = HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, rng)
+      val s6                =
+        HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
       val s7                = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(
           world,
@@ -135,10 +145,12 @@ object InflationProbe:
           banks,
           s5,
         ),
-        rng,
+        contract.stages.priceEquityEconomics.newStream(),
       )
-      val s8                = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, banks, rng))
-      val s9                = BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, banks, rng))
+      val s8                =
+        OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, banks, contract.stages.openEconEconomics.newStream()))
+      val s9                =
+        BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, banks, contract.stages.bankingEconomics.newStream()))
 
       val exDev         = exchangeRateValue(world.forex.exchangeRate) / exchangeRateValue(summon[SimParams].forex.baseExRate) - 1.0
       val demandPullM   = toDouble((s4.avgDemandMult.deviationFromOne.toScalar * Scalar(DemandPullWeight)).toCoefficient)
@@ -222,8 +234,7 @@ object InflationProbe:
           priceEquityOutput = s7,
           openEconOutput = s8,
           bankOutput = s9,
-          rng = rng,
-          migRng = rng,
+          randomness = contract.assembly.newStreams(),
         ),
       )
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -2,11 +2,10 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.PLN
-
-import scala.util.Random
 
 object LaborDemandProbe:
 
@@ -150,7 +149,7 @@ object LaborDemandProbe:
   @main def runLaborDemandProbe(seed: Long = 1L, months: Int = 2): Unit =
     given SimParams = SimParams.defaults
 
-    val init  = WorldInit.initialize(seed)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
     var world = init.world
     var firms = init.firms
     var hhs   = init.households
@@ -159,7 +158,7 @@ object LaborDemandProbe:
     println(s"seed=$seed months=$months")
 
     (1 to months).foreach: month =>
-      val rng       = new Random(seed * 1000 + month)
+      val contract  = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
       val beforeAll = sectorSnapshots(firms)
       val hiring    = hiringSummaries(world, firms)
 
@@ -183,11 +182,21 @@ object LaborDemandProbe:
         labor.living,
         labor.regionalWages,
       )
-      val s3     = HouseholdIncomeEconomics.compute(world, firms, hhs, banks, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
+      val s3     =
+        HouseholdIncomeEconomics.compute(
+          world,
+          firms,
+          hhs,
+          banks,
+          s1.lendingBaseRate,
+          s1.resWage,
+          s2Pre.newWage,
+          contract.stages.householdIncomeEconomics.newStream(),
+        )
       val s4     = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
-      val s5     = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, rng)
+      val s5     = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
       val s2Post = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, s5.ioFirms.filter(Firm.isAlive), s5.households)
-      val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, rng)
+      val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
       val s7     = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(
           world,
@@ -202,10 +211,12 @@ object LaborDemandProbe:
           banks,
           s5,
         ),
-        rng,
+        contract.stages.priceEquityEconomics.newStream(),
       )
-      val s8     = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, banks, rng))
-      val s9     = BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, s8, banks, rng))
+      val s8     =
+        OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, banks, contract.stages.openEconEconomics.newStream()))
+      val s9     =
+        BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, s8, banks, contract.stages.bankingEconomics.newStream()))
 
       val afterFirm = sectorSnapshots(s5.ioFirms)
       val changes   = sectorChangeSummaries(firms, s5.ioFirms)
@@ -242,8 +253,7 @@ object LaborDemandProbe:
           priceEquityOutput = s7,
           openEconOutput = s8,
           bankOutput = s9,
-          rng = rng,
-          migRng = rng,
+          randomness = contract.assembly.newStreams(),
         ),
       )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthRandomness.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthRandomness.scala
@@ -1,0 +1,127 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.random.{RandomStream, SeedDerivation}
+
+/** Explicit month-step randomness contract.
+  *
+  * Deterministic replay of one monthly step starts when both the state boundary
+  * and the month `rootSeed` are fixed. All stage and mechanism streams are
+  * derived deterministically from that explicit seed and stay independent.
+  */
+object MonthRandomness:
+
+  enum StreamKey:
+    case HouseholdIncomeEconomics
+    case FirmEconomics
+    case HouseholdFinancialEconomics
+    case PriceEquityEconomics
+    case OpenEconEconomics
+    case BankingEconomics
+    case FdiMa
+    case FirmEntry
+    case StartupStaffing
+    case RegionalMigration
+
+  case class StreamSeed(
+      key: StreamKey,
+      seed: Long,
+  ):
+    def newStream(): RandomStream =
+      RandomStream.seeded(seed)
+
+  case class StageStreams(
+      householdIncomeEconomics: RandomStream,
+      firmEconomics: RandomStream,
+      householdFinancialEconomics: RandomStream,
+      priceEquityEconomics: RandomStream,
+      openEconEconomics: RandomStream,
+      bankingEconomics: RandomStream,
+  )
+
+  case class AssemblyStreams(
+      fdiMa: RandomStream,
+      firmEntry: RandomStream,
+      startupStaffing: RandomStream,
+      regionalMigration: RandomStream,
+  )
+
+  case class StageSeeds(
+      householdIncomeEconomics: StreamSeed,
+      firmEconomics: StreamSeed,
+      householdFinancialEconomics: StreamSeed,
+      priceEquityEconomics: StreamSeed,
+      openEconEconomics: StreamSeed,
+      bankingEconomics: StreamSeed,
+  ):
+    def all: Vector[StreamSeed] =
+      Vector(
+        householdIncomeEconomics,
+        firmEconomics,
+        householdFinancialEconomics,
+        priceEquityEconomics,
+        openEconEconomics,
+        bankingEconomics,
+      )
+
+    def newStreams(): StageStreams =
+      StageStreams(
+        householdIncomeEconomics = householdIncomeEconomics.newStream(),
+        firmEconomics = firmEconomics.newStream(),
+        householdFinancialEconomics = householdFinancialEconomics.newStream(),
+        priceEquityEconomics = priceEquityEconomics.newStream(),
+        openEconEconomics = openEconEconomics.newStream(),
+        bankingEconomics = bankingEconomics.newStream(),
+      )
+
+  case class AssemblySeeds(
+      fdiMa: StreamSeed,
+      firmEntry: StreamSeed,
+      startupStaffing: StreamSeed,
+      regionalMigration: StreamSeed,
+  ):
+    def all: Vector[StreamSeed] =
+      Vector(
+        fdiMa,
+        firmEntry,
+        startupStaffing,
+        regionalMigration,
+      )
+
+    def newStreams(): AssemblyStreams =
+      AssemblyStreams(
+        fdiMa = fdiMa.newStream(),
+        firmEntry = firmEntry.newStream(),
+        startupStaffing = startupStaffing.newStream(),
+        regionalMigration = regionalMigration.newStream(),
+      )
+
+  case class Contract(
+      rootSeed: Long,
+      stages: StageSeeds,
+      assembly: AssemblySeeds,
+  ):
+    def all: Vector[StreamSeed] =
+      stages.all ++ assembly.all
+
+  object Contract:
+    def fromSeed(rootSeed: Long): Contract =
+      Contract(
+        rootSeed = rootSeed,
+        stages = StageSeeds(
+          householdIncomeEconomics = deriveStream(rootSeed, StreamKey.HouseholdIncomeEconomics),
+          firmEconomics = deriveStream(rootSeed, StreamKey.FirmEconomics),
+          householdFinancialEconomics = deriveStream(rootSeed, StreamKey.HouseholdFinancialEconomics),
+          priceEquityEconomics = deriveStream(rootSeed, StreamKey.PriceEquityEconomics),
+          openEconEconomics = deriveStream(rootSeed, StreamKey.OpenEconEconomics),
+          bankingEconomics = deriveStream(rootSeed, StreamKey.BankingEconomics),
+        ),
+        assembly = AssemblySeeds(
+          fdiMa = deriveStream(rootSeed, StreamKey.FdiMa),
+          firmEntry = deriveStream(rootSeed, StreamKey.FirmEntry),
+          startupStaffing = deriveStream(rootSeed, StreamKey.StartupStaffing),
+          regionalMigration = deriveStream(rootSeed, StreamKey.RegionalMigration),
+        ),
+      )
+
+  private def deriveStream(rootSeed: Long, key: StreamKey): StreamSeed =
+    StreamSeed(key, SeedDerivation.derive(rootSeed, key.ordinal.toLong))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -16,6 +16,7 @@ case class MonthTrace(
     month: Int,
     boundary: MonthBoundaryTrace,
     seedTransition: SeedTransitionTrace,
+    randomness: MonthRandomness.Contract,
     timing: MonthTimingTrace,
     executedFlows: Sfc.SemanticFlows,
     validations: Vector[MonthValidation],

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -21,9 +21,10 @@ engine/
 |------|----------------|
 | `World.scala` | Case class holding all macro state, decomposed into 7 nested types: `SocialState`, `FinancialMarketsState`, `ExternalState`, `RealState`, `MechanismsState`, `MonetaryPlumbingState`, `FlowState`. |
 | `MonthSemantics.scala` | Tiny typed phase markers for the internal month step: pre-seed, same-month operational state, post-assembly state, and next pre-seed extraction. |
+| `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and assembly streams for deterministic replay and auditability. |
 | `OperationalSignals.scala` | Explicit same-month signal surface for month-`t` operational execution, kept distinct from persisted start-of-month `DecisionSignals`. |
 | `SignalExtraction.scala` | Explicit post-to-pre boundary: derives next-month `DecisionSignals` and typed seed provenance from realized month-`t` outcomes. |
-| `MonthTrace.scala` | Boundary-focused audit artifact with a stable month core (`boundary`, `seedTransition`, validations) plus extensible typed timing envelopes. |
+| `MonthTrace.scala` | Boundary-focused audit artifact with a stable month core (`boundary`, `seedTransition`, `randomness`, validations) plus extensible typed timing envelopes. |
 
 ## Month Step Boundary
 
@@ -36,17 +37,19 @@ case class StepOutput(
   stateIn: SimState,
   operationalSignals: OperationalSignals,
   signalExtraction: SignalExtraction.Output,
+  randomness: MonthRandomness.Contract,
   trace: MonthTrace,
   nextState: SimState,
   ...
 )
 
-def step(state: SimState, rng: Random): StepOutput
+def step(state: SimState, randomness: MonthRandomness.Contract): StepOutput
 ```
 
 Read it as a month transition:
 
 - `stateIn.world.seedIn` is the persisted `pre` input surface.
+- `randomness` is the explicit month-level randomness surface; fixing `stateIn` and `randomness.rootSeed` fixes replay for one step.
 - `MonthOutcome` is the internal bridge from same-month computation to post-month assembly.
 - `operationalSignals` is the explicit same-month surface created inside the step.
 - `signalExtraction` is the dedicated `post -> pre` boundary.
@@ -80,7 +83,7 @@ against 13 accounting identities each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point. `step(state, rng)` is the explicit month boundary: it computes typed `StageOutputs`, narrows them into `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point. `step(state, randomness)` is the explicit month boundary: it computes typed `StageOutputs`, narrows them into `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `FirmWages`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `StateAdapter.scala` | Legacy bridge from economics/world state into specific flow inputs. Kept only as transitional adapter code around the newer pipeline. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -8,7 +8,7 @@ import com.boombustgroup.amorfati.engine.mechanisms.{TaxRevenue, YieldCurve}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.Distribute
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Banking sector economics — aggregate values for MonthlyCalculus.
   *
@@ -39,7 +39,7 @@ object BankingEconomics:
       s7: PriceEquityEconomics.Output,        // price/equity (inflation, GDP, equity state, macropru)
       s8: OpenEconEconomics.StepOutput,       // open economy (NBP rate, bond yield, QE, FX, BoP)
       banks: Vector[Banking.BankState],       // explicit bank population
-      depositRng: scala.util.Random,          // deterministic RNG for deposit flight decisions
+      depositRng: RandomStream,               // deterministic RNG for deposit flight decisions
   )
 
   case class StepOutput(
@@ -166,7 +166,7 @@ object BankingEconomics:
       priceEquityOutput: PriceEquityEconomics.Output,
       openEconOutput: OpenEconEconomics.StepOutput,
       banks: Vector[Banking.BankState],
-      depositRng: Random,
+      depositRng: RandomStream,
   )
 
   case class Result(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.engine.{OperationalSignals, World}
 import com.boombustgroup.amorfati.engine.markets.{CalvoPricing, CorporateBondMarket, IntermediateMarket, LaborMarket}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Firm sector economics — production, I-O intermediate market, CAPEX
   * decisions, financing splits (equity/bonds/bank loans), labor matching, NPL
@@ -174,7 +174,7 @@ object FirmEconomics:
       govPurchases: PLN,
       laggedInvestDemand: PLN,
       fiscalRuleStatus: com.boombustgroup.amorfati.engine.markets.FiscalRules.RuleStatus,
-      rng: Random,
+      rng: RandomStream,
   )
 
   /** Full step output — all fields previously in FirmProcessingStep.Output. */
@@ -293,7 +293,7 @@ object FirmEconomics:
       s2: LaborEconomics.Output,
       s3: HouseholdIncomeEconomics.Output,
       s4: DemandEconomics.Output,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): StepOutput =
     val stepIn = StepInput(w, firms, households, banks, s1, s2, s3, s4)
     runInternal(stepIn, rng)
@@ -338,7 +338,7 @@ object FirmEconomics:
   // ---- Core pipeline (shared by compute + runStep) ----
 
   @boundaryEscape
-  private def runInternal(stepIn: StepInput, rng: Random)(using p: SimParams): StepOutput =
+  private def runInternal(stepIn: StepInput, rng: RandomStream)(using p: SimParams): StepOutput =
     val lending                             = prepareLending(stepIn, rng)
     val fp                                  = processFirms(stepIn.firms, lending, rng)
     val bonded                              = applyBondAbsorption(fp, stepIn.w, stepIn.banks)
@@ -372,7 +372,7 @@ object FirmEconomics:
     * wages for firm decision-making.
     */
   @boundaryEscape
-  private def prepareLending(in: StepInput, rng: Random)(using p: SimParams): LendingConditions =
+  private def prepareLending(in: StepInput, rng: RandomStream)(using p: SimParams): LendingConditions =
     import ComputationBoundary.toDouble
     val bsec               = in.w.bankingSector
     val nBanks             = in.banks.length
@@ -402,7 +402,7 @@ object FirmEconomics:
   private def processFirms(
       firms: Vector[Firm.State],
       lending: LendingConditions,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): FirmProcessingResult =
     val outcomes = firms.map: f =>
       val rate    = lending.rates(f.bankId.toInt)
@@ -528,7 +528,7 @@ object FirmEconomics:
   private def processLaborMarket(
       ioFirms: Vector[Firm.State],
       in: StepInput,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): (Vector[Household.State], Int) =
     val afterSep     = LaborMarket.separations(in.s3.updatedHouseholds, in.firms, ioFirms)
     val searchResult = LaborMarket.jobSearch(afterSep, ioFirms, in.s2.newWage, rng, in.s2.regionalWages)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 /** Pure economic logic for household financial flows — no state mutation, no
@@ -42,7 +43,7 @@ object HouseholdFinancialEconomics:
       month: Int,
       employed: Int,
       hhAgg: Household.Aggregates,
-      @annotation.unused rng: scala.util.Random,
+      @annotation.unused rng: RandomStream,
   )(using p: SimParams): Output =
     import ComputationBoundary.toDouble
     val hhDebtService       = hhAgg.totalDebtService

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdIncomeEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdIncomeEconomics.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.engine.mechanisms.SectoralMobility
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Pure economic logic for household income determination — no state mutation,
   * no flows.
@@ -48,7 +48,7 @@ object HouseholdIncomeEconomics:
       lendingBaseRate: Rate,
       resWage: PLN,
       newWage: PLN,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Output =
     import ComputationBoundary.toDouble
     val importAdj = Share(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, GvcTrade,
 import com.boombustgroup.amorfati.engine.mechanisms.Expectations
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Self-contained open economy economics — calls market functions directly.
   *
@@ -159,7 +159,7 @@ object OpenEconEconomics:
       fdiRepatriation: PLN,
       foreignDividendOutflow: PLN,
       month: Int,
-      commodityRng: Random,
+      commodityRng: RandomStream,
   )
 
   @boundaryEscape
@@ -355,7 +355,7 @@ object OpenEconEconomics:
       s6: HouseholdFinancialEconomics.Output,
       s7: PriceEquityEconomics.Output,
       banks: Vector[Banking.BankState],
-      commodityRng: Random,
+      commodityRng: RandomStream,
   )
 
   private val NbfiDepositRateSpread = 0.02

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -8,7 +8,7 @@ import com.boombustgroup.amorfati.engine.mechanisms.{EuFunds, Macroprudential}
 import com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Pure economic logic for price level dynamics, GPW equity market, GDP
   * computation, macroprudential policy, Arthur-style sigma evolution, and
@@ -137,7 +137,7 @@ object PriceEquityEconomics:
   // ---------------------------------------------------------------------------
 
   @boundaryEscape
-  private[economics] def rewireFirms(firms: Vector[Firm.State], rho: Double, rng: Random)(using p: SimParams): Vector[Firm.State] =
+  private[economics] def rewireFirms(firms: Vector[Firm.State], rho: Double, rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
     import ComputationBoundary.toDouble
     if rho == 0.0 then return firms
 
@@ -222,7 +222,7 @@ object PriceEquityEconomics:
   // ---------------------------------------------------------------------------
 
   @boundaryEscape
-  def compute(in: Input, rng: Random)(using p: SimParams): Output =
+  def compute(in: Input, rng: RandomStream)(using p: SimParams): Output =
     import ComputationBoundary.toDouble
     val living2           = in.s5.ioFirms.filter(Firm.isAlive)
     val nLiving           = living2.length.toDouble

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -9,7 +9,7 @@ import com.boombustgroup.amorfati.engine.markets.{EquityMarket, LaborMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, InformalEconomy, SectoralMobility}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** WorldAssembly economics: aggregation, informal economy, observables.
   *
@@ -112,8 +112,7 @@ object WorldAssemblyEconomics:
       priceEquityOutput: PriceEquityEconomics.Output,
       openEconOutput: OpenEconEconomics.StepOutput,
       bankOutput: BankingEconomics.StepOutput,
-      rng: Random,
-      migRng: Random,
+      randomness: MonthRandomness.AssemblyStreams,
   )
 
   case class Result(
@@ -196,22 +195,20 @@ object WorldAssemblyEconomics:
 
   private[engine] def computePostMonth(
       step: StepInput,
-      rng: Random,
-      migRng: Random,
+      randomness: MonthRandomness.AssemblyStreams,
   )(using SimParams): PostResult =
     runPostStep(
       step,
-      rng,
-      migRng,
+      randomness,
     )
 
   private[engine] def computePostMonth(in: Input)(using SimParams): PostResult =
-    computePostMonth(buildStepInput(in), in.rng, in.migRng)
+    computePostMonth(buildStepInput(in), in.randomness)
 
   def compute(in: Input)(using SimParams): Result =
     val step        = buildStepInput(in)
     val signalInput = buildSignalExtractionInput(step)
-    val post        = computePostMonth(step, in.rng, in.migRng)
+    val post        = computePostMonth(step, in.randomness)
     val seed        = extractSignalExtraction(signalInput, post)
     Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)
 
@@ -219,9 +216,9 @@ object WorldAssemblyEconomics:
   // runStep — migrated from WorldAssemblyStep.run
   // ---------------------------------------------------------------------------
 
-  def runStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): StepOutput =
+  def runStep(in: StepInput, randomness: MonthRandomness.AssemblyStreams)(using p: SimParams): StepOutput =
     val signalInput      = buildSignalExtractionInput(in)
-    val post             = runPostStep(in, rng, migRng)
+    val post             = runPostStep(in, randomness)
     val signalExtraction = extractSignalExtraction(signalInput, post)
     StepOutput(
       newWorld = advanceToBoundaryWorld(post.world, signalExtraction.seedOut),
@@ -232,7 +229,7 @@ object WorldAssemblyEconomics:
       signalExtraction = signalExtraction,
     )
 
-  private[engine] def runPostStep(in: StepInput, rng: Random, migRng: Random)(using p: SimParams): PostResult =
+  private[engine] def runPostStep(in: StepInput, randomness: MonthRandomness.AssemblyStreams)(using p: SimParams): PostResult =
     val equityAfterStep = finalizeEquity(in)
     val fofResidual     = computeFofResidual(in)
     val informal        = computeInformalEconomy(in)
@@ -241,21 +238,21 @@ object WorldAssemblyEconomics:
 
     val newW = assembleWorld(in, equityAfterStep, fofResidual, informal, obs)
 
-    val postFdiFirms = applyFdiMa(in.s9.reassignedFirms, rng)
+    val postFdiFirms = applyFdiMa(in.s9.reassignedFirms, randomness.fdiMa)
     val entryStep    =
       val r = FirmEntry.process(
         postFdiFirms,
         newW.real.automationRatio,
         newW.real.hybridRatio,
         FirmEntry.LaggedEntrySignals.fromDecisionSignals(seedIn),
-        rng,
+        randomness.firmEntry,
       )
       EntryStepResult(r.firms, r.births, r.netBirths, r.entrantIds)
 
-    val startupStaffing = applyStartupStaffing(in, entryStep.firms, in.s9.reassignedHouseholds, rng)
+    val startupStaffing = applyStartupStaffing(in, entryStep.firms, in.s9.reassignedHouseholds, randomness.startupStaffing)
 
     // Regional migration: unemployed HH may relocate between NUTS-1 regions
-    val postMigHh  = RegionalMigration(startupStaffing.households, in.s2.regionalWages, migRng).households
+    val postMigHh  = RegionalMigration(startupStaffing.households, in.s2.regionalWages, randomness.regionalMigration).households
     val finalFirms = syncStartupStaffing(startupStaffing.firms, postMigHh)
     val finalW     = newW
       .updatePipeline(_ => buildPostMonthPipelineState(in))
@@ -363,7 +360,7 @@ object WorldAssemblyEconomics:
       in: StepInput,
       firms: Vector[Firm.State],
       households: Vector[Household.State],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): StartupStaffingResult =
     val startupIds = firms.filter(f => Firm.isAlive(f) && Firm.isInStartup(f)).map(_.id).toSet
     if startupIds.isEmpty then StartupStaffingResult(syncStartupStaffing(firms, households), households, in.s9.finalHhAgg, 0, Share.One)
@@ -665,7 +662,7 @@ object WorldAssemblyEconomics:
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign
     * ownership, representing cross-border mergers and acquisitions.
     */
-  private def applyFdiMa(firms: Vector[Firm.State], rng: Random)(using p: SimParams): Vector[Firm.State] =
+  private def applyFdiMa(firms: Vector[Firm.State], rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
     if p.fdi.maProb > Share.Zero then
       firms.map: f =>
         if Firm.isAlive(f) && !f.foreignOwned &&

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -301,16 +301,16 @@ object FlowSimulation:
   private def computeStageOutputs(
       input: StepInput,
   )(using p: SimParams): StageOutputs =
-    val randomness      = input.randomness.stages
-    val stateIn         = input.stateIn
-    val w               = stateIn.world
-    val firms           = stateIn.firms
-    val households      = stateIn.households
-    val banks           = stateIn.banks
-    val fiscal          = FiscalConstraintEconomics.compute(w, banks)
-    val s1              = FiscalConstraintEconomics.toOutput(fiscal)
-    val labor           = LaborEconomics.compute(w, firms, households, s1)
-    val s2Pre           = LaborEconomics.Output(
+    val randomness        = input.randomness.stages
+    val stateIn           = input.stateIn
+    val w                 = stateIn.world
+    val firms             = stateIn.firms
+    val households        = stateIn.households
+    val banks             = stateIn.banks
+    val fiscal            = FiscalConstraintEconomics.compute(w, banks)
+    val s1                = FiscalConstraintEconomics.toOutput(fiscal)
+    val labor             = LaborEconomics.compute(w, firms, households, s1)
+    val s2Pre             = LaborEconomics.Output(
       labor.wage,
       labor.employed,
       labor.laborDemand,
@@ -327,7 +327,7 @@ object FlowSimulation:
       labor.living,
       labor.regionalWages,
     )
-    val s3              = HouseholdIncomeEconomics.compute(
+    val s3                = HouseholdIncomeEconomics.compute(
       w,
       firms,
       households,
@@ -337,12 +337,12 @@ object FlowSimulation:
       s2Pre.newWage,
       randomness.householdIncomeEconomics.newStream(),
     )
-    val s4              = DemandEconomics.compute(DemandEconomics.Input(w, s2Pre.employed, s2Pre.living, s3.domesticCons))
-    val s5              = FirmEconomics.runStep(w, firms, households, banks, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
-    val postLivingFirms = s5.ioFirms.filter(Firm.isAlive)
-    val s2              = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
-    val s6              = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())
-    val s7              = PriceEquityEconomics.compute(
+    val s4                = DemandEconomics.compute(DemandEconomics.Input(w, s2Pre.employed, s2Pre.living, s3.domesticCons))
+    val s5                = FirmEconomics.runStep(w, firms, households, banks, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
+    val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
+    val s2                = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
+    val s6                = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())
+    val s7                = PriceEquityEconomics.compute(
       PriceEquityEconomics.Input(
         w,
         s1.m,
@@ -358,7 +358,7 @@ object FlowSimulation:
       ),
       randomness.priceEquityEconomics.newStream(),
     )
-    val openEcon        = OpenEconEconomics.compute(
+    val openEcon          = OpenEconEconomics.compute(
       OpenEconEconomics.Input(
         w = w,
         employed = s2.employed,
@@ -390,11 +390,12 @@ object FlowSimulation:
         commodityRng = randomness.openEconEconomics.newStream(),
       ),
     )
-    val s8              = OpenEconEconomics.runStep(
+    val s8                = OpenEconEconomics.runStep(
       OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, banks, randomness.openEconEconomics.newStream()),
     )
-    val operational     = operationalSignals(s2, s4)
-    val bankingInput    = BankingEconomics.Input(
+    val operational       = operationalSignals(s2, s4)
+    val bankingDepositRng = randomness.bankingEconomics.newStream()
+    val bankingInput      = BankingEconomics.Input(
       w = w,
       month = fiscal.month,
       lendingBaseRate = fiscal.lendingBaseRate,
@@ -418,16 +419,16 @@ object FlowSimulation:
       priceEquityOutput = s7,
       openEconOutput = s8,
       banks = banks,
-      depositRng = randomness.bankingEconomics.newStream(),
+      depositRng = bankingDepositRng,
     )
-    val s9              = BankingEconomics.runStep(
-      BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, banks, randomness.bankingEconomics.newStream()),
+    val s9                = BankingEconomics.runStep(
+      BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, banks, bankingDepositRng),
     )
-    val banking         = BankingEconomics.toResult(s9, bankingInput)
-    val agg             = s3.hhAgg
-    val eq              = w.financial.equity
-    val h               = s9.housingAfterFlows
-    val calc            = MonthlyCalculus(
+    val banking           = BankingEconomics.toResult(s9, bankingInput)
+    val agg               = s3.hhAgg
+    val eq                = w.financial.equity
+    val h                 = s9.housingAfterFlows
+    val calc              = MonthlyCalculus(
       month = fiscal.month,
       resWage = fiscal.resWage,
       lendingBaseRate = fiscal.lendingBaseRate,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -9,8 +9,6 @@ import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
-import scala.util.Random
-
 /** New flow-based simulation pipeline.
   *
   * Three stages per month:
@@ -26,7 +24,7 @@ object FlowSimulation:
   /** Single typed input to one monthly step.
     *
     * The simulation loop should treat this as the month-`t` boundary state that
-    * flows into one `step(state, rng)` transition.
+    * flows into one `step(state, randomness)` transition.
     */
   case class SimState(
       world: World,
@@ -246,6 +244,7 @@ object FlowSimulation:
   case class StepInput(
       stateIn: SimState,
       seedIn: MonthSemantics.SeedIn,
+      randomness: MonthRandomness.Contract,
   )
 
   /** Same-month stage outputs computed exactly once and reused by every
@@ -301,8 +300,8 @@ object FlowSimulation:
     */
   private def computeStageOutputs(
       input: StepInput,
-      rng: Random,
   )(using p: SimParams): StageOutputs =
+    val randomness      = input.randomness.stages
     val stateIn         = input.stateIn
     val w               = stateIn.world
     val firms           = stateIn.firms
@@ -328,12 +327,21 @@ object FlowSimulation:
       labor.living,
       labor.regionalWages,
     )
-    val s3              = HouseholdIncomeEconomics.compute(w, firms, households, banks, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
+    val s3              = HouseholdIncomeEconomics.compute(
+      w,
+      firms,
+      households,
+      banks,
+      s1.lendingBaseRate,
+      s1.resWage,
+      s2Pre.newWage,
+      randomness.householdIncomeEconomics.newStream(),
+    )
     val s4              = DemandEconomics.compute(DemandEconomics.Input(w, s2Pre.employed, s2Pre.living, s3.domesticCons))
-    val s5              = FirmEconomics.runStep(w, firms, households, banks, s1, s2Pre, s3, s4, rng)
+    val s5              = FirmEconomics.runStep(w, firms, households, banks, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
     val postLivingFirms = s5.ioFirms.filter(Firm.isAlive)
     val s2              = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
-    val s6              = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, rng)
+    val s6              = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())
     val s7              = PriceEquityEconomics.compute(
       PriceEquityEconomics.Input(
         w,
@@ -348,7 +356,7 @@ object FlowSimulation:
         banks,
         s5,
       ),
-      rng,
+      randomness.priceEquityEconomics.newStream(),
     )
     val openEcon        = OpenEconEconomics.compute(
       OpenEconEconomics.Input(
@@ -379,10 +387,12 @@ object FlowSimulation:
         foreignDividendOutflow = s7.foreignDividendOutflow,
         banks = banks,
         month = fiscal.month,
-        commodityRng = rng,
+        commodityRng = randomness.openEconEconomics.newStream(),
       ),
     )
-    val s8              = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, banks, rng))
+    val s8              = OpenEconEconomics.runStep(
+      OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, banks, randomness.openEconEconomics.newStream()),
+    )
     val operational     = operationalSignals(s2, s4)
     val bankingInput    = BankingEconomics.Input(
       w = w,
@@ -408,9 +418,11 @@ object FlowSimulation:
       priceEquityOutput = s7,
       openEconOutput = s8,
       banks = banks,
-      depositRng = rng,
+      depositRng = randomness.bankingEconomics.newStream(),
     )
-    val s9              = BankingEconomics.runStep(BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, banks, rng))
+    val s9              = BankingEconomics.runStep(
+      BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, banks, randomness.bankingEconomics.newStream()),
+    )
     val banking         = BankingEconomics.toResult(s9, bankingInput)
     val agg             = s3.hhAgg
     val eq              = w.financial.equity
@@ -501,13 +513,13 @@ object FlowSimulation:
 
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
-  def computeCalculus(state: SimState, rng: Random)(using p: SimParams): MonthlyCalculus =
+  def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
     computeStageOutputs(
       StepInput(
         stateIn = state,
         seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
+        randomness = randomness,
       ),
-      rng,
     ).calculus
 
   /** Full month-step contract.
@@ -522,6 +534,7 @@ object FlowSimulation:
       calculus: MonthlyCalculus,
       operationalSignals: OperationalSignals,
       signalExtraction: SignalExtraction.Output,
+      randomness: MonthRandomness.Contract,
       flows: Vector[BatchedFlow],
       execution: ExecutionResult,
       sfcResult: Sfc.SfcResult,
@@ -703,11 +716,8 @@ object FlowSimulation:
   private def assemblePostMonth(
       input: StepInput,
       stageView: MonthSemantics.StageView,
-      rng: Random,
   )(using p: SimParams): MonthSemantics.PostAssembly =
     val stages    = stageView.value
-    // Keep migration draws on an independent RNG stream.
-    val migRng    = new Random(rng.nextLong())
     val assembled = WorldAssemblyEconomics.computePostMonth(
       WorldAssemblyEconomics.Input(
         w = input.stateIn.world,
@@ -734,8 +744,7 @@ object FlowSimulation:
         openEconOutput = stages.openEcon,
         bankOutput = stages.banking,
         banks = input.stateIn.banks,
-        rng = rng,
-        migRng = migRng,
+        randomness = input.randomness.assembly.newStreams(),
       ),
     )
     // This stays at month `t`: the boundary seed is still `seedIn` here.
@@ -768,13 +777,12 @@ object FlowSimulation:
 
   private def computeMonthOutcome(
       input: StepInput,
-      rng: Random,
   )(using p: SimParams): MonthOutcome =
     // Keep the month-step pipeline explicit:
     // `seedIn/pre -> same-month stages -> post-month assembly -> seedOut/next-pre`.
-    val stageView   = MonthSemantics.At[StageOutputs, MonthSemantics.SameMonth](computeStageOutputs(input, rng))
+    val stageView   = MonthSemantics.At[StageOutputs, MonthSemantics.SameMonth](computeStageOutputs(input))
     val operational = buildOperationalSignals(stageView)
-    val post        = assemblePostMonth(input, stageView, rng)
+    val post        = assemblePostMonth(input, stageView)
     val seedOut     = extractSeedOut(stageView, post)
 
     MonthOutcome(
@@ -827,6 +835,7 @@ object FlowSimulation:
         seedOut = seedOut.seedOut,
         provenance = seedOut.provenance,
       ),
+      randomness = input.randomness,
       timing = MonthTimingTrace(
         Vector(
           MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.LaborSignals, traceInputs.labor),
@@ -844,9 +853,13 @@ object FlowSimulation:
     * The internal month-step shape is now explicit:
     * `stateIn -> StepInput -> MonthOutcome -> nextState`.
     */
-  def step(stateIn: SimState, rng: Random)(using p: SimParams): StepOutput =
-    val input      = StepInput(stateIn, MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn))
-    val outcome    = computeMonthOutcome(input, rng)
+  def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
+    val input      = StepInput(
+      stateIn,
+      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
+      randomness,
+    )
+    val outcome    = computeMonthOutcome(input)
     val flows      = emitAllBatches(outcome.stages.value.calculus)
     val execution  = executeBatches(flows).fold(
       err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
@@ -875,6 +888,7 @@ object FlowSimulation:
       calculus = outcome.stages.value.calculus,
       operationalSignals = outcome.operational.value,
       signalExtraction = outcome.seedOut.value,
+      randomness = randomness,
       flows,
       execution,
       sfcResult,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.agents.Firm
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Calvo staggered pricing: micro-founded price stickiness.
   *
@@ -69,7 +69,7 @@ object CalvoPricing:
       currentMarkup: Multiplier,
       sectorDemandMult: Multiplier,
       wageGrowthMonthly: Coefficient,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): FirmMarkupResult =
     if p.pricing.calvoTheta.sampleBelow(rng) then FirmMarkupResult(optimalMarkup(sectorDemandMult, wageGrowthMonthly), priceChanged = true)
     else FirmMarkupResult(currentMarkup, priceChanged = false)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.markets
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 /** Global Value Chain trade: per-sector exports/imports with partner
@@ -90,7 +91,7 @@ object GvcTrade:
       exchangeRate: ExchangeRate,
       autoRatio: Share,
       month: Int,
-      rng: scala.util.Random,
+      rng: RandomStream,
   )
 
   def step(in: StepInput)(using p: SimParams): State =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.mechanisms.SectoralMobility
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Labor market: wage determination, separations, job search, wage updating.
   *
@@ -109,7 +109,7 @@ object LaborMarket:
       households: Vector[Household.State],
       firms: Vector[Firm.State],
       marketWage: PLN,
-      @scala.annotation.unused rng: Random,
+      @scala.annotation.unused rng: RandomStream,
       regionalWages: Map[Region, PLN] = Map.empty,
       eligibleFirmIds: Set[FirmId] = Set.empty,
   )(using p: SimParams): JobSearchResult =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/FirmEntry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/FirmEntry.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.config.{FirmSizeDistribution, SimParams}
 import com.boombustgroup.amorfati.engine.DecisionSignals
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Endogenous firm entry: replaces a share of bankrupt firm slots and may also
   * append net new firms when unemployment exceeds NAIRU. Sector choice is
@@ -70,7 +70,7 @@ object FirmEntry:
       automationRatio: Share,
       hybridRatio: Share,
       laggedSignals: LaggedEntrySignals,
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Result =
     val living        = firms.filter(Firm.isAlive)
     val profitSignals = computeProfitSignals(living)
@@ -91,7 +91,7 @@ object FirmEntry:
       totalAdoption: Share,
       livingIds: Vector[Int],
       sectorWeights: Vector[Multiplier],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): (Vector[Firm.State], Set[FirmId]) =
     val deadSlots = firms.filterNot(Firm.isAlive)
     if deadSlots.isEmpty then return (firms, Set.empty)
@@ -125,7 +125,7 @@ object FirmEntry:
       totalAdoption: Share,
       livingIds: Vector[Int],
       sectorWeights: Vector[Multiplier],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): (Vector[Firm.State], Int, Set[FirmId]) =
     val signal   = expansionaryEntrySignal(laggedSignals)
     if signal <= Share.Zero then return (firms, 0, Set.empty)
@@ -176,7 +176,7 @@ object FirmEntry:
       sectorWeights: Vector[Multiplier],
       totalAdoption: Share,
       livingIds: Vector[Int],
-      rng: Random,
+      rng: RandomStream,
   )(using p: SimParams): Firm.State =
     val newSector    = pickSector(sectorWeights, rng)
     val firmSize     = FirmSizeDistribution.draw(rng)
@@ -219,7 +219,7 @@ object FirmEntry:
     * automation; conventional entrants use Traditional (workers hired via labor
     * market in subsequent steps).
     */
-  private def chooseTechnology(isAiNative: Boolean, firmSize: Int, rng: Random): TechState =
+  private def chooseTechnology(isAiNative: Boolean, firmSize: Int, rng: RandomStream): TechState =
     if isAiNative then
       val hybridWorkers = Math.max(HybridMinWorkers, firmSize)
       TechState.Hybrid(hybridWorkers, TypedRandom.randomBetween(MinAiProductivity, MaxAiProductivity, rng))
@@ -229,7 +229,7 @@ object FirmEntry:
     * conventional entrants draw from sector baseline with Gaussian noise,
     * clamped to the feasible range for non-digital firms.
     */
-  private def drawDigitalReadiness(isAiNative: Boolean, sector: Int, rng: Random)(using p: SimParams): Share =
+  private def drawDigitalReadiness(isAiNative: Boolean, sector: Int, rng: RandomStream)(using p: SimParams): Share =
     if isAiNative then TypedRandom.randomBetween(AiNativeMinDr, AiNativeMaxDr, rng)
     else
       TypedRandom
@@ -237,7 +237,7 @@ object FirmEntry:
         .clamp(ConventionalDrFloor, ConventionalDrCap)
 
   /** Assign network neighbors from the living firm population. */
-  private def assignNeighbors(livingIds: Vector[Int], rng: Random): Vector[FirmId] =
+  private def assignNeighbors(livingIds: Vector[Int], rng: RandomStream): Vector[FirmId] =
     val nNeighbors = Math.min(MaxNeighbors, livingIds.length)
     if nNeighbors > 0 then rng.shuffle(livingIds.toList).take(nNeighbors).map(FirmId(_)).toVector
     else Vector.empty[FirmId]
@@ -257,10 +257,10 @@ object FirmEntry:
   private def initGreenCapital(firmSize: Int, sector: Int)(using p: SimParams): PLN =
     (firmSize * p.climate.greenKLRatios(sector)) * p.climate.greenInitRatio
 
-  private def pickSector(sectorWeights: Vector[Multiplier], rng: Random): Int =
+  private def pickSector(sectorWeights: Vector[Multiplier], rng: RandomStream): Int =
     WeightedSelection.choose(sectorWeights, rng)
 
-  private def drawStartupTargetWorkers(firmSize: Int, rng: Random): Int =
+  private def drawStartupTargetWorkers(firmSize: Int, rng: RandomStream): Int =
     val lower = Math.min(firmSize, StartupMinWorkers.max(Math.min(2, firmSize)))
     val upper = Math.min(firmSize, StartupMaxWorkers).max(lower)
     rng.between(lower, upper + 1)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/SectoralMobility.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/SectoralMobility.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
 import scala.annotation.unused
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Cross-sector labour mobility: friction-based transitions, voluntary quits,
   * wage penalties.
@@ -83,7 +83,7 @@ object SectoralMobility:
       vacancies: Vector[Int],
       matrix: Vector[Vector[Share]],
       vacancyWeight: Coefficient,
-      rng: Random,
+      rng: RandomStream,
   )(using @unused p: SimParams): Int =
     val scores = gravityScores(from, wages, vacancies, matrix, vacancyWeight)
     if scores.forall(_ <= Multiplier.Zero) then uniformFallback(from, rng)
@@ -117,7 +117,7 @@ object SectoralMobility:
       .getOrElse(scores.indices.find(_ != from).get)
 
   /** Uniform random fallback when all scores are zero. */
-  private def uniformFallback(from: Int, rng: Random): Int =
+  private def uniformFallback(from: Int, rng: RandomStream): Int =
     val others = (0 until NumSectors).filter(_ != from)
     others(rng.nextInt(others.length))
 

--- a/src/main/scala/com/boombustgroup/amorfati/fp/ScalarProvider.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/fp/ScalarProvider.scala
@@ -1,17 +1,18 @@
 package com.boombustgroup.amorfati.fp
 
 import FixedPointBase.*
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Dimensionless scalar used for algebraic composition and ratios. */
 object ScalarProvider:
   opaque type Scalar = Long
 
   object Scalar:
-    val Zero: Scalar                                                          = 0L
-    val One: Scalar                                                           = Scale
-    def apply(d: Double): Scalar                                              = Math.round(d * Scale)
-    def fromRaw(raw: Long): Scalar                                            = raw
-    def fraction(num: Int, den: Int): Scalar                                  =
+    val Zero: Scalar                                                     = 0L
+    val One: Scalar                                                      = Scale
+    def apply(d: Double): Scalar                                         = Math.round(d * Scale)
+    def fromRaw(raw: Long): Scalar                                       = raw
+    def fraction(num: Int, den: Int): Scalar                             =
       if den == 0 then Zero
       else
         val scaled         = BigInt(num.toLong) * BigInt(Scale)
@@ -26,7 +27,7 @@ object ScalarProvider:
           if twiceRemainder > denominatorAbs then (quotient + resultSign).toLong
           else if quotient % 2 == 0 then quotient.toLong
           else (quotient + resultSign).toLong
-    def randomBetween(lo: Scalar, hi: Scalar, rng: scala.util.Random): Scalar =
+    def randomBetween(lo: Scalar, hi: Scalar, rng: RandomStream): Scalar =
       if hi <= lo then lo
       else Scalar.fromRaw(rng.between(lo.toLong, hi.toLong))
 

--- a/src/main/scala/com/boombustgroup/amorfati/fp/ShareProvider.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/fp/ShareProvider.scala
@@ -1,16 +1,17 @@
 package com.boombustgroup.amorfati.fp
 
 import FixedPointBase.*
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Bounded [0,1] fractions, probabilities, proportions. */
 object ShareProvider:
   opaque type Share = Long
 
   object Share:
-    val Zero: Share                           = 0L
-    val One: Share                            = Scale
-    def apply(d: Double): Share               = Math.round(d * Scale)
-    def fraction(num: Int, den: Int): Share   =
+    val Zero: Share                         = 0L
+    val One: Share                          = Scale
+    def apply(d: Double): Share             = Math.round(d * Scale)
+    def fraction(num: Int, den: Int): Share =
       if den == 0 then Zero
       else
         val scaled         = BigInt(num.toLong) * BigInt(Scale)
@@ -25,8 +26,8 @@ object ShareProvider:
           if twiceRemainder > denominatorAbs then (quotient + resultSign).toLong
           else if quotient % 2 == 0 then quotient.toLong
           else (quotient + resultSign).toLong
-    def fromRaw(raw: Long): Share             = raw
-    def random(rng: scala.util.Random): Share = Share.fromRaw(rng.nextInt(Scale.toInt).toLong)
+    def fromRaw(raw: Long): Share           = raw
+    def random(rng: RandomStream): Share    = Share.fromRaw(rng.nextInt(Scale.toInt).toLong)
 
   extension (s: Share)
     inline def toLong: Long                = s
@@ -48,7 +49,7 @@ object ShareProvider:
     def <=(other: Share): Boolean          = s <= other
 
     /** True if rng.nextDouble() < this share. For probability sampling. */
-    def sampleBelow(rng: scala.util.Random): Boolean = rng.nextInt(Scale.toInt) < s
+    def sampleBelow(rng: RandomStream): Boolean = rng.nextInt(Scale.toInt) < s
 
   extension (n: Int) def *(s: Share): Double = n.toDouble * (s.toDouble / ScaleD)
 

--- a/src/main/scala/com/boombustgroup/amorfati/init/FirmInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/FirmInit.scala
@@ -3,9 +3,8 @@ package com.boombustgroup.amorfati.init
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.*
 import com.boombustgroup.amorfati.networks.Network
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
-
-import scala.util.Random
 
 /** Initial firm population factory.
   *
@@ -38,18 +37,18 @@ object FirmInit:
   private val InitHybridProb     = 0.08      // ~8% of eligible firms start as Hybrid (OECD 2024: 5-10%)
 
   /** Create firm array with all post-creation enhancements. */
-  def create(rng: Random)(using p: SimParams): Vector[Firm.State] =
-    val adjList           = buildNetwork(rng)
-    val sectorAssignments = assignSectors(rng)
-    val skeleton          = buildSkeleton(adjList, sectorAssignments, rng)
-    val withCapAndBank    = assignCapitalAndBank(skeleton, rng)
-    val withFdi           = assignForeignOwnership(withCapAndBank, rng)
-    val withSoe           = assignStateOwnership(withFdi, rng)
+  def create(randomness: InitRandomness.FirmStreams)(using p: SimParams): Vector[Firm.State] =
+    val adjList           = buildNetwork(randomness.network)
+    val sectorAssignments = assignSectors(randomness.sectorAssignments)
+    val skeleton          = buildSkeleton(adjList, sectorAssignments, randomness.skeleton, randomness.regions)
+    val withCapAndBank    = assignCapitalAndBank(skeleton, randomness.capitalAndBank)
+    val withFdi           = assignForeignOwnership(withCapAndBank, randomness.foreignOwnership)
+    val withSoe           = assignStateOwnership(withFdi, randomness.stateOwnership)
     finalize(withSoe)
 
   /** Build network adjacency list from configured topology. */
   @boundaryEscape
-  private def buildNetwork(rng: Random)(using p: SimParams): Array[Array[Int]] =
+  private def buildNetwork(rng: RandomStream)(using p: SimParams): Array[Array[Int]] =
     import ComputationBoundary.toDouble
     p.topology match
       case Topology.Ws      => Network.wattsStrogatz(p.pop.firmsCount, p.firm.networkK, toDouble(p.firm.networkRewireP), rng)
@@ -59,7 +58,7 @@ object FirmInit:
 
   /** Assign sectors to firm slots based on GUS structural shares, shuffled. */
   @boundaryEscape
-  private def assignSectors(rng: Random)(using p: SimParams): Vector[Int] =
+  private def assignSectors(rng: RandomStream)(using p: SimParams): Vector[Int] =
     import ComputationBoundary.toDouble
     val perSector  = p.sectorDefs.map(s => (toDouble(s.share) * p.pop.firmsCount).toInt)
     val lastSector = p.sectorDefs.length - 1
@@ -73,10 +72,10 @@ object FirmInit:
   private def buildSkeleton(
       adjList: Array[Array[Int]],
       sectorAssignments: Vector[Int],
-      rng: Random,
+      rng: RandomStream,
+      regionRng: RandomStream,
   )(using p: SimParams): Vector[Firm.State] =
     import ComputationBoundary.toDouble
-    val regionRng = new Random(rng.nextLong()) // isolated sub-RNG: one draw from main, then independent
     (0 until p.pop.firmsCount)
       .map: i =>
         val sec          = p.sectorDefs(sectorAssignments(i))
@@ -122,7 +121,7 @@ object FirmInit:
     * assignment).
     */
   @boundaryEscape
-  private def assignCapitalAndBank(firms: Vector[Firm.State], rng: Random)(using p: SimParams): Vector[Firm.State] =
+  private def assignCapitalAndBank(firms: Vector[Firm.State], rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
     import ComputationBoundary.toDouble
     firms.map: f =>
       val withCap = f.copy(capitalStock = PLN(toDouble(p.capital.klRatios(f.sector.toInt)) * Firm.workerCount(f)))
@@ -131,13 +130,13 @@ object FirmInit:
   /** Mark firms as foreign-owned based on per-sector FDI shares (rng: ownership
     * draw).
     */
-  private def assignForeignOwnership(firms: Vector[Firm.State], rng: Random)(using p: SimParams): Vector[Firm.State] =
+  private def assignForeignOwnership(firms: Vector[Firm.State], rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
     firms.map: f =>
       if p.fdi.foreignShares(f.sector.toInt).sampleBelow(rng) then f.copy(foreignOwned = true)
       else f
 
   /** Mark firms as state-owned based on sector-specific SOE shares. */
-  private def assignStateOwnership(firms: Vector[Firm.State], rng: Random): Vector[Firm.State] =
+  private def assignStateOwnership(firms: Vector[Firm.State], rng: RandomStream): Vector[Firm.State] =
     firms.map: f =>
       if StateOwned.sectorSoeShare(f.sector.toInt).sampleBelow(rng) then f.copy(stateOwned = true)
       else f

--- a/src/main/scala/com/boombustgroup/amorfati/init/ImmigrantInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/ImmigrantInit.scala
@@ -3,16 +3,14 @@ package com.boombustgroup.amorfati.init
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 
-import scala.util.Random
-
 /** Factory for initial immigrant stock. */
 object ImmigrantInit:
 
   /** Spawn initial immigrants when ImmigEnabled && ImmigInitStock > 0. Uses
     * households.length as startId internally. Returns updated household vector.
     */
-  def create(rng: Random, households: Vector[Household.State])(using p: SimParams): Vector[Household.State] =
+  def create(randomness: InitRandomness.ImmigrationStreams, households: Vector[Household.State])(using p: SimParams): Vector[Household.State] =
     if p.immigration.initStock > 0 then
-      val immigrants = Immigration.spawnImmigrants(p.immigration.initStock, households.length, rng)
+      val immigrants = Immigration.spawnImmigrants(p.immigration.initStock, households.length, randomness.initialStock)
       households ++ immigrants
     else households

--- a/src/main/scala/com/boombustgroup/amorfati/init/InitRandomness.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/InitRandomness.scala
@@ -1,0 +1,134 @@
+package com.boombustgroup.amorfati.init
+
+import com.boombustgroup.amorfati.random.{RandomStream, SeedDerivation}
+
+/** Explicit initialization randomness contract.
+  *
+  * Bootstrapping replay becomes deterministic once both the config and the
+  * `rootSeed` are fixed.
+  */
+object InitRandomness:
+
+  enum StreamKey:
+    case FirmNetwork
+    case FirmSectorAssignments
+    case FirmSkeleton
+    case FirmRegions
+    case FirmCapitalAndBank
+    case FirmForeignOwnership
+    case FirmStateOwnership
+    case HouseholdNetwork
+    case HouseholdAttributes
+    case HouseholdInitialUnemployment
+    case InitialImmigrantStock
+
+  case class StreamSeed(
+      key: StreamKey,
+      seed: Long,
+  ):
+    def newStream(): RandomStream =
+      RandomStream.seeded(seed)
+
+  case class FirmStreams(
+      network: RandomStream,
+      sectorAssignments: RandomStream,
+      skeleton: RandomStream,
+      regions: RandomStream,
+      capitalAndBank: RandomStream,
+      foreignOwnership: RandomStream,
+      stateOwnership: RandomStream,
+  )
+
+  case class HouseholdStreams(
+      network: RandomStream,
+      attributes: RandomStream,
+      initialUnemployment: RandomStream,
+  )
+
+  case class ImmigrationStreams(
+      initialStock: RandomStream,
+  )
+
+  case class FirmSeeds(
+      network: StreamSeed,
+      sectorAssignments: StreamSeed,
+      skeleton: StreamSeed,
+      regions: StreamSeed,
+      capitalAndBank: StreamSeed,
+      foreignOwnership: StreamSeed,
+      stateOwnership: StreamSeed,
+  ):
+    def all: Vector[StreamSeed] =
+      Vector(network, sectorAssignments, skeleton, regions, capitalAndBank, foreignOwnership, stateOwnership)
+
+    def newStreams(): FirmStreams =
+      FirmStreams(
+        network = network.newStream(),
+        sectorAssignments = sectorAssignments.newStream(),
+        skeleton = skeleton.newStream(),
+        regions = regions.newStream(),
+        capitalAndBank = capitalAndBank.newStream(),
+        foreignOwnership = foreignOwnership.newStream(),
+        stateOwnership = stateOwnership.newStream(),
+      )
+
+  case class HouseholdSeeds(
+      network: StreamSeed,
+      attributes: StreamSeed,
+      initialUnemployment: StreamSeed,
+  ):
+    def all: Vector[StreamSeed] =
+      Vector(network, attributes, initialUnemployment)
+
+    def newStreams(): HouseholdStreams =
+      HouseholdStreams(
+        network = network.newStream(),
+        attributes = attributes.newStream(),
+        initialUnemployment = initialUnemployment.newStream(),
+      )
+
+  case class ImmigrationSeeds(
+      initialStock: StreamSeed,
+  ):
+    def all: Vector[StreamSeed] =
+      Vector(initialStock)
+
+    def newStreams(): ImmigrationStreams =
+      ImmigrationStreams(
+        initialStock = initialStock.newStream(),
+      )
+
+  case class Contract(
+      rootSeed: Long,
+      firms: FirmSeeds,
+      households: HouseholdSeeds,
+      immigration: ImmigrationSeeds,
+  ):
+    def all: Vector[StreamSeed] =
+      firms.all ++ households.all ++ immigration.all
+
+  object Contract:
+    def fromSeed(rootSeed: Long): Contract =
+      Contract(
+        rootSeed = rootSeed,
+        firms = FirmSeeds(
+          network = deriveStream(rootSeed, StreamKey.FirmNetwork),
+          sectorAssignments = deriveStream(rootSeed, StreamKey.FirmSectorAssignments),
+          skeleton = deriveStream(rootSeed, StreamKey.FirmSkeleton),
+          regions = deriveStream(rootSeed, StreamKey.FirmRegions),
+          capitalAndBank = deriveStream(rootSeed, StreamKey.FirmCapitalAndBank),
+          foreignOwnership = deriveStream(rootSeed, StreamKey.FirmForeignOwnership),
+          stateOwnership = deriveStream(rootSeed, StreamKey.FirmStateOwnership),
+        ),
+        households = HouseholdSeeds(
+          network = deriveStream(rootSeed, StreamKey.HouseholdNetwork),
+          attributes = deriveStream(rootSeed, StreamKey.HouseholdAttributes),
+          initialUnemployment = deriveStream(rootSeed, StreamKey.HouseholdInitialUnemployment),
+        ),
+        immigration = ImmigrationSeeds(
+          initialStock = deriveStream(rootSeed, StreamKey.InitialImmigrantStock),
+        ),
+      )
+
+  private def deriveStream(rootSeed: Long, key: StreamKey): StreamSeed =
+    StreamSeed(key, SeedDerivation.derive(rootSeed, key.ordinal.toLong))

--- a/src/main/scala/com/boombustgroup/amorfati/init/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/init/README.md
@@ -1,14 +1,16 @@
 # Initialization
 
 The init package contains factory objects that build the initial simulation
-state from a seed and configuration. All factories are stateless objects with
-pure `create`/`initialize` methods — no mutable fields.
+state from configuration plus an explicit initialization randomness contract.
+All factories are stateless objects with pure `create`/`initialize` methods —
+no mutable fields.
 
 ## Files
 
 | File | Object | Role |
 |------|--------|------|
-| `WorldInit.scala` | `WorldInit` | Orchestrator — calls all sub-factories, assembles `InitResult` |
+| `InitRandomness.scala` | `InitRandomness` | Explicit initialization randomness contract: one root seed split into named streams for firms, households, and initial immigration |
+| `WorldInit.scala` | `WorldInit` | Orchestrator — consumes `InitRandomness.Contract`, calls all sub-factories, assembles `InitResult` |
 | `FirmInit.scala` | `FirmInit` | Creates firm array, assigns network topology, applies sector enhancements |
 | `BankInit.scala` | `BankInit` | Creates 7-bank sector, distributes deposits/loans/bonds across banks |
 | `ImmigrantInit.scala` | `ImmigrantInit` | Establishes the initial immigrant stock in the labour market |

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -7,24 +7,23 @@ import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, FiscalBud
 import com.boombustgroup.amorfati.engine.mechanisms.{Macroprudential, SectoralMobility}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
-
 /** Orchestrates all initialization factories and assembles World. */
 object WorldInit:
 
-  /** Initialize a complete simulation world from a seed. */
+  /** Initialize a complete simulation world from an explicit randomness
+    * contract.
+    */
   @boundaryEscape
-  def initialize(seed: Long)(using p: SimParams): InitResult =
+  def initialize(randomness: InitRandomness.Contract)(using p: SimParams): InitResult =
     import ComputationBoundary.toDouble
-    val rng = new Random(seed)
 
     // --- Firms ---
-    val firms = FirmInit.create(rng)
+    val firms = FirmInit.create(randomness.firms.newStreams())
     assert(firms.length == p.pop.firmsCount)
 
     // --- Households ---
-    val households0    = Household.Init.create(rng, firms)
-    val households     = ImmigrantInit.create(rng, households0)
+    val households0    = Household.Init.create(randomness.households.newStreams(), firms)
+    val households     = ImmigrantInit.create(randomness.immigration.newStreams(), households0)
     val totalPop       = households.length
     val initEmployed   = households.count(_.status.isInstanceOf[HhStatus.Employed])
     val initUnemployed = totalPop - initEmployed

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.CsvWriter
@@ -69,15 +69,15 @@ object McRunner:
             Some((MonthSnapshot(month + 1, newState, monthData), (newState, month + 1)))
 
   private def initSeed(seed: Long)(using p: SimParams) =
-    val init    = WorldInit.initialize(seed)
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
     val runtime = Sfc.RuntimeState(init.world, init.firms, init.households, init.banks)
     val errors  = InitCheck.validate(runtime)
     if errors.nonEmpty then Left(SimError.Init(errors))
     else Right(FlowSimulation.SimState.fromInit(init))
 
   private def stepMonth(state: FlowSimulation.SimState, seed: Long, month: Int)(using p: SimParams) =
-    val rng    = new scala.util.Random(seed * 10000 + month)
-    val result = engine.flows.FlowSimulation.step(state, rng)
+    val stepSeed = seed * 10000 + month
+    val result   = engine.flows.FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(stepSeed))
     result.sfcResult match
       case Left(errors) =>
         Left(SimError.SfcViolation(month + 1, errors))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -19,7 +19,7 @@ schema, summary statistics, and CSV I/O. It is the only consumer of
 Main ──→ McRunner.run(rc)
            │
            ├── for seed ← 1..N:
-           │     WorldInit.initialize(seed)
+           │     WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
            │     Simulation.step  (no McRunConfig)
            │     SimOutput.compute  → Array[Double]
            │

--- a/src/main/scala/com/boombustgroup/amorfati/networks/Network.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/networks/Network.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.networks
 import com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
 import com.boombustgroup.amorfati.types.Share
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Graph generation algorithms for agent interaction networks.
   *
@@ -46,7 +46,7 @@ object Network:
     * @return
     *   adjacency lists (symmetric, no self-loops)
     */
-  def wattsStrogatz(n: Int, k: Int, p: Double, rng: Random): Array[Array[Int]] =
+  def wattsStrogatz(n: Int, k: Int, p: Double, rng: RandomStream): Array[Array[Int]] =
     val adj = Array.fill(n)(scala.collection.mutable.Set.empty[Int])
 
     // Ring lattice: connect each node to k/2 nearest neighbors on each side
@@ -84,7 +84,7 @@ object Network:
     adj.map(_.toArray)
 
   /** Typed overload for household rewiring probability. */
-  def wattsStrogatz(n: Int, k: Int, p: Share, rng: Random): Array[Array[Int]] =
+  def wattsStrogatz(n: Int, k: Int, p: Share, rng: RandomStream): Array[Array[Int]] =
     wattsStrogatz(n, k, p.toLong.toDouble / ScaleD, rng)
 
   /** Generate an Erdős–Rényi G(n,p) random graph with target average degree.
@@ -103,7 +103,7 @@ object Network:
     * @return
     *   adjacency lists (symmetric, no self-loops)
     */
-  def erdosRenyi(n: Int, avgDegree: Int, rng: Random): Array[Array[Int]] =
+  def erdosRenyi(n: Int, avgDegree: Int, rng: RandomStream): Array[Array[Int]] =
     val adj = Array.fill(n)(scala.collection.mutable.Set.empty[Int])
     val p   = avgDegree.toDouble / (n - 1)
     for
@@ -132,7 +132,7 @@ object Network:
     * @return
     *   adjacency lists (symmetric, no self-loops)
     */
-  def barabasiAlbert(n: Int, m: Int, rng: Random): Array[Array[Int]] =
+  def barabasiAlbert(n: Int, m: Int, rng: RandomStream): Array[Array[Int]] =
     val adj         = Array.fill(n)(scala.collection.mutable.Set.empty[Int])
     val seedSize    = m + 1
     // Seed: complete graph on first m+1 nodes

--- a/src/main/scala/com/boombustgroup/amorfati/random/RandomStream.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/random/RandomStream.scala
@@ -1,0 +1,50 @@
+package com.boombustgroup.amorfati.random
+
+/** Project-wide RNG facade.
+  *
+  * Domain code depends on this opaque type instead of `scala.util.Random`. The
+  * underlying engine stays an implementation detail of the `random` package.
+  */
+opaque type RandomStream = scala.util.Random
+
+object RandomStream:
+
+  def seeded(seed: Long): RandomStream =
+    new scala.util.Random(seed)
+
+  def fresh(): RandomStream =
+    new scala.util.Random()
+
+  /** Migration/testing adapter for the rare cases that need a custom
+    * `scala.util.Random` implementation.
+    */
+  def wrap(random: scala.util.Random): RandomStream =
+    random
+
+  extension (stream: RandomStream)
+    def nextInt(boundExclusive: Int): Int =
+      stream.nextInt(boundExclusive)
+
+    def nextLong(): Long =
+      stream.nextLong()
+
+    def nextLong(boundExclusive: Long): Long =
+      stream.nextLong(boundExclusive)
+
+    def nextDouble(): Double =
+      stream.nextDouble()
+
+    def nextGaussian(): Double =
+      stream.nextGaussian()
+
+    def between(minInclusive: Int, maxExclusive: Int): Int =
+      stream.between(minInclusive, maxExclusive)
+
+    def between(minInclusive: Long, maxExclusive: Long): Long =
+      stream.between(minInclusive, maxExclusive)
+
+    def between(minInclusive: Double, maxExclusive: Double): Double =
+      stream.between(minInclusive, maxExclusive)
+
+    def shuffle[A](values: Seq[A]): Vector[A] =
+      stream.shuffle(values).toVector

--- a/src/main/scala/com/boombustgroup/amorfati/random/SeedDerivation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/random/SeedDerivation.scala
@@ -1,0 +1,13 @@
+package com.boombustgroup.amorfati.random
+
+/** Stable seed splitting from one explicit root seed. */
+object SeedDerivation:
+
+  def derive(rootSeed: Long, keySalt: Long): Long =
+    mix64(rootSeed ^ mix64(keySalt + 1L))
+
+  def mix64(input: Long): Long =
+    var z = input + 0x9e3779b97f4a7c15L
+    z = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L
+    z = (z ^ (z >>> 27)) * 0x94d049bb133111ebL
+    z ^ (z >>> 31)

--- a/src/main/scala/com/boombustgroup/amorfati/types.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/types.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati
 import com.boombustgroup.amorfati.fp.FixedPointBase
 
 import scala.annotation.targetName
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Fixed-point type system for SFC-ABM engine.
   *
@@ -267,24 +267,24 @@ object types:
 
   object TypedRandom:
     @targetName("randomShareBetween")
-    def randomBetween(lo: Share, hi: Share, rng: Random): Share =
+    def randomBetween(lo: Share, hi: Share, rng: RandomStream): Share =
       if hi < lo then throw IllegalArgumentException(s"Share.randomBetween requires lo <= hi, got lo=$lo hi=$hi")
       else if hi == lo then lo
       else Share.fromRaw(rng.between(lo.toLong, hi.toLong))
 
-    def withGaussianNoise(base: Share, stddev: Share, rng: Random): Share =
+    def withGaussianNoise(base: Share, stddev: Share, rng: RandomStream): Share =
       val raw        = base.toLong + scala.math.round(rng.nextGaussian() * stddev.toLong)
       val clampedRaw = scala.math.max(Share.Zero.toLong, scala.math.min(Share.One.toLong, raw))
       Share.fromRaw(clampedRaw)
 
     @targetName("randomMultiplierBetween")
-    def randomBetween(lo: Multiplier, hi: Multiplier, rng: Random): Multiplier =
+    def randomBetween(lo: Multiplier, hi: Multiplier, rng: RandomStream): Multiplier =
       if hi < lo then throw IllegalArgumentException(s"Multiplier.randomBetween requires lo <= hi, got lo=$lo hi=$hi")
       else if hi == lo then lo
       else Multiplier.fromRaw(rng.between(lo.toLong, hi.toLong))
 
   object WeightedSelection:
-    def choose(weights: Vector[Multiplier], rng: Random): Int =
+    def choose(weights: Vector[Multiplier], rng: RandomStream): Int =
       if weights.isEmpty then return -1
       weights.foreach: weight =>
         if weight < Multiplier.Zero then throw IllegalArgumentException(s"WeightedSelection requires non-negative weights, got: $weight")

--- a/src/main/scala/com/boombustgroup/amorfati/util/Distributions.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/util/Distributions.scala
@@ -2,13 +2,13 @@ package com.boombustgroup.amorfati.util
 
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Sampling helpers for standard distributions (Poisson, Beta, Gamma). */
 object Distributions:
 
   /** Sample a categorical index from non-negative fixed-point weights. */
-  private[amorfati] def cdfSample(shares: Vector[Share], rng: Random): Int =
+  private[amorfati] def cdfSample(shares: Vector[Share], rng: RandomStream): Int =
     require(shares.nonEmpty, "shares must be non-empty")
     require(shares.forall(_ >= Share.Zero), s"shares must be non-negative: $shares")
     val total = shares.foldLeft(Share.Zero)(_ + _)
@@ -24,12 +24,12 @@ object Distributions:
     shares.length - 1
 
   /** Sample a share uniformly from [lo, hi]. */
-  def randomShareBetween(lo: Share, hi: Share, rng: Random): Share =
+  def randomShareBetween(lo: Share, hi: Share, rng: RandomStream): Share =
     if hi <= lo then lo
     else Share.fromRaw(rng.between(lo.toLong, hi.toLong))
 
   /** Sample from Poisson(lambda) using Knuth algorithm (small λ). */
-  def poissonSample(lambda: Double, rng: Random): Int =
+  def poissonSample(lambda: Double, rng: RandomStream): Int =
     if lambda <= 0 then 0
     else
       val L = Math.exp(-lambda)
@@ -41,13 +41,13 @@ object Distributions:
       k
 
   /** Sample from Beta(alpha, beta) using two Gamma samples. */
-  def betaSample(alpha: Double, beta: Double, rng: Random): Double =
+  def betaSample(alpha: Double, beta: Double, rng: RandomStream): Double =
     val x = gammaSample(alpha, rng)
     val y = gammaSample(beta, rng)
     if x + y > 0 then x / (x + y) else 0.5
 
   /** Sample from Gamma(shape, 1) using Marsaglia-Tsang method. */
-  def gammaSample(shape: Double, rng: Random): Double =
+  def gammaSample(shape: Double, rng: RandomStream): Double =
     if shape < 1.0 then gammaSample(shape + 1.0, rng) * Math.pow(rng.nextDouble(), 1.0 / shape)
     else
       val d      = shape - 1.0 / 3.0
@@ -72,21 +72,21 @@ object Distributions:
 
   /** Sample a raw fixed-point Gaussian perturbation with dimensionless stddev.
     */
-  def gaussianNoiseRaw(std: Scalar, rng: Random): Long =
+  def gaussianNoiseRaw(std: Scalar, rng: RandomStream): Long =
     math.round(rng.nextGaussian() * std.toLong)
 
   /** Sample a share around mean with Gaussian noise and clamp to bounds. */
-  def gaussianShare(mean: Share, std: Scalar, lo: Share, hi: Share, rng: Random): Share =
+  def gaussianShare(mean: Share, std: Scalar, lo: Share, hi: Share, rng: RandomStream): Share =
     Share.fromRaw((mean.toLong + gaussianNoiseRaw(std, rng)).max(lo.toLong).min(hi.toLong))
 
   /** Sample a PLN value around mean with Gaussian noise and clamp to floor. */
-  def gaussianPlnAtLeast(mean: PLN, std: PLN, floor: PLN, rng: Random): PLN =
+  def gaussianPlnAtLeast(mean: PLN, std: PLN, floor: PLN, rng: RandomStream): PLN =
     PLN.fromRaw((mean.toLong + math.round(std.toLong.toDouble * rng.nextGaussian())).max(floor.toLong))
 
   /** Sample a PLN value from a lognormal distribution. */
-  def lognormalPln(mu: Double, sigma: Double, rng: Random): PLN =
+  def lognormalPln(mu: Double, sigma: Double, rng: RandomStream): PLN =
     PLN(Math.exp(mu + sigma * rng.nextGaussian()))
 
   /** Sample a PLN value uniformly from [0, maxExclusive). */
-  def randomPlnBelow(maxExclusive: PLN, rng: Random): PLN =
+  def randomPlnBelow(maxExclusive: PLN, rng: RandomStream): PLN =
     PLN.fromRaw(rng.nextLong(maxExclusive.toLong.max(1L)))

--- a/src/test/scala/com/boombustgroup/amorfati/OpaqueTypesSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/OpaqueTypesSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -91,7 +92,7 @@ class OpaqueTypesSpec extends AnyFlatSpec with Matchers:
     Share(1.2).clamp(Share.Zero, Share.One) shouldBe Share.One
     Share.Zero shouldBe Share(0.0)
     shareValue(Share.One) shouldBe 1.0 +- 1e-9
-    shareValue(Share.random(new scala.util.Random(0L))) should (be >= 0.0 and be < 1.0)
+    shareValue(Share.random(RandomStream.seeded(0L))) should (be >= 0.0 and be < 1.0)
   }
 
   it should "bridge to other semantic types and counts" in {

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/InitCheckSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/InitCheckSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.accounting
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 
 class InitCheckSpec extends AnyFlatSpec with Matchers:
@@ -11,13 +11,13 @@ class InitCheckSpec extends AnyFlatSpec with Matchers:
   given SimParams = SimParams.defaults
 
   "InitCheck" should "pass for default init" in:
-    val result = WorldInit.initialize(42L)
+    val result = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = Sfc.RuntimeState(result.world, result.firms, result.households, result.banks)
     val errors = InitCheck.validate(state)
     errors shouldBe empty
 
   it should "have exact bond clearing at raw-unit precision for default init" in:
-    val result   = WorldInit.initialize(42L)
+    val result   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val snapshot = Sfc.snapshot(result.world, result.firms, result.households, result.banks)
     val holdings =
       snapshot.bankBondHoldings + snapshot.nbpBondHoldings + snapshot.foreignBondHoldings +
@@ -26,7 +26,7 @@ class InitCheckSpec extends AnyFlatSpec with Matchers:
     holdings shouldBe snapshot.bondsOutstanding
 
   it should "detect tampered bondsOutstanding" in:
-    val result   = WorldInit.initialize(42L)
+    val result   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val snap     = Sfc.snapshot(result.world, result.firms, result.households, result.banks)
     val tampered = snap.copy(bondsOutstanding = snap.bondsOutstanding + PLN(1000.0))
     val errors   = InitCheck.validate(tampered, result.banks, result.firms, result.households)
@@ -34,7 +34,7 @@ class InitCheckSpec extends AnyFlatSpec with Matchers:
     errors.exists(_.identity == "Bond clearing") shouldBe true
 
   it should "detect tampered bank deposits" in:
-    val result        = WorldInit.initialize(42L)
+    val result        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val snap          = Sfc.snapshot(result.world, result.firms, result.households, result.banks)
     val banks         = result.banks
     val tamperedBank0 = banks.updated(0, banks(0).copy(deposits = banks(0).deposits + PLN(5000.0)))
@@ -43,7 +43,7 @@ class InitCheckSpec extends AnyFlatSpec with Matchers:
     errors.exists(_.identity.startsWith("Deposit consistency")) shouldBe true
 
   it should "detect tampered firm debt" in:
-    val result        = WorldInit.initialize(42L)
+    val result        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val snap          = Sfc.snapshot(result.world, result.firms, result.households, result.banks)
     val banks         = result.banks
     val tamperedBank0 = banks.updated(0, banks(0).copy(loans = banks(0).loans + PLN(5000.0)))
@@ -52,7 +52,7 @@ class InitCheckSpec extends AnyFlatSpec with Matchers:
     errors.exists(_.identity.startsWith("Corp loan consistency")) shouldBe true
 
   it should "detect tampered consumer loans" in:
-    val result        = WorldInit.initialize(42L)
+    val result        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val snap          = Sfc.snapshot(result.world, result.firms, result.households, result.banks)
     val banks         = result.banks
     val tamperedBank0 = banks.updated(0, banks(0).copy(consumerLoans = banks(0).consumerLoans + PLN(5000.0)))

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
@@ -9,7 +9,7 @@ import com.boombustgroup.amorfati.agents.Banking.BankStatus
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks:
 
@@ -105,7 +105,7 @@ class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
 
   "assignBank" should "always return valid index in [0, nBanks)" in
     forAll(Gen.choose(0, 5)) { (sector: Int) =>
-      val rng = new Random()
+      val rng = RandomStream.fresh()
       for _ <- 0 until 50 do
         val bId = Banking.assignBank(SectorIdx(sector), configs, rng)
         bId.toInt should be >= 0

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
@@ -105,7 +105,7 @@ class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
 
   "assignBank" should "always return valid index in [0, nBanks)" in
     forAll(Gen.choose(0, 5)) { (sector: Int) =>
-      val rng = RandomStream.seeded(42L)
+      val rng = RandomStream.seeded(42L + sector.toLong)
       for _ <- 0 until 50 do
         val bId = Banking.assignBank(SectorIdx(sector), configs, rng)
         bId.toInt should be >= 0

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
@@ -105,7 +105,7 @@ class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
 
   "assignBank" should "always return valid index in [0, nBanks)" in
     forAll(Gen.choose(0, 5)) { (sector: Int) =>
-      val rng = RandomStream.fresh()
+      val rng = RandomStream.seeded(42L)
       for _ <- 0 until 50 do
         val bId = Banking.assignBank(SectorIdx(sector), configs, rng)
         bId.toInt should be >= 0

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.Generators
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class BankingSectorSpec extends AnyFlatSpec with Matchers:
 
@@ -79,7 +79,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   // ---- assignBank ----
 
   "Banking.assignBank" should "return valid bank index" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 100 do
       val bId = Banking.assignBank(SectorIdx(0), configs, rng)
       bId.toInt should be >= 0
@@ -87,7 +87,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "favor BPS/Coop for agriculture firms" in {
-    val rng         = new Random(42)
+    val rng         = RandomStream.seeded(42)
     val assignments = (0 until 10000).map(_ => Banking.assignBank(SectorIdx(5), configs, rng))
     val bpsCount    = assignments.count(_ == BankId(5))
     // BPS has 0.65 agriculture affinity vs others ~0.15, so it should get disproportionate share
@@ -121,7 +121,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
 
   "Banking.canLend" should "return false for failed bank" in {
     val bank = mkBank(capital = PLN(1e5), status = BankStatus.Failed(30))
-    Banking.canLend(bank, PLN(1000.0), new Random(42), Multiplier.Zero) shouldBe false
+    Banking.canLend(bank, PLN(1000.0), RandomStream.seeded(42), Multiplier.Zero) shouldBe false
   }
 
   it should "reject when projected CAR too low" in {
@@ -129,7 +129,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     // Adding 10000 loan -> projected = 8000/110000 = 0.0727 < 0.08
     val bank    = mkBank(loans = PLN(100000.0), capital = PLN(8000.0))
     // Need to test multiple times since there's a stochastic element
-    val results = (0 until 100).map(_ => Banking.canLend(bank, PLN(10000.0), new Random(42), Multiplier.Zero))
+    val results = (0 until 100).map(_ => Banking.canLend(bank, PLN(10000.0), RandomStream.seeded(42), Multiplier.Zero))
     results.forall(_ == false) shouldBe true
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -128,8 +128,9 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     // capital=8000, loans=100000, existing CAR=0.08
     // Adding 10000 loan -> projected = 8000/110000 = 0.0727 < 0.08
     val bank    = mkBank(loans = PLN(100000.0), capital = PLN(8000.0))
+    val rng     = RandomStream.seeded(42L)
     // Need to test multiple times since there's a stochastic element
-    val results = (0 until 100).map(_ => Banking.canLend(bank, PLN(10000.0), RandomStream.seeded(42), Multiplier.Zero))
+    val results = (0 until 100).map(_ => Banking.canLend(bank, PLN(10000.0), rng, Multiplier.Zero))
     results.forall(_ == false) shouldBe true
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class DepositMobilitySpec extends AnyFlatSpec with Matchers:
 
@@ -62,14 +62,14 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
   "DepositMobility" should "not move deposits when all banks are healthy" in {
     val banks  = Vector(mkBank(0, 0.15), mkBank(1, 0.14))
     val hhs    = Vector(mkHh(0), mkHh(1))
-    val result = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    val result = DepositMobility(hhs, banks, anyBankFailed = false, RandomStream.seeded(42))
     result.households.map(_.bankId) shouldBe hhs.map(_.bankId)
   }
 
   it should "trigger flight from weak bank (low CAR)" in {
     val banks    = Vector(mkBank(0, 0.04), mkBank(1, 0.15)) // bank 0 below threshold
     val hhs      = (0 until 100).map(_ => mkHh(0)).toVector
-    val result   = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    val result   = DepositMobility(hhs, banks, anyBankFailed = false, RandomStream.seeded(42))
     val switched = result.households.count(_.bankId == BankId(1))
     switched should be > 0
   }
@@ -78,7 +78,7 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
     // HH at bank 2, bank 1 fails, healthiest is bank 0 → some HH panic-switch to bank 0
     val banks    = Vector(mkBank(0, 0.15), mkBank(1, 0.15, failed = true), mkBank(2, 0.12))
     val hhs      = (0 until 100).map(_ => mkHh(2)).toVector
-    val result   = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    val result   = DepositMobility(hhs, banks, anyBankFailed = true, RandomStream.seeded(42))
     val switched = result.households.count(_.bankId == BankId(0))
     // With panicRate = 3%, expect ~3 of 100 to switch
     switched should be > 0
@@ -87,14 +87,14 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
   it should "preserve total number of households" in {
     val banks  = Vector(mkBank(0, 0.04), mkBank(1, 0.15))
     val hhs    = (0 until 50).map(i => mkHh(i % 2)).toVector
-    val result = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    val result = DepositMobility(hhs, banks, anyBankFailed = true, RandomStream.seeded(42))
     result.households.length shouldBe hhs.length
   }
 
   it should "move deposits toward healthiest bank" in {
     val banks   = Vector(mkBank(0, 0.04), mkBank(1, 0.20), mkBank(2, 0.12))
     val hhs     = (0 until 100).map(_ => mkHh(0)).toVector
-    val result  = DepositMobility(hhs, banks, anyBankFailed = false, new Random(42))
+    val result  = DepositMobility(hhs, banks, anyBankFailed = false, RandomStream.seeded(42))
     // Bank 1 is healthiest (CAR 20%) — switchers should go there
     val atBank1 = result.households.count(_.bankId == BankId(1))
     val atBank2 = result.households.count(_.bankId == BankId(2))
@@ -104,7 +104,7 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
   it should "be deterministic with same seed" in {
     val banks = Vector(mkBank(0, 0.04), mkBank(1, 0.15))
     val hhs   = (0 until 100).map(_ => mkHh(0)).toVector
-    val r1    = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
-    val r2    = DepositMobility(hhs, banks, anyBankFailed = true, new Random(42))
+    val r1    = DepositMobility(hhs, banks, anyBankFailed = true, RandomStream.seeded(42))
+    val r2    = DepositMobility(hhs, banks, anyBankFailed = true, RandomStream.seeded(42))
     r1.households.map(_.bankId) shouldBe r2.households.map(_.bankId)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EducationSpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.markets
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class EducationSpec extends AnyFlatSpec with Matchers:
 
@@ -18,7 +18,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   // ---- Config helpers ----
 
   "p.social.drawEducation" should "return values in [0, 3]" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 200 do
       val edu = p.social.drawEducation(0, rng)
       edu should be >= 0
@@ -26,7 +26,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return valid education for all sectors (0-5)" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for s <- 0 until 6 do
       for _ <- 0 until 50 do
         val edu = p.social.drawEducation(s, rng)
@@ -35,7 +35,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   }
 
   "p.social.drawImmigrantEducation" should "return values in [0, 3]" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 200 do
       val edu = p.social.drawImmigrantEducation(rng)
       edu should be >= 0
@@ -375,7 +375,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   // ---- Immigrant education ----
 
   "Immigration.spawnImmigrants" should "assign education levels to immigrants" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)
     immigrants.foreach { h =>
       h.education should be >= 0
@@ -384,7 +384,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "clamp immigrant skill within education-specific range" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(200, 0, rng)
     immigrants.foreach { h =>
       val (floor, ceil) = p.social.eduSkillRange(h.education)
@@ -396,7 +396,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   // ---- HouseholdInit education ----
 
   "Household.Init.initialize" should "assign education to all households" in {
-    val rng       = new Random(42)
+    val rng       = RandomStream.seeded(42)
     val mkF       = (id: Int, sec: Int, w: Int) =>
       Firm.State(
         FirmId(id),
@@ -428,7 +428,7 @@ class EducationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "clamp skill within education-specific range" in {
-    val rng       = new Random(42)
+    val rng       = RandomStream.seeded(42)
     val firms     = Vector(
       Firm.State(
         FirmId(0),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -9,7 +9,7 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class FirmSpec extends AnyFlatSpec with Matchers:
 
@@ -272,7 +272,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   "Firm.process" should "keep a Bankrupt firm bankrupt with zero tax/capex" in {
     val f      = mkFirm(TechState.Bankrupt(BankruptReason.Other("test")))
-    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), new Random(42))
+    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     result.taxPaid shouldBe PLN.Zero
     result.capexSpent shouldBe PLN.Zero
     result.firm.tech shouldBe a[TechState.Bankrupt]
@@ -280,7 +280,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   it should "keep an Automated firm alive with large cash" in {
     val f      = mkFirm(TechState.Automated(Multiplier(1.5))).copy(cash = PLN(10000000.0))
-    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), new Random(42))
+    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     Firm.isAlive(result.firm) shouldBe true
   }
 
@@ -294,7 +294,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
         sectorDemandMult = Vector.fill(baseW.pipeline.sectorDemandMult.length)(Multiplier(0.1)),
       ),
     )
-    val result = Firm.process(f, w, Rate(0.20), _ => true, Vector(f), new Random(42))
+    val result = Firm.process(f, w, Rate(0.20), _ => true, Vector(f), RandomStream.seeded(42))
     result.firm.tech shouldBe a[TechState.Bankrupt]
   }
 
@@ -310,9 +310,9 @@ class FirmSpec extends AnyFlatSpec with Matchers:
       )
     val lowAdj     = baseWorld.copy(mechanisms = baseWorld.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highAdj    = baseWorld.copy(mechanisms = baseWorld.mechanisms.copy(informalCyclicalAdj = 0.4))
-    val lowResult  = Firm.process(firm, lowAdj, Rate(0.07), _ => true, Vector(firm), new Random(42))
+    val lowResult  = Firm.process(firm, lowAdj, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
     val highResult =
-      Firm.process(firm, highAdj, Rate(0.07), _ => true, Vector(firm), new Random(42))
+      Firm.process(firm, highAdj, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
 
     lowResult.taxPaid should be > PLN.Zero
     highResult.taxPaid should be > PLN.Zero

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -18,7 +18,7 @@ import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class HouseholdSpec extends AnyFlatSpec with Matchers:
 
@@ -32,7 +32,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   // --- HouseholdInit ---
 
   "Household.Init.initialize" should "create correct number of households" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(100)
     val network = Array.fill(1000)(Array.empty[Int])
     val hhs     = Household.Init.initialize(1000, firms, network, rng)
@@ -40,7 +40,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "start all households as Employed" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(100)
     val network = Array.fill(500)(Array.empty[Int])
     val hhs     = Household.Init.initialize(500, firms, network, rng)
@@ -50,7 +50,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "assign positive savings to all households" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(50)
     val network = Array.fill(200)(Array.empty[Int])
     val hhs     = Household.Init.initialize(200, firms, network, rng)
@@ -58,7 +58,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have MPC in [0.5, 0.98]" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(50)
     val network = Array.fill(500)(Array.empty[Int])
     val hhs     = Household.Init.initialize(500, firms, network, rng)
@@ -69,7 +69,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have skill in [0.3, 1.0]" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(50)
     val network = Array.fill(500)(Array.empty[Int])
     val hhs     = Household.Init.initialize(500, firms, network, rng)
@@ -80,7 +80,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have rent >= floor" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(50)
     val network = Array.fill(500)(Array.empty[Int])
     val hhs     = Household.Init.initialize(500, firms, network, rng)
@@ -90,7 +90,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   // --- Household.step ---
 
   "Household.step" should "not change bankrupt households" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hhs             = Vector(
       mkHousehold(0, HhStatus.Bankrupt, savings = PLN(0.0)),
       mkHousehold(1, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), savings = PLN(50000.0)),
@@ -100,7 +100,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "increase unemployment months for unemployed" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hhs             = Vector(
       mkHousehold(0, HhStatus.Unemployed(3), savings = PLN(50000.0)),
     )
@@ -113,28 +113,28 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "apply skill decay after scarring onset" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(0, HhStatus.Unemployed(5), savings = PLN(100000.0), skill = 0.8)
     val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
     updated(0).skill should be < Share(0.8)
   }
 
   it should "not decay skill before scarring onset" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(0, HhStatus.Unemployed(1), savings = PLN(100000.0), skill = 0.8)
     val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
     updated(0).skill shouldBe Share(0.8)
   }
 
   it should "apply health scarring after onset" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(0, HhStatus.Unemployed(5), savings = PLN(100000.0), healthPenalty = 0.0)
     val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
     updated(0).healthPenalty should be > Share.Zero
   }
 
   it should "not bankrupt household after a single month of deep distress" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(0, HhStatus.Unemployed(1), savings = PLN(-10000.0), rent = PLN(1800.0))
     val (updated, _, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
     updated(0).status should not be HhStatus.Bankrupt
@@ -142,7 +142,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "bankrupt household after persistent deep distress" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(
       0,
       HhStatus.Unemployed(1),
@@ -154,7 +154,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "reset financial distress months after recovery" in {
-    val rng             = new Random(42)
+    val rng             = RandomStream.seeded(42)
     val hh              = mkHousehold(
       0,
       HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)),
@@ -167,14 +167,14 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return None for perBankHhFlows when bankRates not provided" in {
-    val rng         = new Random(42)
+    val rng         = RandomStream.seeded(42)
     val hhs         = Vector(mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), savings = PLN(50000.0)))
     val (_, _, pbf) = Household.step(hhs, mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
     pbf shouldBe None
   }
 
   it should "let unemployed households smooth consumption by drawing down savings" in {
-    val rng               = new Random(42)
+    val rng               = RandomStream.seeded(42)
     val hh                = mkHousehold(0, HhStatus.Unemployed(1), savings = PLN(30000.0), rent = PLN(1800.0))
     val (updated, agg, _) = Household.step(Vector(hh), mkWorld(), PLN(8000.0), PLN(4666.0), Share(0.4), rng)
 
@@ -185,7 +185,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   // --- Variable-rate debt service + deposit interest ---
 
   "Household.step with bankRates" should "use variable lending rate for debt service" in {
-    val rng              = new Random(42)
+    val rng              = RandomStream.seeded(42)
     val debt             = PLN(100000.0)
     val hhs              = Vector(
       mkHousehold(
@@ -221,7 +221,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "pay deposit interest to HH with positive savings" in {
-    val rng                = new Random(42)
+    val rng                = RandomStream.seeded(42)
     val savings            = PLN(100000.0)
     val hhs                = Vector(
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)), savings = savings, bankId = 0),
@@ -240,7 +240,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "include deposit interest in totalIncome" in {
-    val rng            = new Random(42)
+    val rng            = RandomStream.seeded(42)
     val savings        = PLN(200000.0)
     val wage           = 8000.0
     val depRate        = 0.04
@@ -260,7 +260,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "accumulate per-bank flows correctly for 2 banks" in {
-    val rng              = new Random(42)
+    val rng              = RandomStream.seeded(42)
     val hhs              = Vector(
       mkHousehold(
         0,
@@ -303,7 +303,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "not pay deposit interest on negative savings" in {
-    val rng                = new Random(42)
+    val rng                = RandomStream.seeded(42)
     val hhs                = Vector(
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)), savings = PLN(-5000.0), bankId = 0),
     )
@@ -322,7 +322,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
   // --- Immigration: remittance deduction ---
 
   "Household.step" should "not deduct remittances from non-immigrant HH" in {
-    val rng         = new Random(42)
+    val rng         = RandomStream.seeded(42)
     val wage        = 8000.0
     val hhs         = Vector(
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(wage)), savings = PLN(50000.0))

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationPropertySpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
 
@@ -12,7 +12,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   given SimParams = SimParams.defaults
 
   "Immigration.computeInflow" should "always return non-negative" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 100 do
       val wage   = PLN(rng.nextDouble() * 20000)
       val unemp  = Share(rng.nextDouble())
@@ -21,7 +21,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   }
 
   "Immigration.computeOutflow" should "always return non-negative" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 100 do
       val stock  = rng.nextInt(10000)
       val result = Immigration.computeOutflow(stock)
@@ -29,7 +29,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   }
 
   "Immigration.chooseSector" should "produce all 6 sectors over many draws" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val sectors = (0 until 1000).map(_ => Immigration.chooseSector(rng).toInt).toSet
     sectors.size shouldBe 6
     sectors.foreach { s =>
@@ -39,7 +39,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   }
 
   "Immigration.spawnImmigrants" should "all have isImmigrant=true" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 10 do
       val count      = rng.nextInt(50) + 1
       val immigrants = Immigration.spawnImmigrants(count, 0, rng)
@@ -48,7 +48,7 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have savings in [0, 5000] range" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(200, 0, rng)
     immigrants.foreach { h =>
       h.savings should be >= PLN.Zero
@@ -57,19 +57,19 @@ class ImmigrationPropertySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have zero debt" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(50, 0, rng)
     immigrants.foreach(_.debt shouldBe PLN.Zero)
   }
 
   it should "have rent >= 800" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)
     immigrants.foreach(_.monthlyRent should be >= PLN(800.0))
   }
 
   "Immigration.step" should "preserve non-negative stock" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 100 do
       val prevStock = rng.nextInt(5000)
       val prev      = Immigration.State(prevStock, 0, 0, PLN.Zero)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class ImmigrationSpec extends AnyFlatSpec with Matchers:
 
@@ -42,7 +42,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
   // ---- chooseSector ----
 
   "Immigration.chooseSector" should "return valid sector index (0-5)" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     for _ <- 0 until 100 do
       val sector = Immigration.chooseSector(rng)
       sector.toInt should be >= 0
@@ -52,31 +52,31 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
   // ---- spawnImmigrants ----
 
   "Immigration.spawnImmigrants" should "create correct number of immigrants" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(50, 1000, rng)
     immigrants.length shouldBe 50
   }
 
   it should "set isImmigrant=true on all spawned HH" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(20, 500, rng)
     immigrants.foreach(_.isImmigrant shouldBe true)
   }
 
   it should "assign sequential IDs starting from startId" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(5, 100, rng)
     immigrants.map(_.id) shouldBe Vector(HhId(100), HhId(101), HhId(102), HhId(103), HhId(104))
   }
 
   it should "start all immigrants as Unemployed(0)" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(10, 0, rng)
     immigrants.foreach(_.status shouldBe HhStatus.Unemployed(0))
   }
 
   it should "clamp skill within valid range" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)
     immigrants.foreach { h =>
       h.skill should be >= Share(0.15)
@@ -85,7 +85,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "clamp MPC within valid range" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)
     immigrants.foreach { h =>
       h.mpc should be >= Share(0.7)
@@ -94,7 +94,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "set lastSectorIdx to a valid sector" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)
     immigrants.foreach { h =>
       h.lastSectorIdx.toInt should be >= 0
@@ -103,7 +103,7 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce zero immigrants when count is 0" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(0, 0, rng)
     immigrants shouldBe empty
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/RegionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/RegionSpec.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class RegionSpec extends AnyFlatSpec with Matchers:
 
@@ -70,14 +70,14 @@ class RegionSpec extends AnyFlatSpec with Matchers:
       mkHh(HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(8000.0)), Region.East),
     )
     val wages  = Map(Region.Central -> PLN(10000.0), Region.East -> PLN(6000.0))
-    val result = RegionalMigration(hh, wages, new Random(42))
+    val result = RegionalMigration(hh, wages, RandomStream.seeded(42))
     result.households.head.region shouldBe Region.East
   }
 
   it should "potentially move unemployed toward higher-wage region" in {
     val hhs    = (0 until 100).map(_ => mkHh(HhStatus.Unemployed(3), Region.East)).toVector
     val wages  = Map(Region.Central -> PLN(12000.0), Region.East -> PLN(6000.0))
-    val result = RegionalMigration(hhs, wages, new Random(42))
+    val result = RegionalMigration(hhs, wages, RandomStream.seeded(42))
     val moved  = result.households.count(_.region != Region.East)
     moved should be >= 0 // may be 0 if housing barrier blocks all
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/SocialTransferSpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.markets.FiscalBudget
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.util.Distributions
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 /** Social transfers (800+ child benefit) unit tests. */
 class SocialTransferSpec extends AnyFlatSpec with Matchers:
@@ -41,17 +41,17 @@ class SocialTransferSpec extends AnyFlatSpec with Matchers:
   }
 
   "poissonSample" should "return 0 for lambda=0" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     Distributions.poissonSample(0.0, rng) shouldBe 0
   }
 
   it should "return 0 for negative lambda" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     Distributions.poissonSample(-1.0, rng) shouldBe 0
   }
 
   it should "have mean approximately equal to lambda" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val lambda  = 0.35
     val n       = 10000
     val samples = (0 until n).map(_ => Distributions.poissonSample(lambda, rng))
@@ -60,7 +60,7 @@ class SocialTransferSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce non-negative values" in {
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val samples = (0 until 1000).map(_ => Distributions.poissonSample(0.35, rng))
     all(samples) should be >= 0
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
@@ -142,7 +143,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   "applyDigitalDrift" should "increase DR for alive firms" in {
     val f      = mkFirm(TechState.Traditional(10), dr = 0.40)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), new scala.util.Random(42))
+    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     // DR should be at least initial + drift (could also get digital investment boost)
     td.toDouble(result.firm.digitalReadiness) should be >= (0.40 + td.toDouble(p.firm.digiDrift) - 0.001)
   }
@@ -150,14 +151,14 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   it should "cap digitalReadiness at 1.0" in {
     val f      = mkFirm(TechState.Traditional(10), dr = 0.999)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), new scala.util.Random(42))
+    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     td.toDouble(result.firm.digitalReadiness) should be <= 1.0
   }
 
   it should "not change DR for bankrupt firms" in {
     val f      = mkFirm(TechState.Bankrupt(BankruptReason.Other("test")), dr = 0.50)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), new scala.util.Random(42))
+    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     td.toDouble(result.firm.digitalReadiness) shouldBe 0.50
   }
 
@@ -170,7 +171,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val w          = mkWorld(autoRatio = 0.5)
     // With MR=MC labor adjustment, firms adjust headcount AND invest in DR
     // concurrently. Run enough rounds for DR to increase above drift baseline.
-    val rng        = new scala.util.Random(42)
+    val rng        = RandomStream.seeded(42)
     var f1         = f
     for _ <- 0 until 200 do f1 = Firm.process(f1, w, Rate(0.07), _ => false, Vector(f1), rng).firm
     assume(Firm.isAlive(f1), "firm must survive processing")
@@ -186,7 +187,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val w        = mkWorld(autoRatio = 0.5)
     // Over many trials, no investment should happen (only drift)
     for _ <- 0 until 100 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), new scala.util.Random(42))
+      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), RandomStream.seeded(42))
       // DR should be at most initial + drift (no investment boost)
       // But net income is added to cash, so firm may become solvent enough
       // Just verify no investment boost beyond drift
@@ -222,7 +223,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   "Hybrid firm" should "gain at least 0.005 + drift in DR per month" in {
     val f      = mkFirm(TechState.Hybrid(5, Multiplier(1.1)), dr = 0.40)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), new scala.util.Random(42))
+    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     if Firm.isAlive(result.firm) then
       // Hybrid learning (+0.005) + natural drift (+0.001)
       td.toDouble(result.firm.digitalReadiness) should be >= (0.40 + 0.005 + td.toDouble(p.firm.digiDrift) - 0.001)
@@ -236,7 +237,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val w      = mkWorld()
     // Simulate 10 months — at minimum, drift alone adds 10 × 0.001 = 0.01
     for _ <- 0 until 10 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), new scala.util.Random(42))
+      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), RandomStream.seeded(42))
       if Firm.isAlive(result.firm) then f = result.firm.copy(cash = PLN(1000000.0)) // reset cash for next round
     td.toDouble(f.digitalReadiness) should be >= (initDR + 10 * td.toDouble(p.firm.digiDrift) - 0.001)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
@@ -185,9 +185,10 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     // Cash so low firm can't afford 2× digiCost, but not negative (would bankrupt)
     val f        = mkFirm(TechState.Traditional(10), cash = digiCost * 0.5, dr = 0.30)
     val w        = mkWorld(autoRatio = 0.5)
+    val rng      = RandomStream.seeded(42L)
     // Over many trials, no investment should happen (only drift)
     for _ <- 0 until 100 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), RandomStream.seeded(42))
+      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), rng)
       // DR should be at most initial + drift (no investment boost)
       // But net income is added to cash, so firm may become solvent enough
       // Just verify no investment boost beyond drift
@@ -235,9 +236,10 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val initDR = 0.30
     var f      = mkFirm(TechState.Traditional(10), cash = 1000000.0, dr = initDR)
     val w      = mkWorld()
+    val rng    = RandomStream.seeded(42L)
     // Simulate 10 months — at minimum, drift alone adds 10 × 0.001 = 0.01
     for _ <- 0 until 10 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), RandomStream.seeded(42))
+      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), rng)
       if Firm.isAlive(result.firm) then f = result.firm.copy(cash = PLN(1000000.0)) // reset cash for next round
     td.toDouble(f.digitalReadiness) should be >= (initDR + 10 * td.toDouble(p.firm.digiDrift) - 0.001)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/config/FirmSizeDistributionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/FirmSizeDistributionSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class FirmSizeDistributionSpec extends AnyFlatSpec with Matchers:
 
@@ -13,7 +13,7 @@ class FirmSizeDistributionSpec extends AnyFlatSpec with Matchers:
   private val p: SimParams = summon[SimParams]
 
   "FirmSizeDistribution.draw" should "return values in valid ranges for Gus distribution" in {
-    val rng        = new Random(42)
+    val rng        = RandomStream.seeded(42)
     val sizes      = (0 until 10000).map(_ => FirmSizeDistribution.draw(rng))
     // Gus mode: micro 1-9, small 10-49, medium 50-249, large 250+
     sizes.foreach(s => s should (be >= 1 and be <= p.pop.firmSizeLargeMax))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CalvoPricingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CalvoPricingSpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class CalvoPricingSpec extends AnyFlatSpec with Matchers:
 
@@ -34,7 +34,7 @@ class CalvoPricingSpec extends AnyFlatSpec with Matchers:
 
   "updateFirmMarkup" should "change markup with high probability (theta)" in {
     // Run 100 times, expect ~15 changes (theta=0.15)
-    val rng     = new Random(42)
+    val rng     = RandomStream.seeded(42)
     val results = (0 until 100).map(_ => CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), rng))
     val changed = results.count(_.priceChanged)
     changed should be > 5
@@ -42,16 +42,18 @@ class CalvoPricingSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "keep markup unchanged when not selected" in {
-    val rng    = new Random:
-      override def nextInt(n: Int): Int = n - 1
+    val rng    = RandomStream.wrap(
+      new scala.util.Random:
+        override def nextInt(n: Int): Int = n - 1,
+    )
     val result = CalvoPricing.updateFirmMarkup(Multiplier(1.2), Multiplier.One, Coefficient.Zero, rng)
     result.priceChanged shouldBe false
     result.newMarkup.bd shouldBe BigDecimal("1.2") +- BigDecimal("0.001")
   }
 
   it should "be deterministic with same seed" in {
-    val r1 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), new Random(42))
-    val r2 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), new Random(42))
+    val r1 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), RandomStream.seeded(42))
+    val r2 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), RandomStream.seeded(42))
     r1.newMarkup.bd shouldBe r2.newMarkup.bd +- BigDecimal("0.0000000001")
     r1.priceChanged shouldBe r2.priceChanged
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CommodityPriceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CommodityPriceSpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class CommodityPriceSpec extends AnyFlatSpec with Matchers:
 
@@ -25,7 +25,7 @@ class CommodityPriceSpec extends AnyFlatSpec with Matchers:
       exchangeRate = ExchangeRate(4.33),
       autoRatio = Share.Zero,
       month = month,
-      rng = new Random(seed * 31 + month),
+      rng = RandomStream.seeded(seed * 31 + month),
     )
 
   "GvcTrade.step" should "initialize with PriceIndex.Base for all price indices" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorPropertySpec.scala
@@ -7,6 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.boombustgroup.amorfati.Generators.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.markets.GvcTrade
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class ExternalSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks:
@@ -34,7 +35,7 @@ class ExternalSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChe
         ExchangeRate(er),
         Share(autoR),
         month,
-        rng = new scala.util.Random(42),
+        rng = RandomStream.seeded(42),
       ),
     )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.markets.GvcTrade
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class ExternalSectorSpec extends AnyFlatSpec with Matchers:
@@ -21,7 +22,7 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
       price: Double = 1.0,
       autoR: Double = 0.0,
       month: Int = 30,
-  ) = GvcTrade.StepInput(prev, sectorOutputs, PriceIndex(price), ExchangeRate(er), Share(autoR), month, rng = new scala.util.Random(42))
+  ) = GvcTrade.StepInput(prev, sectorOutputs, PriceIndex(price), ExchangeRate(er), Share(autoR), month, rng = RandomStream.seeded(42))
 
   // ---- Initialization ----
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class FdiCompositionSpec extends AnyFlatSpec with Matchers:
@@ -68,7 +69,7 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
   "calcPnL (via Firm.process)" should "produce profitShiftCost=0 for domestic firm" in {
     val f = mkFirm(TechState.Traditional(10)).copy(foreignOwned = false)
     val w = mkWorld()
-    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), new scala.util.Random(42))
+    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
     r.profitShiftCost shouldBe PLN.Zero
   }
 
@@ -105,7 +106,7 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
     // When FDI is enabled and firm has low cash, repatriation is capped
     val f = mkFirm(TechState.Traditional(10)).copy(foreignOwned = true, cash = PLN(100.0))
     val w = mkWorld()
-    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), new scala.util.Random(42))
+    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
     // Even with FDI enabled, cash should not go below what the base logic sets
     // With FDI disabled (default), just verify firm processes normally
     Firm.isAlive(r.firm) || !Firm.isAlive(r.firm) shouldBe true // always true, no crash

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
@@ -7,6 +7,7 @@ import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.mechanisms.FirmEntry
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class FirmEntrySpec extends AnyFlatSpec with Matchers:
@@ -18,7 +19,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   private def runEntry(
       firms: Vector[Firm.State],
       unemploymentRate: Double,
-      rng: scala.util.Random,
+      rng: RandomStream,
       laggedHiringSlack: Share = Share.One,
       inflation: Rate = Rate.Zero,
       expectedInflation: Rate = Rate.Zero,
@@ -165,7 +166,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   "New entrant" should "be micro size (1-9 workers)" in {
-    val rng   = new scala.util.Random(42)
+    val rng   = RandomStream.seeded(42)
     val sizes = (1 to 100).map(_ => Math.max(1, rng.between(1, 10)))
     sizes.foreach { s =>
       s should be >= 1
@@ -237,7 +238,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have high digital readiness (0.50-0.90)" in {
-    val rng = new scala.util.Random(42)
+    val rng = RandomStream.seeded(42)
     val drs = (1 to 100).map(_ => rng.between(0.50, 0.90))
     drs.foreach { dr =>
       dr should be >= 0.50
@@ -251,7 +252,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have low digital readiness (0.02-0.30)" in {
-    val rng = new scala.util.Random(42)
+    val rng = RandomStream.seeded(42)
     val drs = (1 to 100).map { _ =>
       val sec = p.sectorDefs(2) // Retail
       Math.max(0.02, Math.min(0.30, td.toDouble(sec.baseDigitalReadiness) + rng.nextGaussian() * 0.10))
@@ -267,7 +268,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   "Sector choice" should "reach all 6 sectors with profit-weighted draws" in {
-    val rng         = new scala.util.Random(42)
+    val rng         = RandomStream.seeded(42)
     val weights     = Array(0.8, 0.6, 1.2, 0.5, 0.1, 0.7)
     val totalWeight = weights.sum
     val sectors     = (1 to 1000).map { _ =>
@@ -437,7 +438,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   "Net creation" should "produce zero new firms when unemployment <= NAIRU" in {
     val firms  = mkFirms(100)
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.04, rng)
     result.netBirths shouldBe 0
     result.firms.length shouldBe firms.length
@@ -445,7 +446,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   "Replacement entry" should "recreate some dead firms even when unemployment <= NAIRU" in {
     val firms  = mkFirms(20) ++ Vector(mkDeadFirm(20), mkDeadFirm(21), mkDeadFirm(22), mkDeadFirm(23))
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.04, rng)
     result.netBirths shouldBe 0
     result.births should be > 0
@@ -455,7 +456,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "preserve vector length when only replacements occur" in {
     val firms  = mkFirms(20) ++ Vector(mkDeadFirm(20), mkDeadFirm(21))
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.04, rng)
     result.netBirths shouldBe 0
     result.firms.length shouldBe firms.length
@@ -463,7 +464,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "count only appended firms as netBirths" in {
     val firms  = mkFirms(100) ++ Vector(mkDeadFirm(100), mkDeadFirm(101), mkDeadFirm(102))
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.20, rng)
     result.births should be >= result.netBirths
     result.netBirths should be > 0
@@ -472,7 +473,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "produce firms when unemployment > NAIRU" in {
     val firms  = mkFirms(100)
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.15, rng)
     result.netBirths should be > 0
     result.firms.length should be > firms.length
@@ -480,14 +481,14 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "respect hard cap" in {
     val firms  = mkFirms(10000)
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.50, rng)
     result.netBirths should be <= p.firm.netEntryMaxMonthly
   }
 
   it should "assign sequential FirmIds" in {
     val firms    = mkFirms(100)
-    val rng      = new scala.util.Random(42)
+    val rng      = RandomStream.seeded(42)
     val result   = runEntry(firms, 0.20, rng)
     val newFirms = result.firms.drop(firms.length)
     newFirms.zipWithIndex.foreach: (f, i) =>
@@ -496,7 +497,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "create firms with GUS size distribution" in {
     val firms    = mkFirms(100)
-    val rng      = new scala.util.Random(42)
+    val rng      = RandomStream.seeded(42)
     val result   = runEntry(firms, 0.20, rng)
     val newFirms = result.firms.drop(firms.length)
     newFirms.foreach: f =>
@@ -505,7 +506,7 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "initialize entrants with startup ramp-up state" in {
     val firms    = mkFirms(100)
-    val rng      = new scala.util.Random(42)
+    val rng      = RandomStream.seeded(42)
     val result   = runEntry(firms, 0.20, rng)
     val newFirms = result.firms.drop(firms.length)
     newFirms.foreach: f =>
@@ -517,34 +518,34 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
 
   it should "dampen net entry when lagged hiring slack is tight" in {
     val firms       = mkFirms(1000)
-    val looseResult = runEntry(firms, 0.20, new scala.util.Random(42))
-    val tightResult = runEntry(firms, 0.20, new scala.util.Random(42), laggedHiringSlack = Share(0.5))
+    val looseResult = runEntry(firms, 0.20, RandomStream.seeded(42))
+    val tightResult = runEntry(firms, 0.20, RandomStream.seeded(42), laggedHiringSlack = Share(0.5))
     tightResult.netBirths.should(be < looseResult.netBirths)
   }
 
   it should "dampen net entry when startup absorption is weak" in {
     val firms        = mkFirms(1000)
-    val strongAbsorb = runEntry(firms, 0.20, new scala.util.Random(42), inflation = Rate(0.03), expectedInflation = Rate(0.025))
+    val strongAbsorb = runEntry(firms, 0.20, RandomStream.seeded(42), inflation = Rate(0.03), expectedInflation = Rate(0.025))
     val weakAbsorb   =
-      runEntry(firms, 0.20, new scala.util.Random(42), inflation = Rate(0.03), expectedInflation = Rate(0.025), startupAbsorptionRate = Share(0.25))
+      runEntry(firms, 0.20, RandomStream.seeded(42), inflation = Rate(0.03), expectedInflation = Rate(0.025), startupAbsorptionRate = Share(0.25))
     weakAbsorb.netBirths should be < strongAbsorb.netBirths
   }
 
   it should "suppress expansionary net entry under deflation and negative expectations" in {
     val firms  = mkFirms(1000)
-    val result = runEntry(firms, 0.20, new scala.util.Random(42), inflation = Rate(-0.02), expectedInflation = Rate(-0.01))
+    val result = runEntry(firms, 0.20, RandomStream.seeded(42), inflation = Rate(-0.02), expectedInflation = Rate(-0.01))
     result.netBirths.shouldBe(0)
   }
 
   it should "allow expansionary net entry when labor slack is high and nominal conditions are positive" in {
     val firms  = mkFirms(1000)
-    val result = runEntry(firms, 0.20, new scala.util.Random(42), inflation = Rate(0.03), expectedInflation = Rate(0.025))
+    val result = runEntry(firms, 0.20, RandomStream.seeded(42), inflation = Rate(0.03), expectedInflation = Rate(0.025))
     result.netBirths.should(be > 0)
   }
 
   it should "preserve existing firms unchanged" in {
     val firms  = mkFirms(100)
-    val rng    = new scala.util.Random(42)
+    val rng    = RandomStream.seeded(42)
     val result = runEntry(firms, 0.20, rng)
     result.firms.take(firms.length).map(_.id) shouldBe firms.map(_.id)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.engine.mechanisms.InformalEconomy
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 
 class InformalEconomySpec extends AnyFlatSpec with Matchers:
@@ -329,14 +329,14 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
   }
 
   "Informal calibration" should "keep default runtime ratios in a plausible envelope over 12 months" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     val realizedShares = collection.mutable.ArrayBuffer.empty[Share]
     val evasionRatios  = collection.mutable.ArrayBuffer.empty[Share]
 
     (1 to 12).foreach: month =>
-      val result     = FlowSimulation.step(state, new scala.util.Random(42L * 1000 + month))
+      val result     = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       realizedShares += Share(result.nextState.world.flows.realizedTaxShadowShare)
       val monthlyGdp = result.nextState.world.cachedMonthlyGdpProxy
       val ratio      =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class LaborMarketSpec extends AnyFlatSpec with Matchers:
 
@@ -69,7 +69,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
   // --- jobSearch ---
 
   "LaborMarket.jobSearch" should "employ unemployed when vacancies exist" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val firms  = mkFirms(3)
     val hhs    = Vector(
       mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0))),
@@ -83,7 +83,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "prefer higher-skilled workers" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val firms  = Vector(mkFirms(1)(0))
     // Only 1 vacancy: Traditional(10) needs 10, but we have 11 workers
     val hhs    = Vector(
@@ -106,7 +106,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "let startup firms keep hiring up to startupTargetWorkers during startup" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val firms  = Vector(
       mkFirms(1)(0).copy(
         tech = TechState.Traditional(1),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
@@ -26,8 +26,8 @@ class MonthRandomnessSpec extends AnyFlatSpec with Matchers:
     )
     first.all.map(_.seed).distinct should have size first.all.size
     first.all.map(_.seed) should not equal third.all.map(_.seed)
-    first.stages.openEconEconomics.newStream().nextLong() shouldBe second.stages.openEconEconomics.newStream().nextLong()
-    first.stages.openEconEconomics.newStream().nextLong() should not equal third.stages.openEconEconomics.newStream().nextLong()
-    first.assembly.regionalMigration.newStream().nextDouble() shouldBe second.assembly.regionalMigration.newStream().nextDouble()
-    first.assembly.regionalMigration.newStream().nextDouble() should not equal third.assembly.regionalMigration.newStream().nextDouble()
+    first.stages.openEconEconomics.seed shouldBe second.stages.openEconEconomics.seed
+    first.stages.openEconEconomics.seed should not equal third.stages.openEconEconomics.seed
+    first.assembly.regionalMigration.seed shouldBe second.assembly.regionalMigration.seed
+    first.assembly.regionalMigration.seed should not equal third.assembly.regionalMigration.seed
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
@@ -27,5 +27,7 @@ class MonthRandomnessSpec extends AnyFlatSpec with Matchers:
     first.all.map(_.seed).distinct should have size first.all.size
     first.all.map(_.seed) should not equal third.all.map(_.seed)
     first.stages.openEconEconomics.newStream().nextLong() shouldBe second.stages.openEconEconomics.newStream().nextLong()
+    first.stages.openEconEconomics.newStream().nextLong() should not equal third.stages.openEconEconomics.newStream().nextLong()
     first.assembly.regionalMigration.newStream().nextDouble() shouldBe second.assembly.regionalMigration.newStream().nextDouble()
+    first.assembly.regionalMigration.newStream().nextDouble() should not equal third.assembly.regionalMigration.newStream().nextDouble()
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
@@ -8,6 +8,7 @@ class MonthRandomnessSpec extends AnyFlatSpec with Matchers:
   "MonthRandomness.Contract" should "derive stable named streams from one root seed" in {
     val first  = MonthRandomness.Contract.fromSeed(1234L)
     val second = MonthRandomness.Contract.fromSeed(1234L)
+    val third  = MonthRandomness.Contract.fromSeed(1235L)
 
     first shouldBe second
     first.rootSeed shouldBe 1234L
@@ -24,6 +25,7 @@ class MonthRandomnessSpec extends AnyFlatSpec with Matchers:
       MonthRandomness.StreamKey.RegionalMigration,
     )
     first.all.map(_.seed).distinct should have size first.all.size
+    first.all.map(_.seed) should not equal third.all.map(_.seed)
     first.stages.openEconEconomics.newStream().nextLong() shouldBe second.stages.openEconEconomics.newStream().nextLong()
     first.assembly.regionalMigration.newStream().nextDouble() shouldBe second.assembly.regionalMigration.newStream().nextDouble()
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthRandomnessSpec.scala
@@ -1,0 +1,29 @@
+package com.boombustgroup.amorfati.engine
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MonthRandomnessSpec extends AnyFlatSpec with Matchers:
+
+  "MonthRandomness.Contract" should "derive stable named streams from one root seed" in {
+    val first  = MonthRandomness.Contract.fromSeed(1234L)
+    val second = MonthRandomness.Contract.fromSeed(1234L)
+
+    first shouldBe second
+    first.rootSeed shouldBe 1234L
+    first.all.map(_.key).toSet shouldBe Set(
+      MonthRandomness.StreamKey.HouseholdIncomeEconomics,
+      MonthRandomness.StreamKey.FirmEconomics,
+      MonthRandomness.StreamKey.HouseholdFinancialEconomics,
+      MonthRandomness.StreamKey.PriceEquityEconomics,
+      MonthRandomness.StreamKey.OpenEconEconomics,
+      MonthRandomness.StreamKey.BankingEconomics,
+      MonthRandomness.StreamKey.FdiMa,
+      MonthRandomness.StreamKey.FirmEntry,
+      MonthRandomness.StreamKey.StartupStaffing,
+      MonthRandomness.StreamKey.RegionalMigration,
+    )
+    first.all.map(_.seed).distinct should have size first.all.size
+    first.stages.openEconEconomics.newStream().nextLong() shouldBe second.stages.openEconEconomics.newStream().nextLong()
+    first.assembly.regionalMigration.newStream().nextDouble() shouldBe second.assembly.regionalMigration.newStream().nextDouble()
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilityPropertySpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class SectoralMobilityPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks:
 
@@ -50,7 +50,7 @@ class SectoralMobilityPropertySpec extends AnyFlatSpec with Matchers with ScalaC
 
   "selectTargetSector" should "always return a valid sector != from" in
     forAll(Gen.choose(0, 5)) { from =>
-      val rng    = new Random(42)
+      val rng    = RandomStream.seeded(42)
       val wages  = Vector.fill(6)(PLN(10000.0))
       val vac    = Vector.fill(6)(5)
       val target =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SectoralMobilitySpec.scala
@@ -8,7 +8,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
 
@@ -76,7 +76,7 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
   // --- selectTargetSector ---
 
   "selectTargetSector" should "not select the source sector" in {
-    val rng   = new Random(42)
+    val rng   = RandomStream.seeded(42)
     val wages = Vector(PLN(10000.0), PLN(12000.0), PLN(8000.0), PLN(15000.0), PLN(9000.0), PLN(7000.0))
     val vac   = Vector(5, 10, 3, 8, 2, 1)
     for _ <- 0 until 100 do
@@ -86,7 +86,7 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "prefer high-wage high-vacancy low-friction sectors" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     // Sector 1 (Mfg): high wage, high vacancies
     // Sector 5 (Agr): high friction from BPO (0.9)
     val wages  = Vector(PLN(0.0), PLN(20000.0), PLN(5000.0), PLN(5000.0), PLN(5000.0), PLN(5000.0))
@@ -101,7 +101,7 @@ class SectoralMobilitySpec extends AnyFlatSpec with Matchers:
   }
 
   it should "handle all-zero wages gracefully" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val wages  = Vector.fill(6)(PLN.Zero)
     val vac    = Vector.fill(6)(0)
     val target =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -2,10 +2,9 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.OperationalSignals
+import com.boombustgroup.amorfati.engine.{MonthRandomness, OperationalSignals}
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
-import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,11 +13,12 @@ import org.scalatest.matchers.should.Matchers
 class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
+  private val TestSeed       = 42L
 
   "BankingEconomics (own Input)" should "produce flows that close at SFC == 0L" in {
-    val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
-    val w    = init.world
-    val rng  = RandomStream.seeded(42)
+    val init            = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
+    val w               = init.world
+    val stageRandomness = MonthRandomness.Contract.fromSeed(TestSeed).stages.newStreams()
 
     val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
@@ -40,10 +40,20 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
       labor.living,
       labor.regionalWages,
     )
-    val s3     = HouseholdIncomeEconomics.compute(w, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, rng)
+    val s3     =
+      HouseholdIncomeEconomics.compute(
+        w,
+        init.firms,
+        init.households,
+        init.banks,
+        s1.lendingBaseRate,
+        s1.resWage,
+        s2.newWage,
+        stageRandomness.householdIncomeEconomics,
+      )
     val s4     = DemandEconomics.compute(DemandEconomics.Input(w, s2.employed, s2.living, s3.domesticCons))
-    val s5     = FirmEconomics.runStep(w, init.firms, init.households, init.banks, s1, s2, s3, s4, rng)
-    val s6     = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, rng)
+    val s5     = FirmEconomics.runStep(w, init.firms, init.households, init.banks, s1, s2, s3, s4, stageRandomness.firmEconomics)
+    val s6     = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, stageRandomness.householdFinancialEconomics)
     val s7     = PriceEquityEconomics.compute(
       PriceEquityEconomics.Input(
         w,
@@ -58,9 +68,11 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
         init.banks,
         s5,
       ),
-      rng,
+      stageRandomness.priceEquityEconomics,
     )
-    val s8     = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, init.banks, rng))
+    val s8     = OpenEconEconomics.runStep(
+      OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, init.banks, stageRandomness.openEconEconomics),
+    )
 
     val res = BankingEconomics.compute(
       BankingEconomics.Input(
@@ -92,7 +104,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
         priceEquityOutput = s7,
         openEconOutput = s8,
         banks = init.banks,
-        depositRng = rng,
+        depositRng = stageRandomness.bankingEconomics,
       ),
     )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -4,7 +4,8 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.OperationalSignals
 import com.boombustgroup.amorfati.engine.flows.*
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -15,9 +16,9 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   "BankingEconomics (own Input)" should "produce flows that close at SFC == 0L" in {
-    val init = WorldInit.initialize(42L)
+    val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val w    = init.world
-    val rng  = new scala.util.Random(42)
+    val rng  = RandomStream.seeded(42)
 
     val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/DynamicNetworkSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/DynamicNetworkSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
 import com.boombustgroup.amorfati.types.*
 
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
 
@@ -14,13 +14,13 @@ class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
 
   "PriceEquityEconomics.rewireFirms" should "return unchanged firms when rho=0" in {
     val firms  = mkFirms(20)
-    val result = PriceEquityEconomics.rewireFirms(firms, 0.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 0.0, RandomStream.seeded(42))
     result shouldBe theSameInstanceAs(firms)
   }
 
   it should "preserve total firm count" in {
     val firms  = mkFirmsWithBankrupt(20, 5)
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     result.length shouldBe 20
   }
 
@@ -28,7 +28,7 @@ class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
     val firms = mkFirmsWithBankrupt(20, 5)
     firms.count(!Firm.isAlive(_)) shouldBe 5
 
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     // All bankrupt firms should be replaced
     result.count(!Firm.isAlive(_)) shouldBe 0
     // Replaced firms should be Traditional
@@ -37,26 +37,26 @@ class DynamicNetworkSpec extends AnyFlatSpec with Matchers:
 
   it should "give new firms neighbors" in {
     val firms  = mkFirmsWithBankrupt(30, 3)
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     // Replaced firms (indices 0-2) should have neighbors
     for i <- 0 until 3 do result(i).neighbors.length should be > 0
   }
 
   it should "return unchanged when no bankrupt firms exist" in {
     val firms  = mkFirms(20)
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     result shouldBe theSameInstanceAs(firms)
   }
 
   it should "preserve sector assignment" in {
     val firms  = mkFirmsWithBankrupt(20, 3, sector = 2)
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     for i <- 0 until 3 do result(i).sector.toInt shouldBe 2
   }
 
   it should "set initialSize on new entrants matching their worker count" in {
     val firms  = mkFirmsWithBankrupt(20, 3)
-    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, new Random(42))
+    val result = PriceEquityEconomics.rewireFirms(firms, 1.0, RandomStream.seeded(42))
     for i <- 0 until 3 do
       val f = result(i)
       f.initialSize should be > 0

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -4,7 +4,8 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.OperationalSignals
 import com.boombustgroup.amorfati.engine.flows.*
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,9 +15,9 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val init = WorldInit.initialize(42L)
+  private val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w    = init.world
-  private val rng  = new scala.util.Random(42)
+  private val rng  = RandomStream.seeded(42)
 
   private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
   private val s1     = FiscalConstraintEconomics.toOutput(fiscal)
@@ -41,10 +42,10 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private val s3     = HouseholdIncomeEconomics.compute(w, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, rng)
   private val s4     = DemandEconomics.compute(DemandEconomics.Input(w, s2.employed, s2.living, s3.domesticCons))
 
-  private val rng2  = new scala.util.Random(42)
+  private val rng2  = RandomStream.seeded(42)
   private val oldS5 = FirmEconomics.runStep(w, init.firms, init.households, init.banks, s1, s2, s3, s4, rng2)
 
-  private val rng3   = new scala.util.Random(42)
+  private val rng3   = RandomStream.seeded(42)
   private val result = FirmEconomics.compute(
     FirmEconomics.Input(
       w = w,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -10,7 +10,7 @@ class FiscalConstraintEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val init  = WorldInit.initialize(42L)
+  private val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val world = init.world
 
   "FiscalConstraintEconomics.compute" should "produce consistent result and output" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -12,7 +12,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val initResult = WorldInit.initialize(42L)
+  private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val world      = initResult.world
   private val firms      = initResult.firms
   private val households = initResult.households

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -14,10 +14,11 @@ import org.scalatest.matchers.should.Matchers
 class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
+  private val TestSeed       = 42L
 
-  private val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+  private val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
   private val w    = init.world
-  private val rng  = RandomStream.seeded(42)
+  private val rng  = RandomStream.seeded(TestSeed)
 
   // Run pipeline through Economics objects
   private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
@@ -90,7 +91,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
       fdiRepatriation = s5.sumFdiRepatriation,
       foreignDividendOutflow = s7.foreignDividendOutflow,
       month = s1.m,
-      commodityRng = RandomStream.seeded(42),
+      commodityRng = RandomStream.seeded(TestSeed),
     ),
   )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -3,7 +3,8 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.flows.*
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,9 +15,9 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val init = WorldInit.initialize(42L)
+  private val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w    = init.world
-  private val rng  = new scala.util.Random(42)
+  private val rng  = RandomStream.seeded(42)
 
   // Run pipeline through Economics objects
   private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
@@ -89,7 +90,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
       fdiRepatriation = s5.sumFdiRepatriation,
       foreignDividendOutflow = s7.foreignDividendOutflow,
       month = s1.m,
-      commodityRng = new scala.util.Random(42),
+      commodityRng = RandomStream.seeded(42),
     ),
   )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -2,8 +2,9 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthTraceStage, OperationalSignals, SignalExtraction, World}
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthRandomness, MonthTraceStage, OperationalSignals, SignalExtraction, World}
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -32,9 +33,9 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
   private val baseline = buildFixture(42L)
 
   private def buildFixture(seed: Long): PipelineFixture =
-    val init  = WorldInit.initialize(seed)
-    val world = init.world
-    val rng   = new scala.util.Random(seed)
+    val init     = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
+    val world    = init.world
+    val contract = MonthRandomness.Contract.fromSeed(seed)
 
     val fiscal = FiscalConstraintEconomics.compute(world, init.banks)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
@@ -56,12 +57,22 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       labor.living,
       labor.regionalWages,
     )
-    val s3     = HouseholdIncomeEconomics.compute(world, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2Pre.newWage, rng)
+    val s3     =
+      HouseholdIncomeEconomics.compute(
+        world,
+        init.firms,
+        init.households,
+        init.banks,
+        s1.lendingBaseRate,
+        s1.resWage,
+        s2Pre.newWage,
+        contract.stages.householdIncomeEconomics.newStream(),
+      )
     val s4     = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
-    val s5     = FirmEconomics.runStep(world, init.firms, init.households, init.banks, s1, s2Pre, s3, s4, rng)
+    val s5     = FirmEconomics.runStep(world, init.firms, init.households, init.banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
     val living = s5.ioFirms.filter(Firm.isAlive)
     val s2     = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
-    val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, rng)
+    val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
     val s7     = PriceEquityEconomics.compute(
       PriceEquityEconomics.Input(
         world,
@@ -76,10 +87,16 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
         init.banks,
         s5,
       ),
-      rng,
+      contract.stages.priceEquityEconomics.newStream(),
     )
-    val s8     = OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, init.banks, rng))
-    val s9     = BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, init.banks, rng))
+    val s8     =
+      OpenEconEconomics.runStep(
+        OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, init.banks, contract.stages.openEconEconomics.newStream()),
+      )
+    val s9     =
+      BankingEconomics.runStep(
+        BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, init.banks, contract.stages.bankingEconomics.newStream()),
+      )
 
     PipelineFixture(world, init.firms, init.households, init.banks, s1, s2Pre, s2, s3, s4, s5, s6, s7, s8, s9)
 
@@ -143,7 +160,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       govPurchases = baseline.s4.govPurchases,
       laggedInvestDemand = baseline.s4.laggedInvestDemand,
       fiscalRuleStatus = baseline.s4.fiscalRuleStatus,
-      rng = new scala.util.Random(seed),
+      rng = RandomStream.seeded(seed),
     )
 
   private def baseBankingComputeInput(world: World, operationalSignals: OperationalSignals, seed: Long): BankingEconomics.Input =
@@ -171,7 +188,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       priceEquityOutput = baseline.s7,
       openEconOutput = baseline.s8,
       banks = baseline.banks,
-      depositRng = new scala.util.Random(seed),
+      depositRng = RandomStream.seeded(seed),
     )
 
   private def baseComputeInput(world: World): WorldAssemblyEconomics.Input =
@@ -200,9 +217,11 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       priceEquityOutput = baseline.s7,
       openEconOutput = baseline.s8,
       bankOutput = baseline.s9,
-      rng = new scala.util.Random(42L),
-      migRng = new scala.util.Random(4242L),
+      randomness = MonthRandomness.Contract.fromSeed(42L).assembly.newStreams(),
     )
+
+  private def assemblyRandomness(seed: Long): MonthRandomness.AssemblyStreams =
+    MonthRandomness.Contract.fromSeed(seed).assembly.newStreams()
 
   private def allEmployed(
       households: Vector[Household.State],
@@ -254,7 +273,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     )
 
   private def netBirths(in: WorldAssemblyEconomics.StepInput): Int =
-    WorldAssemblyEconomics.runStep(in, new scala.util.Random(1234L), new scala.util.Random(5678L)).newWorld.flows.netFirmBirths
+    WorldAssemblyEconomics.runStep(in, assemblyRandomness(1234L)).newWorld.flows.netFirmBirths
 
   "DemandEconomics.compute" should "smooth sector hiring plans from lagged decision signals while keeping same-month pressure fixed" in {
     val weakLagged   = withSeedSignals(
@@ -445,7 +464,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
   it should "persist extracted same-month hiring slack into next-month decision signals" in {
     val input  = entrySensitiveInput
     val base   = input.copy(s2 = input.s2.copy(operationalHiringSlack = Share(0.21)))
-    val result = WorldAssemblyEconomics.runStep(base, new scala.util.Random(1234L), new scala.util.Random(5678L))
+    val result = WorldAssemblyEconomics.runStep(base, assemblyRandomness(1234L))
 
     result.newWorld.pipeline.operationalHiringSlack shouldBe Share(0.21)
     result.newWorld.pipeline.laggedHiringSlack shouldBe Share(0.21)
@@ -454,7 +473,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
 
   it should "keep post-month assembly distinct from the next-month seed boundary" in {
     val input = entrySensitiveInput.copy(s2 = entrySensitiveInput.s2.copy(operationalHiringSlack = Share(0.21)))
-    val post  = WorldAssemblyEconomics.runPostStep(input, new scala.util.Random(1234L), new scala.util.Random(5678L))
+    val post  = WorldAssemblyEconomics.runPostStep(input, assemblyRandomness(1234L))
 
     post.world.pipeline.operationalHiringSlack shouldBe Share(0.21)
     post.world.seedIn shouldBe input.w.seedIn

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -1,9 +1,10 @@
 package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.PLN
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -13,10 +14,9 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   "WorldAssemblyEconomics (own Input)" should "produce valid world after simulation step" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val w      = result.nextState.world
 
     w.month.shouldBe(1)
@@ -26,10 +26,9 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "preserve public-spending semantic aggregates on the assembled world" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val w      = result.nextState.world
 
     w.gov.domesticBudgetDemand shouldBe (w.gov.govCurrentSpend + w.gov.govCapitalSpend)
@@ -47,7 +46,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "overwrite only supported financial slice from ledger snapshot while preserving unsupported QE metrics" in {
-    val init      = WorldInit.initialize(42L)
+    val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val base      = init.world.copy(
       gov = init.world.gov.copy(
         financial = init.world.gov.financial.copy(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
@@ -19,12 +20,11 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
   private val td             = ComputationBoundary
 
   "FlowSimulation (autonomous)" should "run 12 months with SFC == 0L" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
 
       withClue(s"Month $month: ") {
         result.execution.totalWealth.shouldBe(0L)
@@ -35,13 +35,12 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce evolving economy (GDP changes)" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
     val gdps  = scala.collection.mutable.ArrayBuffer[Double]()
 
     (1 to 12).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       state = result.nextState
       gdps += td.toDouble(state.world.cachedMonthlyGdpProxy)
     }
@@ -51,12 +50,11 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "maintain positive employment throughout" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       state = result.nextState
 
       withClue(s"Month $month: ") {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -131,10 +132,9 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "drive FlowSimulation main path through BatchedFlow" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val legacy = AggregateBatchContract.toLegacyFlows(result.flows)
 
     result.flows should not be empty

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 class FlowPipelineSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
-  private val init           = WorldInit.initialize(42L)
+  private val init           = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w              = init.world
 
   /** Run one month through the new flow pipeline (partial -- Steps 1-2

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -19,10 +20,9 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   "FlowSimulation.emitAllBatches" should "preserve SFC at 0L" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
     result.execution.totalWealth shouldBe 0L
@@ -30,12 +30,11 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "preserve SFC across 12 months" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
       withClue(s"Month $month: ") {
@@ -48,10 +47,9 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "emit 30+ mechanism IDs" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
     result.execution.totalWealth shouldBe 0L

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -3,8 +3,8 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthSemantics, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthRandomness, MonthSemantics, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{ImperativeInterpreter, Interpreter}
@@ -25,22 +25,20 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
         .toVector
 
   "FlowSimulation.step" should "produce SFC == 0L on real World" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     result.execution.totalWealth shouldBe 0L
     result.sfcResult shouldBe Right(())
     result.calculus.employed should be > 0
   }
 
   it should "expose the month boundary as SimState -> StepOutput -> (nextState, trace)" in {
-    val init        = WorldInit.initialize(42L)
+    val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)
-    val stateRng    = new scala.util.Random(42L)
-    val rerunRng    = new scala.util.Random(42L)
-    val stateResult = FlowSimulation.step(state, stateRng)
-    val repeated    = FlowSimulation.step(state, rerunRng)
+    val contract    = MonthRandomness.Contract.fromSeed(42L)
+    val stateResult = FlowSimulation.step(state, contract)
+    val repeated    = FlowSimulation.step(state, contract)
 
     stateResult.stateIn shouldBe state
     stateResult.transition shouldBe ((stateResult.nextState, stateResult.trace))
@@ -53,10 +51,10 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "keep explicit pre and next-pre seed wrappers aligned with step outputs" in {
-    val init    = WorldInit.initialize(42L)
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state   = FlowSimulation.SimState.fromInit(init)
     val seedIn  = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn)
-    val result  = FlowSimulation.step(state, new scala.util.Random(42L))
+    val result  = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val seedOut = MonthSemantics.At[com.boombustgroup.amorfati.engine.SignalExtraction.Output, MonthSemantics.NextPre](result.signalExtraction)
 
     seedIn.value shouldBe state.world.seedIn
@@ -66,13 +64,41 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.trace.seedTransition.seedOut shouldBe seedOut.value.seedOut
   }
 
+  it should "accept an explicit month-step randomness contract with named stage and assembly streams" in {
+    val init       = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state      = FlowSimulation.SimState.fromInit(init)
+    val contract   = MonthRandomness.Contract.fromSeed(1234L)
+    val fromSeed   = FlowSimulation.step(state, contract)
+    val fromReplay = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(1234L))
+
+    fromSeed.randomness shouldBe contract
+    fromSeed.trace.randomness shouldBe contract
+    fromSeed.trace.randomness.all.map(_.key).toSet shouldBe Set(
+      MonthRandomness.StreamKey.HouseholdIncomeEconomics,
+      MonthRandomness.StreamKey.FirmEconomics,
+      MonthRandomness.StreamKey.HouseholdFinancialEconomics,
+      MonthRandomness.StreamKey.PriceEquityEconomics,
+      MonthRandomness.StreamKey.OpenEconEconomics,
+      MonthRandomness.StreamKey.BankingEconomics,
+      MonthRandomness.StreamKey.FdiMa,
+      MonthRandomness.StreamKey.FirmEntry,
+      MonthRandomness.StreamKey.StartupStaffing,
+      MonthRandomness.StreamKey.RegionalMigration,
+    )
+    fromSeed.trace.randomness.all.map(_.seed).distinct should have size fromSeed.trace.randomness.all.size
+    fromSeed.nextState.world shouldBe fromReplay.nextState.world
+    fromSeed.nextState.firms shouldBe fromReplay.nextState.firms
+    canonicalHouseholds(fromSeed.nextState.households) shouldBe canonicalHouseholds(fromReplay.nextState.households)
+    fromSeed.nextState.banks shouldBe fromReplay.nextState.banks
+    fromSeed.trace shouldBe fromReplay.trace
+  }
+
   it should "produce SFC == 0L across 12 months (autonomous driving)" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 12).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       withClue(s"Month $month: ") {
         result.execution.totalWealth shouldBe 0L
         result.sfcResult shouldBe Right(())
@@ -82,16 +108,16 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "propagate informal-economy pressure into fiscal outputs without breaking SFC" in {
-    val init          = WorldInit.initialize(42L)
+    val init          = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val lowShadowW    = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highShadowW   = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.4))
     val lowShadowRun  = FlowSimulation.step(
       FlowSimulation.SimState(lowShadowW, init.firms, init.households, init.banks, init.householdAggregates),
-      new scala.util.Random(42L),
+      MonthRandomness.Contract.fromSeed(42L),
     )
     val highShadowRun = FlowSimulation.step(
       FlowSimulation.SimState(highShadowW, init.firms, init.households, init.banks, init.householdAggregates),
-      new scala.util.Random(42L),
+      MonthRandomness.Contract.fromSeed(42L),
     )
 
     lowShadowRun.execution.totalWealth shouldBe 0L
@@ -106,18 +132,16 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce 30+ mechanism IDs" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     result.flows.map(_.mechanism).toSet.size should be > 30
   }
 
   it should "emit a typed MonthTrace with stable boundaries and typed timing envelopes" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val trace  = result.trace
 
     val demandSignals = trace.timing.requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.DemandSignals)
@@ -125,6 +149,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     trace.month shouldBe result.nextState.world.month
     trace.seedTransition.seedIn shouldBe init.world.seedIn
     trace.seedTransition.seedOut shouldBe result.nextState.world.seedIn
+    trace.randomness shouldBe result.randomness
     trace.boundary.startSnapshot.stock shouldBe Sfc.snapshot(init.world, init.firms, init.households, init.banks)
     trace.boundary.endSnapshot.stock shouldBe Sfc.snapshot(
       result.nextState.world,
@@ -170,10 +195,9 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "keep MonthTrace seed transitions consistent with timing envelopes and end-of-month boundary data" in {
-    val init   = WorldInit.initialize(42L)
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
-    val rng    = new scala.util.Random(42L)
-    val result = FlowSimulation.step(state, rng)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val trace  = result.trace
 
     trace.seedTransition.seedOut shouldBe DecisionSignals(
@@ -197,10 +221,9 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "match the legacy pure interpreter on aggregate execution balances" in {
-    val init      = WorldInit.initialize(42L)
+    val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val initState = FlowSimulation.SimState.fromInit(init)
-    val rng       = new scala.util.Random(42L)
-    val result    = FlowSimulation.step(initState, rng)
+    val result    = FlowSimulation.step(initState, MonthRandomness.Contract.fromSeed(42L))
     val state     = AggregateBatchContract.emptyExecutionState()
 
     ImperativeInterpreter.planAndApplyAll(state, result.flows) shouldBe Right(())

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -19,13 +19,14 @@ import org.scalatest.matchers.should.Matchers
 class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
+  private val TestSeed       = 42L
 
-  private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+  private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
   private val w          = initResult.world
-  private val rng        = RandomStream.seeded(42)
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =
+    val rng                = RandomStream.seeded(TestSeed)
     val fiscal             = FiscalConstraintEconomics.compute(w, initResult.banks)
     val s1                 = FiscalConstraintEconomics.toOutput(fiscal)
     val labor              = LaborEconomics.compute(w, initResult.firms, initResult.households, s1)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -4,7 +4,8 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -19,9 +20,9 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private val initResult = WorldInit.initialize(42L)
+  private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w          = initResult.world
-  private val rng        = new scala.util.Random(42)
+  private val rng        = RandomStream.seeded(42)
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -2,10 +2,10 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
-import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -26,7 +26,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =
-    val rng                = RandomStream.seeded(TestSeed)
+    val stageRandomness    = MonthRandomness.Contract.fromSeed(TestSeed).stages.newStreams()
     val fiscal             = FiscalConstraintEconomics.compute(w, initResult.banks)
     val s1                 = FiscalConstraintEconomics.toOutput(fiscal)
     val labor              = LaborEconomics.compute(w, initResult.firms, initResult.households, s1)
@@ -47,9 +47,28 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
       labor.living,
       labor.regionalWages,
     )
-    val s3                 = HouseholdIncomeEconomics.compute(w, initResult.firms, initResult.households, initResult.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, rng)
+    val s3                 = HouseholdIncomeEconomics.compute(
+      w,
+      initResult.firms,
+      initResult.households,
+      initResult.banks,
+      s1.lendingBaseRate,
+      s1.resWage,
+      s2.newWage,
+      stageRandomness.householdIncomeEconomics,
+    )
     val s4                 = DemandEconomics.compute(DemandEconomics.Input(w, s2.employed, s2.living, s3.domesticCons))
-    val s5                 = FirmEconomics.runStep(w, initResult.firms, initResult.households, initResult.banks, s1, s2, s3, s4, rng)
+    val s5                 = FirmEconomics.runStep(
+      w,
+      initResult.firms,
+      initResult.households,
+      initResult.banks,
+      s1,
+      s2,
+      s3,
+      s4,
+      stageRandomness.firmEconomics,
+    )
     val postLivingFirms    = s5.ioFirms.filter(Firm.isAlive)
     val postLaborDemand    = postLivingFirms.map(Firm.workerCount).sum
     val postAvailableLabor = LaborMarket.laborSupplyAtWage(s2.newWage, s1.resWage, w.derivedTotalPopulation)
@@ -64,7 +83,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
       living = postLivingFirms,
     )
     @annotation.unused
-    val s6                 = HouseholdFinancialEconomics.compute(w, s1.m, s2Post.employed, s3.hhAgg, rng)
+    val s6                 = HouseholdFinancialEconomics.compute(w, s1.m, s2Post.employed, s3.hhAgg, stageRandomness.householdFinancialEconomics)
 
     Vector.concat(
       // Tier 1: Social funds (from LaborEconomics output)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,12 +18,11 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   "Multi-month flow verification (120 months)" should "preserve SFC at 0L every month" in {
-    val init  = WorldInit.initialize(42L)
+    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state = FlowSimulation.SimState.fromInit(init)
 
     (1 to 120).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
 
       withClue(s"SFC violated at month $month: ") {
         result.execution.totalWealth shouldBe 0L
@@ -33,13 +33,12 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce increasing total flow volume over time" in {
-    val init    = WorldInit.initialize(42L)
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     var state   = FlowSimulation.SimState.fromInit(init)
     var volumes = Vector.empty[Long]
 
     (1 to 120).foreach { month =>
-      val rng    = new scala.util.Random(42L * 1000 + month)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
       volumes = volumes :+ AggregateBatchContract.totalTransferred(result.flows)
 
       state = result.nextState

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,12 +23,11 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
 
   "FlowSimulation.step (multi-seed)" should "produce SFC == 0L for all seeds × months" in
     seeds.foreach { seed =>
-      val init  = WorldInit.initialize(seed)
+      val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
       var state = FlowSimulation.SimState.fromInit(init)
 
       (1 to months).foreach { month =>
-        val rng    = new scala.util.Random(seed * 1000 + month)
-        val result = FlowSimulation.step(state, rng)
+        val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + month))
         withClue(s"Seed $seed, month $month: ") {
           result.execution.totalWealth.shouldBe(0L)
         }
@@ -37,11 +37,10 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
 
   it should "produce realistic employment (3-97%) for all seeds at month 12" in
     seeds.foreach { seed =>
-      val init  = WorldInit.initialize(seed)
+      val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
       var state = FlowSimulation.SimState.fromInit(init)
       (1 to months).foreach { m =>
-        val rng    = new scala.util.Random(seed * 1000 + m)
-        val result = FlowSimulation.step(state, rng)
+        val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + m))
         state = result.nextState
       }
 
@@ -55,11 +54,10 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
 
   it should "produce positive GDP for all seeds" in
     seeds.foreach { seed =>
-      val init  = WorldInit.initialize(seed)
+      val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
       var state = FlowSimulation.SimState.fromInit(init)
       (1 to months).foreach { m =>
-        val rng    = new scala.util.Random(seed * 1000 + m)
-        val result = FlowSimulation.step(state, rng)
+        val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + m))
         state = result.nextState
       }
 
@@ -70,10 +68,9 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
 
   it should "emit 30+ mechanism IDs for all seeds" in
     seeds.foreach { seed =>
-      val init   = WorldInit.initialize(seed)
+      val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
       val state  = FlowSimulation.SimState.fromInit(init)
-      val rng    = new scala.util.Random(seed)
-      val result = FlowSimulation.step(state, rng)
+      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed))
 
       withClue(s"Seed $seed mechanisms: ") {
         result.flows.map(_.mechanism).toSet.size should be > 30

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.ledger
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.init.WorldInit
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,7 +14,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
   private given SimParams = SimParams.defaults
 
   private def simState(seed: Long = 42L): FlowSimulation.SimState =
-    val init = WorldInit.initialize(seed)
+    val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
     FlowSimulation.SimState.fromInit(init)
 
   private def enrichedSimState(): FlowSimulation.SimState =

--- a/src/test/scala/com/boombustgroup/amorfati/init/InitRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/InitRandomnessSpec.scala
@@ -8,6 +8,7 @@ class InitRandomnessSpec extends AnyFlatSpec with Matchers:
   "InitRandomness.Contract" should "derive stable named streams from one root seed" in {
     val first  = InitRandomness.Contract.fromSeed(1234L)
     val second = InitRandomness.Contract.fromSeed(1234L)
+    val third  = InitRandomness.Contract.fromSeed(4321L)
 
     first shouldBe second
     first.rootSeed shouldBe 1234L
@@ -25,6 +26,7 @@ class InitRandomnessSpec extends AnyFlatSpec with Matchers:
       InitRandomness.StreamKey.InitialImmigrantStock,
     )
     first.all.map(_.seed).distinct should have size first.all.size
+    first.all.map(_.seed) should not equal third.all.map(_.seed)
     first.firms.network.newStream().nextLong() shouldBe second.firms.network.newStream().nextLong()
     first.immigration.initialStock.newStream().nextDouble() shouldBe second.immigration.initialStock.newStream().nextDouble()
   }

--- a/src/test/scala/com/boombustgroup/amorfati/init/InitRandomnessSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/InitRandomnessSpec.scala
@@ -1,0 +1,30 @@
+package com.boombustgroup.amorfati.init
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class InitRandomnessSpec extends AnyFlatSpec with Matchers:
+
+  "InitRandomness.Contract" should "derive stable named streams from one root seed" in {
+    val first  = InitRandomness.Contract.fromSeed(1234L)
+    val second = InitRandomness.Contract.fromSeed(1234L)
+
+    first shouldBe second
+    first.rootSeed shouldBe 1234L
+    first.all.map(_.key).toSet shouldBe Set(
+      InitRandomness.StreamKey.FirmNetwork,
+      InitRandomness.StreamKey.FirmSectorAssignments,
+      InitRandomness.StreamKey.FirmSkeleton,
+      InitRandomness.StreamKey.FirmRegions,
+      InitRandomness.StreamKey.FirmCapitalAndBank,
+      InitRandomness.StreamKey.FirmForeignOwnership,
+      InitRandomness.StreamKey.FirmStateOwnership,
+      InitRandomness.StreamKey.HouseholdNetwork,
+      InitRandomness.StreamKey.HouseholdAttributes,
+      InitRandomness.StreamKey.HouseholdInitialUnemployment,
+      InitRandomness.StreamKey.InitialImmigrantStock,
+    )
+    first.all.map(_.seed).distinct should have size first.all.size
+    first.firms.network.newStream().nextLong() shouldBe second.firms.network.newStream().nextLong()
+    first.immigration.initialStock.newStream().nextDouble() shouldBe second.immigration.initialStock.newStream().nextDouble()
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/networks/NetworkPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/networks/NetworkPropertySpec.scala
@@ -4,7 +4,7 @@ import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks:
 
@@ -21,7 +21,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
 
   "wattsStrogatz" should "produce symmetric adjacency" in
     forAll(genN, genK) { (n: Int, k: Int) =>
-      val adj = Network.wattsStrogatz(n, k, 0.10, new Random(42))
+      val adj = Network.wattsStrogatz(n, k, 0.10, RandomStream.seeded(42))
       for
         i <- 0 until n
         j <- adj(i)
@@ -30,14 +30,14 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
 
   it should "have no self-loops" in
     forAll(genN, genK) { (n: Int, k: Int) =>
-      val adj = Network.wattsStrogatz(n, k, 0.10, new Random(42))
+      val adj = Network.wattsStrogatz(n, k, 0.10, RandomStream.seeded(42))
       for i <- 0 until n do adj(i) should not contain i
     }
 
   it should "have exact degree k when p=0" in
     forAll(genN, genK) { (n: Int, k: Int) =>
       whenever(n > k) {
-        val adj = Network.wattsStrogatz(n, k, 0.0, new Random(42))
+        val adj = Network.wattsStrogatz(n, k, 0.0, RandomStream.seeded(42))
         for i <- 0 until n do adj(i).toSet.size shouldBe k
       }
     }
@@ -45,7 +45,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   it should "have average degree approximately k" in
     forAll(genN, genK) { (n: Int, k: Int) =>
       whenever(n > k) {
-        val adj    = Network.wattsStrogatz(n, k, 0.10, new Random(42))
+        val adj    = Network.wattsStrogatz(n, k, 0.10, RandomStream.seeded(42))
         val avgDeg = adj.map(_.length).sum.toDouble / n
         avgDeg shouldBe (k.toDouble +- (k * 0.3))
       }
@@ -54,7 +54,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   it should "be connected (single component)" in
     forAll(genN) { (n: Int) =>
       whenever(n >= 20) {
-        val adj     = Network.wattsStrogatz(n, 6, 0.10, new Random(42))
+        val adj     = Network.wattsStrogatz(n, 6, 0.10, RandomStream.seeded(42))
         val visited = new Array[Boolean](n)
         val queue   = scala.collection.mutable.Queue(0)
         visited(0) = true
@@ -71,7 +71,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
 
   "erdosRenyi" should "produce symmetric adjacency" in
     forAll(genN) { (n: Int) =>
-      val adj = Network.erdosRenyi(n, 6, new Random(42))
+      val adj = Network.erdosRenyi(n, 6, RandomStream.seeded(42))
       for
         i <- 0 until n
         j <- adj(i)
@@ -80,7 +80,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
 
   it should "have no self-loops" in
     forAll(genN) { (n: Int) =>
-      val adj = Network.erdosRenyi(n, 6, new Random(42))
+      val adj = Network.erdosRenyi(n, 6, RandomStream.seeded(42))
       for i <- 0 until n do adj(i) should not contain i
     }
 
@@ -88,7 +88,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
     forAll(genN) { (n: Int) =>
       whenever(n >= 30) {
         val target = 6
-        val adj    = Network.erdosRenyi(n, target, new Random(42))
+        val adj    = Network.erdosRenyi(n, target, RandomStream.seeded(42))
         val avgDeg = adj.map(_.length).sum.toDouble / n
         avgDeg shouldBe (target.toDouble +- (target * 0.5))
       }
@@ -99,7 +99,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   "barabasiAlbert" should "produce symmetric adjacency" in
     forAll(genN) { (n: Int) =>
       whenever(n >= 10) {
-        val adj = Network.barabasiAlbert(n, 3, new Random(42))
+        val adj = Network.barabasiAlbert(n, 3, RandomStream.seeded(42))
         for
           i <- 0 until n
           j <- adj(i)
@@ -110,7 +110,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   it should "have no self-loops" in
     forAll(genN) { (n: Int) =>
       whenever(n >= 10) {
-        val adj = Network.barabasiAlbert(n, 3, new Random(42))
+        val adj = Network.barabasiAlbert(n, 3, RandomStream.seeded(42))
         for i <- 0 until n do adj(i) should not contain i
       }
     }
@@ -118,7 +118,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   it should "have no isolated nodes" in
     forAll(genN) { (n: Int) =>
       whenever(n >= 10) {
-        val adj = Network.barabasiAlbert(n, 3, new Random(42))
+        val adj = Network.barabasiAlbert(n, 3, RandomStream.seeded(42))
         for i <- 0 until n do adj(i).length should be > 0
       }
     }
@@ -127,7 +127,7 @@ class NetworkPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
     forAll(genN) { (n: Int) =>
       whenever(n >= 20) {
         val m      = 3
-        val adj    = Network.barabasiAlbert(n, m, new Random(42))
+        val adj    = Network.barabasiAlbert(n, m, RandomStream.seeded(42))
         val avgDeg = adj.map(_.length).sum.toDouble / n
         avgDeg shouldBe (2.0 * m +- (m * 1.5))
       }

--- a/src/test/scala/com/boombustgroup/amorfati/networks/NetworkSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/networks/NetworkSpec.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.networks
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import scala.util.Random
+import com.boombustgroup.amorfati.random.RandomStream
 
 class NetworkSpec extends AnyFlatSpec with Matchers:
 
@@ -12,23 +12,23 @@ class NetworkSpec extends AnyFlatSpec with Matchers:
   // --- Watts-Strogatz ---
 
   "wattsStrogatz" should "produce average degree ≈ k" in {
-    val adj    = Network.wattsStrogatz(1000, 6, 0.10, new Random(42))
+    val adj    = Network.wattsStrogatz(1000, 6, 0.10, RandomStream.seeded(42))
     val avgDeg = adj.map(_.length).sum.toDouble / adj.length
     avgDeg shouldBe 6.0 +- 0.3 // ±5%
   }
 
   it should "be symmetric" in {
-    val adj = Network.wattsStrogatz(1000, 6, 0.10, new Random(42))
+    val adj = Network.wattsStrogatz(1000, 6, 0.10, RandomStream.seeded(42))
     for i <- adj.indices; j <- adj(i) do adj(j) should contain(i)
   }
 
   it should "have no self-loops" in {
-    val adj = Network.wattsStrogatz(1000, 6, 0.10, new Random(42))
+    val adj = Network.wattsStrogatz(1000, 6, 0.10, RandomStream.seeded(42))
     for i <- adj.indices do adj(i) should not contain i
   }
 
   it should "be a single connected component" in {
-    val adj     = Network.wattsStrogatz(1000, 6, 0.10, new Random(42))
+    val adj     = Network.wattsStrogatz(1000, 6, 0.10, RandomStream.seeded(42))
     val visited = Array.fill(adj.length)(false)
     val queue   = scala.collection.mutable.Queue(0)
     visited(0) = true
@@ -41,27 +41,27 @@ class NetworkSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "produce exact degree k when p=0.0" in {
-    val adj = Network.wattsStrogatz(1000, 6, 0.0, new Random(42))
+    val adj = Network.wattsStrogatz(1000, 6, 0.0, RandomStream.seeded(42))
     for i <- adj.indices do adj(i).length shouldBe 6
   }
 
   // --- Erdos-Renyi ---
 
   "erdosRenyi" should "produce average degree ≈ target" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val adj    = Network.erdosRenyi(1000, 6, rng)
     val avgDeg = adj.map(_.length).sum.toDouble / adj.length
     avgDeg shouldBe 6.0 +- 0.9 // ±15%
   }
 
   it should "be symmetric" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     val adj = Network.erdosRenyi(1000, 6, rng)
     for i <- adj.indices; j <- adj(i) do adj(j) should contain(i)
   }
 
   it should "have no self-loops" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     val adj = Network.erdosRenyi(1000, 6, rng)
     for i <- adj.indices do adj(i) should not contain i
   }
@@ -69,26 +69,26 @@ class NetworkSpec extends AnyFlatSpec with Matchers:
   // --- Barabasi-Albert ---
 
   "barabasiAlbert" should "produce average degree ≈ 2m" in {
-    val rng    = new Random(42)
+    val rng    = RandomStream.seeded(42)
     val adj    = Network.barabasiAlbert(1000, 3, rng)
     val avgDeg = adj.map(_.length).sum.toDouble / adj.length
     avgDeg shouldBe 6.0 +- 0.6 // ±10%
   }
 
   it should "be symmetric" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     val adj = Network.barabasiAlbert(1000, 3, rng)
     for i <- adj.indices; j <- adj(i) do adj(j) should contain(i)
   }
 
   it should "have no self-loops" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     val adj = Network.barabasiAlbert(1000, 3, rng)
     for i <- adj.indices do adj(i) should not contain i
   }
 
   it should "have no isolated nodes" in {
-    val rng = new Random(42)
+    val rng = RandomStream.seeded(42)
     val adj = Network.barabasiAlbert(1000, 3, rng)
     for i <- adj.indices do adj(i).length should be > 0
   }


### PR DESCRIPTION
Closes #318

## Summary
- introduce explicit randomness contracts for both monthly execution and world initialization
- add a shared RandomStream/SeedDerivation layer and remove scala.util.Random from production-domain APIs
- route flow simulation, init, diagnostics, Monte Carlo, and assembly economics through named randomness ownership
- update tests and READMEs to reflect the new contract-based entry points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved to an explicit, typed randomness model: initialization and per-step randomness are now structured into named streams; month audit traces include randomness metadata for reproducible runs.
  * Added deterministic seed-derivation and stream helpers to produce independent, replayable substreams.
* **Tests**
  * Updated suites to use the new randomness APIs and validate deterministic, reproducible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->