### PR TITLE
Expose a first-class unfold driver over the monthly step

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.{MonthDriver, MonthRandomness}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 
@@ -15,30 +15,31 @@ object BankruptcyProbe:
   @main def runBankruptcyProbe(seed: Long = 1L, months: Int = 12): Unit =
     given SimParams = SimParams.defaults
 
-    val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
-    var state = FlowSimulation.SimState.fromInit(init)
+    val initState = FlowSimulation.SimState.fromInit(WorldInit.initialize(InitRandomness.Contract.fromSeed(seed)))
 
     println(s"seed=$seed months=$months")
 
-    (1 to months).foreach: month =>
-      val prevById     = state.firms.map(f => f.id -> f).toMap
-      val result       = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + month))
-      val newBankrupts = result.nextState.firms.flatMap: f =>
-        bankruptReason(f).flatMap: reason =>
-          prevById.get(f.id).flatMap(bankruptReason) match
-            case Some(_) => None
-            case None    => Some((reason, f.sector.toInt))
+    MonthDriver
+      .unfoldSteps(initState): state =>
+        Some(MonthRandomness.Contract.fromSeed(seed * 1000L + state.world.month.toLong + 1L))
+      .take(months)
+      .foreach: result =>
+        val month        = result.nextState.world.month
+        val prevById     = result.stateIn.firms.map(f => f.id -> f).toMap
+        val newBankrupts = result.nextState.firms.flatMap: f =>
+          bankruptReason(f).flatMap: reason =>
+            prevById.get(f.id).flatMap(bankruptReason) match
+              case Some(_) => None
+              case None    => Some((reason, f.sector.toInt))
 
-      val byReason    = newBankrupts.groupMapReduce(_._1)(_ => 1)(_ + _).toVector.sortBy(-_._2)
-      val bySector    = newBankrupts.groupMapReduce(_._2)(_ => 1)(_ + _).toVector.sortBy(_._1)
-      val unemp       = result.nextState.householdAggregates.unemploymentRate(result.nextState.world.derivedTotalPopulation)
-      val demandMults = result.nextState.world.pipeline.sectorDemandMult
+        val byReason    = newBankrupts.groupMapReduce(_._1)(_ => 1)(_ + _).toVector.sortBy(-_._2)
+        val bySector    = newBankrupts.groupMapReduce(_._2)(_ => 1)(_ + _).toVector.sortBy(_._1)
+        val unemp       = result.nextState.householdAggregates.unemploymentRate(result.nextState.world.derivedTotalPopulation)
+        val demandMults = result.nextState.world.pipeline.sectorDemandMult
 
