### PR TITLE
Derive MonthTrace from typed month outcome inputs

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -30,11 +30,41 @@ object MonthTrace:
   ): MonthTimingEnvelope =
     MonthTimingEnvelope(key, payload)
 
+  def fromCore(
+      executionMonth: ExecutionMonth,
+      randomness: MonthRandomness.Contract,
+      core: MonthTraceCore,
+      executedFlows: Sfc.SemanticFlows,
+      validations: Vector[MonthValidation],
+  ): MonthTrace =
+    MonthTrace(
+      executionMonth = executionMonth,
+      boundary = core.boundary,
+      seedTransition = core.seedTransition,
+      randomness = randomness,
+      timing = core.timing,
+      executedFlows = executedFlows,
+      validations = validations,
+    )
+
+case class MonthTraceCore(
+    boundary: MonthBoundaryTrace,
+    seedTransition: SeedTransitionTrace,
+    timing: MonthTimingTrace,
+)
+
 /** Stable start/end month boundary snapshots. */
 case class MonthBoundaryTrace(
     startSnapshot: MonthBoundarySnapshot,
     endSnapshot: MonthBoundarySnapshot,
 )
+
+object MonthBoundaryTrace:
+  def from(
+      startSnapshot: MonthBoundarySnapshot,
+      endSnapshot: MonthBoundarySnapshot,
+  ): MonthBoundaryTrace =
+    MonthBoundaryTrace(startSnapshot, endSnapshot)
 
 /** Explicit post-to-pre boundary observed by the trace. */
 case class SeedTransitionTrace(
@@ -42,6 +72,17 @@ case class SeedTransitionTrace(
     seedOut: DecisionSignals,
     provenance: SeedOutProvenance,
 )
+
+object SeedTransitionTrace:
+  def from(
+      seedIn: MonthSemantics.SeedIn,
+      seedOut: MonthSemantics.SeedOut,
+  ): SeedTransitionTrace =
+    SeedTransitionTrace(
+      seedIn = seedIn.value,
+      seedOut = seedOut.value.seedOut,
+      provenance = seedOut.value.provenance,
+    )
 
 /** Compact boundary snapshot used at the start and end of a month trace. */
 case class MonthBoundarySnapshot(
@@ -114,6 +155,13 @@ object MonthTimingPayload:
       netFirmBirths: Int,
   ) extends MonthTimingPayload
 
+case class MonthTimingInputs(
+    labor: MonthTimingPayload.LaborSignals,
+    demand: MonthTimingPayload.DemandSignals,
+    nominal: MonthTimingPayload.NominalSignals,
+    firmDynamics: MonthTimingPayload.FirmDynamics,
+)
+
 /** One typed timing envelope attached to the month trace interior. */
 case class MonthTimingEnvelope(
     key: MonthTimingEnvelopeKey,
@@ -157,6 +205,17 @@ case class MonthTimingTrace(
 
   def firmDynamics: MonthTimingPayload.FirmDynamics =
     requirePayload[MonthTimingPayload.FirmDynamics](MonthTimingEnvelopeKey.FirmDynamics)
+
+object MonthTimingTrace:
+  def fromInputs(inputs: MonthTimingInputs): MonthTimingTrace =
+    MonthTimingTrace(
+      Vector(
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.LaborSignals, inputs.labor),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.DemandSignals, inputs.demand),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.NominalSignals, inputs.nominal),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.FirmDynamics, inputs.firmDynamics),
+      ),
+    )
 
 enum MonthValidationKind:
   case Sfc

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -124,10 +124,10 @@ object MonthBoundarySnapshot:
 
 /** Extensible envelope keys for typed same-month timing artifacts. */
 enum MonthTimingEnvelopeKey:
-  case LaborSignals
-  case DemandSignals
-  case NominalSignals
-  case FirmDynamics
+  case Labor
+  case Demand
+  case Nominal
+  case Firm
 
 /** Marker trait for typed same-month timing payloads. */
 sealed trait MonthTimingPayload
@@ -195,25 +195,25 @@ case class MonthTimingTrace(
       throw new IllegalStateException(s"MonthTimingTrace missing payload ${ct.runtimeClass.getSimpleName} at envelope $key")
 
   def laborSignals: MonthTimingPayload.LaborSignals =
-    requirePayload[MonthTimingPayload.LaborSignals](MonthTimingEnvelopeKey.LaborSignals)
+    requirePayload[MonthTimingPayload.LaborSignals](MonthTimingEnvelopeKey.Labor)
 
   def demandSignals: MonthTimingPayload.DemandSignals =
-    requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.DemandSignals)
+    requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.Demand)
 
   def nominalSignals: MonthTimingPayload.NominalSignals =
