### PR TITLE
Introduce typed simulation month boundaries

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.ledger.Distribute
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.mechanisms.{Macroprudential, YieldCurve}
 import com.boombustgroup.amorfati.types.*
 
@@ -61,7 +62,7 @@ object Banking:
     */
   enum BankStatus:
     case Active(consecutiveLowCar: Int)
-    case Failed(month: Int)
+    case Failed(month: ExecutionMonth)
 
   // ---------------------------------------------------------------------------
   // Aggregate balance sheet (sum over all per-bank BankStates)
@@ -219,10 +220,10 @@ object Banking:
       case BankStatus.Failed(_) => true
       case _                    => false
 
-    /** Month of failure, or 0 if active. */
-    def failedMonth: Int = status match
-      case BankStatus.Failed(m) => m
-      case _                    => 0
+    /** Month of failure, if this bank has already been resolved. */
+    def failedMonth: Option[ExecutionMonth] = status match
+      case BankStatus.Failed(m) => Some(m)
+      case _                    => None
 
     /** Consecutive months with CAR below regulatory minimum, or 0 if failed. */
     def consecutiveLowCar: Int = status match
@@ -468,7 +469,7 @@ object Banking:
     */
   def checkFailures(
       banks: Vector[BankState],
-      month: Int,       // simulation month (recorded in BankStatus.Failed)
+      month: ExecutionMonth, // execution month (recorded in BankStatus.Failed)
       enabled: Boolean, // whether failure mechanism is active
       ccyb: Multiplier, // countercyclical capital buffer
   )(using p: SimParams): FailureCheckResult =

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -470,8 +470,8 @@ object Banking:
   def checkFailures(
       banks: Vector[BankState],
       month: ExecutionMonth, // execution month (recorded in BankStatus.Failed)
-      enabled: Boolean, // whether failure mechanism is active
-      ccyb: Multiplier, // countercyclical capital buffer
+      enabled: Boolean,      // whether failure mechanism is active
+      ccyb: Multiplier,      // countercyclical capital buffer
   )(using p: SimParams): FailureCheckResult =
     if !enabled then
       FailureCheckResult(

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -798,8 +798,8 @@ object Firm:
   private[amorfati] def adoptionWillingnessMultiplier(month: ExecutionMonth, localAuto: Share)(using p: SimParams): Share =
     val elapsedMonths = month.toInt - 1
     val rampFrac      = Scalar.fraction(elapsedMonths, p.firm.adoptionRampMonths).clamp(Scalar.Zero, Scalar.One).toShare
-    val baseLevel = Share(UncertaintyBase) + Share(UncertaintySlope) * rampFrac
-    val demoBoost =
+    val baseLevel     = Share(UncertaintyBase) + Share(UncertaintySlope) * rampFrac
+    val demoBoost     =
       if localAuto > p.firm.demoEffectThresh then p.firm.demoEffectBoost * (localAuto - p.firm.demoEffectThresh)
       else Share.Zero
     (baseLevel + demoBoost).min(Share.One)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -1109,7 +1109,8 @@ object Firm:
     */
   private def energyAndEtsCost(firm: State, revenue: PLN, month: ExecutionMonth, commodityPrice: PriceIndex)(using p: SimParams): PLN =
     val baseEnergy: PLN      = revenue * p.climate.energyCostShares(firm.sector.toInt)
-    val etsGrowth            = (Scalar.One + p.climate.etsPriceDrift.monthly.toScalar).pow(month.toInt)
+    val monthsElapsed        = month.previousCompleted
+    val etsGrowth            = (Scalar.One + p.climate.etsPriceDrift.monthly.toScalar).pow(monthsElapsed.toInt)
     val carbonSurcharge      = p.climate.carbonIntensity(firm.sector.toInt) * (etsGrowth - Scalar.One)
     val greenDiscount: Share = if firm.greenCapital > PLN.Zero then
       val targetGK = workerCount(firm) * p.climate.greenKLRatios(firm.sector.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -796,7 +796,8 @@ object Firm:
     (pFull, pHyb)
 
   private[amorfati] def adoptionWillingnessMultiplier(month: ExecutionMonth, localAuto: Share)(using p: SimParams): Share =
-    val rampFrac  = Scalar.fraction(month.toInt, p.firm.adoptionRampMonths).clamp(Scalar.Zero, Scalar.One).toShare
+    val elapsedMonths = month.toInt - 1
+    val rampFrac      = Scalar.fraction(elapsedMonths, p.firm.adoptionRampMonths).clamp(Scalar.Zero, Scalar.One).toShare
     val baseLevel = Share(UncertaintyBase) + Share(UncertaintySlope) * rampFrac
     val demoBoost =
       if localAuto > p.firm.demoEffectThresh then p.firm.demoEffectBoost * (localAuto - p.firm.demoEffectThresh)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{OperationalSignals, World}
 import com.boombustgroup.amorfati.fp.FixedPointBase.bankerRound
 import com.boombustgroup.amorfati.types.*
@@ -456,13 +457,14 @@ object Firm:
   def process(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
       rng: RandomStream,
   )(using p: SimParams): Result =
-    val decision = decide(firm, w, operationalSignals, lendRate, bankCanLend, allFirms, rng)
+    val decision = decide(firm, w, executionMonth, operationalSignals, lendRate, bankCanLend, allFirms, rng)
     val r0       = updateHiringSignalState(execute(firm, decision), firm, w, operationalSignals)
     val r0a      = applyLoanAmortization(r0)
     val r1       = applyGreenInvestment(r0a)
@@ -475,12 +477,13 @@ object Firm:
   def process(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
       allFirms: Vector[State],
       rng: RandomStream,
   )(using p: SimParams): Result =
-    process(firm, w, OperationalSignals.fromBridgedWorld(w), lendRate, bankCanLend, allFirms, rng)
+    process(firm, w, executionMonth, OperationalSignals.fromBridgedWorld(w), lendRate, bankCanLend, allFirms, rng)
 
   // ---- Decide (all match logic + RandomStream rolls) ----
 
@@ -489,6 +492,7 @@ object Firm:
   private def decide(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
@@ -497,9 +501,9 @@ object Firm:
   )(using p: SimParams): Decision =
     firm.tech match
       case _: TechState.Bankrupt         => Decision.StayBankrupt
-      case _: TechState.Automated        => decideAutomated(firm, w, operationalSignals, lendRate)
-      case TechState.Hybrid(wkrs, aiEff) => decideHybrid(firm, w, operationalSignals, lendRate, bankCanLend, wkrs, aiEff, rng)
-      case TechState.Traditional(wkrs)   => decideTraditional(firm, w, operationalSignals, lendRate, bankCanLend, allFirms, wkrs, rng)
+      case _: TechState.Automated        => decideAutomated(firm, w, executionMonth, operationalSignals, lendRate)
+      case TechState.Hybrid(wkrs, aiEff) => decideHybrid(firm, w, executionMonth, operationalSignals, lendRate, bankCanLend, wkrs, aiEff, rng)
+      case TechState.Traditional(wkrs)   => decideTraditional(firm, w, executionMonth, operationalSignals, lendRate, bankCanLend, allFirms, wkrs, rng)
 
   /** Smooth labor adjustment: Δworkers = λ × (target − current), with severance
     * costs. Target = break-even headcount from P&L. If adjustment insufficient
@@ -594,6 +598,7 @@ object Firm:
   private def decideAutomated(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
   )(using p: SimParams): Decision =
@@ -605,7 +610,7 @@ object Firm:
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,
       lendRate,
-      w.month,
+      executionMonth,
     )
     val nc  = firm.cash + pnl.netAfterTax
     if nc < PLN.Zero then Decision.GoBankrupt(pnl, nc, BankruptReason.AiDebtTrap)
@@ -615,6 +620,7 @@ object Firm:
   private def decideHybrid(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
@@ -630,7 +636,7 @@ object Firm:
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,
       lendRate,
-      w.month,
+      executionMonth,
     )
     val ready2 = (firm.digitalReadiness + Share(HybridMonthlyDrDrift)).min(Share.One)
 
@@ -763,6 +769,7 @@ object Firm:
       pnl: PnL,
       fullAi: UpgradeCandidate,
       hybrid: UpgradeCandidate,
+      executionMonth: ExecutionMonth,
       w: World,
       allFirms: Vector[State],
   )(using p: SimParams): (Share, Share) =
@@ -774,7 +781,7 @@ object Firm:
       if !fullAi.profitable && fullAi.canPay && fullAi.ready && fullAi.bankOk then firm.riskProfile * firm.digitalReadiness * Share(StrategicAdoptBase)
       else Share.Zero
 
-    val willingnessMultiplier = adoptionWillingnessMultiplier(w.month, localAuto)
+    val willingnessMultiplier = adoptionWillingnessMultiplier(executionMonth, localAuto)
 
     val rawFull = willingnessMultiplier *
       (if fullAi.feasible then (firm.riskProfile * Share(RiskWeightFullAi) + panic + desper) * firm.digitalReadiness
@@ -788,8 +795,8 @@ object Firm:
     val pHyb  = rawHyb.min(Share.One - pFull)
     (pFull, pHyb)
 
-  private[amorfati] def adoptionWillingnessMultiplier(month: Int, localAuto: Share)(using p: SimParams): Share =
-    val rampFrac  = Scalar.fraction(month, p.firm.adoptionRampMonths).clamp(Scalar.Zero, Scalar.One).toShare
+  private[amorfati] def adoptionWillingnessMultiplier(month: ExecutionMonth, localAuto: Share)(using p: SimParams): Share =
+    val rampFrac  = Scalar.fraction(month.toInt, p.firm.adoptionRampMonths).clamp(Scalar.Zero, Scalar.One).toShare
     val baseLevel = Share(UncertaintyBase) + Share(UncertaintySlope) * rampFrac
     val demoBoost =
       if localAuto > p.firm.demoEffectThresh then p.firm.demoEffectBoost * (localAuto - p.firm.demoEffectThresh)
@@ -905,6 +912,7 @@ object Firm:
   private def decideTraditional(
       firm: State,
       w: World,
+      executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
       bankCanLend: PLN => Boolean,
@@ -920,12 +928,12 @@ object Firm:
       w.external.gvc.importCostIndex,
       w.external.gvc.commodityPriceIndex,
       lendRate,
-      w.month,
+      executionMonth,
     )
     if isInStartup(firm) then return startupFallbackDecision(firm, pnl, workers, TechState.Traditional(_), w.householdMarket.marketWage)
     val ai            = evaluateFullAi(firm, pnl, w, lendRate, bankCanLend)
     val (hyb, hWkrs)  = evaluateHybrid(firm, pnl, workers, w, lendRate, bankCanLend)
-    val (pFull, pHyb) = adoptionProbabilities(firm, pnl, ai, hyb, w, allFirms)
+    val (pFull, pHyb) = adoptionProbabilities(firm, pnl, ai, hyb, executionMonth, w, allFirms)
     val roll          = Share.random(rng)
 
     if roll < pFull then rollFullAiUpgrade(firm, pnl, ai, rng)
@@ -1098,9 +1106,9 @@ object Firm:
   /** Energy cost including EU ETS carbon surcharge, net of green capital
     * discount.
     */
-  private def energyAndEtsCost(firm: State, revenue: PLN, month: Int, commodityPrice: PriceIndex)(using p: SimParams): PLN =
+  private def energyAndEtsCost(firm: State, revenue: PLN, month: ExecutionMonth, commodityPrice: PriceIndex)(using p: SimParams): PLN =
     val baseEnergy: PLN      = revenue * p.climate.energyCostShares(firm.sector.toInt)
-    val etsGrowth            = (Scalar.One + p.climate.etsPriceDrift.monthly.toScalar).pow(month)
+    val etsGrowth            = (Scalar.One + p.climate.etsPriceDrift.monthly.toScalar).pow(month.toInt)
     val carbonSurcharge      = p.climate.carbonIntensity(firm.sector.toInt) * (etsGrowth - Scalar.One)
     val greenDiscount: Share = if firm.greenCapital > PLN.Zero then
       val targetGK = workerCount(firm) * p.climate.greenKLRatios(firm.sector.toInt)
@@ -1119,7 +1127,7 @@ object Firm:
       importPrice: PriceIndex,
       commodityPrice: PriceIndex,
       lendRate: Rate,
-      month: Int,
+      month: ExecutionMonth,
   )(using p: SimParams): PnL =
     val revenue: PLN         = (domesticPrice * computeCapacity(firm)) * sectorDemandMult
     val labor: PLN           = workerCount(firm) * (wage * effectiveWageMult(firm.sector))
@@ -1159,7 +1167,7 @@ object Firm:
       importPrice: PriceIndex,
       commodityPrice: PriceIndex,
       lendRate: Rate,
-      month: Int,
+      month: ExecutionMonth,
   )(using p: SimParams): PLN =
     computePnL(
       firm,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankruptcyProbe.scala
@@ -21,10 +21,10 @@ object BankruptcyProbe:
 
     MonthDriver
       .unfoldSteps(initState): state =>
-        Some(MonthRandomness.Contract.fromSeed(seed * 1000L + state.world.month.toLong + 1L))
+        Some(MonthRandomness.Contract.fromSeed(seed * 1000L + state.completedMonth.toLong + 1L))
       .take(months)
       .foreach: result =>
-        val month        = result.nextState.world.month
+        val month        = result.executionMonth
         val prevById     = result.stateIn.firms.map(f => f.id -> f).toMap
         val newBankrupts = result.nextState.firms.flatMap: f =>
           bankruptReason(f).flatMap: reason =>
@@ -38,7 +38,7 @@ object BankruptcyProbe:
         val demandMults = result.nextState.world.pipeline.sectorDemandMult
 
         println(
-          s"month=$month unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",
+          s"month=${month.toInt} unemp=$unemp deaths=${newBankrupts.size} demand2=${demandMults(2)} demand3=${demandMults(3)} demand4=${demandMults(4)}",
         )
         if newBankrupts.nonEmpty then
           println(s"  reasons=${byReason.mkString(", ")}")

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.diagnostics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.RegionalClearing
@@ -73,7 +74,7 @@ object InflationProbe:
     (1 to months).foreach: month =>
       val population        = world.derivedTotalPopulation.max(1)
       val contract          = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
-      val fiscal            = FiscalConstraintEconomics.compute(world, banks)
+      val fiscal            = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
       val s1                = FiscalConstraintEconomics.toOutput(fiscal)
       val labor             = LaborEconomics.compute(world, firms, hhs, s1)
       val prevWage          = toDouble(world.householdMarket.marketWage)

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.diagnostics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.PLN
@@ -162,7 +163,7 @@ object LaborDemandProbe:
       val beforeAll = sectorSnapshots(firms)
       val hiring    = hiringSummaries(world, firms)
 
-      val fiscal = FiscalConstraintEconomics.compute(world, banks)
+      val fiscal = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
       val s1     = FiscalConstraintEconomics.toOutput(fiscal)
       val labor  = LaborEconomics.compute(world, firms, hhs, s1)
       val s2Pre  = LaborEconomics.Output(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 import scala.reflect.ClassTag
@@ -13,7 +14,7 @@ import scala.reflect.ClassTag
   * envelopes.
   */
 case class MonthTrace(
-    month: Int,
+    executionMonth: ExecutionMonth,
     boundary: MonthBoundaryTrace,
     seedTransition: SeedTransitionTrace,
     randomness: MonthRandomness.Contract,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/SimulationMonth.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/SimulationMonth.scala
@@ -1,0 +1,61 @@
+package com.boombustgroup.amorfati.engine
+
+/** Strong month types for the month-by-month engine boundary.
+  *
+  * `CompletedMonth` lives on the persistent simulation boundary state and
+  * counts how many months have already been closed.
+  *
+  * `ExecutionMonth` is the month currently being realized by one engine step.
+  */
+object SimulationMonth:
+
+  opaque type CompletedMonth = Int
+  object CompletedMonth:
+    val Zero: CompletedMonth = 0
+
+    def apply(value: Int): CompletedMonth =
+      require(value >= 0, s"CompletedMonth must be >= 0, got $value")
+      value
+
+    extension (month: CompletedMonth)
+      inline def toInt: Int   = month
+      inline def toLong: Long = month.toLong
+
+      def next: ExecutionMonth =
+        ExecutionMonth(month + 1)
+
+      def advanceBy(delta: Int): CompletedMonth =
+        require(delta >= 0, s"CompletedMonth delta must be >= 0, got $delta")
+        CompletedMonth(month + delta)
+
+    given Ordering[CompletedMonth] = Ordering.Int
+
+  opaque type ExecutionMonth = Int
+  object ExecutionMonth:
+    val First: ExecutionMonth = 1
+
+    def apply(value: Int): ExecutionMonth =
+      require(value >= 1, s"ExecutionMonth must be >= 1, got $value")
+      value
+
+    extension (month: ExecutionMonth)
+      inline def toInt: Int   = month
+      inline def toLong: Long = month.toLong
+
+      def completed: CompletedMonth =
+        CompletedMonth(month)
+
+      def previousCompleted: CompletedMonth =
+        CompletedMonth(month - 1)
+
+      def next: ExecutionMonth =
+        ExecutionMonth(month + 1)
+
+      def advanceBy(delta: Int): ExecutionMonth =
+        require(delta >= 0, s"ExecutionMonth delta must be >= 0, got $delta")
+        ExecutionMonth(month + delta)
+
+      def monthInYear: Int =
+        ((month - 1) % 12) + 1
+
+    given Ordering[ExecutionMonth] = Ordering.Int

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -12,7 +12,6 @@ import com.boombustgroup.amorfati.types.*
   * not need to be provided at init.
   */
 case class World(
-    month: Int,                                                                       // simulation month (1-indexed)
     inflation: Rate,                                                                  // CPI YoY inflation
     priceLevel: PriceIndex,                                                           // cumulative CPI index (base = 1.0)
     currentSigmas: Vector[Sigma],                                                     // per-sector σ (Arthur increasing returns)
@@ -79,7 +78,6 @@ object SocialState:
 
 object World:
   def apply(
-      month: Int,
       inflation: Rate,
       priceLevel: PriceIndex,
       gdpProxy: Double,
@@ -112,7 +110,6 @@ object World:
       mechanisms.expectations.expectedInflation,
     )
     new World(
-      month = month,
       inflation = inflation,
       priceLevel = priceLevel,
       currentSigmas = currentSigmas,
@@ -134,7 +131,6 @@ object World:
     )
 
   def apply(
-      month: Int,
       inflation: Rate,
       priceLevel: Double,
       gdpProxy: Double,
@@ -167,7 +163,6 @@ object World:
       mechanisms.expectations.expectedInflation,
     )
     new World(
-      month = month,
       inflation = inflation,
       priceLevel = PriceIndex(priceLevel),
       currentSigmas = currentSigmas,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{BondAuction, FiscalBudget, HousingMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{TaxRevenue, YieldCurve}
 import com.boombustgroup.amorfati.types.*
@@ -143,7 +144,7 @@ object BankingEconomics:
   case class Input(
       w: World,
       // Raw values from earlier calculus (avoids Step.Output dependency)
-      month: Int,
+      month: ExecutionMonth,
       lendingBaseRate: Rate,
       resWage: PLN,
       baseMinWage: PLN,
@@ -701,7 +702,7 @@ object BankingEconomics:
     val finalForeignBondHoldings = in.w.gov.foreignBondHoldings + foreignSale.actualSold
 
     val failResult =
-      Banking.checkFailures(tfiSale.banks, in.s1.m, true, in.s7.newMacropru.ccyb)
+      Banking.checkFailures(tfiSale.banks, in.s1.m.toInt, true, in.s7.newMacropru.ccyb)
 
     // Interbank contagion: failed banks impose losses on counterparties
     val exposures      = InterbankContagion.buildExposureMatrix(tfiSale.banks)
@@ -709,7 +710,7 @@ object BankingEconomics:
       if failResult.anyFailed then InterbankContagion.applyContagionLosses(failResult.banks, exposures)
       else failResult.banks
     // Re-check for secondary failures triggered by contagion losses
-    val secondaryFail  = Banking.checkFailures(afterContagion, in.s1.m, true, in.s7.newMacropru.ccyb)
+    val secondaryFail  = Banking.checkFailures(afterContagion, in.s1.m.toInt, true, in.s7.newMacropru.ccyb)
     val afterFailCheck = secondaryFail.banks
     val anyFailed      = failResult.anyFailed || secondaryFail.anyFailed
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -702,7 +702,7 @@ object BankingEconomics:
     val finalForeignBondHoldings = in.w.gov.foreignBondHoldings + foreignSale.actualSold
 
     val failResult =
-      Banking.checkFailures(tfiSale.banks, in.s1.m.toInt, true, in.s7.newMacropru.ccyb)
+      Banking.checkFailures(tfiSale.banks, in.s1.m, true, in.s7.newMacropru.ccyb)
 
     // Interbank contagion: failed banks impose losses on counterparties
     val exposures      = InterbankContagion.buildExposureMatrix(tfiSale.banks)
@@ -710,7 +710,7 @@ object BankingEconomics:
       if failResult.anyFailed then InterbankContagion.applyContagionLosses(failResult.banks, exposures)
       else failResult.banks
     // Re-check for secondary failures triggered by contagion losses
-    val secondaryFail  = Banking.checkFailures(afterContagion, in.s1.m.toInt, true, in.s7.newMacropru.ccyb)
+    val secondaryFail  = Banking.checkFailures(afterContagion, in.s1.m, true, in.s7.newMacropru.ccyb)
     val afterFailCheck = secondaryFail.banks
     val anyFailed      = failResult.anyFailed || secondaryFail.anyFailed
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{OperationalSignals, World}
 import com.boombustgroup.amorfati.engine.markets.{CalvoPricing, CorporateBondMarket, IntermediateMarket, LaborMarket}
 import com.boombustgroup.amorfati.types.*
@@ -82,6 +83,7 @@ object FirmEconomics:
   /** Per-bank lending rates and credit approval, shared across phases. */
   private case class LendingConditions(
       firmWorld: World,                       // world with current-month wages for firm decision-making
+      executionMonth: ExecutionMonth,         // realized month currently being executed
       operationalSignals: OperationalSignals, // same-month demand / labor surface for incumbent firms
       rates: Vector[Rate],                    // per-bank lending rates
       lendingRates: Vector[Double],           // rates as Double (for Output)
@@ -145,7 +147,7 @@ object FirmEconomics:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       // From FiscalConstraint
-      month: Int,
+      month: ExecutionMonth,
       lendingBaseRate: Rate,
       resWage: PLN,
       baseMinWage: PLN,
@@ -386,13 +388,12 @@ object FirmEconomics:
       operationalHiringSlack = in.s2.operationalHiringSlack,
     )
     val world              = in.w.copy(
-      month = in.s1.m,
       householdMarket = in.w.householdMarket.copy(
         marketWage = in.s2.newWage,
         reservationWage = in.s1.resWage,
       ),
     )
-    LendingConditions(world, operationalSignals, rates, rates.map(toDouble(_)), canLend, nBanks)
+    LendingConditions(world, in.s1.m, operationalSignals, rates, rates.map(toDouble(_)), canLend, nBanks)
 
   // ---- Phase 2: Per-firm processing ----
 
@@ -407,7 +408,7 @@ object FirmEconomics:
     val outcomes = firms.map: f =>
       val rate    = lending.rates(f.bankId.toInt)
       val canLend = (amt: PLN) => lending.bankCanLend(f.bankId.toInt, amt)
-      val r       = Firm.process(f, lending.firmWorld, lending.operationalSignals, rate, canLend, firms, rng)
+      val r       = Firm.process(f, lending.firmWorld, lending.executionMonth, lending.operationalSignals, rate, canLend, firms, rng)
       val fin     = splitFinancing(r)
 
       FirmOutcome(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.mechanisms.YieldCurve
 import com.boombustgroup.amorfati.types.*
@@ -17,7 +18,7 @@ object FiscalConstraintEconomics:
   private val ExpectationsBlendWeight = 0.5
 
   case class Result(
-      month: Int,
+      month: ExecutionMonth,
       baseMinWage: PLN,
       updatedMinWagePriceLevel: PriceIndex,
       resWage: PLN,
@@ -26,24 +27,24 @@ object FiscalConstraintEconomics:
 
   /** Bridge type — same fields as the deleted FiscalConstraintStep.Output. */
   case class Output(
-      m: Int,
+      month: ExecutionMonth,
       baseMinWage: PLN,
       updatedMinWagePriceLevel: PriceIndex,
       resWage: PLN,
       lendingBaseRate: Rate,
-  )
+  ):
+    def m: ExecutionMonth = month
 
   def toOutput(r: Result): Output =
     Output(r.month, r.baseMinWage, r.updatedMinWagePriceLevel, r.resWage, r.lendingBaseRate)
 
   @boundaryEscape
-  def compute(w: World, banks: Vector[Banking.BankState])(using p: SimParams): Result =
+  def compute(w: World, banks: Vector[Banking.BankState], month: ExecutionMonth)(using p: SimParams): Result =
     import ComputationBoundary.toDouble
-    val m       = w.month + 1
     val bankAgg = Banking.aggregateFromBanks(banks)
 
     val (baseMinWage, updatedMinWagePriceLevel) =
-      val isAdjustMonth = m > 0 && m % p.fiscal.minWageAdjustMonths == 0
+      val isAdjustMonth = month.toInt % p.fiscal.minWageAdjustMonths == 0
       if isAdjustMonth then
         val cumInfl     =
           if p.fiscal.minWageInflationIndex && w.gov.minWagePriceLevel > PriceIndex.Zero then toDouble(w.priceLevel) / toDouble(w.gov.minWagePriceLevel) - 1.0
@@ -70,4 +71,4 @@ object FiscalConstraintEconomics:
     val lendingBaseRate =
       ExpectationsBlendWeight * rawLendingBaseRate + (1.0 - ExpectationsBlendWeight) * toDouble(w.mechanisms.expectations.expectedRate)
 
-    Result(m, PLN(baseMinWage), updatedMinWagePriceLevel, PLN(resWage), Rate(lendingBaseRate))
+    Result(month, PLN(baseMinWage), updatedMinWagePriceLevel, PLN(resWage), Rate(lendingBaseRate))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -65,17 +65,18 @@ object HouseholdFinancialEconomics:
     // Tourism services export/import (#47)
     val (tourismExport, tourismImport) =
       val exchangeRate   = exchangeRateValue(w.forex.exchangeRate)
+      val monthInt       = month.toInt
       val monthInYear    = month.monthInYear
       val seasonalFactor = 1.0 + toDouble(p.tourism.seasonality) *
         Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)
       val inboundErAdj   = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.tourism.erElasticity))
       val outboundErAdj  = Math.pow(toDouble(p.forex.baseExRate) / exchangeRate, toDouble(p.tourism.erElasticity))
-      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, month.toInt.toDouble)
+      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, monthInt.toDouble)
       val disruption     =
-        if p.tourism.shockMonth > 0 && month.toInt >= p.tourism.shockMonth then
+        if p.tourism.shockMonth > 0 && monthInt >= p.tourism.shockMonth then
           toDouble(p.tourism.shockSize) * Math.pow(
             1.0 - toDouble(p.tourism.shockRecovery),
-            (month.toInt - p.tourism.shockMonth).toDouble,
+            (monthInt - p.tourism.shockMonth).toDouble,
           )
         else 0.0
       val shockFactor    = 1.0 - disruption

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -55,9 +55,10 @@ object HouseholdFinancialEconomics:
     val diasporaInflow =
       val exchangeRate  = exchangeRateValue(w.forex.exchangeRate)
       val wap           = w.social.demographics.workingAgePop
+      val elapsedMonths = month.previousCompleted.toInt
       val base          = toDouble(p.remittance.perCapita) * wap.toDouble
       val erAdj         = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.remittance.erElasticity))
-      val trendAdj      = Math.pow(1.0 + toDouble(p.remittance.growthRate) / 12.0, month.toInt.toDouble)
+      val trendAdj      = Math.pow(1.0 + toDouble(p.remittance.growthRate) / 12.0, elapsedMonths.toDouble)
       val unempForRemit = toDouble(w.unemploymentRate(employed))
       val cyclicalAdj   = 1.0 + toDouble(p.remittance.cyclicalSens) * Math.max(0.0, unempForRemit - DiasporaUnempThreshold)
       PLN(base * erAdj * trendAdj * cyclicalAdj)
@@ -66,12 +67,13 @@ object HouseholdFinancialEconomics:
     val (tourismExport, tourismImport) =
       val exchangeRate   = exchangeRateValue(w.forex.exchangeRate)
       val monthInt       = month.toInt
+      val elapsedMonths  = month.previousCompleted.toInt
       val monthInYear    = month.monthInYear
       val seasonalFactor = 1.0 + toDouble(p.tourism.seasonality) *
         Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)
       val inboundErAdj   = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.tourism.erElasticity))
       val outboundErAdj  = Math.pow(toDouble(p.forex.baseExRate) / exchangeRate, toDouble(p.tourism.erElasticity))
