### PR TITLE
Strengthen MonthSemantics transition guards

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
@@ -27,40 +27,127 @@ object MonthSemantics:
   /** Extracted seed that becomes the `pre` surface for month `t+1`. */
   sealed trait NextPre extends Phase
 
-  /** Zero-cost phase tag. The underlying runtime representation stays `A`. */
+  /** Zero-cost phase tag. The underlying runtime representation stays `A`. Raw
+    * tagging stays private to this object; callers use named boundary helpers
+    * instead of arbitrary `At` construction or unwrapping.
+    */
   opaque type At[+A, P <: Phase] = A
 
-  object At:
-    /** Constructor is kept engine-internal so phase tags are introduced
-      * deliberately.
-      */
-    private[engine] inline def apply[A, P <: Phase](value: A): At[A, P] = value
+  private inline def wrap[A, P <: Phase](value: A): At[A, P] = value
 
-    /** Explicit unwrap used at phase boundaries. */
-    extension [A, P <: Phase](staged: At[A, P]) private[engine] inline def value: A = staged
+  private inline def unwrap[A, P <: Phase](staged: At[A, P]): A = staged
 
   /** Start-of-month seed consumed by timing-sensitive blocks. */
   type SeedIn = At[DecisionSignals, Pre]
 
+  inline def seedIn(signals: DecisionSignals): SeedIn =
+    wrap[DecisionSignals, Pre](signals)
+
+  extension (seedIn: SeedIn)
+    inline def decisionSignals: DecisionSignals =
+      unwrap(seedIn)
+
   /** Same-month operational signal surface derived inside the step. */
   type Operational = At[OperationalSignals, SameMonth]
+
+  inline def operational(signals: OperationalSignals): Operational =
+    wrap[OperationalSignals, SameMonth](signals)
+
+  extension (operational: Operational)
+    inline def operationalSignals: OperationalSignals =
+      unwrap(operational)
 
   /** Same-month signal boundary reused by operational, timing, and seed
     * extraction.
     */
   type SignalView = At[SignalBoundaryInputs, SameMonth]
 
+  private[engine] inline def signalView(signals: SignalBoundaryInputs): SignalView =
+    wrap[SignalBoundaryInputs, SameMonth](signals)
+
+  extension (signalView: SignalView)
+    private[engine] inline def labor =
+      unwrap(signalView).labor
+
+    private[engine] inline def demand =
+      unwrap(signalView).demand
+
   /** Same-month flow translation plan consumed by batch emission. */
   type FlowPlan = At[MonthlyCalculus, SameMonth]
+
+  private[engine] inline def flowPlan(calculus: MonthlyCalculus): FlowPlan =
+    wrap[MonthlyCalculus, SameMonth](calculus)
+
+  extension (flowPlan: FlowPlan)
+    inline def calculus: MonthlyCalculus =
+      unwrap(flowPlan)
 
   /** Same-month payload narrowed for post-month world assembly. */
   type PostInputs = At[WorldAssemblyEconomics.StepInput, SameMonth]
 
+  private[engine] inline def postInputs(input: WorldAssemblyEconomics.StepInput): PostInputs =
+    wrap[WorldAssemblyEconomics.StepInput, SameMonth](input)
+
+  extension (postInputs: PostInputs)
+    private[engine] inline def assemblyInput: WorldAssemblyEconomics.StepInput =
+      unwrap(postInputs)
+
   /** Same-month payload narrowed for executed-flow semantic projection. */
   type SemanticProjection = At[SemanticFlowInputs, SameMonth]
+
+  private[engine] inline def semanticProjection(inputs: SemanticFlowInputs): SemanticProjection =
+    wrap[SemanticFlowInputs, SameMonth](inputs)
+
+  extension (semanticProjection: SemanticProjection)
+    private[engine] inline def labor =
+      unwrap(semanticProjection).labor
+
+    private[engine] inline def hhIncome =
+      unwrap(semanticProjection).hhIncome
+
+    private[engine] inline def firms =
+      unwrap(semanticProjection).firms
+
+    private[engine] inline def hhFinancial =
+      unwrap(semanticProjection).hhFinancial
+
+    private[engine] inline def prices =
+      unwrap(semanticProjection).prices
+
+    private[engine] inline def openEcon =
+      unwrap(semanticProjection).openEcon
+
+    private[engine] inline def banking =
+      unwrap(semanticProjection).banking
 
   /** Realized post-month assembly before extracting the next seed. */
   type PostAssembly = At[PostMonth, Post]
 