-      println(
-        s"month=$month unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",
-      )
-      if newBankrupts.nonEmpty then
-        println(s"  reasons=${byReason.mkString(", ")}")
-        println(s"  sectors=${bySector.mkString(", ")}")
-
-      state = result.nextState
+        println(
+          s"month=$month unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",
+        )
+        if newBankrupts.nonEmpty then
+          println(s"  reasons=${byReason.mkString(", ")}")
+          println(s"  sectors=${bySector.mkString(", ")}")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
@@ -1,0 +1,28 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+
+/** Shared unfold-style driver over the explicit monthly step boundary.
+  *
+  * This is orchestration glue at the engine level: callers own the schedule of
+  * month-level randomness contracts, while [[FlowSimulation.step]] remains the
+  * narrow one-month transition.
+  */
+object MonthDriver:
+
+  type SimState   = FlowSimulation.SimState
+  type StepOutput = FlowSimulation.StepOutput
+
+  /** Caller-owned month schedule for the engine unfold.
+    *
+    * Returning `Some(contract)` executes one monthly step from the provided
+    * state boundary. Returning `None` closes the unfold.
+    */
+  type RandomnessSchedule = SimState => Option[MonthRandomness.Contract]
+
+  def unfoldSteps(initialState: SimState)(schedule: RandomnessSchedule)(using p: SimParams): Iterator[StepOutput] =
+    Iterator.unfold(initialState): state =>
+      schedule(state).map: randomness =>
+        val output = FlowSimulation.step(state, randomness)
+        (output, output.nextState)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -22,6 +22,7 @@ engine/
 | `World.scala` | Case class holding all macro state, decomposed into 7 nested types: `SocialState`, `FinancialMarketsState`, `ExternalState`, `RealState`, `MechanismsState`, `MonetaryPlumbingState`, `FlowState`. |
 | `MonthSemantics.scala` | Tiny typed phase markers for the internal month step: pre-seed, same-month operational state, post-assembly state, and next pre-seed extraction. |
 | `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and assembly streams for deterministic replay and auditability. |
+| `MonthDriver.scala` | Shared month-by-month unfold driver over the explicit `FlowSimulation.step` boundary. |
 | `OperationalSignals.scala` | Explicit same-month signal surface for month-`t` operational execution, kept distinct from persisted start-of-month `DecisionSignals`. |
 | `SignalExtraction.scala` | Explicit post-to-pre boundary: derives next-month `DecisionSignals` and typed seed provenance from realized month-`t` outcomes. |
 | `MonthTrace.scala` | Boundary-focused audit artifact with a stable month core (`boundary`, `seedTransition`, `randomness`, validations) plus extensible typed timing envelopes. |
@@ -44,6 +45,9 @@ case class StepOutput(
 )
 
 def step(state: SimState, randomness: MonthRandomness.Contract): StepOutput
+object MonthDriver:
+  type RandomnessSchedule = SimState => Option[MonthRandomness.Contract]
+  def unfoldSteps(initialState: SimState)(schedule: RandomnessSchedule): Iterator[StepOutput]
 ```
 
 Read it as a month transition:
@@ -55,6 +59,7 @@ Read it as a month transition:
 - `signalExtraction` is the dedicated `post -> pre` boundary.
 - `trace` is the emitted audit artifact for month `t`.
 - `nextState` is the typed month `t+1` boundary state.
+- `MonthDriver.unfoldSteps` is the first-class month driver: callers own the explicit randomness schedule, while the engine owns the `stateIn -> step -> nextState` unfold.
 
 ## economics/
 
@@ -83,7 +88,7 @@ against 13 accounting identities each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point. `step(state, randomness)` is the explicit month boundary: it computes typed `StageOutputs`, narrows them into `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes typed `StageOutputs`, narrows them into `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `FirmWages`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `StateAdapter.scala` | Legacy bridge from economics/world state into specific flow inputs. Kept only as transitional adapter code around the newer pipeline. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -289,6 +289,87 @@ object FlowSimulation:
       seedOut: MonthSemantics.SeedOut,
   )
 