-      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, monthInt.toDouble)
+      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, elapsedMonths.toDouble)
       val disruption     =
         if p.tourism.shockMonth > 0 && monthInt >= p.tourism.shockMonth then
           toDouble(p.tourism.shockSize) * Math.pow(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -40,7 +41,7 @@ object HouseholdFinancialEconomics:
   @boundaryEscape
   def compute(
       w: World,
-      month: Int,
+      month: ExecutionMonth,
       employed: Int,
       hhAgg: Household.Aggregates,
       @annotation.unused rng: RandomStream,
@@ -56,7 +57,7 @@ object HouseholdFinancialEconomics:
       val wap           = w.social.demographics.workingAgePop
       val base          = toDouble(p.remittance.perCapita) * wap.toDouble
       val erAdj         = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.remittance.erElasticity))
-      val trendAdj      = Math.pow(1.0 + toDouble(p.remittance.growthRate) / 12.0, month.toDouble)
+      val trendAdj      = Math.pow(1.0 + toDouble(p.remittance.growthRate) / 12.0, month.toInt.toDouble)
       val unempForRemit = toDouble(w.unemploymentRate(employed))
       val cyclicalAdj   = 1.0 + toDouble(p.remittance.cyclicalSens) * Math.max(0.0, unempForRemit - DiasporaUnempThreshold)
       PLN(base * erAdj * trendAdj * cyclicalAdj)
@@ -64,17 +65,17 @@ object HouseholdFinancialEconomics:
     // Tourism services export/import (#47)
     val (tourismExport, tourismImport) =
       val exchangeRate   = exchangeRateValue(w.forex.exchangeRate)
-      val monthInYear    = (month % 12) + 1
+      val monthInYear    = month.monthInYear
       val seasonalFactor = 1.0 + toDouble(p.tourism.seasonality) *
         Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)
       val inboundErAdj   = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.tourism.erElasticity))
       val outboundErAdj  = Math.pow(toDouble(p.forex.baseExRate) / exchangeRate, toDouble(p.tourism.erElasticity))
-      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, month.toDouble)
+      val trendAdj       = Math.pow(1.0 + toDouble(p.tourism.growthRate) / 12.0, month.toInt.toDouble)
       val disruption     =