+  inline def postAssembly(postMonth: PostMonth): PostAssembly =
+    wrap[PostMonth, Post](postMonth)
+
+  extension (post: PostAssembly)
+    inline def assembled =
+      unwrap(post).assembled
+
+    inline def boundaryOut =
+      unwrap(post).boundaryOut
+
+    inline def timing =
+      unwrap(post).timing
+
   /** Extracted next-month seed plus provenance. */
   type SeedOut = At[SignalExtraction.Output, NextPre]
+
+  inline def seedOut(output: SignalExtraction.Output): SeedOut =
+    wrap[SignalExtraction.Output, NextPre](output)
+
+  extension (seedOut: SeedOut)
+    inline def signalExtraction: SignalExtraction.Output =
+      unwrap(seedOut)
+
+    inline def nextSeed: DecisionSignals =
+      unwrap(seedOut).seedOut
+
+    inline def provenance: SeedOutProvenance =
+      unwrap(seedOut).provenance

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthTrace.scala
@@ -79,9 +79,9 @@ object SeedTransitionTrace:
       seedOut: MonthSemantics.SeedOut,
   ): SeedTransitionTrace =
     SeedTransitionTrace(
-      seedIn = seedIn.value,
-      seedOut = seedOut.value.seedOut,
-      provenance = seedOut.value.provenance,
+      seedIn = seedIn.decisionSignals,
+      seedOut = seedOut.nextSeed,
+      provenance = seedOut.provenance,
     )
 
 /** Compact boundary snapshot used at the start and end of a month trace. */

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -696,14 +696,14 @@ object FlowSimulation:
       batches: Vector[BatchedFlow],
       fofResidual: PLN,
   )(using p: SimParams): Sfc.SemanticFlows =
-    val labor    = semanticProjection.labor
-    val hhIncome = semanticProjection.hhIncome
-    val firms    = semanticProjection.firms
+    val labor       = semanticProjection.labor
+    val hhIncome    = semanticProjection.hhIncome
+    val firms       = semanticProjection.firms
     val hhFinancial = semanticProjection.hhFinancial
-    val prices   = semanticProjection.prices
-    val openEcon = semanticProjection.openEcon
-    val banking  = semanticProjection.banking
-    val evidence = ExecutedBatchEvidence.from(batches)
+    val prices      = semanticProjection.prices
+    val openEcon    = semanticProjection.openEcon
+    val banking     = semanticProjection.banking
+    val evidence    = ExecutedBatchEvidence.from(batches)
     Sfc.SemanticFlows(
       govSpending =
         banking.newGovWithYield.domesticBudgetOutlays + labor.newZus.govSubvention + labor.newNfz.govSubvention + labor.newEarmarked.totalGovSubvention,
@@ -886,9 +886,9 @@ object FlowSimulation:
       input: StepInput,
       outcome: MonthOutcome,
   ): SimState =
-    val assembled = outcome.post.assembled
-    val nextSeed  = outcome.seedOut.nextSeed
-    val nextWorld = assembled.world.updatePipeline(_.withDecisionSignals(nextSeed))
+    val assembled   = outcome.post.assembled
+    val nextSeed    = outcome.seedOut.nextSeed
+    val nextWorld   = assembled.world.updatePipeline(_.withDecisionSignals(nextSeed))
     val currentSeed = input.seedIn.decisionSignals
 
     // `advanceState` is the only legal `post -> next-pre` transition:

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -4,7 +4,6 @@ import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
-import com.boombustgroup.amorfati.engine.MonthSemantics.At.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.types.*
@@ -334,12 +333,12 @@ object FlowSimulation:
   def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
     val input      = stepInput(stateIn, randomness)
     val outcome    = computeMonthOutcome(input)