+  /** Full month-step contract.
+    *
+    * `stateIn -> StepOutput(nextState, trace)` is the explicit monthly
+    * boundary. The runtime may still drive this incrementally, but the
+    * architectural shape is a single transition from one [[SimState]] to the
+    * next.
+    */
+  case class StepOutput(
+      stateIn: SimState,
+      calculus: MonthlyCalculus,
+      operationalSignals: OperationalSignals,
+      signalExtraction: SignalExtraction.Output,
+      randomness: MonthRandomness.Contract,
+      flows: Vector[BatchedFlow],
+      execution: ExecutionResult,
+      sfcResult: Sfc.SfcResult,
+      trace: MonthTrace,
+      nextState: SimState,
+  ):
+    def transition: (SimState, MonthTrace) = (nextState, trace)
+
+  /** Single-month explicit public boundary.
+    *
+    * [[com.boombustgroup.amorfati.engine.MonthDriver.unfoldSteps]] is the
+    * preferred runtime entrypoint, but `step` remains public as the narrow
+    * one-month contract used by tests, replay, and diagnostics.
+    */
+  def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
+    val input      = StepInput(
+      stateIn,
+      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
+      randomness,
+    )
+    val outcome    = computeMonthOutcome(input)
+    val flows      = emitAllBatches(outcome.stages.value.calculus)
+    val execution  = executeBatches(flows).fold(
+      err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
+      identity,
+    )
+    val nextState  = advanceState(input, outcome.post, outcome.seedOut)
+    val sfcFlows   = buildSfcFlows(outcome.stages, flows, nextState.world.plumbing.fofResidual)
+    val sfcResult  = Sfc.validate(
+      prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
+      curr = runtimeState(nextState.world, nextState.firms, nextState.households, nextState.banks),
+      flows = sfcFlows,
+      batches = flows,
+      executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
+      totalWealth = execution.totalWealth,
+    )
+    val monthTrace = buildMonthTrace(
+      input = input,
+      outcome = outcome,
+      nextState = nextState,
+      executedFlows = sfcFlows,
+      sfcResult = sfcResult,
+    )
+
+    StepOutput(
+      stateIn = stateIn,
+      calculus = outcome.stages.value.calculus,
+      operationalSignals = outcome.operational.value,
+      signalExtraction = outcome.seedOut.value,
+      randomness = randomness,
+      flows,
+      execution,
+      sfcResult,
+      trace = monthTrace,
+      nextState = nextState,
+    )
+
+  /** Public API: compute calculus only (for tests that need MonthlyCalculus).
+    */
+  def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
+    computeStageOutputs(
+      StepInput(
+        stateIn = state,
+        seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
+        randomness = randomness,
+      ),
+    ).calculus
+
   /** Compute MonthlyCalculus by chaining all Economics. Uses old pipeline steps
     * for HH/Demand/Firm/PriceEquity (pure calculus). Uses self-contained
     * OpenEconEconomics for monetary/external. Runs BankingEconomics exactly
@@ -298,9 +379,7 @@ object FlowSimulation:
     * Returns typed [[StageOutputs]] so later boundaries do not depend on one
     * broad transport bag.
     */
-  private def computeStageOutputs(
-      input: StepInput,
-  )(using p: SimParams): StageOutputs =
+  private def computeStageOutputs(input: StepInput)(using p: SimParams): StageOutputs =
     val randomness        = input.randomness.stages
     val stateIn           = input.stateIn
     val w                 = stateIn.world
@@ -512,38 +591,6 @@ object FlowSimulation:
     )
     StageOutputs(fiscal, s2, s3, s4, s5, s6, s7, s8, s9, calc)
 
-  /** Public API: compute calculus only (for tests that need MonthlyCalculus).
-    */
-  def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
-    computeStageOutputs(
-      StepInput(
-        stateIn = state,
-        seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
-        randomness = randomness,
-      ),
-    ).calculus
-
-  /** Full month-step contract.
-    *
-    * `stateIn -> StepOutput(nextState, trace)` is the explicit monthly
-    * boundary. The runtime may still drive this incrementally, but the
-    * architectural shape is a single transition from one [[SimState]] to the
-    * next.
-    */
-  case class StepOutput(
-      stateIn: SimState,
-      calculus: MonthlyCalculus,
-      operationalSignals: OperationalSignals,
-      signalExtraction: SignalExtraction.Output,
-      randomness: MonthRandomness.Contract,
-      flows: Vector[BatchedFlow],
-      execution: ExecutionResult,
-      sfcResult: Sfc.SfcResult,
-      trace: MonthTrace,
-      nextState: SimState,
-  ):
-    def transition: (SimState, MonthTrace) = (nextState, trace)
-
   private def executeBatches(flows: Vector[BatchedFlow]): Either[String, ExecutionResult] =
     val state = AggregateBatchContract.emptyExecutionState()
     ImperativeInterpreter
@@ -714,10 +761,7 @@ object FlowSimulation:
       ),
     )
 