-        if p.tourism.shockMonth > 0 && month >= p.tourism.shockMonth then
+        if p.tourism.shockMonth > 0 && month.toInt >= p.tourism.shockMonth then
           toDouble(p.tourism.shockSize) * Math.pow(
             1.0 - toDouble(p.tourism.shockRecovery),
-            (month - p.tourism.shockMonth).toDouble,
+            (month.toInt - p.tourism.shockMonth).toDouble,
           )
         else 0.0
       val shockFactor    = 1.0 - disruption

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, GvcTrade, OpenEconomy}
 import com.boombustgroup.amorfati.engine.mechanisms.Expectations
@@ -158,7 +159,7 @@ object OpenEconEconomics:
       profitShifting: PLN,
       fdiRepatriation: PLN,
       foreignDividendOutflow: PLN,
-      month: Int,
+      month: ExecutionMonth,
       commodityRng: RandomStream,
   )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.{FirmSizeDistribution, SimParams}
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{EquityMarket, PriceLevel}
 import com.boombustgroup.amorfati.engine.mechanisms.{EuFunds, Macroprudential}
 import com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
@@ -34,7 +35,7 @@ object PriceEquityEconomics:
 
   case class Input(
       w: World,                         // current world state
-      month: Int,                       // month counter
+      month: ExecutionMonth,            // realized simulation month
       newWage: PLN,                     // new wage from labor market
       employed: Int,                    // employment count
       wageGrowth: Coefficient,          // wage growth coefficient
@@ -231,7 +232,7 @@ object PriceEquityEconomics:
     val aggInventoryStock = PLN.fromRaw(living2.map(_.inventory.toLong).sum)
     val aggGreenCapital   = PLN.fromRaw(living2.map(_.greenCapital.toLong).sum)
 
-    val euMonthly = EuFunds.monthlyTransfer(in.month)
+    val euMonthly = EuFunds.monthlyTransfer(in.month.toInt)
 
     val govGdpContribution = governmentDemandContribution(in.govPurchases)
     val euCofin            = EuFunds.cofinancing(euMonthly)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -232,7 +232,7 @@ object PriceEquityEconomics:
     val aggInventoryStock = PLN.fromRaw(living2.map(_.inventory.toLong).sum)
     val aggGreenCapital   = PLN.fromRaw(living2.map(_.greenCapital.toLong).sum)
 
-    val euMonthly = EuFunds.monthlyTransfer(in.month.toInt)
+    val euMonthly = EuFunds.monthlyTransfer(in.month)
 
     val govGdpContribution = governmentDemandContribution(in.govPurchases)
     val euCofin            = EuFunds.cofinancing(euMonthly)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.agents.RegionalMigration
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.markets.{EquityMarket, LaborMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, InformalEconomy, SectoralMobility}
@@ -91,7 +92,7 @@ object WorldAssemblyEconomics:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       // Raw values
-      month: Int,
+      month: ExecutionMonth,
       lendingBaseRate: Rate,
       resWage: PLN,
       baseMinWage: PLN,
@@ -349,9 +350,9 @@ object WorldAssemblyEconomics:
     )
 
     val monthsPerYear = 12.0
-    val etsPrice      = toDouble(p.climate.etsBasePrice) * Math.pow(1.0 + toDouble(p.climate.etsPriceDrift) / monthsPerYear, in.s1.m.toDouble)
+    val etsPrice      = toDouble(p.climate.etsBasePrice) * Math.pow(1.0 + toDouble(p.climate.etsPriceDrift) / monthsPerYear, in.s1.m.toInt.toDouble)
 
-    val monthInYear           = ((in.s1.m - 1) % 12) + 1
+    val monthInYear           = in.s1.m.monthInYear
     val tourismSeasonalFactor = 1.0 + toDouble(p.tourism.seasonality) * Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)
 
     Observables(depositFacilityUsage, etsPrice, tourismSeasonalFactor)
@@ -422,7 +423,6 @@ object WorldAssemblyEconomics:
   ): World =
     val ledgerSupported  = buildLedgerSupportedSnapshot(in)
     val provisionalWorld = World(
-      month = in.s1.m,
       inflation = in.s7.newInfl,
       priceLevel = in.s7.newPrice,
       currentSigmas = in.s7.newSigmas,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -350,7 +350,8 @@ object WorldAssemblyEconomics:
     )
 
     val monthsPerYear = 12.0