-    requirePayload[MonthTimingPayload.NominalSignals](MonthTimingEnvelopeKey.NominalSignals)
+    requirePayload[MonthTimingPayload.NominalSignals](MonthTimingEnvelopeKey.Nominal)
 
   def firmDynamics: MonthTimingPayload.FirmDynamics =
-    requirePayload[MonthTimingPayload.FirmDynamics](MonthTimingEnvelopeKey.FirmDynamics)
+    requirePayload[MonthTimingPayload.FirmDynamics](MonthTimingEnvelopeKey.Firm)
 
 object MonthTimingTrace:
   def fromInputs(inputs: MonthTimingInputs): MonthTimingTrace =
     MonthTimingTrace(
       Vector(
-        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.LaborSignals, inputs.labor),
-        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.DemandSignals, inputs.demand),
-        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.NominalSignals, inputs.nominal),
-        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.FirmDynamics, inputs.firmDynamics),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.Labor, inputs.labor),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.Demand, inputs.demand),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.Nominal, inputs.nominal),
+        MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.Firm, inputs.firmDynamics),
       ),
     )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -54,7 +54,7 @@ Read it as a month transition:
 
 - `stateIn.world.seedIn` is the persisted `pre` input surface.
 - `randomness` is the explicit month-level randomness surface; fixing `stateIn` and `randomness.rootSeed` fixes replay for one step.
-- `MonthOutcome` is the internal bridge from same-month computation to post-month assembly.
+- `MonthOutcome` is the internal bridge from same-month computation to post-month assembly, including the typed trace core derived from those boundaries.
 - `operationalSignals` is the explicit same-month surface created inside the step.
 - `signalExtraction` is the dedicated `post -> pre` boundary.
 - `trace` is the emitted audit artifact for month `t`.

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -248,6 +248,7 @@ object FlowSimulation:
       executionMonth: ExecutionMonth,
       seedIn: MonthSemantics.SeedIn,
       randomness: MonthRandomness.Contract,
+      boundaryIn: MonthBoundarySnapshot,
   )
 
   /** Same-month stage outputs computed exactly once and reused by every
@@ -266,19 +267,13 @@ object FlowSimulation:
       calculus: MonthlyCalculus,
   )
 
-  case class TraceInputs(
-      labor: MonthTimingPayload.LaborSignals,
-      demand: MonthTimingPayload.DemandSignals,
-      nominal: MonthTimingPayload.NominalSignals,
-      firmDynamics: MonthTimingPayload.FirmDynamics,
-  )
-
   /** Post-assembly view of month `t`: assembled world plus the narrow payload
     * needed to build [[MonthTrace]].
     */
   case class PostMonth(
       assembled: WorldAssemblyEconomics.PostResult,
-      traceInputs: TraceInputs,
+      boundaryOut: MonthBoundarySnapshot,
+      timing: MonthTimingTrace,
   )
 
   /** Full typed boundary carried through one step: pre-step seed, same-month
@@ -290,6 +285,7 @@ object FlowSimulation:
       stages: MonthSemantics.StageView,
       post: MonthSemantics.PostAssembly,
       seedOut: MonthSemantics.SeedOut,
+      traceCore: MonthTraceCore,
   )
 
   /** Full month-step contract.
@@ -321,12 +317,7 @@ object FlowSimulation:
     * one-month contract used by tests, replay, and diagnostics.
     */
   def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