-  private def assemblePostMonth(
-      input: StepInput,
-      stageView: MonthSemantics.StageView,
-  )(using p: SimParams): MonthSemantics.PostAssembly =
+  private def assemblePostMonth(input: StepInput, stageView: MonthSemantics.StageView)(using p: SimParams): MonthSemantics.PostAssembly =
     val stages    = stageView.value
     val assembled = WorldAssemblyEconomics.computePostMonth(
       WorldAssemblyEconomics.Input(
@@ -751,10 +795,7 @@ object FlowSimulation:
     // This stays at month `t`: the boundary seed is still `seedIn` here.
     MonthSemantics.At[PostMonth, MonthSemantics.Post](PostMonth(assembled, buildTraceInputs(stageView, assembled)))
 
-  private def extractSeedOut(
-      stageView: MonthSemantics.StageView,
-      post: MonthSemantics.PostAssembly,
-  ): MonthSemantics.SeedOut =
+  private def extractSeedOut(stageView: MonthSemantics.StageView, post: MonthSemantics.PostAssembly): MonthSemantics.SeedOut =
     val assembled = post.value.assembled
     val employed  = Household.countEmployed(assembled.households)
     val stages    = stageView.value
@@ -776,9 +817,7 @@ object FlowSimulation:
       ),
     )
 
-  private def computeMonthOutcome(
-      input: StepInput,
-  )(using p: SimParams): MonthOutcome =
+  private def computeMonthOutcome(input: StepInput)(using p: SimParams): MonthOutcome =
     // Keep the month-step pipeline explicit:
     // `seedIn/pre -> same-month stages -> post-month assembly -> seedOut/next-pre`.
     val stageView   = MonthSemantics.At[StageOutputs, MonthSemantics.SameMonth](computeStageOutputs(input))
@@ -847,52 +886,4 @@ object FlowSimulation:
       ),
       executedFlows = executedFlows,
       validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
-    )
-
-  /** Full step: compute calculus → emit flows → assemble new World.
-    *
-    * The internal month-step shape is now explicit:
-    * `stateIn -> StepInput -> MonthOutcome -> nextState`.
-    */
-  def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
-    val input      = StepInput(
-      stateIn,
-      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
-      randomness,
-    )
-    val outcome    = computeMonthOutcome(input)
-    val flows      = emitAllBatches(outcome.stages.value.calculus)
-    val execution  = executeBatches(flows).fold(
-      err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
-      identity,
-    )
-    val nextState  = advanceState(input, outcome.post, outcome.seedOut)
-    val sfcFlows   = buildSfcFlows(outcome.stages, flows, nextState.world.plumbing.fofResidual)
-    val sfcResult  = Sfc.validate(
-      prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
-      curr = runtimeState(nextState.world, nextState.firms, nextState.households, nextState.banks),
-      flows = sfcFlows,
-      batches = flows,
-      executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
-      totalWealth = execution.totalWealth,
-    )
-    val monthTrace = buildMonthTrace(
-      input = input,
-      outcome = outcome,
-      nextState = nextState,
-      executedFlows = sfcFlows,
-      sfcResult = sfcResult,
-    )
-
-    StepOutput(
-      stateIn = stateIn,
-      calculus = outcome.stages.value.calculus,
-      operationalSignals = outcome.operational.value,
-      signalExtraction = outcome.seedOut.value,
-      randomness = randomness,
-      flows,
-      execution,
-      sfcResult,
-      trace = monthTrace,
-      nextState = nextState,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -53,20 +53,20 @@ object McRunner:
 
   /** Pure simulation — returns Either, no side effects. For tests. */
   def runSingle(seed: Long, durationMonths: Int = McRunConfig.DefaultRunDuration)(using p: SimParams): Either[SimError, RunResult] =
-    initSeed(seed).flatMap(loop(_, seed, 0, Vector.empty, durationMonths))
+    initSeed(seed).flatMap: initState =>
+      materializeRun(initState, runtimeSteps(seed, initState).take(durationMonths))
 
   /** Streaming simulation — emits one [[MonthSnapshot]] per month. */
   private def seedStream(seed: Long, durationMonths: Int)(using SimParams) =
     ZStream.unwrap(ZIO.fromEither(initSeed(seed)).map(simulateMonths(seed, _, durationMonths)))
 
   private def simulateMonths(seed: Long, initState: FlowSimulation.SimState, durationMonths: Int)(using p: SimParams) =
-    ZStream.unfoldZIO((initState, 0)):
-      case (_, month) if month >= durationMonths => ZIO.none
-      case (state, month)                        =>
-        ZIO
-          .fromEither(stepMonth(state, seed, month))
-          .map: (newState, monthData) =>
-            Some((MonthSnapshot(month + 1, newState, monthData), (newState, month + 1)))
+    val steps = runtimeSteps(seed, initState).take(durationMonths)
+    ZStream
+      .unfold(steps): iterator =>
+        if iterator.hasNext then Some((iterator.next(), iterator))
+        else None
+      .mapZIO(result => ZIO.fromEither(stepSnapshot(result)))
 
   private def initSeed(seed: Long)(using p: SimParams) =
     val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
@@ -75,37 +75,46 @@ object McRunner:
     if errors.nonEmpty then Left(SimError.Init(errors))
     else Right(FlowSimulation.SimState.fromInit(init))
 
-  private def stepMonth(state: FlowSimulation.SimState, seed: Long, month: Int)(using p: SimParams) =
-    val stepSeed = seed * 10000 + month
-    val result   = engine.flows.FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(stepSeed))
+  private def runtimeSteps(seed: Long, initState: FlowSimulation.SimState)(using p: SimParams): Iterator[FlowSimulation.StepOutput] =
+    MonthDriver.unfoldSteps(initState): state =>
+      Some(MonthRandomness.Contract.fromSeed(runtimeRootSeed(seed, state)))
+
+  private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
+    // Preserve the runtime month-seed convention used before the shared driver.
+    seed * 10000L + state.world.month.toLong
+
+  private def stepSnapshot(result: FlowSimulation.StepOutput)(using p: SimParams): Either[SimError, MonthSnapshot] =
     result.sfcResult match
       case Left(errors) =>