-    val etsPrice      = toDouble(p.climate.etsBasePrice) * Math.pow(1.0 + toDouble(p.climate.etsPriceDrift) / monthsPerYear, in.s1.m.toInt.toDouble)
+    val elapsedMonths = in.s1.m.previousCompleted.toInt.toDouble
+    val etsPrice      = toDouble(p.climate.etsBasePrice) * Math.pow(1.0 + toDouble(p.climate.etsPriceDrift) / monthsPerYear, elapsedMonths)
 
     val monthInYear           = in.s1.m.monthInYear
     val tourismSeasonalFactor = 1.0 + toDouble(p.tourism.seasonality) * Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -5,6 +5,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.MonthSemantics.At.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -27,6 +28,7 @@ object FlowSimulation:
     * flows into one `step(state, randomness)` transition.
     */
   case class SimState(
+      completedMonth: CompletedMonth,
       world: World,
       firms: Vector[Firm.State],
       households: Vector[Household.State],
@@ -36,7 +38,7 @@ object FlowSimulation:
 
   object SimState:
     def fromInit(init: com.boombustgroup.amorfati.init.WorldInit.InitResult): SimState =
-      SimState(init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      SimState(CompletedMonth.Zero, init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
   case class ExecutionResult(
       snapshot: Map[(EntitySector, AssetType, Int), Long],
@@ -46,7 +48,7 @@ object FlowSimulation:
   /** All calculus results needed to feed flow mechanisms. */
   case class MonthlyCalculus(
       // Stage 1: Fiscal constraint
-      month: Int,
+      month: ExecutionMonth,
       resWage: PLN,
       lendingBaseRate: Rate,
       baseMinWage: PLN,
@@ -243,6 +245,7 @@ object FlowSimulation:
   /** Typed month-`t` boundary input used internally by [[step]]. */
   case class StepInput(
       stateIn: SimState,
+      executionMonth: ExecutionMonth,
       seedIn: MonthSemantics.SeedIn,
       randomness: MonthRandomness.Contract,
   )
@@ -298,6 +301,7 @@ object FlowSimulation:
     */
   case class StepOutput(
       stateIn: SimState,
+      executionMonth: ExecutionMonth,
       calculus: MonthlyCalculus,
       operationalSignals: OperationalSignals,
       signalExtraction: SignalExtraction.Output,
@@ -318,9 +322,10 @@ object FlowSimulation:
     */
   def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
     val input      = StepInput(
-      stateIn,
-      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
-      randomness,
+      stateIn = stateIn,
+      executionMonth = stateIn.completedMonth.next,
+      seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
+      randomness = randomness,
     )
     val outcome    = computeMonthOutcome(input)
     val flows      = emitAllBatches(outcome.stages.value.calculus)
@@ -348,6 +353,7 @@ object FlowSimulation:
 
     StepOutput(
       stateIn = stateIn,
+      executionMonth = input.executionMonth,
       calculus = outcome.stages.value.calculus,
       operationalSignals = outcome.operational.value,
       signalExtraction = outcome.seedOut.value,
@@ -365,6 +371,7 @@ object FlowSimulation:
     computeStageOutputs(
       StepInput(
         stateIn = state,
+        executionMonth = state.completedMonth.next,
         seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
         randomness = randomness,
       ),
@@ -386,7 +393,7 @@ object FlowSimulation:
     val firms             = stateIn.firms
     val households        = stateIn.households
     val banks             = stateIn.banks
-    val fiscal            = FiscalConstraintEconomics.compute(w, banks)
+    val fiscal            = FiscalConstraintEconomics.compute(w, banks, input.executionMonth)
     val s1                = FiscalConstraintEconomics.toOutput(fiscal)
     val labor             = LaborEconomics.compute(w, firms, households, s1)
     val s2Pre             = LaborEconomics.Output(
@@ -848,6 +855,7 @@ object FlowSimulation:
     require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")
 
     SimState(
+      completedMonth = input.executionMonth.completed,
       world = nextWorld,
       firms = assembled.firms,
       households = assembled.households,
@@ -865,7 +873,7 @@ object FlowSimulation:
     val traceInputs = outcome.post.value.traceInputs
     val seedOut     = outcome.seedOut.value
     MonthTrace(
-      month = nextState.world.month,
+      executionMonth = input.executionMonth,
       boundary = MonthBoundaryTrace(
         startSnapshot = MonthBoundarySnapshot.capture(input.stateIn.world, input.stateIn.firms, input.stateIn.households, input.stateIn.banks),
         endSnapshot = MonthBoundarySnapshot.capture(nextState.world, nextState.firms, nextState.households, nextState.banks),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.ledger
 
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
 import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
@@ -393,7 +394,7 @@ object LedgerStateAdapter:
       banks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
   ): SupportedFinancialSnapshot =
-    roundTripSupported(FlowSimulation.SimState(world, firms, households, banks, householdAggregates))
+    roundTripSupported(FlowSimulation.SimState(CompletedMonth.Zero, world, firms, households, banks, householdAggregates))
 
   def populate(state: MutableWorldState, sim: FlowSimulation.SimState): Unit =
     val supported = supportedSnapshot(sim)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/CapitalFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/CapitalFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.markets
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 /** Capital flight and hot money: risk-off, carry trade, EM sentiment.
@@ -57,7 +58,7 @@ object CapitalFlows:
     *   GDP proxy for scaling
     */
   def compute(
-      month: Int,
+      month: ExecutionMonth,
       yieldSpread: Rate,
       bidToCover: Multiplier,
       prevCarry: CarryState,
@@ -65,13 +66,13 @@ object CapitalFlows:
   )(using p: SimParams): Result =
     // 1. Global risk-off shock: outflow = GDP × magnitude
     val riskOff =
-      if p.forex.riskOffShockMonth > 0 && month == p.forex.riskOffShockMonth then -(monthlyGdp * p.forex.riskOffMagnitude)
+      if p.forex.riskOffShockMonth > 0 && month.toInt == p.forex.riskOffShockMonth then -(monthlyGdp * p.forex.riskOffMagnitude)
       else PLN.Zero
 
     // 2. Carry trade: accumulate when spread > threshold, unwind on risk-off
     val spreadAboveThreshold = (yieldSpread - p.forex.carryThreshold).max(Rate.Zero)
-    val isRiskOff            = p.forex.riskOffShockMonth > 0 && month >= p.forex.riskOffShockMonth &&
-      month < p.forex.riskOffShockMonth + p.forex.riskOffDurationMonths
+    val isRiskOff            = p.forex.riskOffShockMonth > 0 && month.toInt >= p.forex.riskOffShockMonth &&
+      month.toInt < p.forex.riskOffShockMonth + p.forex.riskOffDurationMonths
     val carryAccumulation    =
       if !isRiskOff then monthlyGdp * (spreadAboveThreshold * p.forex.carryAccumulationRate)
       else PLN.Zero

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.markets
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
@@ -90,7 +91,7 @@ object GvcTrade:
       priceLevel: PriceIndex,
       exchangeRate: ExchangeRate,
       autoRatio: Share,
-      month: Int,
+      month: ExecutionMonth,
       rng: RandomStream,
   )
 
@@ -109,15 +110,15 @@ object GvcTrade:
     val commodityDrift   = p.gvc.commodityDrift.monthly.toCoefficient
     val commodityNoise   = Coefficient(in.rng.nextGaussian()) * p.gvc.commodityVolatility.toCoefficient
     val commodityShock   =
-      if p.gvc.commodityShockMonth > 0 && in.month == p.gvc.commodityShockMonth then p.gvc.commodityShockMag.toCoefficient
+      if p.gvc.commodityShockMonth > 0 && in.month.toInt == p.gvc.commodityShockMonth then p.gvc.commodityShockMag.toCoefficient
       else Coefficient.Zero
     val commodityGrowth  = (commodityShock + commodityDrift + commodityNoise).growthMultiplier
     val newCommodity     = in.prev.commodityPriceIndex * commodityGrowth
     val newImportCost    = newForeignPrice * newCommodity
-    val shockActive      = p.gvc.demandShockMonth > 0 && in.month >= p.gvc.demandShockMonth
+    val shockActive      = p.gvc.demandShockMonth > 0 && in.month.toInt >= p.gvc.demandShockMonth
     val shockMag         = if shockActive then p.gvc.demandShockSize else Share.Zero
     val updatedFirms     = evolveFirms(in.prev.foreignFirms, monthlyInflation, shockActive, in.month)
-    val foreignGdpFactor = compoundedGrowth(p.gvc.foreignGdpGrowth.monthly.growthMultiplier, in.month)
+    val foreignGdpFactor = compoundedGrowth(p.gvc.foreignGdpGrowth.monthly.growthMultiplier, in.month.toInt)
     val erEffect         = realExchangeRateEffect(in.priceLevel, in.exchangeRate)
     val exports          = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio)
     val imports          = computeSectorImports(updatedFirms, nSectors, in.sectorOutputs, in.priceLevel, in.exchangeRate)
@@ -140,12 +141,12 @@ object GvcTrade:
       firms: Vector[ForeignFirm],
       monthlyInflation: Rate,
       shockActive: Boolean,
-      month: Int,
+      month: ExecutionMonth,
   )(using p: SimParams): Vector[ForeignFirm] =
     val recoveryRate = p.gvc.disruptionRecovery
     firms.map: ff =>
       val afterShock =
-        if shockActive && month == p.gvc.demandShockMonth &&
+        if shockActive && month.toInt == p.gvc.demandShockMonth &&
           p.gvc.demandShockSectors.contains(ff.sectorId)
         then ff.copy(baseExportDemand = ff.baseExportDemand * (Share.One - p.gvc.demandShockSize))
         else ff

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
@@ -118,7 +118,8 @@ object GvcTrade:
     val shockActive      = p.gvc.demandShockMonth > 0 && in.month.toInt >= p.gvc.demandShockMonth
     val shockMag         = if shockActive then p.gvc.demandShockSize else Share.Zero
     val updatedFirms     = evolveFirms(in.prev.foreignFirms, monthlyInflation, shockActive, in.month)
-    val foreignGdpFactor = compoundedGrowth(p.gvc.foreignGdpGrowth.monthly.growthMultiplier, in.month.toInt)
+    val elapsedMonths    = in.month.previousCompleted.toInt
+    val foreignGdpFactor = compoundedGrowth(p.gvc.foreignGdpGrowth.monthly.growthMultiplier, elapsedMonths)
     val erEffect         = realExchangeRateEffect(in.priceLevel, in.exchangeRate)
     val exports          = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio)
     val imports          = computeSectorImports(updatedFirms, nSectors, in.sectorOutputs, in.priceLevel, in.exchangeRate)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.markets
 
 import com.boombustgroup.amorfati.agents.Nbp
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 /** Open economy: trade, BoP, exchange rate, NFA dynamics.
@@ -88,7 +89,7 @@ object OpenEconomy:
       gdp: PLN,
       priceLevel: PriceIndex,
       sectorOutputs: Vector[PLN],
-      month: Int,
+      month: ExecutionMonth,
       inflation: Rate = Rate.Zero,
       nbpFxReserves: PLN,
       gvcExports: Option[PLN] = None,
@@ -155,7 +156,7 @@ object OpenEconomy:
 
   private def computeExports(in: StepInput)(using p: SimParams): PLN =
     in.gvcExports.getOrElse:
-      val foreignGdpFactor = compoundedGrowth(p.openEcon.foreignGdpGrowth.monthly.growthMultiplier, in.month)
+      val foreignGdpFactor = compoundedGrowth(p.openEcon.foreignGdpGrowth.monthly.growthMultiplier, in.month.toInt)
       val ulcEffect        = (in.autoRatio * p.openEcon.ulcExportBoost).growthMultiplier
       val realExRate       = realExchangeRateEffect(in.prevForex.exchangeRate, in.priceLevel)
       ((realExRate * p.openEcon.exportBase) * foreignGdpFactor) * ulcEffect
@@ -192,7 +193,7 @@ object OpenEconomy:
       monthlyGdp * portfolioRate
     val yieldSpread       = in.bondYield - p.forex.foreignRate
     val capitalFlight     = CapitalFlows.compute(
-      month = in.month,
+      month = in.month.toInt,
       yieldSpread = yieldSpread,
       bidToCover = in.prevBidToCover,
       prevCarry = CapitalFlows.CarryState(in.prevBop.carryTradeStock),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -193,7 +193,7 @@ object OpenEconomy:
       monthlyGdp * portfolioRate
     val yieldSpread       = in.bondYield - p.forex.foreignRate
     val capitalFlight     = CapitalFlows.compute(
-      month = in.month.toInt,
+      month = in.month,
       yieldSpread = yieldSpread,
       bidToCover = in.prevBidToCover,
       prevCarry = CapitalFlows.CarryState(in.prevBop.carryTradeStock),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/OpenEconomy.scala
@@ -156,7 +156,8 @@ object OpenEconomy:
 
   private def computeExports(in: StepInput)(using p: SimParams): PLN =
     in.gvcExports.getOrElse:
-      val foreignGdpFactor = compoundedGrowth(p.openEcon.foreignGdpGrowth.monthly.growthMultiplier, in.month.toInt)
+      val elapsedMonths    = (in.month.toInt - 1).max(0)
+      val foreignGdpFactor = compoundedGrowth(p.openEcon.foreignGdpGrowth.monthly.growthMultiplier, elapsedMonths)
       val ulcEffect        = (in.autoRatio * p.openEcon.ulcExportBoost).growthMultiplier
       val realExRate       = realExchangeRateEffect(in.prevForex.exchangeRate, in.priceLevel)
       ((realExRate * p.openEcon.exportBase) * foreignGdpFactor) * ulcEffect

--- a/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/EuFunds.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/mechanisms/EuFunds.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.mechanisms
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.math.EuFundsMath
 import com.boombustgroup.amorfati.types.*
 
@@ -23,7 +24,7 @@ object EuFunds:
 
   @boundaryEscape
   /** Monthly EU transfer in PLN, following a Beta(α,β) absorption curve. */
-  def monthlyTransfer(month: Int)(using p: SimParams): PLN =
+  def monthlyTransfer(month: ExecutionMonth)(using p: SimParams): PLN =
     val totalPln = EuFundsMath.totalEnvelopePln(
       p.fiscal.euFundsTotalEur,
       p.forex.baseExRate,
@@ -31,7 +32,7 @@ object EuFunds:
       ReferenceEconomy,
     )
     totalPln * EuFundsMath.monthlyWeight(
-      month,
+      month.toInt,
       p.fiscal.euFundsStartMonth,
       p.fiscal.euFundsPeriodMonths,
       p.fiscal.euFundsAlpha,

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -97,7 +97,6 @@ object WorldInit:
     )
 
     val world = World(
-      month = 0,
       inflation = initInflation,
       priceLevel = PriceIndex(1.0),
       currentSigmas = p.sectorDefs.map(_.sigma),

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -90,7 +90,7 @@ object McRunner:
         Left(SimError.SfcViolation(result.executionMonth, errors))
       case Right(())    =>
         val monthData = SimOutput.compute(
-          result.stateIn.completedMonth.toInt,
+          result.executionMonth,
           result.nextState.world,
           result.nextState.firms,
           result.nextState.households,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -145,11 +145,11 @@ object McRunner:
       CsvWriter.write(
         new File("mc", seedFileName(seed, rc)),
         colNames.mkString(";"),
-        0 until result.timeSeries.nMonths,
-      ): t =>
-        val row = result.timeSeries.monthRow(t)
+        result.timeSeries.executionMonths,
+      ): month =>
+        val row = result.timeSeries.monthRow(month)
         val sb  = new StringBuilder
-        sb.append(f"${row(0)}%.0f")
+        sb.append(month.toInt)
         for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
         sb.toString
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -6,6 +6,7 @@ import com.boombustgroup.amorfati.agents.Banking.BankState
 import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
@@ -21,7 +22,7 @@ import java.util.concurrent.TimeUnit
 object McRunner:
 
   /** Single month snapshot emitted by [[seedStream]]. */
-  private case class MonthSnapshot(month: Int, state: FlowSimulation.SimState, monthData: Array[Double])
+  private case class MonthSnapshot(executionMonth: ExecutionMonth, state: FlowSimulation.SimState, monthData: Array[Double])
 
   /** Run N seeds in parallel, each streaming months via [[seedStream]]. Writes
     * per-seed CSV + aggregated HH/bank CSVs. Fails with [[SimError]].
@@ -81,22 +82,22 @@ object McRunner:
 
   private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
     // Preserve the runtime month-seed convention used before the shared driver.
-    seed * 10000L + state.world.month.toLong
+    seed * 10000L + state.completedMonth.toLong
 
   private def stepSnapshot(result: FlowSimulation.StepOutput)(using p: SimParams): Either[SimError, MonthSnapshot] =
     result.sfcResult match
       case Left(errors) =>
-        Left(SimError.SfcViolation(result.nextState.world.month, errors))
+        Left(SimError.SfcViolation(result.executionMonth, errors))
       case Right(())    =>
         val monthData = SimOutput.compute(
-          result.stateIn.world.month,
+          result.stateIn.completedMonth.toInt,
           result.nextState.world,
           result.nextState.firms,
           result.nextState.households,
           result.nextState.banks,
           result.nextState.householdAggregates,
         )
-        Right(MonthSnapshot(result.nextState.world.month, result.nextState, monthData))
+        Right(MonthSnapshot(result.executionMonth, result.nextState, monthData))
 
   private def materializeRun(
       initState: FlowSimulation.SimState,
@@ -119,7 +120,7 @@ object McRunner:
   /** Consume a seed stream into RunResult, collecting monthly data. */
   private def materializeSeed(seed: Long, rc: McRunConfig)(using p: SimParams) =
     seedStream(seed, rc.runDurationMonths)
-      .tap(s => ZIO.succeed(printMonthProgress(seed, rc.nSeeds, s.month, rc.runDurationMonths)))
+      .tap(s => ZIO.succeed(printMonthProgress(seed, rc.nSeeds, s.executionMonth, rc.runDurationMonths)))
       .runFold((Option.empty[FlowSimulation.SimState], Vector.empty[Array[Double]])):
         case ((_, series), snapshot) => (Some(snapshot.state), series :+ snapshot.monthData)
       .flatMap:
@@ -216,12 +217,12 @@ object McRunner:
 
   private val BarWidth = 20
 
-  private def printMonthProgress(seed: Long, total: Int, month: Int, duration: Int): Unit =
-    val frac   = month.toDouble / duration
+  private def printMonthProgress(seed: Long, total: Int, month: ExecutionMonth, duration: Int): Unit =
+    val frac   = month.toInt.toDouble / duration
     val filled = (frac * BarWidth).toInt
     val bar    = "\u2588" * filled + "\u2591" * (BarWidth - filled)
     val pct    = (frac * 100).toInt
-    print(f"\r  Seed $seed%3d/$total [$bar] $month%3d/${duration}m ($pct%3d%%)")
+    print(f"\r  Seed $seed%3d/$total [$bar] ${month.toInt}%3d/${duration}m ($pct%3d%%)")
 
   private def printSeedDone(seed: Long, total: Int, result: RunResult, dt: Long) =
     val last  = result.timeSeries.lastMonth

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
 
@@ -13,9 +14,9 @@ object SimError:
     override def toString: String =
       s"Init validation failed:\n${errors.map(e => s"  ${e.identity}: expected=${e.expected}, actual=${e.actual}").mkString("\n")}"
 
-  case class SfcViolation(month: Int, errors: Vector[Sfc.SfcIdentityError]) extends SimError:
+  case class SfcViolation(month: ExecutionMonth, errors: Vector[Sfc.SfcIdentityError]) extends SimError:
     override def toString: String =
-      s"SFC violation at M$month:\n${errors.map(e => s"  ${e.identity}: ${e.msg} (expected=${e.expected}, actual=${e.actual}, diff=${(e.actual - e.expected).abs})").mkString("\n")}"
+      s"SFC violation at M${month.toInt}:\n${errors.map(e => s"  ${e.identity}: ${e.msg} (expected=${e.expected}, actual=${e.actual}, diff=${(e.actual - e.expected).abs})").mkString("\n")}"
 
 /** Result of a single simulation run. */
 case class RunResult(

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -63,7 +63,7 @@ object TimeSeries:
     /** Zero-based row indices for compatibility with collection-style
       * iteration.
       */
-    inline def indices: Range = ts.indices
+    inline def indices: Range = 0 until ts.length
 
     /** Iterate through raw rows without exposing the backing array type. */
     inline def foreach(f: Array[Double] => Unit): Unit =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -33,12 +33,21 @@ opaque type TimeSeries = Array[Array[Double]]
 object TimeSeries:
   inline def wrap(raw: Array[Array[Double]]): TimeSeries = raw
 
+  private def rowIndex(ts: TimeSeries, month: ExecutionMonth): Int =
+    val idx = month.previousCompleted.toInt
+    require(idx < ts.length, s"ExecutionMonth M${month.toInt} outside TimeSeries of ${ts.length} months")
+    idx
+
   extension (ts: TimeSeries)
     /** Type-safe access: `ts.at(month, Col.Inflation)`. */
-    inline def at(month: Int, col: Col): Double = ts(month)(col.ordinal)
+    inline def at(month: ExecutionMonth, col: Col): Double = ts(rowIndex(ts, month))(col.ordinal)
 
-    /** Raw row for a given month. */
-    inline def monthRow(month: Int): Array[Double] = ts(month)
+    /** Raw row for a realized execution month. */
+    inline def monthRow(month: ExecutionMonth): Array[Double] = ts(rowIndex(ts, month))
+
+    /** Execution months materialized in this series, starting from M1. */
+    def executionMonths: Vector[ExecutionMonth] =
+      Vector.tabulate(ts.length)(offset => ExecutionMonth.First.advanceBy(offset))
 
     /** Last row of the series. */
     inline def lastMonth: Array[Double] = ts(ts.length - 1)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -31,38 +31,47 @@ case class RunResult(
 opaque type TimeSeries = Array[Array[Double]]
 
 object TimeSeries:
+  /** Wrap raw Monte Carlo output rows without runtime overhead. */
   inline def wrap(raw: Array[Array[Double]]): TimeSeries = raw
 
+  /** Convert a realized execution month to the underlying zero-based row index.
+    */
   private def rowIndex(ts: TimeSeries, month: ExecutionMonth): Int =
     val idx = month.previousCompleted.toInt
     require(idx < ts.length, s"ExecutionMonth M${month.toInt} outside TimeSeries of ${ts.length} months")
     idx
 
   extension (ts: TimeSeries)
-    /** Type-safe access: `ts.at(month, Col.Inflation)`. */
+    /** Read one typed cell from a realized execution month. */
     inline def at(month: ExecutionMonth, col: Col): Double = ts(rowIndex(ts, month))(col.ordinal)
 
-    /** Raw row for a realized execution month. */
+    /** Raw Monte Carlo row for a realized execution month. */
     inline def monthRow(month: ExecutionMonth): Array[Double] = ts(rowIndex(ts, month))
 
-    /** Execution months materialized in this series, starting from M1. */
+    /** All realized execution months materialized in this series, starting from
+      * M1.
+      */
     def executionMonths: Vector[ExecutionMonth] =
       Vector.tabulate(ts.length)(offset => ExecutionMonth.First.advanceBy(offset))
 
-    /** Last row of the series. */
+    /** Raw row for the latest realized month in the run. */
     inline def lastMonth: Array[Double] = ts(ts.length - 1)
 
-    /** Number of months in the series. */
+    /** Number of realized months stored in the series. */
     inline def nMonths: Int = ts.length
 
-    // ---- Source-compat with Array[Array[Double]] (tests, existing call sites) ----
-    inline def length: Int                             = ts.length
-    inline def indices: Range                          = 0 until ts.length
-    inline def apply(month: Int): Array[Double]        = ts(month)
+    /** Zero-based row indices for compatibility with collection-style
+      * iteration.
+      */
+    inline def indices: Range = ts.indices
+
+    /** Iterate through raw rows without exposing the backing array type. */
     inline def foreach(f: Array[Double] => Unit): Unit =
       var i = 0
       while i < ts.length do { f(ts(i)); i += 1 }
-    def map[B](f: Array[Double] => B): Vector[B]       =
+
+    /** Map over raw rows while preserving the opaque TimeSeries wrapper. */
+    def map[B](f: Array[Double] => B): Vector[B] =
       val b = Vector.newBuilder[B]
       b.sizeHint(ts.length)
       var i = 0

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.montecarlo
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
 import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
@@ -28,7 +29,7 @@ object SimOutput:
 
   /** Shared pre-computed context (computed once per timestep). */
   private class Ctx(
-      val t: Int,
+      val executionMonth: ExecutionMonth,
       val world: World,
       val firms: Vector[Firm.State],
       val households: Vector[Household.State],
@@ -62,7 +63,7 @@ object SimOutput:
   // -------------------------------------------------------------------------
 
   private def coreGroup: Vector[ColumnDef] = Vector(
-    ColumnDef("Month", ctx => (ctx.t + 1).toDouble),
+    ColumnDef("Month", ctx => ctx.executionMonth.toInt.toDouble),
     ColumnDef("Inflation", ctx => td.toDouble(ctx.world.inflation)),
     ColumnDef("Unemployment", ctx => ctx.unemployPct),
     ColumnDef(
@@ -598,7 +599,7 @@ object SimOutput:
 
   /** Compute one row. Returns Array[Double] for MC aggregation. */
   def compute(
-      t: Int,
+      executionMonth: ExecutionMonth,
       world: World,
       firms: Vector[Firm.State],
       households: Vector[Household.State],
@@ -607,7 +608,7 @@ object SimOutput:
   )(using p: SimParams): Array[Double] =
     val living     = firms.filter(Firm.isAlive)
     val aliveBanks = banks.filterNot(_.failed).toVector
-    val ctx        = Ctx(t, world, firms, households, banks, householdAggregates, living, living.length.toDouble, aliveBanks, p)
+    val ctx        = Ctx(executionMonth, world, firms, households, banks, householdAggregates, living, living.length.toDouble, aliveBanks, p)
     val result     = new Array[Double](schema.length)
     var i          = 0
     while i < schema.length do

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -300,7 +300,6 @@ object Generators:
   // --- World generator ---
 
   val genWorld: Gen[World] = for
-    month    <- Gen.choose(1, 120)
     infl     <- genInflation
     price    <- genPrice
     gov      <- genGovState
@@ -313,7 +312,6 @@ object Generators:
     hybR     <- genFraction
     gdp      <- Gen.choose(1e6, 1e11)
   yield World(
-    month = month,
     inflation = Rate(infl),
     priceLevel = price,
     gdpProxy = gdp,

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -655,7 +655,7 @@ object Generators:
       htmBookYield = Rate(bookYld),
       reservesAtNbp = PLN(reserves),
       interbankNet = PLN(ibNet),
-      status = if failed then Banking.BankStatus.Failed(30) else Banking.BankStatus.Active(lowCar),
+      status = if failed then Banking.BankStatus.Failed(SimulationMonth.ExecutionMonth(30)) else Banking.BankStatus.Active(lowCar),
       demandDeposits = PLN.Zero,
       termDeposits = PLN.Zero,
       loansShort = PLN.Zero,

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -24,7 +24,6 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       govDebt: Double = 0.0,
   ): World =
     World(
-      month = 1,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorPropertySpec.scala
@@ -7,6 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.boombustgroup.amorfati.Generators.*
 import com.boombustgroup.amorfati.agents.Banking.BankStatus
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 import com.boombustgroup.amorfati.random.RandomStream
@@ -133,7 +134,7 @@ class BankingSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
   "checkFailures" should "never un-fail a bank" in
     forAll(genBanking.State) { (bs: Banking.State) =>
       val failedBefore = bs.banks.filter(_.failed).map(_.id).toSet
-      val afterCheck   = Banking.checkFailures(bs.banks, 50, enabled = true, Multiplier.Zero)
+      val afterCheck   = Banking.checkFailures(bs.banks, ExecutionMonth(50), enabled = true, Multiplier.Zero)
       val failedAfter  = afterCheck.banks.filter(_.failed).map(_.id).toSet
       failedBefore.subsetOf(failedAfter) shouldBe true
     }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.agents.Banking.BankStatus
 import com.boombustgroup.amorfati.Generators
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 import com.boombustgroup.amorfati.random.RandomStream
@@ -97,7 +98,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   // ---- lendingRate ----
 
   "Banking.lendingRate" should "return high spread for failed bank" in {
-    val bank = mkBank(status = BankStatus.Failed(30))
+    val bank = mkBank(status = BankStatus.Failed(ExecutionMonth(30)))
     val rate = Banking.lendingRate(bank, configs(0), Rate(0.05), Rate.Zero)
     td.toDouble(rate) shouldBe (0.05 + 0.50) +- 0.001
   }
@@ -120,7 +121,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   // ---- canLend ----
 
   "Banking.canLend" should "return false for failed bank" in {
-    val bank = mkBank(capital = PLN(1e5), status = BankStatus.Failed(30))
+    val bank = mkBank(capital = PLN(1e5), status = BankStatus.Failed(ExecutionMonth(30)))
     Banking.canLend(bank, PLN(1000.0), RandomStream.seeded(42), Multiplier.Zero) shouldBe false
   }
 
@@ -182,7 +183,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   it should "set failed banks' interbankNet to zero" in {
     val banks   = Vector(
       mkBank(id = 0, loans = PLN(3e5)),
-      mkBank(id = 1, deposits = PLN(5e5), loans = PLN(8e5), capital = PLN(1e5), status = BankStatus.Failed(30)),
+      mkBank(id = 1, deposits = PLN(5e5), loans = PLN(8e5), capital = PLN(1e5), status = BankStatus.Failed(ExecutionMonth(30))),
     )
     val cleared = Banking.clearInterbank(banks, configs.take(2))
     cleared(1).interbankNet shouldBe PLN.Zero
@@ -194,14 +195,14 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     val banks = Vector(
       mkBank(capital = PLN(1000.0), status = BankStatus.Active(5)), // Very low CAR
     )
-    val result = Banking.checkFailures(banks, 30, enabled = false, Multiplier.Zero)
+    val result = Banking.checkFailures(banks, ExecutionMonth(30), enabled = false, Multiplier.Zero)
     result.anyFailed shouldBe false
     result.banks(0).failed shouldBe false
   }
 
   it should "trigger after 3 consecutive months of low CAR" in {
     val bank   = mkBank(capital = PLN(1000.0), status = BankStatus.Active(2))
-    val result = Banking.checkFailures(Vector(bank), 30, enabled = true, Multiplier.Zero)
+    val result = Banking.checkFailures(Vector(bank), ExecutionMonth(30), enabled = true, Multiplier.Zero)
     result.anyFailed shouldBe true
     result.banks(0).failed shouldBe true
     result.banks(0).capital shouldBe PLN.Zero // Shareholders wiped
@@ -209,7 +210,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
 
   it should "reset consecutive counter when CAR recovers" in {
     val bank   = mkBank(status = BankStatus.Active(2)) // CAR = 0.20 > MinCar
-    val result = Banking.checkFailures(Vector(bank), 30, enabled = true, Multiplier.Zero)
+    val result = Banking.checkFailures(Vector(bank), ExecutionMonth(30), enabled = true, Multiplier.Zero)
     result.anyFailed shouldBe false
     result.banks(0).consecutiveLowCar shouldBe 0
   }
@@ -219,7 +220,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   "Banking.resolveFailures" should "transfer deposits to healthiest bank" in {
     val banks  = Vector(
       mkBank(id = 0, deposits = PLN(500000.0), loans = PLN(100000.0), capital = PLN(50000.0), govBondHoldings = PLN(10000.0)),
-      mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000.0), capital = PLN(0.0), govBondHoldings = PLN(5000.0), status = BankStatus.Failed(30)),
+      mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000.0), capital = PLN(0.0), govBondHoldings = PLN(5000.0), status = BankStatus.Failed(ExecutionMonth(30))),
     )
     val result = Banking.resolveFailures(banks)
     td.toDouble(result.banks(0).deposits) shouldBe 800000.0 +- 0.01 // absorbed 300k
@@ -328,7 +329,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   it should "route to healthiest bank when current bank failed" in {
     val banks = Vector(
       mkBank(id = 0),
-      mkBank(id = 1, capital = PLN(1e5), status = BankStatus.Failed(30)),
+      mkBank(id = 1, capital = PLN(1e5), status = BankStatus.Failed(ExecutionMonth(30))),
     )
     Banking.reassignBankId(BankId(1), banks) shouldBe BankId(0)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -220,7 +220,14 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   "Banking.resolveFailures" should "transfer deposits to healthiest bank" in {
     val banks  = Vector(
       mkBank(id = 0, deposits = PLN(500000.0), loans = PLN(100000.0), capital = PLN(50000.0), govBondHoldings = PLN(10000.0)),
-      mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000.0), capital = PLN(0.0), govBondHoldings = PLN(5000.0), status = BankStatus.Failed(ExecutionMonth(30))),
+      mkBank(
+        id = 1,
+        deposits = PLN(300000.0),
+        loans = PLN(80000.0),
+        capital = PLN(0.0),
+        govBondHoldings = PLN(5000.0),
+        status = BankStatus.Failed(ExecutionMonth(30)),
+      ),
     )
     val result = Banking.resolveFailures(banks)
     td.toDouble(result.banks(0).deposits) shouldBe 800000.0 +- 0.01 // absorbed 300k

--- a/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -26,7 +27,7 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
       htmBookYield = Rate(0.05),
       reservesAtNbp = PLN.Zero,
       interbankNet = PLN.Zero,
-      status = if failed then Banking.BankStatus.Failed(0) else Banking.BankStatus.Active(0),
+      status = if failed then Banking.BankStatus.Failed(ExecutionMonth.First) else Banking.BankStatus.Active(0),
       demandDeposits = PLN(6e9),
       termDeposits = PLN(4e9),
       loansShort = PLN(3e9),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -276,6 +276,25 @@ class FirmSpec extends AnyFlatSpec with Matchers:
     Firm.computeLocalAutoRatio(firms(0), firms) shouldBe Share.Zero
   }
 
+  "Firm.computePnL" should "keep ETS surcharge at baseline in the first execution month" in {
+    val firm         = mkFirm(TechState.Traditional(10), sector = 1)
+    val commodity    = PriceIndex.Base
+    val pnl          = Firm.computePnL(
+      firm = firm,
+      wage = p.household.baseWage,
+      sectorDemandMult = Multiplier.One,
+      domesticPrice = PriceIndex.Base,
+      importPrice = PriceIndex.Base,
+      commodityPrice = commodity,
+      lendRate = Rate.Zero,
+      month = ExecutionMonth.First,
+    )
+    val baseEnergy   = pnl.revenue * p.climate.energyCostShares(firm.sector.toInt)
+    val expectedCost = commodity * baseEnergy
+
+    pnl.energyCost shouldBe expectedCost
+  }
+
   // --- Firm.process ---
 
   "Firm.process" should "keep a Bankrupt firm bankrupt with zero tax/capex" in {

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -6,6 +6,7 @@ import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
 
@@ -13,8 +14,9 @@ import com.boombustgroup.amorfati.random.RandomStream
 
 class FirmSpec extends AnyFlatSpec with Matchers:
 
-  given SimParams          = SimParams.defaults
-  private val p: SimParams = summon[SimParams]
+  given SimParams              = SimParams.defaults
+  private val p: SimParams     = summon[SimParams]
+  private val ExecutionMonth31 = ExecutionMonth(31)
 
   // --- Firm.isAlive ---
 
@@ -248,19 +250,19 @@ class FirmSpec extends AnyFlatSpec with Matchers:
   }
 
   "Firm.adoptionWillingnessMultiplier" should "increase with local demonstration effects above threshold" in {
-    val below = Firm.adoptionWillingnessMultiplier(month = 12, localAuto = Share(0.30))
-    val above = Firm.adoptionWillingnessMultiplier(month = 12, localAuto = Share(0.80))
+    val below = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth(12), localAuto = Share(0.30))
+    val above = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth(12), localAuto = Share(0.80))
 
-    above should be > below
+    above.should(be > below)
   }
 
   it should "increase over time until the ramp saturates" in {
-    val early = Firm.adoptionWillingnessMultiplier(month = 0, localAuto = Share.Zero)
-    val mid   = Firm.adoptionWillingnessMultiplier(month = 18, localAuto = Share.Zero)
-    val late  = Firm.adoptionWillingnessMultiplier(month = 72, localAuto = Share.Zero)
+    val early = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth.First, localAuto = Share.Zero)
+    val mid   = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth(18), localAuto = Share.Zero)
+    val late  = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth(72), localAuto = Share.Zero)
 
-    mid should be > early
-    late should be >= mid
+    mid.should(be > early)
+    late.should(be >= mid)
   }
 
   it should "return 0.0 for firm with no neighbors" in {
@@ -272,7 +274,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   "Firm.process" should "keep a Bankrupt firm bankrupt with zero tax/capex" in {
     val f      = mkFirm(TechState.Bankrupt(BankruptReason.Other("test")))
-    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, mkWorld(), ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     result.taxPaid shouldBe PLN.Zero
     result.capexSpent shouldBe PLN.Zero
     result.firm.tech shouldBe a[TechState.Bankrupt]
@@ -280,7 +282,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   it should "keep an Automated firm alive with large cash" in {
     val f      = mkFirm(TechState.Automated(Multiplier(1.5))).copy(cash = PLN(10000000.0))
-    val result = Firm.process(f, mkWorld(), Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, mkWorld(), ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     Firm.isAlive(result.firm) shouldBe true
   }
 
@@ -294,7 +296,7 @@ class FirmSpec extends AnyFlatSpec with Matchers:
         sectorDemandMult = Vector.fill(baseW.pipeline.sectorDemandMult.length)(Multiplier(0.1)),
       ),
     )
-    val result = Firm.process(f, w, Rate(0.20), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, w, ExecutionMonth31, Rate(0.20), _ => true, Vector(f), RandomStream.seeded(42))
     result.firm.tech shouldBe a[TechState.Bankrupt]
   }
 
@@ -310,9 +312,9 @@ class FirmSpec extends AnyFlatSpec with Matchers:
       )
     val lowAdj     = baseWorld.copy(mechanisms = baseWorld.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highAdj    = baseWorld.copy(mechanisms = baseWorld.mechanisms.copy(informalCyclicalAdj = 0.4))
-    val lowResult  = Firm.process(firm, lowAdj, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
+    val lowResult  = Firm.process(firm, lowAdj, ExecutionMonth31, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
     val highResult =
-      Firm.process(firm, highAdj, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
+      Firm.process(firm, highAdj, ExecutionMonth31, Rate(0.07), _ => true, Vector(firm), RandomStream.seeded(42))
 
     lowResult.taxPaid should be > PLN.Zero
     highResult.taxPaid should be > PLN.Zero
@@ -367,7 +369,6 @@ class FirmSpec extends AnyFlatSpec with Matchers:
 
   private def mkWorld(): World =
     World(
-      month = 31,
       inflation = Rate(0.02),
       priceLevel = PriceIndex.Base,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/FirmSpec.scala
@@ -265,6 +265,12 @@ class FirmSpec extends AnyFlatSpec with Matchers:
     late.should(be >= mid)
   }
 
+  it should "start at the documented base willingness in the first execution month" in {
+    val first = Firm.adoptionWillingnessMultiplier(month = ExecutionMonth.First, localAuto = Share.Zero)
+
+    first.shouldBe(Share(0.15))
+  }
+
   it should "return 0.0 for firm with no neighbors" in {
     val firms = Vector(mkFirmWithNeighbors(0, TechState.Traditional(10), Vector.empty[FirmId]))
     Firm.computeLocalAutoRatio(firms(0), firms) shouldBe Share.Zero

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -433,7 +433,6 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
 
   private def mkWorld(): World =
     World(
-      month = 31,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -25,7 +26,7 @@ class InterbankContagionSpec extends AnyFlatSpec with Matchers:
       htmBookYield = Rate(0.05),
       reservesAtNbp = PLN.Zero,
       interbankNet = PLN(interbankNet),
-      status = if failed then Banking.BankStatus.Failed(0) else Banking.BankStatus.Active(0),
+      status = if failed then Banking.BankStatus.Failed(ExecutionMonth.First) else Banking.BankStatus.Active(0),
       demandDeposits = PLN(6e9),
       termDeposits = PLN(4e9),
       loansShort = PLN(1.5e9),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/StagedDigitalizationSpec.scala
@@ -5,15 +5,17 @@ import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
 
-  given SimParams          = SimParams.defaults
-  private val p: SimParams = summon[SimParams]
-  private val td           = ComputationBoundary
+  given SimParams              = SimParams.defaults
+  private val p: SimParams     = summon[SimParams]
+  private val td               = ComputationBoundary
+  private val ExecutionMonth31 = ExecutionMonth(31)
 
   // ---- Helpers ----
 
@@ -41,7 +43,6 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
 
   private def mkWorld(autoRatio: Double = 0.0, hybridRatio: Double = 0.0): World =
     World(
-      month = 31,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 1e9,
@@ -143,7 +144,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   "applyDigitalDrift" should "increase DR for alive firms" in {
     val f      = mkFirm(TechState.Traditional(10), dr = 0.40)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     // DR should be at least initial + drift (could also get digital investment boost)
     td.toDouble(result.firm.digitalReadiness) should be >= (0.40 + td.toDouble(p.firm.digiDrift) - 0.001)
   }
@@ -151,14 +152,14 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   it should "cap digitalReadiness at 1.0" in {
     val f      = mkFirm(TechState.Traditional(10), dr = 0.999)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     td.toDouble(result.firm.digitalReadiness) should be <= 1.0
   }
 
   it should "not change DR for bankrupt firms" in {
     val f      = mkFirm(TechState.Bankrupt(BankruptReason.Other("test")), dr = 0.50)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     td.toDouble(result.firm.digitalReadiness) shouldBe 0.50
   }
 
@@ -173,7 +174,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     // concurrently. Run enough rounds for DR to increase above drift baseline.
     val rng        = RandomStream.seeded(42)
     var f1         = f
-    for _ <- 0 until 200 do f1 = Firm.process(f1, w, Rate(0.07), _ => false, Vector(f1), rng).firm
+    for _ <- 0 until 200 do f1 = Firm.process(f1, w, ExecutionMonth31, Rate(0.07), _ => false, Vector(f1), rng).firm
     assume(Firm.isAlive(f1), "firm must survive processing")
     // DR should have increased from digital investment (beyond just drift)
     val drIncrease = td.toDouble(f1.digitalReadiness) - td.toDouble(f.digitalReadiness)
@@ -188,7 +189,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val rng      = RandomStream.seeded(42L)
     // Over many trials, no investment should happen (only drift)
     for _ <- 0 until 100 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), rng)
+      val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => false, Vector(f), rng)
       // DR should be at most initial + drift (no investment boost)
       // But net income is added to cash, so firm may become solvent enough
       // Just verify no investment boost beyond drift
@@ -224,7 +225,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
   "Hybrid firm" should "gain at least 0.005 + drift in DR per month" in {
     val f      = mkFirm(TechState.Hybrid(5, Multiplier(1.1)), dr = 0.40)
     val w      = mkWorld()
-    val result = Firm.process(f, w, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
+    val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => true, Vector(f), RandomStream.seeded(42))
     if Firm.isAlive(result.firm) then
       // Hybrid learning (+0.005) + natural drift (+0.001)
       td.toDouble(result.firm.digitalReadiness) should be >= (0.40 + 0.005 + td.toDouble(p.firm.digiDrift) - 0.001)
@@ -239,7 +240,7 @@ class StagedDigitalizationSpec extends AnyFlatSpec with Matchers:
     val rng    = RandomStream.seeded(42L)
     // Simulate 10 months — at minimum, drift alone adds 10 × 0.001 = 0.01
     for _ <- 0 until 10 do
-      val result = Firm.process(f, w, Rate(0.07), _ => false, Vector(f), rng)
+      val result = Firm.process(f, w, ExecutionMonth31, Rate(0.07), _ => false, Vector(f), rng)
       if Firm.isAlive(result.firm) then f = result.firm.copy(cash = PLN(1000000.0)) // reset cash for next round
     td.toDouble(f.digitalReadiness) should be >= (initDR + 10 * td.toDouble(p.firm.digiDrift) - 0.001)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.CapitalFlows
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,40 +14,41 @@ class CapitalFlowsSpec extends AnyFlatSpec with Matchers:
   private val td    = ComputationBoundary
   private val gdp   = PLN(100e9)
   private val carry = CapitalFlows.CarryState.zero
+  private val Month1 = ExecutionMonth.First
 
   "CapitalFlows.compute" should "produce zero adjustment when no shock and spread below threshold" in {
-    val result = CapitalFlows.compute(1, Rate(0.02), Multiplier(2.0), carry, gdp)
+    val result = CapitalFlows.compute(Month1, Rate(0.02), Multiplier(2.0), carry, gdp)
     td.toDouble(result.totalAdjustment) shouldBe 0.0 +- 1.0
   }
 
   it should "accumulate carry trade when spread exceeds threshold" in {
     val highSpread = Rate(0.08) // well above carryThreshold (3%)
-    val result     = CapitalFlows.compute(1, highSpread, Multiplier(2.0), carry, gdp)
+    val result     = CapitalFlows.compute(Month1, highSpread, Multiplier(2.0), carry, gdp)
     td.toDouble(result.newCarryState.stock) should be > 0.0
     td.toDouble(result.carryTradeFlow) should be > 0.0
   }
 
   it should "not accumulate carry when spread below threshold" in {
     val lowSpread = Rate(0.02) // below carryThreshold (3%)
-    val result    = CapitalFlows.compute(1, lowSpread, Multiplier(2.0), carry, gdp)
+    val result    = CapitalFlows.compute(Month1, lowSpread, Multiplier(2.0), carry, gdp)
     result.newCarryState.stock shouldBe PLN.Zero
   }
 
   it should "trigger auction outflow when bid-to-cover is low" in {
     val lowBtc = Multiplier(0.80) // below auctionConfidenceThreshold (0.90)
-    val result = CapitalFlows.compute(1, Rate(0.05), lowBtc, carry, gdp)
+    val result = CapitalFlows.compute(Month1, Rate(0.05), lowBtc, carry, gdp)
     td.toDouble(result.auctionSignal) should be < 0.0
   }
 
   it should "not trigger auction outflow when bid-to-cover is healthy" in {
     val highBtc = Multiplier(1.50)
-    val result  = CapitalFlows.compute(1, Rate(0.05), highBtc, carry, gdp)
+    val result  = CapitalFlows.compute(Month1, Rate(0.05), highBtc, carry, gdp)
     result.auctionSignal shouldBe PLN.Zero
   }
 
   it should "preserve carry stock when no risk-off" in {
     val withCarry = CapitalFlows.CarryState(PLN(10e9))
-    val result    = CapitalFlows.compute(1, Rate(0.05), Multiplier(2.0), withCarry, gdp)
+    val result    = CapitalFlows.compute(Month1, Rate(0.05), Multiplier(2.0), withCarry, gdp)
     // Stock should grow (accumulation) or stay (no unwind without risk-off)
     td.toDouble(result.newCarryState.stock) should be >= 10e9
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CapitalFlowsSpec.scala
@@ -11,9 +11,9 @@ class CapitalFlowsSpec extends AnyFlatSpec with Matchers:
 
   given SimParams = SimParams.defaults
 
-  private val td    = ComputationBoundary
-  private val gdp   = PLN(100e9)
-  private val carry = CapitalFlows.CarryState.zero
+  private val td     = ComputationBoundary
+  private val gdp    = PLN(100e9)
+  private val carry  = CapitalFlows.CarryState.zero
   private val Month1 = ExecutionMonth.First
 
   "CapitalFlows.compute" should "produce zero adjustment when no shock and spread below threshold" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CommodityPriceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CommodityPriceSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.GvcTrade
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -24,7 +25,7 @@ class CommodityPriceSpec extends AnyFlatSpec with Matchers:
       priceLevel = PriceIndex.Base,
       exchangeRate = ExchangeRate(4.33),
       autoRatio = Share.Zero,
-      month = month,
+      month = ExecutionMonth(month),
       rng = RandomStream.seeded(seed * 31 + month),
     )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/DiasporaRemittanceSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
 
@@ -153,7 +154,7 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
       gdp = PLN(1e9),
       priceLevel = PriceIndex.Base,
       sectorOutputs = Vector.fill(6)(PLN(1e8)),
-      month = 1,
+      month = ExecutionMonth(1),
       nbpFxReserves = prevBop.reserves,
     )
     val resultWith    = OpenEconomy.step(base.copy(diasporaInflow = PLN(1000.0)))
@@ -176,7 +177,7 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
       gdp = PLN(1e9),
       priceLevel = PriceIndex.Base,
       sectorOutputs = Vector.fill(6)(PLN(1e8)),
-      month = 1,
+      month = ExecutionMonth(1),
       nbpFxReserves = prevBop.reserves,
     )
     val result = OpenEconomy.step(base.copy(remittanceOutflow = PLN(500.0), diasporaInflow = PLN(800.0)))
@@ -201,7 +202,6 @@ class DiasporaRemittanceSpec extends AnyFlatSpec with Matchers:
 
   "World" should "default diasporaRemittanceInflow to 0.0" in {
     val w = World(
-      month = 0,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EnergyClimateSpec.scala
@@ -170,7 +170,6 @@ class EnergyClimateSpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   private def mkMinimalWorld() = World(
-    month = 0,
     inflation = Rate(0.02),
     priceLevel = 1.0,
     gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EuFundsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EuFundsSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.FiscalBudget
 import com.boombustgroup.amorfati.engine.mechanisms.EuFunds
 import com.boombustgroup.amorfati.math.EuFundsMath
@@ -17,26 +18,28 @@ class EuFundsSpec extends AnyFlatSpec with Matchers:
   // --- monthlyTransfer tests ---
   // Note: monthlyTransfer depends on Config env vars. Default: start=1, period=84
 
-  "monthlyTransfer" should "return 0 before startMonth" in
-    EuFunds.monthlyTransfer(0).shouldBe(PLN.Zero)
+  "monthlyTransfer" should "return 0 before startMonth when the configured start month is after month 1" in {
+    if p.fiscal.euFundsStartMonth > 1 then EuFunds.monthlyTransfer(ExecutionMonth(p.fiscal.euFundsStartMonth - 1)).shouldBe(PLN.Zero)
+    else succeed
+  }
 
   it should "return positive value at startMonth" in
-    EuFunds.monthlyTransfer(p.fiscal.euFundsStartMonth).should(be > PLN.Zero)
+    EuFunds.monthlyTransfer(ExecutionMonth(p.fiscal.euFundsStartMonth)).should(be > PLN.Zero)
 
   it should "return 0 after startMonth + periodMonths" in {
     val afterEnd = p.fiscal.euFundsStartMonth + p.fiscal.euFundsPeriodMonths + 1
-    EuFunds.monthlyTransfer(afterEnd).shouldBe(PLN.Zero)
+    EuFunds.monthlyTransfer(ExecutionMonth(afterEnd)).shouldBe(PLN.Zero)
   }
 
   it should "return positive value in the middle of the period" in {
     val mid = p.fiscal.euFundsStartMonth + p.fiscal.euFundsPeriodMonths / 2
-    td.toDouble(EuFunds.monthlyTransfer(mid)).should(be > 0.0)
+    td.toDouble(EuFunds.monthlyTransfer(ExecutionMonth(mid))).should(be > 0.0)
   }
 
   it should "sum to ~totalAllocation over full period" in {
     val totalPln = EuFundsMath.totalEnvelopePln(p.fiscal.euFundsTotalEur, p.forex.baseExRate, p.pop.firmsCount, 10000)
     val sum      = (1 to p.fiscal.euFundsPeriodMonths + p.fiscal.euFundsStartMonth).map { m =>
-      EuFunds.monthlyTransfer(m)
+      EuFunds.monthlyTransfer(ExecutionMonth(m))
     }.sum
     td.toDouble(sum).shouldBe(td.toDouble(totalPln) +- (td.toDouble(totalPln) * 0.02))
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorPropertySpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.boombustgroup.amorfati.Generators.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.GvcTrade
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -34,7 +35,7 @@ class ExternalSectorPropertySpec extends AnyFlatSpec with Matchers with ScalaChe
         PriceIndex(price),
         ExchangeRate(er),
         Share(autoR),
-        month,
+        ExecutionMonth(month),
         rng = RandomStream.seeded(42),
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.GvcTrade
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -22,7 +23,7 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
       price: Double = 1.0,
       autoR: Double = 0.0,
       month: Int = 30,
-  ) = GvcTrade.StepInput(prev, sectorOutputs, PriceIndex(price), ExchangeRate(er), Share(autoR), month, rng = RandomStream.seeded(42))
+  ) = GvcTrade.StepInput(prev, sectorOutputs, PriceIndex(price), ExchangeRate(er), Share(autoR), ExecutionMonth(month), rng = RandomStream.seeded(42))
 
   // ---- Initialization ----
 
@@ -69,43 +70,43 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
 
   "GvcTrade.step" should "produce positive total exports" in {
     val r = GvcTrade.step(baseInput())
-    r.totalExports should be > PLN.Zero
+    r.totalExports.should(be > PLN.Zero)
   }
 
   it should "produce positive total intermediate imports" in {
     val r = GvcTrade.step(baseInput())
-    r.totalIntermImports should be > PLN.Zero
+    r.totalIntermImports.should(be > PLN.Zero)
   }
 
   it should "evolve foreign price index upward" in {
     val r = GvcTrade.step(baseInput())
-    r.foreignPriceIndex should be > PriceIndex.Base
+    r.foreignPriceIndex.should(be > PriceIndex.Base)
   }
 
   it should "have 6-element sector exports" in {
     val r = GvcTrade.step(baseInput())
-    r.sectorExports.length shouldBe 6
-    r.sectorExports.foreach(e => e should be >= PLN.Zero)
+    r.sectorExports.length.shouldBe(6)
+    r.sectorExports.foreach(e => e.should(be >= PLN.Zero))
   }
 
   it should "have 6-element sector imports" in {
     val r = GvcTrade.step(baseInput())
-    r.sectorImports.length shouldBe 6
-    r.sectorImports.foreach(i => i should be >= PLN.Zero)
+    r.sectorImports.length.shouldBe(6)
+    r.sectorImports.foreach(i => i.should(be >= PLN.Zero))
   }
 
   it should "increase exports with higher automation" in {
     val r0 = GvcTrade.step(baseInput(autoR = 0.0))
     val r1 = GvcTrade.step(baseInput(autoR = 0.5))
-    r1.totalExports should be > r0.totalExports
+    r1.totalExports.should(be > r0.totalExports)
   }
 
   it should "have zero disruption when no shock applied" in {
     val r = GvcTrade.step(baseInput())
-    r.disruptionIndex shouldBe Share.Zero
+    r.disruptionIndex.shouldBe(Share.Zero)
   }
 
   it should "have import cost index >= 1.0 (foreign inflation)" in {
     val r = GvcTrade.step(baseInput())
-    r.importCostIndex should be >= PriceIndex.Base
+    r.importCostIndex.should(be >= PriceIndex.Base)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
@@ -73,6 +73,14 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
     r.totalExports.should(be > PLN.Zero)
   }
 
+  it should "keep export demand at baseline in the first execution month" in {
+    val init = GvcTrade.initial
+    val r    = GvcTrade.step(baseInput(prev = init, month = 1))
+
+    r.totalExports shouldBe init.totalExports
+    r.sectorExports shouldBe init.sectorExports
+  }
+
   it should "produce positive total intermediate imports" in {
     val r = GvcTrade.step(baseInput())
     r.totalIntermImports.should(be > PLN.Zero)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
@@ -12,8 +13,9 @@ import com.boombustgroup.amorfati.types.*
 
 class FdiCompositionSpec extends AnyFlatSpec with Matchers:
 
-  given SimParams          = SimParams.defaults
-  private val p: SimParams = summon[SimParams]
+  given SimParams              = SimParams.defaults
+  private val p: SimParams     = summon[SimParams]
+  private val ExecutionMonth31 = ExecutionMonth(31)
   // --- Config defaults ---
 
   "FdiForeignShares" should "have 6 values" in {
@@ -69,7 +71,7 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
   "calcPnL (via Firm.process)" should "produce profitShiftCost=0 for domestic firm" in {
     val f = mkFirm(TechState.Traditional(10)).copy(foreignOwned = false)
     val w = mkWorld()
-    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
+    val r = Firm.process(f, w, ExecutionMonth31, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
     r.profitShiftCost shouldBe PLN.Zero
   }
 
@@ -106,7 +108,7 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
     // When FDI is enabled and firm has low cash, repatriation is capped
     val f = mkFirm(TechState.Traditional(10)).copy(foreignOwned = true, cash = PLN(100.0))
     val w = mkWorld()
-    val r = Firm.process(f, w, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
+    val r = Firm.process(f, w, ExecutionMonth31, Rate(0.06), _ => true, Vector(f), RandomStream.seeded(42))
     // Even with FDI enabled, cash should not go below what the base logic sets
     // With FDI disabled (default), just verify firm processes normally
     Firm.isAlive(r.firm) || !Firm.isAlive(r.firm) shouldBe true // always true, no crash
@@ -161,7 +163,6 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
 
   private def mkWorld(): World =
     World(
-      month = 31,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FirmEntrySpec.scala
@@ -91,7 +91,6 @@ class FirmEntrySpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   private def mkMinimalWorld() = World(
-    month = 0,
     inflation = Rate(0.0),
     priceLevel = 1.0,
     gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -75,7 +75,6 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   private def mkMinimalWorld() = World(
-    month = 0,
     inflation = Rate(0.0),
     priceLevel = 1.0,
     gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InventorySpec.scala
@@ -77,7 +77,6 @@ class InventorySpec extends AnyFlatSpec with Matchers:
   // ==========================================================================
 
   private def mkMinimalWorld() = World(
-    month = 0,
     inflation = Rate(0.0),
     priceLevel = 1.0,
     gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -402,7 +402,14 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
   "healthiestBankId" should "return bank with highest capital when all fail" in {
     val banks = Vector(
-      mkBank(id = 0, deposits = PLN(500000.0), loans = PLN(100000), capital = PLN(-20000), nplAmount = PLN(50000), status = BankStatus.Failed(ExecutionMonth(3))),
+      mkBank(
+        id = 0,
+        deposits = PLN(500000.0),
+        loans = PLN(100000),
+        capital = PLN(-20000),
+        nplAmount = PLN(50000),
+        status = BankStatus.Failed(ExecutionMonth(3)),
+      ),
       mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000), capital = PLN(-5000), nplAmount = PLN(30000), status = BankStatus.Failed(ExecutionMonth(3))),
       mkBank(id = 2, deposits = PLN(200000.0), loans = PLN(60000), capital = PLN(-15000), nplAmount = PLN(20000), status = BankStatus.Failed(ExecutionMonth(3))),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.agents.Banking.BankStatus
@@ -126,7 +127,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return zero for failed bank" in {
-    val banks  = Vector(mkBank(deposits = PLN(1200000.0), capital = PLN.Zero, status = BankStatus.Failed(5)))
+    val banks  = Vector(mkBank(deposits = PLN(1200000.0), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(5))))
     val result = Banking.computeBfgLevy(banks)
     result.perBank(0) shouldBe PLN.Zero
     result.total shouldBe PLN.Zero
@@ -136,7 +137,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
     val banks    = Vector(
       mkBank(id = 0, deposits = PLN(1000000.0)),
       mkBank(id = 1, deposits = PLN(2000000.0), capital = PLN(200000)),
-      mkBank(id = 2, deposits = PLN(500000.0), capital = PLN(50000), status = BankStatus.Failed(3)),
+      mkBank(id = 2, deposits = PLN(500000.0), capital = PLN(50000), status = BankStatus.Failed(ExecutionMonth(3))),
     )
     val result   = Banking.computeBfgLevy(banks)
     val expected = (1000000.0 + 2000000.0) * td.toDouble(p.banking.bfgLevyRate) / 12.0
@@ -162,7 +163,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "not haircut deposits below guarantee threshold" in {
-    val banks  = Vector(mkBank(deposits = PLN(300000.0), capital = PLN.Zero, status = BankStatus.Failed(5)))
+    val banks  = Vector(mkBank(deposits = PLN(300000.0), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(5))))
     val result = Banking.applyBailIn(banks)
     result.banks(0).deposits shouldBe PLN(300000.0)
     result.totalLoss shouldBe PLN.Zero
@@ -181,7 +182,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
   it should "apply before resolution (bail-in then resolve)" in {
     val banks        = Vector(
-      mkBank(id = 0, deposits = PLN(1000000.0), loans = PLN(100000), capital = PLN.Zero, nplAmount = PLN(50000), status = BankStatus.Failed(5)),
+      mkBank(id = 0, deposits = PLN(1000000.0), loans = PLN(100000), capital = PLN.Zero, nplAmount = PLN(50000), status = BankStatus.Failed(ExecutionMonth(5))),
       mkBank(id = 1, deposits = PLN(2000000.0), loans = PLN(200000), capital = PLN(200000)),
     )
     val afterBailIn  = Banking.applyBailIn(banks)
@@ -315,7 +316,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-10000),
         nplAmount = PLN(50000),
         govBondHoldings = PLN(20e9),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
       mkBank(
         id = 1,
@@ -324,7 +325,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-5000),
         nplAmount = PLN(30000),
         govBondHoldings = PLN(15e9),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
       mkBank(
         id = 2,
@@ -333,7 +334,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-20000),
         nplAmount = PLN(20000),
         govBondHoldings = PLN(13.8e9),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
     )
     val totalBondsBefore = banks.map(b => td.toDouble(b.govBondHoldings)).sum
@@ -354,7 +355,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-5000),
         nplAmount = PLN(50000),
         interbankNet = PLN(1000.0),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
       mkBank(
         id = 1,
@@ -363,7 +364,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-3000),
         nplAmount = PLN(30000),
         interbankNet = PLN(-600.0),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
       mkBank(
         id = 2,
@@ -372,7 +373,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN(-10000),
         nplAmount = PLN(20000),
         interbankNet = PLN(-400.0),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
     )
     val result               = Banking.resolveFailures(banks)
@@ -390,7 +391,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         capital = PLN.Zero,
         nplAmount = PLN(50000),
         govBondHoldings = PLN(10e9),
-        status = BankStatus.Failed(3),
+        status = BankStatus.Failed(ExecutionMonth(3)),
       ),
       mkBank(id = 1, deposits = PLN(2000000.0), loans = PLN(200000), capital = PLN(200000), govBondHoldings = PLN(5e9)),
     )
@@ -401,9 +402,9 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
   "healthiestBankId" should "return bank with highest capital when all fail" in {
     val banks = Vector(
-      mkBank(id = 0, deposits = PLN(500000.0), loans = PLN(100000), capital = PLN(-20000), nplAmount = PLN(50000), status = BankStatus.Failed(3)),
-      mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000), capital = PLN(-5000), nplAmount = PLN(30000), status = BankStatus.Failed(3)),
-      mkBank(id = 2, deposits = PLN(200000.0), loans = PLN(60000), capital = PLN(-15000), nplAmount = PLN(20000), status = BankStatus.Failed(3)),
+      mkBank(id = 0, deposits = PLN(500000.0), loans = PLN(100000), capital = PLN(-20000), nplAmount = PLN(50000), status = BankStatus.Failed(ExecutionMonth(3))),
+      mkBank(id = 1, deposits = PLN(300000.0), loans = PLN(80000), capital = PLN(-5000), nplAmount = PLN(30000), status = BankStatus.Failed(ExecutionMonth(3))),
+      mkBank(id = 2, deposits = PLN(200000.0), loans = PLN(60000), capital = PLN(-15000), nplAmount = PLN(20000), status = BankStatus.Failed(ExecutionMonth(3))),
     )
     // Bank 1 has highest (least negative) capital: -5000
     Banking.healthiestBankId(banks) shouldBe BankId(1)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -199,7 +199,6 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
   "World" should "default bfgFundBalance=0 and bailInLoss=0" in {
     val w = World(
-      month = 0,
       inflation = Rate(0.02),
       priceLevel = 1.0,
       gdpProxy = 100000.0,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -28,7 +28,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "have Month column = 1..60" in {
-    for t <- 0 until duration do ts(t)(Col.Month.ordinal) shouldBe (t + 1).toDouble
+    for month <- ts.executionMonths do ts.at(month, Col.Month) shouldBe month.toInt.toDouble
   }
 
   it should "keep adoption ratio in [0, 1]" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -1,9 +1,11 @@
 package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.montecarlo.McRunner.runSingle
 import com.boombustgroup.amorfati.montecarlo.SimOutput
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
+import com.boombustgroup.amorfati.montecarlo.TimeSeries
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -17,13 +19,16 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
   private val duration = 60 // months
 
   // Single shared run — all tests read from this result
-  private lazy val result = runSingle(42, duration).fold(e => fail(e.toString), identity)
-  private def ts          = result.timeSeries
+  private lazy val result                     = runSingle(42, duration).fold(e => fail(e.toString), identity)
+  private def ts                              = result.timeSeries
+  private def month(t: Int): ExecutionMonth   = ExecutionMonth.First.advanceBy(t)
+  private def row(t: Int)                     = ts.monthRow(month(t))
+  private def row(series: TimeSeries, t: Int) = series.monthRow(month(t))
 
   // --- Basic output sanity ---
 
   "runSingle" should "produce 60 rows x 227 columns" in {
-    ts.length shouldBe duration
+    ts.nMonths shouldBe duration
     for row <- ts do row.length shouldBe SimOutput.nCols
   }
 
@@ -33,36 +38,36 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   it should "keep adoption ratio in [0, 1]" in {
     for t <- 0 until duration do
-      ts(t)(Col.TotalAdoption.ordinal) should be >= 0.0
-      ts(t)(Col.TotalAdoption.ordinal) should be <= 1.0
+      row(t)(Col.TotalAdoption.ordinal) should be >= 0.0
+      row(t)(Col.TotalAdoption.ordinal) should be <= 1.0
   }
 
   it should "keep unemployment in [0, 1]" in {
     for t <- 0 until duration do
-      ts(t)(Col.Unemployment.ordinal) should be >= 0.0
-      ts(t)(Col.Unemployment.ordinal) should be <= 1.0
+      row(t)(Col.Unemployment.ordinal) should be >= 0.0
+      row(t)(Col.Unemployment.ordinal) should be <= 1.0
   }
 
   it should "produce no NaN or Infinity in output" in {
-    for t <- ts.indices; c <- ts(t).indices do
+    for t <- ts.indices; c <- row(t).indices do
       withClue(s"Month ${t + 1}, col $c: ") {
-        ts(t)(c).isNaN shouldBe false
-        ts(t)(c).isInfinite shouldBe false
+        row(t)(c).isNaN shouldBe false
+        row(t)(c).isInfinite shouldBe false
       }
   }
 
   it should "have positive sigma values" in {
-    for t <- 0 until duration; s <- 0 until 6 do ts(t)(Col.sectorSigma(s).ordinal) should be > 0.0
+    for t <- 0 until duration; s <- 0 until 6 do row(t)(Col.sectorSigma(s).ordinal) should be > 0.0
   }
 
   it should "have positive mean degree" in {
-    for t <- 0 until duration do ts(t)(Col.MeanDegree.ordinal) should be > 0.0
+    for t <- 0 until duration do row(t)(Col.MeanDegree.ordinal) should be > 0.0
   }
 
   it should "keep price level above floor (0.30)" in {
     for t <- ts.indices do
       withClue(s"Month ${t + 1}: ") {
-        ts(t)(Col.PriceLevel.ordinal) should be >= 0.30
+        row(t)(Col.PriceLevel.ordinal) should be >= 0.30
       }
   }
 
@@ -70,7 +75,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   it should "be reproducible with the same seed" in {
     val r2 = runSingle(42, duration).fold(e => fail(e.toString), identity)
-    for t <- 0 until duration; c <- 0 until SimOutput.nCols do ts(t)(c) shouldBe r2.timeSeries(t)(c)
+    for t <- 0 until duration; c <- 0 until SimOutput.nCols do row(t)(c) shouldBe row(r2.timeSeries, t)(c)
   }
 
   // --- Terminal state ---
@@ -98,20 +103,20 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
   it should "keep BondYield non-negative after month 1" in {
     for t <- 1 until duration do
       withClue(s"Month ${t + 1}: ") {
-        ts(t)(Col.BondYield.ordinal) should be >= 0.0
+        row(t)(Col.BondYield.ordinal) should be >= 0.0
       }
   }
 
   it should "have non-zero BondsOutstanding after month 1" in {
-    val nonZero = (1 until duration).exists(t => ts(t)(Col.BondsOutstanding.ordinal) != 0.0)
+    val nonZero = (1 until duration).exists(t => row(t)(Col.BondsOutstanding.ordinal) != 0.0)
     nonZero shouldBe true
   }
 
   it should "satisfy bond clearing identity at every month" in {
     for t <- ts.indices do
-      val outstanding = ts(t)(Col.BondsOutstanding.ordinal)
-      val holders     = ts(t)(Col.BankBondHoldings.ordinal) + ts(t)(Col.ForeignBondHoldings.ordinal) + ts(t)(Col.NbpBondHoldings.ordinal) +
-        ts(t)(Col.PpkBondHoldings.ordinal) + ts(t)(Col.InsGovBondHoldings.ordinal) + ts(t)(Col.NbfiTfiGovBondHoldings.ordinal)
+      val outstanding = row(t)(Col.BondsOutstanding.ordinal)
+      val holders     = row(t)(Col.BankBondHoldings.ordinal) + row(t)(Col.ForeignBondHoldings.ordinal) + row(t)(Col.NbpBondHoldings.ordinal) +
+        row(t)(Col.PpkBondHoldings.ordinal) + row(t)(Col.InsGovBondHoldings.ordinal) + row(t)(Col.NbfiTfiGovBondHoldings.ordinal)
       withClue(s"Month ${t + 1}: holders($holders) vs outstanding($outstanding): ") {
         holders shouldBe outstanding +- 1.0
       }
@@ -122,7 +127,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
   it should "have non-negative unemployment benefits" in {
     for t <- ts.indices do
       withClue(s"Month ${t + 1}: ") {
-        ts(t)(Col.UnempBenefitSpend.ordinal) should be >= 0.0
+        row(t)(Col.UnempBenefitSpend.ordinal) should be >= 0.0
       }
   }
 
@@ -133,10 +138,10 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   it should "cut NBP rate when inflation is negative (symmetric Taylor)" in {
     val initialRate    = 0.0575
-    val deflationMonth = ts.indices.find(t => ts(t)(Col.Inflation.ordinal) < 0.0)
+    val deflationMonth = ts.indices.find(t => row(t)(Col.Inflation.ordinal) < 0.0)
     deflationMonth match
       case Some(t) =>
-        val rateAfterDeflation = ((t + 1) until duration).map(m => ts(m)(Col.RefRate.ordinal))
+        val rateAfterDeflation = ((t + 1) until duration).map(m => row(m)(Col.RefRate.ordinal))
         rateAfterDeflation.exists(_ < initialRate) shouldBe true
       case None    =>
         succeed
@@ -146,8 +151,8 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   it should "have interbank rate deviating from refRate" in {
     val deviates = ts.indices.exists { t =>
-      val ibRate  = ts(t)(Col.InterbankRate.ordinal)
-      val refRate = ts(t)(Col.RefRate.ordinal)
+      val ibRate  = row(t)(Col.InterbankRate.ordinal)
+      val refRate = row(t)(Col.RefRate.ordinal)
       Math.abs(ibRate - refRate) > 1e-6
     }
     deviates shouldBe true
@@ -156,8 +161,8 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
   it should "have finite MinBankCAR at all months" in {
     for t <- ts.indices do
       withClue(s"Month ${t + 1}: ") {
-        ts(t)(Col.MinBankCAR.ordinal).isNaN shouldBe false
-        ts(t)(Col.MinBankCAR.ordinal).isInfinite shouldBe false
+        row(t)(Col.MinBankCAR.ordinal).isNaN shouldBe false
+        row(t)(Col.MinBankCAR.ordinal).isInfinite shouldBe false
       }
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonetaryPlumbingSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.agents.Banking
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
 
 /** Reserve Interest, Standing Facilities, Interbank Interest tests. */
@@ -130,7 +131,7 @@ class MonetaryPlumbingSpec extends AnyFlatSpec with Matchers:
       htmBookYield = Rate.Zero,
       reservesAtNbp = reservesAtNbp,
       interbankNet = interbankNet,
-      status = if failed then Banking.BankStatus.Failed(30) else Banking.BankStatus.Active(0),
+      status = if failed then Banking.BankStatus.Failed(ExecutionMonth(30)) else Banking.BankStatus.Active(0),
       demandDeposits = PLN.Zero,
       termDeposits = PLN.Zero,
       loansShort = PLN.Zero,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomyPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomyPropertySpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import com.boombustgroup.amorfati.Generators.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.OpenEconomy
 import com.boombustgroup.amorfati.types.*
 
@@ -62,7 +63,7 @@ class OpenEconomyPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckP
     gdp = PLN(gdp),
     priceLevel = PriceIndex(price),
     sectorOutputs = defaultSectorOutputs,
-    month = month,
+    month = ExecutionMonth(month),
     nbpFxReserves = prevBop.reserves,
   )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
@@ -43,6 +43,12 @@ class OpenEconomySpec extends AnyFlatSpec with Matchers:
     td.toDouble(r.bop.exports) should be > 0.0
   }
 
+  it should "use zero elapsed foreign GDP growth in the first execution month" in {
+    val r = OpenEconomy.step(baseInput(month = 1))
+
+    td.toDouble(r.bop.exports) shouldBe (td.toDouble(p.openEcon.exportBase) +- 0.01)
+  }
+
   it should "increase exports with higher automation (ULC effect)" in {
     val r0 = OpenEconomy.step(baseInput(autoRatio = 0.0))
     val r1 = OpenEconomy.step(baseInput(autoRatio = 0.5))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/OpenEconomySpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.OpenEconomy
 import com.boombustgroup.amorfati.types.*
 
@@ -31,7 +32,7 @@ class OpenEconomySpec extends AnyFlatSpec with Matchers:
     gdp = gdp,
     priceLevel = PriceIndex.Base,
     sectorOutputs = baseSectorOutputs,
-    month = month,
+    month = ExecutionMonth(month),
     nbpFxReserves = prevBop.reserves,
   )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/TourismSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine
 import org.scalatest.flatspec.AnyFlatSpec
 import com.boombustgroup.amorfati.Generators
 import org.scalatest.matchers.should.Matchers
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.types.*
 
@@ -207,7 +208,7 @@ class TourismSpec extends AnyFlatSpec with Matchers:
       gdp = PLN(1e9),
       priceLevel = PriceIndex.Base,
       sectorOutputs = Vector.fill(p.sectorDefs.length)(PLN(1e8)),
-      month = 1,
+      month = ExecutionMonth(1),
       nbpFxReserves = prevBop.reserves,
     )
     val resultWith    = OpenEconomy.step(base.copy(tourismExport = PLN(1000.0)))
@@ -230,7 +231,7 @@ class TourismSpec extends AnyFlatSpec with Matchers:
       gdp = PLN(1e9),
       priceLevel = PriceIndex.Base,
       sectorOutputs = Vector.fill(p.sectorDefs.length)(PLN(1e8)),
-      month = 1,
+      month = ExecutionMonth(1),
       nbpFxReserves = prevBop.reserves,
     )
     val resultWith    = OpenEconomy.step(base.copy(tourismImport = PLN(500.0)))
@@ -245,7 +246,6 @@ class TourismSpec extends AnyFlatSpec with Matchers:
 
   "World" should "default tourismExport and tourismImport to 0.0" in {
     val w = World(
-      month = 0,
       inflation = Rate(0.02),
       priceLevel = PriceIndex.Base,
       gdpProxy = 1e9,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{MonthRandomness, OperationalSignals}
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -20,7 +21,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     val w               = init.world
     val stageRandomness = MonthRandomness.Contract.fromSeed(TestSeed).stages.newStreams()
 
-    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
     val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
     val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.OperationalSignals
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -19,7 +20,7 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private val w    = init.world
   private val rng  = RandomStream.seeded(42)
 
-  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
+  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
   private val s1     = FiscalConstraintEconomics.toOutput(fiscal)
   private val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
   private val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomicsSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,7 +15,7 @@ class FiscalConstraintEconomicsSpec extends AnyFlatSpec with Matchers:
   private val world = init.world
 
   "FiscalConstraintEconomics.compute" should "produce consistent result and output" in {
-    val result = FiscalConstraintEconomics.compute(world, init.banks)
+    val result = FiscalConstraintEconomics.compute(world, init.banks, ExecutionMonth.First)
     val output = FiscalConstraintEconomics.toOutput(result)
 
     output.m shouldBe result.month
@@ -25,6 +26,7 @@ class FiscalConstraintEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "advance month by 1" in {
-    val result = FiscalConstraintEconomics.compute(world, init.banks)
-    result.month shouldBe world.month + 1
+    val completedMonth = CompletedMonth.Zero
+    val result         = FiscalConstraintEconomics.compute(world, init.banks, completedMonth.next)
+    result.month shouldBe completedMonth.next
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -18,7 +19,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
   private val households = initResult.households
 
   private val s1 = FiscalConstraintEconomics.Output(
-    m = 1,
+    month = ExecutionMonth.First,
     lendingBaseRate = world.nbp.referenceRate,
     resWage = world.householdMarket.reservationWage,
     baseMinWage = world.gov.minWageLevel,
@@ -80,5 +81,5 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
 
     post.laborDemand shouldBe postLiving.map(Firm.workerCount).sum
     post.employed shouldBe 0
-    ComputationBoundary.toDouble(post.newWage) should be >= ComputationBoundary.toDouble(s1.resWage)
+    ComputationBoundary.toDouble(post.newWage).should(be >= ComputationBoundary.toDouble(s1.resWage))
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
@@ -21,7 +22,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
   private val rng  = RandomStream.seeded(TestSeed)
 
   // Run pipeline through Economics objects
-  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
+  private val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
   private val s1     = FiscalConstraintEconomics.toOutput(fiscal)
   private val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
   private val s2     = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -100,6 +100,37 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
     ComputationBoundary.toDouble(newResult.newRefRate) should be >= 0.0
   }
 
+  it should "keep diaspora inflow growth at baseline in the first execution month" in {
+    import ComputationBoundary.toDouble
+
+    val exchangeRate  = w.forex.exchangeRate.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
+    val wap           = w.social.demographics.workingAgePop
+    val base          = toDouble(p.remittance.perCapita) * wap.toDouble
+    val erAdj         = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.remittance.erElasticity))
+    val unempForRemit = toDouble(w.unemploymentRate(s2.employed))
+    val cyclicalAdj   = 1.0 + toDouble(p.remittance.cyclicalSens) * Math.max(0.0, unempForRemit - 0.05)
+    val expected      = PLN(base * erAdj * cyclicalAdj)
+
+    s6.diasporaInflow shouldBe expected
+  }
+
+  it should "keep tourism growth at baseline in the first execution month" in {
+    import ComputationBoundary.toDouble
+
+    val exchangeRate   = w.forex.exchangeRate.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
+    val monthInYear    = s1.m.monthInYear
+    val seasonalFactor = 1.0 + toDouble(p.tourism.seasonality) *
+      Math.cos(2 * Math.PI * (monthInYear - p.tourism.peakMonth) / 12.0)
+    val inboundErAdj   = Math.pow(exchangeRate / toDouble(p.forex.baseExRate), toDouble(p.tourism.erElasticity))
+    val outboundErAdj  = Math.pow(toDouble(p.forex.baseExRate) / exchangeRate, toDouble(p.tourism.erElasticity))
+    val baseGdp        = Math.max(0.0, toDouble(w.cachedMonthlyGdpProxy))
+    val expectedExport = PLN(baseGdp * toDouble(p.tourism.inboundShare) * seasonalFactor * inboundErAdj)
+    val expectedImport = PLN(baseGdp * toDouble(p.tourism.outboundShare) * seasonalFactor * outboundErAdj)
+
+    s6.tourismExport shouldBe expectedExport
+    s6.tourismImport shouldBe expectedImport
+  }
+
   it should "produce a valid bond yield" in {
     ComputationBoundary.toDouble(newResult.newBondYield) should be >= 0.0
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthRandomness, MonthTraceStage, OperationalSignals, SignalExtraction, World}
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
@@ -37,7 +38,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     val world    = init.world
     val contract = MonthRandomness.Contract.fromSeed(seed)
 
-    val fiscal = FiscalConstraintEconomics.compute(world, init.banks)
+    val fiscal = FiscalConstraintEconomics.compute(world, init.banks, ExecutionMonth.First)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
     val labor  = LaborEconomics.compute(world, init.firms, init.households, s1)
     val s2Pre  = LaborEconomics.Output(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
-import com.boombustgroup.amorfati.types.PLN
+import com.boombustgroup.amorfati.types.{ComputationBoundary, PLN}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,6 +24,15 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     w.derivedTotalPopulation.should(be > 0)
     result.nextState.householdAggregates.employed.should(be > 0)
     w.external.tourismSeasonalFactor.should(not be 0.0)
+  }
+
+  it should "keep ETS observables at the base price in the first execution month" in {
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state  = FlowSimulation.SimState.fromInit(init)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val w      = result.nextState.world
+
+    w.real.etsPrice.shouldBe(ComputationBoundary.toDouble(p.climate.etsBasePrice) +- 1e-10)
   }
 
   it should "preserve public-spending semantic aggregates on the assembled world" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -19,10 +20,10 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val w      = result.nextState.world
 
-    w.month.shouldBe(1)
-    w.derivedTotalPopulation should be > 0
-    result.nextState.householdAggregates.employed should be > 0
-    w.external.tourismSeasonalFactor should not be 0.0
+    result.nextState.completedMonth shouldBe CompletedMonth(1)
+    w.derivedTotalPopulation.should(be > 0)
+    result.nextState.householdAggregates.employed.should(be > 0)
+    w.external.tourismSeasonalFactor.should(not be 0.0)
   }
 
   it should "preserve public-spending semantic aggregates on the assembled world" in {
@@ -42,7 +43,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     )
 
     w.gov.domesticBudgetDemand shouldBe result.calculus.govPurchases
-    w.gov.domesticBudgetOutlays should be >= w.gov.domesticBudgetDemand
+    w.gov.domesticBudgetOutlays.should(be >= w.gov.domesticBudgetDemand)
   }
 
   it should "overwrite only supported financial slice from ledger snapshot while preserving unsupported QE metrics" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
@@ -22,7 +23,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
     */
   private def runOneMonth: (Map[Int, Long], LaborEconomics.Result) =
     // Step 1: Fiscal constraints (pure calculus)
-    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
 
     // Step 2: Labor economics (pure calculus)
     val s1    = FiscalConstraintEconomics.toOutput(fiscal)
@@ -48,18 +49,18 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
   it should "produce realistic wage" in {
     val (_, labor) = runOneMonth
     val td         = ComputationBoundary
-    td.toDouble(labor.wage) should be > 3000.0
-    td.toDouble(labor.wage) should be < 20000.0
+    td.toDouble(labor.wage).should(be > 3000.0)
+    td.toDouble(labor.wage).should(be < 20000.0)
   }
 
   it should "produce realistic employment" in {
     val (_, labor) = runOneMonth
-    labor.employed should be > 50000
-    labor.employed should be < 120000
+    labor.employed.should(be > 50000)
+    labor.employed.should(be < 120000)
   }
 
   it should "emit non-trivial fund flows" in {
-    val fiscal = FiscalConstraintEconomics.compute(w, init.banks)
+    val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
     val s1     = FiscalConstraintEconomics.toOutput(fiscal)
     val labor  = LaborEconomics.compute(w, init.firms, init.households, s1)
 
@@ -70,6 +71,6 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
       EarmarkedFlows.emit(StateAdapter.earmarkedInput(labor)),
     )
 
-    flows.length should be > 5
-    flows.map(_.amount).sum should be > 0L
+    flows.length.should(be > 5)
+    flows.map(_.amount).sum.should(be > 0L)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -11,6 +11,7 @@ import com.boombustgroup.amorfati.engine.{
   MonthTimingEnvelopeKey,
   MonthTimingPayload,
   MonthTraceStage,
+  SimulationMonth,
 }
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
@@ -106,13 +107,14 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val state = FlowSimulation.SimState.fromInit(init)
     val steps = MonthDriver
       .unfoldSteps(state): current =>
-        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.completedMonth.toLong + 1L))
       .take(3)
       .toVector
 
     steps should have size 3
-    steps.map(_.stateIn.world.month) shouldBe Vector(0, 1, 2)
-    steps.map(_.nextState.world.month) shouldBe Vector(1, 2, 3)
+    steps.map(_.stateIn.completedMonth.toInt) shouldBe Vector(0, 1, 2)
+    steps.map(_.executionMonth.toInt) shouldBe Vector(1, 2, 3)
+    steps.map(_.nextState.completedMonth.toInt) shouldBe Vector(1, 2, 3)
     steps.foreach(_.sfcResult shouldBe Right(()))
   }
 
@@ -121,11 +123,11 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val state   = FlowSimulation.SimState.fromInit(init)
     val results = MonthDriver
       .unfoldSteps(state): current =>
-        Option.when(current.world.month < 2)(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+        Option.when(current.completedMonth.toInt < 2)(MonthRandomness.Contract.fromSeed(42L * 1000L + current.completedMonth.toLong + 1L))
       .toVector
 
     results should have size 2
-    results.map(_.nextState.world.month) shouldBe Vector(1, 2)
+    results.map(_.nextState.completedMonth.toInt) shouldBe Vector(1, 2)
   }
 
   it should "produce SFC == 0L across 12 months (autonomous driving)" in {
@@ -133,14 +135,14 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val state   = FlowSimulation.SimState.fromInit(init)
     val results = MonthDriver
       .unfoldSteps(state): current =>
-        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.world.month.toLong + 1L))
+        Some(MonthRandomness.Contract.fromSeed(42L * 1000L + current.completedMonth.toLong + 1L))
       .take(12)
       .toVector
 
     results should have size 12
 
     results.foreach { result =>
-      val month = result.nextState.world.month
+      val month = result.executionMonth.toInt
       withClue(s"Month $month: ") {
         result.execution.totalWealth shouldBe 0L
         result.sfcResult shouldBe Right(())
@@ -153,11 +155,11 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val lowShadowW    = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highShadowW   = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.4))
     val lowShadowRun  = FlowSimulation.step(
-      FlowSimulation.SimState(lowShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      FlowSimulation.SimState(SimulationMonth.CompletedMonth.Zero, lowShadowW, init.firms, init.households, init.banks, init.householdAggregates),
       MonthRandomness.Contract.fromSeed(42L),
     )
     val highShadowRun = FlowSimulation.step(
-      FlowSimulation.SimState(highShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      FlowSimulation.SimState(SimulationMonth.CompletedMonth.Zero, highShadowW, init.firms, init.households, init.banks, init.householdAggregates),
       MonthRandomness.Contract.fromSeed(42L),
     )
 
@@ -187,7 +189,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
     val demandSignals = trace.timing.requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.DemandSignals)
 
-    trace.month shouldBe result.nextState.world.month
+    trace.executionMonth shouldBe result.executionMonth
     trace.seedTransition.seedIn shouldBe init.world.seedIn
     trace.seedTransition.seedOut shouldBe result.nextState.world.seedIn
     trace.randomness shouldBe result.randomness

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -27,7 +28,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =
     val stageRandomness    = MonthRandomness.Contract.fromSeed(TestSeed).stages.newStreams()
-    val fiscal             = FiscalConstraintEconomics.compute(w, initResult.banks)
+    val fiscal             = FiscalConstraintEconomics.compute(w, initResult.banks, ExecutionMonth.First)
     val s1                 = FiscalConstraintEconomics.toOutput(fiscal)
     val labor              = LaborEconomics.compute(w, initResult.firms, initResult.households, s1)
     val s2                 = LaborEconomics.Output(


### PR DESCRIPTION
## Summary
- add typed month wrappers with explicit completed and execution month semantics
- move persistent month state from World into FlowSimulation.SimState and thread executionMonth through the engine boundary
- update Monte Carlo, diagnostics, and tests to use the typed month contract and remove World.month


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified simulation month into a type-safe execution month passed explicitly through the system.

* **Behavior**
  * Reporting, traces, probes, logs, and monthly outputs now consistently use and format the unified execution-month value.

* **Tests**
  * Test suites and fixtures updated to use and validate the new execution-month representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->