-    val flows      = emitAllBatches(outcome.flowPlan.value)
+    val flows      = emitAllBatches(outcome.flowPlan.calculus)
     val execution  = executeBatches(flows).fold(
       err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
       identity,
     )
-    val nextState  = advanceState(input, outcome.post, outcome.seedOut)
+    val nextState  = advanceState(input, outcome)
     val sfcFlows   = buildSfcFlows(outcome.semanticProjection, flows, nextState.world.plumbing.fofResidual)
     val sfcResult  = Sfc.validate(
       prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
@@ -359,9 +358,9 @@ object FlowSimulation:
     StepOutput(
       stateIn = stateIn,
       executionMonth = input.executionMonth,
-      calculus = outcome.flowPlan.value,
-      operationalSignals = outcome.operational.value,
-      signalExtraction = outcome.seedOut.value,
+      calculus = outcome.flowPlan.calculus,
+      operationalSignals = outcome.operational.operationalSignals,
+      signalExtraction = outcome.seedOut.signalExtraction,
       randomness = randomness,
       flows,
       execution,
@@ -382,7 +381,7 @@ object FlowSimulation:
     StepInput(
       stateIn = stateIn,
       executionMonth = stateIn.completedMonth.next,
-      seedIn = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](stateIn.world.seedIn),
+      seedIn = MonthSemantics.seedIn(stateIn.world.seedIn),
       randomness = randomness,
       boundaryIn = MonthBoundarySnapshot.capture(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks),
     )
@@ -697,41 +696,47 @@ object FlowSimulation:
       batches: Vector[BatchedFlow],
       fofResidual: PLN,
   )(using p: SimParams): Sfc.SemanticFlows =