-        Left(SimError.SfcViolation(month + 1, errors))
+        Left(SimError.SfcViolation(result.nextState.world.month, errors))
       case Right(())    =>
         val monthData = SimOutput.compute(
-          month,
+          result.stateIn.world.month,
           result.nextState.world,
           result.nextState.firms,
           result.nextState.households,
           result.nextState.banks,
           result.nextState.householdAggregates,
         )
-        Right((result.nextState, monthData))
+        Right(MonthSnapshot(result.nextState.world.month, result.nextState, monthData))
 
-  @scala.annotation.tailrec
-  private def loop(
-      state: FlowSimulation.SimState,
-      seed: Long,
-      month: Int,
-      monthSeries: Vector[Array[Double]],
-      durationMonths: Int,
+  private def materializeRun(
+      initState: FlowSimulation.SimState,
+      steps: Iterator[FlowSimulation.StepOutput],
   )(using p: SimParams): Either[SimError, RunResult] =
-    if month >= durationMonths then Right(RunResult(TimeSeries.wrap(monthSeries.toArray), state))
-    else
-      stepMonth(state, seed, month) match
-        case Left(err)                    => Left(err)
-        case Right((newState, monthData)) =>
-          loop(newState, seed, month + 1, monthSeries :+ monthData, durationMonths)
+    val monthSeries = Vector.newBuilder[Array[Double]]
+
+    @scala.annotation.tailrec
+    def collect(remaining: Iterator[FlowSimulation.StepOutput], terminal: FlowSimulation.SimState): Either[SimError, RunResult] =
+      if !remaining.hasNext then Right(RunResult(TimeSeries.wrap(monthSeries.result().toArray), terminal))
+      else
+        stepSnapshot(remaining.next()) match
+          case Left(err)       => Left(err)
+          case Right(snapshot) =>
+            monthSeries += snapshot.monthData
+            collect(remaining, snapshot.state)
+
+    collect(steps, initState)
 
   /** Consume a seed stream into RunResult, collecting monthly data. */
   private def materializeSeed(seed: Long, rc: McRunConfig)(using p: SimParams) =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -20,7 +20,7 @@ Main ──→ McRunner.run(rc)
            │
            ├── for seed ← 1..N:
            │     WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
-           │     Simulation.step  (no McRunConfig)
+           │     MonthDriver.unfoldSteps(...).take(runDurationMonths)
            │     SimOutput.compute  → Array[Double]
            │
            ├── McResults.summarize  → DescriptiveStats per column
@@ -28,8 +28,9 @@ Main ──→ McRunner.run(rc)
 ```
 
 `McRunner.runSingle` is the only bridge between this package and the
-engine — it calls `WorldInit.initialize` and `Simulation.step`, then
-maps the resulting state through `SimOutput.compute`.
+engine — it calls `WorldInit.initialize`, drives the shared
+`MonthDriver.unfoldSteps` iterator, then maps each monthly state
+through `SimOutput.compute`.
 
 `runDurationMonths` is a Monte Carlo/runtime concern. It controls how
 many monthly snapshots the runner materializes, but it is not part of

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -3,7 +3,15 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthRandomness, MonthSemantics, MonthTimingEnvelopeKey, MonthTimingPayload, MonthTraceStage}
+import com.boombustgroup.amorfati.engine.{
+  DecisionSignals,
+  MonthDriver,
+  MonthRandomness,
+  MonthSemantics,
+  MonthTimingEnvelopeKey,
+  MonthTimingPayload,
+  MonthTraceStage,
+}
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
@@ -93,17 +101,50 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     fromSeed.trace shouldBe fromReplay.trace
   }
 
-  it should "produce SFC == 0L across 12 months (autonomous driving)" in {
+  it should "expose a first-class unfold driver over the monthly step boundary" in {
     val init  = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
-    var state = FlowSimulation.SimState.fromInit(init)
+    val state = FlowSimulation.SimState.fromInit(init)
+    val steps = MonthDriver
+      .unfoldSteps(state): current =>
+        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+      .take(3)
+      .toVector
 
-    (1 to 12).foreach { month =>
-      val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
+    steps should have size 3
+    steps.map(_.stateIn.world.month) shouldBe Vector(0, 1, 2)
+    steps.map(_.nextState.world.month) shouldBe Vector(1, 2, 3)
+    steps.foreach(_.sfcResult shouldBe Right(()))
+  }
+
+  it should "stop unfolding when the caller closes the randomness schedule" in {
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state   = FlowSimulation.SimState.fromInit(init)
+    val results = MonthDriver
+      .unfoldSteps(state): current =>
+        Option.when(current.world.month < 2)(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+      .toVector
+
+    results should have size 2
+    results.map(_.nextState.world.month) shouldBe Vector(1, 2)
+  }
+
+  it should "produce SFC == 0L across 12 months (autonomous driving)" in {
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state   = FlowSimulation.SimState.fromInit(init)
+    val results = MonthDriver
+      .unfoldSteps(state): current =>
+        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+      .take(12)
+      .toVector
+
+    results should have size 12
+
+    results.foreach { result =>
+      val month = result.nextState.world.month
       withClue(s"Month $month: ") {
         result.execution.totalWealth shouldBe 0L
         result.sfcResult shouldBe Right(())
       }
-      state = result.nextState
     }
   }
 


### PR DESCRIPTION
Closes #319

## Summary
- extract the shared unfold-style monthly driver into engine.MonthDriver
- keep FlowSimulation focused on the explicit single-month step boundary and its typed outputs
- migrate Monte Carlo and the bankruptcy probe to MonthDriver, make materializeRun carry terminal state immutably, and update docs/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engine and Monte Carlo documentation to reflect revised iteration patterns

* **Refactoring**
  * Unified month-by-month simulation iteration mechanism across bankruptcy detection, Monte Carlo execution, and flow simulation
  * Reorganized simulation component code structure for improved consistency

* **Tests**
  * Added tests for month-iteration behavior and schedule-controlled early termination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->