-    val input      = StepInput(
-      stateIn = stateIn,
-      executionMonth = stateIn.completedMonth.next,
-      seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
-      randomness = randomness,
-    )
+    val input      = stepInput(stateIn, randomness)
     val outcome    = computeMonthOutcome(input)
     val flows      = emitAllBatches(outcome.stages.value.calculus)
     val execution  = executeBatches(flows).fold(
@@ -346,7 +337,6 @@ object FlowSimulation:
     val monthTrace = buildMonthTrace(
       input = input,
       outcome = outcome,
-      nextState = nextState,
       executedFlows = sfcFlows,
       sfcResult = sfcResult,
     )
@@ -368,14 +358,19 @@ object FlowSimulation:
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
   def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
-    computeStageOutputs(
-      StepInput(
-        stateIn = state,
-        executionMonth = state.completedMonth.next,
-        seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn),
-        randomness = randomness,
-      ),
-    ).calculus
+    computeStageOutputs(stepInput(state, randomness)).calculus
+
+  private def stepInput(
+      stateIn: SimState,
+      randomness: MonthRandomness.Contract,
+  ): StepInput =
+    StepInput(
+      stateIn = stateIn,
+      executionMonth = stateIn.completedMonth.next,
+      seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
+      randomness = randomness,
+      boundaryIn = MonthBoundarySnapshot.capture(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
+    )
 
   /** Compute MonthlyCalculus by chaining all Economics. Uses old pipeline steps
     * for HH/Demand/Firm/PriceEquity (pure calculus). Uses self-contained
@@ -742,12 +737,12 @@ object FlowSimulation:
     val stages = stageView.value
     MonthSemantics.At[OperationalSignals, MonthSemantics.SameMonth](operationalSignals(stages.labor, stages.demand))
 
-  private def buildTraceInputs(
+  private def buildTimingInputs(
       stageView: MonthSemantics.StageView,
       assembled: WorldAssemblyEconomics.PostResult,
-  ): TraceInputs =
+  ): MonthTimingInputs =
     val stages = stageView.value
-    TraceInputs(
+    MonthTimingInputs(
       labor = MonthTimingPayload.LaborSignals(
         operationalHiringSlack = stages.labor.operationalHiringSlack,
       ),
@@ -800,7 +795,13 @@ object FlowSimulation:
       ),
     )
     // This stays at month `t`: the boundary seed is still `seedIn` here.
-    MonthSemantics.At[PostMonth, MonthSemantics.Post](PostMonth(assembled, buildTraceInputs(stageView, assembled)))
+    MonthSemantics.At[PostMonth, MonthSemantics.Post](
+      PostMonth(
+        assembled = assembled,
+        boundaryOut = MonthBoundarySnapshot.capture(assembled.world, assembled.firms, assembled.households, assembled.banks),
+        timing = MonthTimingTrace.fromInputs(buildTimingInputs(stageView, assembled)),
+      ),
+    )
 
   private def extractSeedOut(stageView: MonthSemantics.StageView, post: MonthSemantics.PostAssembly): MonthSemantics.SeedOut =
     val assembled = post.value.assembled
@@ -824,6 +825,17 @@ object FlowSimulation:
       ),
     )
 
+  private def deriveTraceCore(
+      input: StepInput,
+      post: MonthSemantics.PostAssembly,
+      seedOut: MonthSemantics.SeedOut,
+  ): MonthTraceCore =
+    MonthTraceCore(
+      boundary = MonthBoundaryTrace.from(input.boundaryIn, post.value.boundaryOut),
+      seedTransition = SeedTransitionTrace.from(input.seedIn, seedOut),
+      timing = post.value.timing,
+    )
+
   private def computeMonthOutcome(input: StepInput)(using p: SimParams): MonthOutcome =
     // Keep the month-step pipeline explicit:
     // `seedIn/pre -> same-month stages -> post-month assembly -> seedOut/next-pre`.
@@ -831,12 +843,14 @@ object FlowSimulation:
     val operational = buildOperationalSignals(stageView)
     val post        = assemblePostMonth(input, stageView)
     val seedOut     = extractSeedOut(stageView, post)
+    val traceCore   = deriveTraceCore(input, post, seedOut)
 
     MonthOutcome(
       operational = operational,
       stages = stageView,
       post = post,
       seedOut = seedOut,
+      traceCore = traceCore,
     )
 
   private def advanceState(
@@ -866,32 +880,13 @@ object FlowSimulation:
   private def buildMonthTrace(
       input: StepInput,
       outcome: MonthOutcome,
-      nextState: SimState,
       executedFlows: Sfc.SemanticFlows,
       sfcResult: Sfc.SfcResult,
   ): MonthTrace =
-    val traceInputs = outcome.post.value.traceInputs
-    val seedOut     = outcome.seedOut.value
-    MonthTrace(
+    MonthTrace.fromCore(
       executionMonth = input.executionMonth,
-      boundary = MonthBoundaryTrace(
-        startSnapshot = MonthBoundarySnapshot.capture(input.stateIn.world, input.stateIn.firms, input.stateIn.households, input.stateIn.banks),
-        endSnapshot = MonthBoundarySnapshot.capture(nextState.world, nextState.firms, nextState.households, nextState.banks),
-      ),
-      seedTransition = SeedTransitionTrace(
-        seedIn = input.seedIn.value,
-        seedOut = seedOut.seedOut,
-        provenance = seedOut.provenance,
-      ),
       randomness = input.randomness,
-      timing = MonthTimingTrace(
-        Vector(
-          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.LaborSignals, traceInputs.labor),
-          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.DemandSignals, traceInputs.demand),
-          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.NominalSignals, traceInputs.nominal),
-          MonthTrace.timingEnvelope(MonthTimingEnvelopeKey.FirmDynamics, traceInputs.firmDynamics),
-        ),
-      ),
+      core = outcome.traceCore,
       executedFlows = executedFlows,
       validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
@@ -1,10 +1,14 @@
 package com.boombustgroup.amorfati.engine
 
-import com.boombustgroup.amorfati.types.Share
+import com.boombustgroup.amorfati.types.{Multiplier, Rate, Share}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class MonthTraceSpec extends AnyFlatSpec with Matchers:
+
+  private val sectorDemandMult     = Vector(Multiplier(1.1), Multiplier(0.9))
+  private val sectorDemandPressure = Vector(Multiplier(1.2), Multiplier(0.8))
+  private val sectorHiringSignal   = Vector(Multiplier(1.05), Multiplier(0.95))
 
   "MonthTimingTrace" should "reject duplicate envelope keys" in {
     val err = intercept[IllegalArgumentException]:
@@ -25,4 +29,73 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
 
     err.getMessage should include("LaborSignals")
     err.getMessage should include(MonthTimingEnvelopeKey.LaborSignals.toString)
+  }
+
+  it should "build typed envelopes from timing inputs in a stable order" in {
+    val trace = MonthTimingTrace.fromInputs(
+      MonthTimingInputs(
+        labor = MonthTimingPayload.LaborSignals(Share(0.4)),
+        demand = MonthTimingPayload.DemandSignals(
+          sectorDemandMult = sectorDemandMult,
+          sectorDemandPressure = sectorDemandPressure,
+          sectorHiringSignal = sectorHiringSignal,
+        ),
+        nominal = MonthTimingPayload.NominalSignals(
+          realizedInflation = Rate(0.03),
+          expectedInflation = Rate(0.025),
+        ),
+        firmDynamics = MonthTimingPayload.FirmDynamics(
+          startupAbsorptionRate = Share(0.7),
+          firmBirths = 12,
+          firmDeaths = 4,
+          netFirmBirths = 8,
+        ),
+      ),
+    )
+
+    trace.envelopes.map(_.key) shouldBe Vector(
+      MonthTimingEnvelopeKey.LaborSignals,
+      MonthTimingEnvelopeKey.DemandSignals,
+      MonthTimingEnvelopeKey.NominalSignals,
+      MonthTimingEnvelopeKey.FirmDynamics,
+    )
+    trace.laborSignals.operationalHiringSlack shouldBe Share(0.4)
+    trace.demandSignals.sectorDemandMult shouldBe sectorDemandMult
+    trace.nominalSignals.realizedInflation shouldBe Rate(0.03)
+    trace.firmDynamics.netFirmBirths shouldBe 8
+  }
+
+  "SeedTransitionTrace" should "derive the seed transition from typed month boundaries" in {
+    val seedIn  = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](
+      DecisionSignals(
+        unemploymentRate = Share(0.08),
+        inflation = Rate(0.02),
+        expectedInflation = Rate(0.025),
+        laggedHiringSlack = Share(0.9),
+        startupAbsorptionRate = Share(0.7),
+        sectorDemandMult = sectorDemandMult,
+        sectorDemandPressure = sectorDemandPressure,
+        sectorHiringSignal = sectorHiringSignal,
+      ),
+    )
+    val seedOut = MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
+      SignalExtraction.compute(
+        SignalExtraction.inputFromRealizedOutcomes(
+          unemploymentRate = Share(0.07),
+          laggedHiringSlack = Share(0.85),
+          startupAbsorptionRate = Share(0.75),
+          inflation = Rate(0.03),
+          expectedInflation = Rate(0.028),
+          sectorDemandMult = sectorDemandMult,
+          sectorDemandPressure = sectorDemandPressure,
+          sectorHiringSignal = sectorHiringSignal,
+        ),
+      ),
+    )
+
+    val transition = SeedTransitionTrace.from(seedIn, seedOut)
+
+    transition.seedIn shouldBe seedIn.value
+    transition.seedOut shouldBe seedOut.value.seedOut
+    transition.provenance shouldBe seedOut.value.provenance
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
@@ -14,21 +14,21 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
     val err = intercept[IllegalArgumentException]:
       MonthTimingTrace(
         Vector(
-          MonthTimingEnvelope(MonthTimingEnvelopeKey.LaborSignals, MonthTimingPayload.LaborSignals(Share(0.4))),
-          MonthTimingEnvelope(MonthTimingEnvelopeKey.LaborSignals, MonthTimingPayload.LaborSignals(Share(0.6))),
+          MonthTimingEnvelope(MonthTimingEnvelopeKey.Labor, MonthTimingPayload.LaborSignals(Share(0.4))),
+          MonthTimingEnvelope(MonthTimingEnvelopeKey.Labor, MonthTimingPayload.LaborSignals(Share(0.6))),
         ),
       )
 
     err.getMessage should include("unique envelope keys")
-    err.getMessage should include(MonthTimingEnvelopeKey.LaborSignals.toString)
+    err.getMessage should include(MonthTimingEnvelopeKey.Labor.toString)
   }
 
   it should "fail clearly when a required payload is missing" in {
     val err = intercept[IllegalStateException]:
       MonthTimingTrace(Vector.empty).laborSignals
 
-    err.getMessage should include("LaborSignals")
-    err.getMessage should include(MonthTimingEnvelopeKey.LaborSignals.toString)
+    err.getMessage should include("Labor")
+    err.getMessage should include(MonthTimingEnvelopeKey.Labor.toString)
   }
 
   it should "build typed envelopes from timing inputs in a stable order" in {
@@ -54,10 +54,10 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
     )
 
     trace.envelopes.map(_.key) shouldBe Vector(
-      MonthTimingEnvelopeKey.LaborSignals,
-      MonthTimingEnvelopeKey.DemandSignals,
-      MonthTimingEnvelopeKey.NominalSignals,
-      MonthTimingEnvelopeKey.FirmDynamics,
+      MonthTimingEnvelopeKey.Labor,
+      MonthTimingEnvelopeKey.Demand,
+      MonthTimingEnvelopeKey.Nominal,
+      MonthTimingEnvelopeKey.Firm,
     )
     trace.laborSignals.operationalHiringSlack shouldBe Share(0.4)
     trace.demandSignals.sectorDemandMult shouldBe sectorDemandMult

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -187,7 +187,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val trace  = result.trace
 
-    val demandSignals = trace.timing.requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.DemandSignals)
+    val demandSignals = trace.timing.requirePayload[MonthTimingPayload.DemandSignals](MonthTimingEnvelopeKey.Demand)
 
     trace.executionMonth shouldBe result.executionMonth
     trace.seedTransition.seedIn shouldBe init.world.seedIn
@@ -203,10 +203,10 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     trace.boundary.startSnapshot.inflation shouldBe init.world.inflation
     trace.boundary.endSnapshot.inflation shouldBe result.nextState.world.inflation
     trace.timing.envelopes.map(_.key).toSet shouldBe Set(
-      MonthTimingEnvelopeKey.LaborSignals,
-      MonthTimingEnvelopeKey.DemandSignals,
-      MonthTimingEnvelopeKey.NominalSignals,
-      MonthTimingEnvelopeKey.FirmDynamics,
+      MonthTimingEnvelopeKey.Labor,
+      MonthTimingEnvelopeKey.Demand,
+      MonthTimingEnvelopeKey.Nominal,
+      MonthTimingEnvelopeKey.Firm,
     )
     trace.timing.laborSignals.operationalHiringSlack shouldBe result.nextState.world.pipeline.operationalHiringSlack
     demandSignals.sectorDemandMult shouldBe result.nextState.world.seedIn.sectorDemandMult


### PR DESCRIPTION
## Summary
- derive the MonthTrace core from typed month outcome boundaries instead of manually projecting over broad step internals
- move month boundary snapshots, seed transition derivation, and timing-envelope assembly behind typed MonthTrace helpers
- rename month timing envelope keys to domain categories and extend trace tests around timing inputs and seed transitions

## Testing
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.MonthTraceSpec" "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"

Closes #320
Part of #315.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured month trace construction with new composable builder methods, improving code maintainability and reducing duplication during simulation record assembly across the platform.
  * Enhanced naming consistency for timing-related system identifiers throughout the simulation engine for improved clarity.
  * Optimized internal architecture by streamlining component dependencies and eliminating intermediate data structures within trace generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->