-    val stages   = semanticProjection.value
+    val labor    = semanticProjection.labor
+    val hhIncome = semanticProjection.hhIncome
+    val firms    = semanticProjection.firms
+    val hhFinancial = semanticProjection.hhFinancial
+    val prices   = semanticProjection.prices
+    val openEcon = semanticProjection.openEcon
+    val banking  = semanticProjection.banking
     val evidence = ExecutedBatchEvidence.from(batches)
     Sfc.SemanticFlows(
       govSpending =
-        stages.banking.newGovWithYield.domesticBudgetOutlays + stages.labor.newZus.govSubvention + stages.labor.newNfz.govSubvention + stages.labor.newEarmarked.totalGovSubvention,
+        banking.newGovWithYield.domesticBudgetOutlays + labor.newZus.govSubvention + labor.newNfz.govSubvention + labor.newEarmarked.totalGovSubvention,
       govRevenue =
-        stages.firms.sumTax + stages.prices.dividendTax + stages.banking.pitAfterEvasion + stages.banking.vatAfterEvasion + stages.openEcon.banking.nbpRemittance + stages.banking.exciseAfterEvasion + stages.banking.customsDutyRevenue,
-      nplLoss = stages.firms.nplLoss,
+        firms.sumTax + prices.dividendTax + banking.pitAfterEvasion + banking.vatAfterEvasion + openEcon.banking.nbpRemittance + banking.exciseAfterEvasion + banking.customsDutyRevenue,
+      nplLoss = firms.nplLoss,
       interestIncome = evidence.amount(FlowMechanism.FirmInterestPaid),
       hhDebtService = evidence.amount(FlowMechanism.HhDebtService),
-      totalIncome = stages.hhIncome.totalIncome,
+      totalIncome = hhIncome.totalIncome,
       totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
       newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
-      nplRecovery = stages.firms.nplNew * p.banking.loanRecovery,
-      currentAccount = stages.openEcon.external.newBop.currentAccount,
-      valuationEffect = stages.openEcon.external.oeValuationEffect,
+      nplRecovery = firms.nplNew * p.banking.loanRecovery,
+      currentAccount = openEcon.external.newBop.currentAccount,
+      valuationEffect = openEcon.external.oeValuationEffect,
       bankBondIncome = evidence.amount(FlowMechanism.BankGovBondIncome),
-      qePurchase = stages.openEcon.monetary.qePurchaseAmount,
-      newBondIssuance = stages.banking.actualBondChange,
+      qePurchase = openEcon.monetary.qePurchaseAmount,
+      newBondIssuance = banking.actualBondChange,
       depositInterestPaid = evidence.amount(FlowMechanism.HhDepositInterest),
       reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
       standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
       interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
-      jstDepositChange = stages.banking.jstDepositChange,
-      jstSpending = stages.banking.newJst.spending,
-      jstRevenue = stages.banking.newJst.revenue,
-      zusContributions = stages.labor.newZus.contributions,
-      zusPensionPayments = stages.labor.newZus.pensionPayments,
-      zusGovSubvention = stages.labor.newZus.govSubvention,
-      nfzContributions = stages.labor.newNfz.contributions,
-      nfzSpending = stages.labor.newNfz.spending,
-      nfzGovSubvention = stages.labor.newNfz.govSubvention,
-      dividendIncome = stages.prices.netDomesticDividends,
-      foreignDividendOutflow = stages.prices.foreignDividendOutflow,
-      dividendTax = stages.prices.dividendTax,
+      jstDepositChange = banking.jstDepositChange,
+      jstSpending = banking.newJst.spending,
+      jstRevenue = banking.newJst.revenue,
+      zusContributions = labor.newZus.contributions,
+      zusPensionPayments = labor.newZus.pensionPayments,
+      zusGovSubvention = labor.newZus.govSubvention,
+      nfzContributions = labor.newNfz.contributions,
+      nfzSpending = labor.newNfz.spending,
+      nfzGovSubvention = labor.newNfz.govSubvention,
+      dividendIncome = prices.netDomesticDividends,
+      foreignDividendOutflow = prices.foreignDividendOutflow,
+      dividendTax = prices.dividendTax,
       mortgageInterestIncome = evidence.amount(FlowMechanism.MortgageInterest),
       mortgageNplLoss = evidence.amount(FlowMechanism.MortgageDefault) * (Share.One - p.housing.mortgageRecovery),
       mortgageOrigination = evidence.amount(FlowMechanism.MortgageOrigination),
@@ -740,20 +745,20 @@ object FlowSimulation:
       remittanceOutflow = evidence.amount(FlowMechanism.HhRemittance),
       fofResidual = fofResidual,
       consumerDebtService = evidence.amount(FlowMechanism.HhCcDebtService),
-      consumerNplLoss = stages.hhFinancial.consumerNplLoss,
+      consumerNplLoss = hhFinancial.consumerNplLoss,
       consumerOrigination = evidence.amount(FlowMechanism.HhCcOrigination),
-      consumerPrincipalRepaid = stages.hhFinancial.consumerPrincipal,
+      consumerPrincipalRepaid = hhFinancial.consumerPrincipal,
       consumerDefaultAmount = evidence.amount(FlowMechanism.HhCcDefault),
       corpBondCouponIncome = evidence.amount(FlowMechanism.CorpBondCoupon),
       corpBondDefaultLoss = evidence.amount(FlowMechanism.CorpBondDefault),
       corpBondIssuance = evidence.amount(FlowMechanism.CorpBondIssuance),
       corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
       corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
-      insNetDepositChange = stages.openEcon.nonBank.insNetDepositChange,
-      nbfiDepositDrain = stages.openEcon.nonBank.nbfiDepositDrain,
-      nbfiOrigination = stages.banking.finalNbfi.lastNbfiOrigination,
-      nbfiRepayment = stages.banking.finalNbfi.lastNbfiRepayment,
-      nbfiDefaultAmount = stages.banking.finalNbfi.lastNbfiDefaultAmount,
+      insNetDepositChange = openEcon.nonBank.insNetDepositChange,
+      nbfiDepositDrain = openEcon.nonBank.nbfiDepositDrain,
+      nbfiOrigination = banking.finalNbfi.lastNbfiOrigination,
+      nbfiRepayment = banking.finalNbfi.lastNbfiRepayment,
+      nbfiDefaultAmount = banking.finalNbfi.lastNbfiDefaultAmount,
       fdiProfitShifting = evidence.amount(FlowMechanism.FirmProfitShifting),
       fdiRepatriation = evidence.amount(FlowMechanism.FirmFdiRepatriation),
       diasporaInflow = evidence.amount(FlowMechanism.DiasporaInflow),
@@ -761,12 +766,12 @@ object FlowSimulation:
       tourismImport = evidence.amount(FlowMechanism.TourismImport),
       bfgLevy = evidence.amount(FlowMechanism.BankBfgLevy),
       bailInLoss = evidence.amount(FlowMechanism.BankBailIn),
-      bankCapitalDestruction = stages.banking.multiCapDestruction,
-      investNetDepositFlow = stages.banking.investNetDepositFlow,
+      bankCapitalDestruction = banking.multiCapDestruction,
+      investNetDepositFlow = banking.investNetDepositFlow,
       firmPrincipalRepaid = evidence.amount(FlowMechanism.FirmLoanRepayment),
       unrealizedBondLoss = evidence.amount(FlowMechanism.BankUnrealizedLoss),
-      htmRealizedLoss = stages.banking.htmRealizedLoss,
-      eclProvisionChange = stages.banking.eclProvisionChange,
+      htmRealizedLoss = banking.htmRealizedLoss,
+      eclProvisionChange = banking.eclProvisionChange,
     )
 
   private def operationalSignals(
@@ -781,22 +786,20 @@ object FlowSimulation:
     )
 
   private def buildOperationalSignals(signalView: MonthSemantics.SignalView): MonthSemantics.Operational =
-    val signals = signalView.value
-    MonthSemantics.At[OperationalSignals, MonthSemantics.SameMonth](operationalSignals(signals.labor, signals.demand))
+    MonthSemantics.operational(operationalSignals(signalView.labor, signalView.demand))
 
   private def buildTimingInputs(
       signalView: MonthSemantics.SignalView,
       assembled: WorldAssemblyEconomics.PostResult,
   ): MonthTimingInputs =
-    val signals = signalView.value
     MonthTimingInputs(
       labor = MonthTimingPayload.LaborSignals(
-        operationalHiringSlack = signals.labor.operationalHiringSlack,
+        operationalHiringSlack = signalView.labor.operationalHiringSlack,
       ),
       demand = MonthTimingPayload.DemandSignals(
-        sectorDemandMult = signals.demand.sectorMults,
-        sectorDemandPressure = signals.demand.sectorDemandPressure,
-        sectorHiringSignal = signals.demand.sectorHiringSignal,
+        sectorDemandMult = signalView.demand.sectorMults,
+        sectorDemandPressure = signalView.demand.sectorDemandPressure,
+        sectorHiringSignal = signalView.demand.sectorHiringSignal,
       ),
       nominal = MonthTimingPayload.NominalSignals(
         realizedInflation = assembled.world.inflation,
@@ -815,9 +818,9 @@ object FlowSimulation:
       signalView: MonthSemantics.SignalView,
       randomness: MonthRandomness.AssemblyStreams,
   )(using p: SimParams): MonthSemantics.PostAssembly =
-    val assembled = WorldAssemblyEconomics.computePostMonth(postInputs.value, randomness)
+    val assembled = WorldAssemblyEconomics.computePostMonth(postInputs.assemblyInput, randomness)
     // This stays at month `t`: the boundary seed is still `seedIn` here.
-    MonthSemantics.At[PostMonth, MonthSemantics.Post](
+    MonthSemantics.postAssembly(
       PostMonth(
         assembled = assembled,
         boundaryOut = MonthBoundarySnapshot.capture(assembled.world, assembled.firms, assembled.households, assembled.banks),
@@ -826,23 +829,22 @@ object FlowSimulation:
     )
 
   private def extractSeedOut(signalView: MonthSemantics.SignalView, post: MonthSemantics.PostAssembly): MonthSemantics.SeedOut =
-    val assembled = post.value.assembled
+    val assembled = post.assembled
     val employed  = Household.countEmployed(assembled.households)
-    val signals   = signalView.value
 
-    MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
+    MonthSemantics.seedOut(
       SignalExtraction.compute(
         // Seed extraction is the only place that derives the next boundary
         // signal from realized month-`t` outcomes.
         SignalExtraction.inputFromRealizedOutcomes(
           unemploymentRate = assembled.world.unemploymentRate(employed),
-          laggedHiringSlack = signals.labor.operationalHiringSlack,
+          laggedHiringSlack = signalView.labor.operationalHiringSlack,
           startupAbsorptionRate = assembled.startupAbsorptionRate,
           inflation = assembled.world.inflation,
           expectedInflation = assembled.world.mechanisms.expectations.expectedInflation,
-          sectorDemandMult = signals.demand.sectorMults,
-          sectorDemandPressure = signals.demand.sectorDemandPressure,
-          sectorHiringSignal = signals.demand.sectorHiringSignal,
+          sectorDemandMult = signalView.demand.sectorMults,
+          sectorDemandPressure = signalView.demand.sectorDemandPressure,
+          sectorHiringSignal = signalView.demand.sectorHiringSignal,
         ),
       ),
     )
@@ -853,19 +855,19 @@ object FlowSimulation:
       seedOut: MonthSemantics.SeedOut,
   ): MonthTraceCore =
     MonthTraceCore(
-      boundary = MonthBoundaryTrace.from(input.boundaryIn, post.value.boundaryOut),
+      boundary = MonthBoundaryTrace.from(input.boundaryIn, post.boundaryOut),
       seedTransition = SeedTransitionTrace.from(input.seedIn, seedOut),
-      timing = post.value.timing,
+      timing = post.timing,
     )
 
   private def computeMonthOutcome(input: StepInput)(using p: SimParams): MonthOutcome =
     // Keep the month-step pipeline explicit:
     // `seedIn/pre -> same-month groups -> post-month assembly -> seedOut/next-pre`.
     val stageOutputs       = computeStageOutputs(input)
-    val signalView         = MonthSemantics.At[SignalBoundaryInputs, MonthSemantics.SameMonth](stageOutputs.signals)
-    val flowPlan           = MonthSemantics.At[MonthlyCalculus, MonthSemantics.SameMonth](stageOutputs.flowPlan)
-    val postInputs         = MonthSemantics.At[WorldAssemblyEconomics.StepInput, MonthSemantics.SameMonth](stageOutputs.postAssembly)
-    val semanticProjection = MonthSemantics.At[SemanticFlowInputs, MonthSemantics.SameMonth](stageOutputs.semanticProjection)
+    val signalView         = MonthSemantics.signalView(stageOutputs.signals)
+    val flowPlan           = MonthSemantics.flowPlan(stageOutputs.flowPlan)
+    val postInputs         = MonthSemantics.postInputs(stageOutputs.postAssembly)
+    val semanticProjection = MonthSemantics.semanticProjection(stageOutputs.semanticProjection)
     val operational        = buildOperationalSignals(signalView)
     val post               = assemblePostMonth(postInputs, signalView, input.randomness.assembly.newStreams())
     val seedOut            = extractSeedOut(signalView, post)
@@ -882,17 +884,17 @@ object FlowSimulation:
 
   private def advanceState(
       input: StepInput,
-      post: MonthSemantics.PostAssembly,
-      seedOut: MonthSemantics.SeedOut,
+      outcome: MonthOutcome,
   ): SimState =
-    val assembled = post.value.assembled
-    val nextSeed  = seedOut.value.seedOut
+    val assembled = outcome.post.assembled
+    val nextSeed  = outcome.seedOut.nextSeed
     val nextWorld = assembled.world.updatePipeline(_.withDecisionSignals(nextSeed))
+    val currentSeed = input.seedIn.decisionSignals
 
     // `advanceState` is the only legal `post -> next-pre` transition:
     // post-month assembly still sees the old seed, next state applies `seedOut`.
-    require(input.seedIn.value == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
-    require(assembled.world.seedIn == input.seedIn.value, "PostMonth world must remain on the pre-step seed until advanceState runs")
+    require(currentSeed == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
+    require(assembled.world.seedIn == currentSeed, "PostMonth world must remain on the pre-step seed until advanceState runs")
     require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")
 
     SimState(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthSemanticsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthSemanticsSpec.scala
@@ -3,10 +3,11 @@ package com.boombustgroup.amorfati.engine
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scala.compiletime.testing.typeCheckErrors
 
 class MonthSemanticsSpec extends AnyFlatSpec with Matchers:
 
-  "MonthSemantics.At" should "preserve typed wrappers for pre, same-month, and next-pre boundaries" in {
+  "MonthSemantics" should "preserve typed wrappers for pre, same-month, and next-pre boundaries" in {
     val signals = DecisionSignals(
       unemploymentRate = Share(0.08),
       inflation = Rate(0.03),
@@ -19,7 +20,7 @@ class MonthSemanticsSpec extends AnyFlatSpec with Matchers:
     )
 
     val seedIn: MonthSemantics.SeedIn =
-      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](signals)
+      MonthSemantics.seedIn(signals)
 
     val operationalRaw                          = OperationalSignals(
       sectorDemandMult = signals.sectorDemandMult,
@@ -28,7 +29,7 @@ class MonthSemanticsSpec extends AnyFlatSpec with Matchers:
       operationalHiringSlack = Share(0.37),
     )
     val operational: MonthSemantics.Operational =
-      MonthSemantics.At[OperationalSignals, MonthSemantics.SameMonth](operationalRaw)
+      MonthSemantics.operational(operationalRaw)
 
     val extracted                       = SignalExtraction.compute(
       SignalExtraction.Input(
@@ -49,10 +50,66 @@ class MonthSemanticsSpec extends AnyFlatSpec with Matchers:
       ),
     )
     val seedOut: MonthSemantics.SeedOut =
-      MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](extracted)
+      MonthSemantics.seedOut(extracted)
 
-    seedIn.value shouldBe signals
-    operational.value shouldBe operationalRaw
-    seedOut.value shouldBe extracted
-    seedOut.value.seedOut.laggedHiringSlack shouldBe operationalRaw.operationalHiringSlack
+    seedIn.decisionSignals shouldBe signals
+    operational.operationalSignals shouldBe operationalRaw
+    seedOut.signalExtraction shouldBe extracted
+    seedOut.nextSeed.laggedHiringSlack shouldBe operationalRaw.operationalHiringSlack
+  }
+
+  it should "hide generic tagging and unwrap helpers behind alias-specific transitions" in {
+    typeCheckErrors("""
+      import com.boombustgroup.amorfati.engine.*
+      import com.boombustgroup.amorfati.types.*
+
+      val signals = DecisionSignals(
+        unemploymentRate = Share(0.08),
+        inflation = Rate(0.03),
+        expectedInflation = Rate(0.025),
+        laggedHiringSlack = Share(0.42),
+        startupAbsorptionRate = Share(0.65),
+        sectorDemandMult = Vector(Multiplier(0.9), Multiplier(1.1)),
+        sectorDemandPressure = Vector(Multiplier(0.8), Multiplier(1.2)),
+        sectorHiringSignal = Vector(Multiplier(0.85), Multiplier(1.15)),
+      )
+
+      MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](signals)
+    """) should not be empty
+
+    typeCheckErrors("""
+      import com.boombustgroup.amorfati.engine.*
+      import com.boombustgroup.amorfati.types.*
+
+      val signals = DecisionSignals(
+        unemploymentRate = Share(0.08),
+        inflation = Rate(0.03),
+        expectedInflation = Rate(0.025),
+        laggedHiringSlack = Share(0.42),
+        startupAbsorptionRate = Share(0.65),
+        sectorDemandMult = Vector(Multiplier(0.9), Multiplier(1.1)),
+        sectorDemandPressure = Vector(Multiplier(0.8), Multiplier(1.2)),
+        sectorHiringSignal = Vector(Multiplier(0.85), Multiplier(1.15)),
+      )
+
+      MonthSemantics.seedIn(signals).value
+    """) should not be empty
+
+    typeCheckErrors("""
+      import com.boombustgroup.amorfati.engine.*
+      import com.boombustgroup.amorfati.types.*
+
+      val signals = DecisionSignals(
+        unemploymentRate = Share(0.08),
+        inflation = Rate(0.03),
+        expectedInflation = Rate(0.025),
+        laggedHiringSlack = Share(0.42),
+        startupAbsorptionRate = Share(0.65),
+        sectorDemandMult = Vector(Multiplier(0.9), Multiplier(1.1)),
+        sectorDemandPressure = Vector(Multiplier(0.8), Multiplier(1.2)),
+        sectorHiringSignal = Vector(Multiplier(0.85), Multiplier(1.15)),
+      )
+
+      MonthSemantics.seedOut(signals)
+    """) should not be empty
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthTraceSpec.scala
@@ -66,7 +66,7 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
   }
 
   "SeedTransitionTrace" should "derive the seed transition from typed month boundaries" in {
-    val seedIn  = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](
+    val seedIn  = MonthSemantics.seedIn(
       DecisionSignals(
         unemploymentRate = Share(0.08),
         inflation = Rate(0.02),
@@ -78,7 +78,7 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
         sectorHiringSignal = sectorHiringSignal,
       ),
     )
-    val seedOut = MonthSemantics.At[SignalExtraction.Output, MonthSemantics.NextPre](
+    val seedOut = MonthSemantics.seedOut(
       SignalExtraction.compute(
         SignalExtraction.inputFromRealizedOutcomes(
           unemploymentRate = Share(0.07),
@@ -95,7 +95,7 @@ class MonthTraceSpec extends AnyFlatSpec with Matchers:
 
     val transition = SeedTransitionTrace.from(seedIn, seedOut)
 
-    transition.seedIn shouldBe seedIn.value
-    transition.seedOut shouldBe seedOut.value.seedOut
-    transition.provenance shouldBe seedOut.value.provenance
+    transition.seedIn shouldBe seedIn.decisionSignals
+    transition.seedOut shouldBe seedOut.nextSeed
+    transition.provenance shouldBe seedOut.provenance
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -62,15 +62,15 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   it should "keep explicit pre and next-pre seed wrappers aligned with step outputs" in {
     val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state   = FlowSimulation.SimState.fromInit(init)
-    val seedIn  = MonthSemantics.At[DecisionSignals, MonthSemantics.Pre](state.world.seedIn)
+    val seedIn  = MonthSemantics.seedIn(state.world.seedIn)
     val result  = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
-    val seedOut = MonthSemantics.At[com.boombustgroup.amorfati.engine.SignalExtraction.Output, MonthSemantics.NextPre](result.signalExtraction)
+    val seedOut = MonthSemantics.seedOut(result.signalExtraction)
 
-    seedIn.value shouldBe state.world.seedIn
-    seedOut.value shouldBe result.signalExtraction
-    seedOut.value.seedOut shouldBe result.nextState.world.seedIn
-    result.trace.seedTransition.seedIn shouldBe seedIn.value
-    result.trace.seedTransition.seedOut shouldBe seedOut.value.seedOut
+    seedIn.decisionSignals shouldBe state.world.seedIn
+    seedOut.signalExtraction shouldBe result.signalExtraction
+    seedOut.nextSeed shouldBe result.nextState.world.seedIn
+    result.trace.seedTransition.seedIn shouldBe seedIn.decisionSignals
+    result.trace.seedTransition.seedOut shouldBe seedOut.nextSeed
   }
 
   it should "accept an explicit month-step randomness contract with named stage and assembly streams" in {


### PR DESCRIPTION
## Summary
- replace generic MonthSemantics tagging/unwrap access with named zero-cost boundary helpers
- route FlowSimulation and MonthTrace through the explicit pre -> same-month -> post -> next-pre transitions
- add compile-time guards and update step/trace tests around the tightened API

Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced generic month-tagging with dedicated month-phase constructors and explicit accessors for semantic data.
  * Simplified flow/step wiring to read typed semantic fields directly.
* **Tests**
  * Updated tests to use new constructors and validate direct field access; added compile-time checks ensuring old generic tagging no longer applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->