### PR TITLE
Add montecarlo integration tests and typed runner errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Check formatting
         run: sbt scalafmtCheckAll
 
-      - name: Run tests with coverage
-        run: sbt coverage test coverageReport
+      - name: Run unit tests with coverage
+        run: sbt coverage "root / Test / test" coverageReport
+
+      - name: Run integration tests
+        run: sbt "integrationTests / Test / test"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,34 @@
 lazy val ledger = ProjectRef(file("modules/ledger"), "root")
 
+lazy val baseScalacOptions = Seq(
+  "-Werror",
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-explain",
+  "-Wunused:all",
+)
+
+lazy val testDeps = Seq(
+  "org.scalatest"     %% "scalatest"       % "3.2.19"   % Test,
+  "org.scalacheck"    %% "scalacheck"      % "1.18.1"   % Test,
+  "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test,
+  "dev.zio"           %% "zio-test"        % "2.1.16"   % Test,
+  "dev.zio"           %% "zio-test-sbt"    % "2.1.16"   % Test,
+)
+
+lazy val commonProjectSettings = Seq(
+  organization := "com.boombustgroup",
+  scalaVersion := "3.8.2",
+  scalacOptions ++= baseScalacOptions,
+)
+
 lazy val root = project
   .in(file("."))
   .dependsOn(ledger)
+  .settings(commonProjectSettings)
   .settings(
-    organization               := "com.boombustgroup",
     name                       := "amor-fati",
-    scalaVersion               := "3.8.2",
-    scalacOptions ++= Seq(
-      "-Werror",
-      "-deprecation",
-      "-feature",
-      "-unchecked",
-      "-explain",
-      "-Wunused:all",
-    ),
     mainClass                  := Some("com.boombustgroup.amorfati.Main"),
     assembly / assemblyJarName := "amor-fati.jar",
     Compile / resourceGenerators += Def.task {
@@ -31,13 +45,8 @@ lazy val root = project
     libraryDependencies ++= Seq(
       "dev.zio"           %% "zio"             % "2.1.16",
       "dev.zio"           %% "zio-streams"     % "2.1.16",
-      "org.scalatest"     %% "scalatest"       % "3.2.19"   % Test,
-      "org.scalacheck"    %% "scalacheck"      % "1.18.1"   % Test,
-      "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test,
-      "dev.zio"           %% "zio-test"        % "2.1.16"   % Test,
-      "dev.zio"           %% "zio-test-sbt"    % "2.1.16"   % Test,
       "com.github.lalyos"  % "jfiglet"         % "0.0.9",
-    ),
+    ) ++ testDeps,
     Test / testOptions ++= {
       val heavyTag         = "com.boombustgroup.amorfati.tags.Heavy"
       // Local `sbt test` skips @Heavy suites by default.
@@ -51,4 +60,13 @@ lazy val root = project
       if (excludeHeavyByDefault) Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", heavyTag))
       else Nil
     },
+  )
+
+lazy val integrationTests = project
+  .in(file("integration-tests"))
+  .dependsOn(root)
+  .settings(commonProjectSettings)
+  .settings(
+    name := "amor-fati-integration-tests",
+    libraryDependencies ++= testDeps,
   )

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -1,0 +1,147 @@
+package com.boombustgroup.amorfati.integration.montecarlo
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.fp.{ComputationBoundary, FixedPointBase}
+import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner, RunResult, SimError, SimOutput}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.{Runtime, Unsafe, ZIO}
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val td                 = ComputationBoundary
+  private val DurationMonths     = 3
+  private val Seeds              = Vector(1L, 2L)
+  private val OutputPrefix       = "mc-it"
+  private val RunId              = "csvspec"
+  private val ExpectedHhHeader   =
+    "Seed;HH_Employed;HH_Unemployed;HH_Retraining;HH_Bankrupt;MeanSavings;MedianSavings;Gini_Individual;Gini_Wealth;MeanSkill;MeanHealthPenalty;RetrainingAttempts;RetrainingSuccesses;ConsumptionP10;ConsumptionP50;ConsumptionP90;BankruptcyRate;MeanMonthsToRuin;PovertyRate_50pct;PovertyRate_30pct"
+  private val ExpectedBankHeader =
+    "Seed;BankId;Deposits;Loans;Capital;NPL;CAR;GovBonds;InterbankNet;Failed"
+
+  private def rc =
+    McRunConfig(
+      nSeeds = Seeds.length,
+      outputPrefix = OutputPrefix,
+      runDurationMonths = DurationMonths,
+      runId = RunId,
+    )
+
+  private def filePrefix(rc: McRunConfig) =
+    s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"
+
+  private def seedFileName(seed: Long, rc: McRunConfig) =
+    f"${filePrefix(rc)}_seed${seed}%03d.csv"
+
+  private def unsafeRun[A](zio: ZIO[Any, SimError, A]): A =
+    Unsafe.unsafe:
+      implicit unsafe =>
+        Runtime.default.unsafe.run(zio.either).getOrThrowFiberFailure() match
+          case Right(value) => value
+          case Left(err)    => fail(err.toString)
+
+  private def unsafeRunEither[A](zio: ZIO[Any, SimError, A]): Either[SimError, A] =
+    Unsafe.unsafe:
+      implicit unsafe =>
+        Runtime.default.unsafe.run(zio.either).getOrThrowFiberFailure()
+
+  private def withTempDir[A](f: Path => A): A =
+    val dir = Files.createTempDirectory("mc-runner-it-")
+    try f(dir)
+    finally deleteRecursively(dir)
+
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      Using.resource(Files.walk(dir)): stream =>
+        stream.iterator.asScala.toVector.sortBy(_.getNameCount).reverse.foreach(Files.deleteIfExists)
+
+  private def readLines(path: Path): Vector[String] =
+    Files.readAllLines(path).asScala.toVector
+
+  private def parseCsvRow(line: String): Vector[Double] =
+    line.split(';').toVector.map(_.replace(',', '.').toDouble)
+
+  private def expectedRun(seed: Long): RunResult =
+    McRunner.runSingle(seed, DurationMonths).fold(err => fail(err.toString), identity)
+
+  private def expectedHhRow(seed: Long, result: RunResult): String =
+    val a = result.terminalState.householdAggregates
+    s"$seed;${a.employed};${a.unemployed};${a.retraining};${a.bankrupt};" +
+      f"${td.toDouble(a.meanSavings)}%.2f;${td.toDouble(a.medianSavings)}%.2f;" +
+      f"${td.toDouble(a.giniIndividual)}%.6f;${td.toDouble(a.giniWealth)}%.6f;" +
+      f"${td.toDouble(a.meanSkill)}%.6f;${td.toDouble(a.meanHealthPenalty)}%.6f;" +
+      s"${a.retrainingAttempts};${a.retrainingSuccesses};" +
+      f"${td.toDouble(a.consumptionP10)}%.2f;${td.toDouble(a.consumptionP50)}%.2f;${td.toDouble(a.consumptionP90)}%.2f;" +
+      f"${td.toDouble(a.bankruptcyRate)}%.6f;" +
+      f"${a.meanMonthsToRuin.toLong.toDouble / FixedPointBase.ScaleD}%.2f;" +
+      f"${td.toDouble(a.povertyRate50)}%.6f;${td.toDouble(a.povertyRate30)}%.6f"
+
+  private def expectedBankRows(seed: Long, result: RunResult): Vector[String] =
+    result.terminalState.banks.map: b =>
+      s"$seed;${b.id};" +
+        f"${td.toDouble(b.deposits)}%.2f;${td.toDouble(b.loans)}%.2f;${td.toDouble(b.capital)}%.2f;" +
+        f"${td.toDouble(b.nplRatio)}%.6f;${td.toDouble(b.car)}%.6f;" +
+        f"${td.toDouble(b.govBondHoldings)}%.2f;${td.toDouble(b.interbankNet)}%.2f;" +
+        s"${b.failed}"
+
+  "runZIO" should "write deterministic per-seed and summary CSV files" in withTempDir: outputDir =>
+    unsafeRun(McRunner.runZIO(rc, outputDir.toFile))
+
+    val expectedRuns      = Seeds.map(seed => seed -> expectedRun(seed)).toMap
+    val expectedFileNames = (
+      Seeds.map(seed => seedFileName(seed, rc)) :+
+        s"${filePrefix(rc)}_hh.csv" :+
+        s"${filePrefix(rc)}_banks.csv"
+    ).toSet
+
+    Using.resource(Files.list(outputDir)): stream =>
+      stream.iterator.asScala.map(_.getFileName.toString).toSet shouldBe expectedFileNames
+
+    for seed <- Seeds do
+      val path   = outputDir.resolve(seedFileName(seed, rc))
+      val lines  = readLines(path)
+      val result = expectedRuns(seed)
+
+      lines.head shouldBe SimOutput.colNames.mkString(";")
+      lines.length shouldBe DurationMonths + 1
+
+      for (line, monthIndex) <- lines.tail.zipWithIndex do
+        val actual   = parseCsvRow(line)
+        val month    = ExecutionMonth.First.advanceBy(monthIndex)
+        val expected = result.timeSeries.monthRow(month)
+
+        actual.length shouldBe SimOutput.nCols
+
+        for col <- 0 until SimOutput.nCols do
+          withClue(s"seed=$seed month=${month.toInt} col=$col: ") {
+            actual(col) shouldBe (expected(col) +- 1e-6)
+          }
+
+    val hhLines = readLines(outputDir.resolve(s"${filePrefix(rc)}_hh.csv"))
+    hhLines.head shouldBe ExpectedHhHeader
+    hhLines.length shouldBe Seeds.length + 1
+    hhLines.tail shouldBe Seeds.map(seed => expectedHhRow(seed, expectedRuns(seed)))
+
+    val bankLines = readLines(outputDir.resolve(s"${filePrefix(rc)}_banks.csv"))
+    bankLines.head shouldBe ExpectedBankHeader
+    bankLines.length shouldBe 1 + expectedRuns.valuesIterator.map(_.terminalState.banks.length).sum
+    bankLines.tail shouldBe Seeds.flatMap(seed => expectedBankRows(seed, expectedRuns(seed)))
+
+  it should "surface a typed error when the output location is not a directory" in withTempDir: tempDir =>
+    val outputFile = tempDir.resolve("not-a-directory")
+    Files.writeString(outputFile, "occupied")
+
+    unsafeRunEither(McRunner.runZIO(rc, outputFile.toFile)) match
+      case Left(SimError.OutputFailure(operation, path, details)) =>
+        operation shouldBe "prepare output directory"
+        path shouldBe outputFile.toFile.getPath
+        details should include("not a directory")
+      case other                                       =>
+        fail(s"expected typed output failure, got: $other")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -146,7 +146,8 @@ object McRunner:
       .attemptBlocking:
         if outputDir.exists() then
           if !outputDir.isDirectory then throw java.io.IOException(s"path exists but is not a directory: ${outputDir.getPath}")
-        else if !outputDir.mkdirs() then throw java.io.IOException(s"failed to create output directory: ${outputDir.getPath}")
+        else if !outputDir.mkdirs() && (!outputDir.exists() || !outputDir.isDirectory) then
+          throw java.io.IOException(s"failed to create output directory: ${outputDir.getPath}")
       .mapError(outputFailure("prepare output directory", outputDir))
 
   private def filePrefix(rc: McRunConfig) =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -28,10 +28,13 @@ object McRunner:
     * per-seed CSV + aggregated HH/bank CSVs. Fails with [[SimError]].
     */
   def runZIO(rc: McRunConfig)(using p: SimParams): ZIO[Any, SimError, Unit] =
+    runZIO(rc, new File("mc"))
+
+  private[amorfati] def runZIO(rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, Unit] =
     val parallelism = java.lang.Runtime.getRuntime.availableProcessors()
     for
-      _       <- ZIO.attemptBlocking { val d = new File("mc"); if !d.exists() then d.mkdirs() }.orDie
-      _       <- Console.printLine(s"  run-id: ${rc.runId}").orDie
+      _       <- prepareOutputDir(outputDir)
+      _       <- Console.printLine(s"  run-id: ${rc.runId}").mapError(runtimeFailure("print run id"))
       t0      <- Clock.currentTime(TimeUnit.MILLISECONDS)
       results <- ZStream
         .fromIterable(1L to rc.nSeeds.toLong)
@@ -41,15 +44,15 @@ object McRunner:
             runResult <- materializeSeed(seed, rc)
             et        <- Clock.currentTime(TimeUnit.MILLISECONDS)
             _         <- printSeedDone(seed, rc.nSeeds, runResult, et - st)
-            _         <- writeSeedCsv(seed, rc, runResult).orDie
+            _         <- writeSeedCsv(seed, rc, outputDir, runResult)
           yield (seed, runResult)
         .runCollect
-      _       <- writeHhCsv(rc, results).orDie
-      _       <- writeBankCsv(rc, results).orDie
-      _       <- Console.printLine("").orDie
-      _       <- printSavedZIO(rc).orDie
+      _       <- writeHhCsv(rc, outputDir, results)
+      _       <- writeBankCsv(rc, outputDir, results)
+      _       <- Console.printLine("").mapError(runtimeFailure("print separator"))
+      _       <- printSavedZIO(rc, outputDir)
       t1      <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _       <- Console.printLine(f"\nTotal time: ${(t1 - t0) / 1000.0}%.1f seconds").orDie
+      _       <- Console.printLine(f"\nTotal time: ${(t1 - t0) / 1000.0}%.1f seconds").mapError(runtimeFailure("print total time"))
     yield ()
 
   /** Pure simulation — returns Either, no side effects. For tests. */
@@ -120,7 +123,7 @@ object McRunner:
   /** Consume a seed stream into RunResult, collecting monthly data. */
   private def materializeSeed(seed: Long, rc: McRunConfig)(using p: SimParams) =
     seedStream(seed, rc.runDurationMonths)
-      .tap(s => ZIO.succeed(printMonthProgress(seed, rc.nSeeds, s.executionMonth, rc.runDurationMonths)))
+      .tap(s => printMonthProgressZIO(seed, rc.nSeeds, s.executionMonth, rc.runDurationMonths))
       .runFold((Option.empty[FlowSimulation.SimState], Vector.empty[Array[Double]])):
         case ((_, series), snapshot) => (Some(snapshot.state), series :+ snapshot.monthData)
       .flatMap:
@@ -132,26 +135,43 @@ object McRunner:
   // ---------------------------------------------------------------------------
 
   // $COVERAGE-OFF$ I/O: CSV writers, progress, banner
+  private def runtimeFailure(operation: String)(err: Throwable): SimError =
+    SimError.RuntimeFailure(operation, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))
+
+  private def prepareOutputDir(outputDir: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        if outputDir.exists() then
+          if !outputDir.isDirectory then throw java.io.IOException(s"path exists but is not a directory: ${outputDir.getPath}")
+        else if !outputDir.mkdirs() then throw java.io.IOException(s"failed to create output directory: ${outputDir.getPath}")
+      .mapError(outputFailure("prepare output directory", outputDir))
+
   private def filePrefix(rc: McRunConfig) =
     s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"
 
   private def seedFileName(seed: Long, rc: McRunConfig) =
     f"${filePrefix(rc)}_seed${seed}%03d.csv"
 
-  private def writeSeedCsv(seed: Long, rc: McRunConfig, result: RunResult) =
-    ZIO.attemptBlocking:
-      val nCols    = SimOutput.nCols
-      val colNames = SimOutput.colNames
-      CsvWriter.write(
-        new File("mc", seedFileName(seed, rc)),
-        colNames.mkString(";"),
-        result.timeSeries.executionMonths,
-      ): month =>
-        val row = result.timeSeries.monthRow(month)
-        val sb  = new StringBuilder
-        sb.append(month.toInt)
-        for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
-        sb.toString
+  private def writeSeedCsv(seed: Long, rc: McRunConfig, outputDir: File, result: RunResult) =
+    val outputFile = new File(outputDir, seedFileName(seed, rc))
+    ZIO
+      .attemptBlocking:
+        val nCols    = SimOutput.nCols
+        val colNames = SimOutput.colNames
+        CsvWriter.write(
+          outputFile,
+          colNames.mkString(";"),
+          result.timeSeries.executionMonths,
+        ): month =>
+          val row = result.timeSeries.monthRow(month)
+          val sb  = new StringBuilder
+          sb.append(month.toInt)
+          for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
+          sb.toString
+      .mapError(outputFailure("write per-seed CSV", outputFile))
 
   // ---------------------------------------------------------------------------
   //  HH + Bank CSV writers (from collected results)
@@ -183,12 +203,15 @@ object McRunner:
 
   private val hhHeader = "Seed;" + hhSchema.map(_._1).mkString(";")
 
-  private def writeHhCsv(rc: McRunConfig, results: zio.Chunk[(Long, RunResult)]) =
-    ZIO.attemptBlocking:
-      val rows = results.map: (seed, r) =>
-        val agg = r.terminalState.householdAggregates
-        s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
-      CsvWriter.write(new File("mc", s"${filePrefix(rc)}_hh.csv"), hhHeader, rows)(identity)
+  private def writeHhCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[(Long, RunResult)]) =
+    val outputFile = new File(outputDir, s"${filePrefix(rc)}_hh.csv")
+    ZIO
+      .attemptBlocking:
+        val rows = results.map: (seed, r) =>
+          val agg = r.terminalState.householdAggregates
+          s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
+        CsvWriter.write(outputFile, hhHeader, rows)(identity)
+      .mapError(outputFailure("write household summary CSV", outputFile))
 
   private val bankSchema: Vector[(String, BankState => String)] = Vector(
     ("BankId", b => s"${b.id}"),
@@ -204,18 +227,24 @@ object McRunner:
 
   private val bankHeader = "Seed;" + bankSchema.map(_._1).mkString(";")
 
-  private def writeBankCsv(rc: McRunConfig, results: zio.Chunk[(Long, RunResult)]) =
-    ZIO.attemptBlocking:
-      val rows = results.flatMap: (seed, r) =>
-        r.terminalState.banks.map: b =>
-          s"$seed;" + bankSchema.map(_._2(b)).mkString(";")
-      CsvWriter.write(new File("mc", s"${filePrefix(rc)}_banks.csv"), bankHeader, rows)(identity)
+  private def writeBankCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[(Long, RunResult)]) =
+    val outputFile = new File(outputDir, s"${filePrefix(rc)}_banks.csv")
+    ZIO
+      .attemptBlocking:
+        val rows = results.flatMap: (seed, r) =>
+          r.terminalState.banks.map: b =>
+            s"$seed;" + bankSchema.map(_._2(b)).mkString(";")
+        CsvWriter.write(outputFile, bankHeader, rows)(identity)
+      .mapError(outputFailure("write bank summary CSV", outputFile))
 
   // ---------------------------------------------------------------------------
   //  Progress
   // ---------------------------------------------------------------------------
 
   private val BarWidth = 20
+
+  private def printMonthProgressZIO(seed: Long, total: Int, month: ExecutionMonth, duration: Int): ZIO[Any, SimError, Unit] =
+    ZIO.attempt(printMonthProgress(seed, total, month, duration)).mapError(runtimeFailure("print month progress"))
 
   private def printMonthProgress(seed: Long, total: Int, month: ExecutionMonth, duration: Int): Unit =
     val frac   = month.toInt.toDouble / duration
@@ -236,12 +265,13 @@ object McRunner:
           f"Adopt=${adopt * 100}%5.1f%% | pi=${pi * 100}%5.1f%% | " +
           f"Unemp=${unemp * 100}%5.1f%%",
       )
-      .orDie
+      .mapError(runtimeFailure("print seed summary"))
 
-  private def printSavedZIO(rc: McRunConfig) =
-    val seedFiles = (1L to rc.nSeeds.toLong).map(s => s"mc/${seedFileName(s, rc)}")
-    ZIO.foreachDiscard(seedFiles)(f => Console.printLine(s"Saved: $f")) *>
-      Console.printLine(s"Saved: mc/${filePrefix(rc)}_hh.csv") *>
-      Console.printLine(s"Saved: mc/${filePrefix(rc)}_banks.csv")
+  private def printSavedZIO(rc: McRunConfig, outputDir: File) =
+    val seedFiles = (1L to rc.nSeeds.toLong).map(s => new File(outputDir, seedFileName(s, rc)).getPath)
+    (ZIO.foreachDiscard(seedFiles)(f => Console.printLine(s"Saved: $f")) *>
+      Console.printLine(s"Saved: ${new File(outputDir, s"${filePrefix(rc)}_hh.csv").getPath}") *>
+      Console.printLine(s"Saved: ${new File(outputDir, s"${filePrefix(rc)}_banks.csv").getPath}"))
+      .mapError(runtimeFailure("print saved file paths"))
 
   // $COVERAGE-ON$

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -18,6 +18,14 @@ object SimError:
     override def toString: String =
       s"SFC violation at M${month.toInt}:\n${errors.map(e => s"  ${e.identity}: ${e.msg} (expected=${e.expected}, actual=${e.actual}, diff=${(e.actual - e.expected).abs})").mkString("\n")}"
 
+  case class RuntimeFailure(operation: String, details: String) extends SimError:
+    override def toString: String =
+      s"Runtime failure during $operation: $details"
+
+  case class OutputFailure(operation: String, path: String, details: String) extends SimError:
+    override def toString: String =
+      s"Output failure during $operation at $path: $details"
+
 /** Result of a single simulation run. */
 case class RunResult(
     timeSeries: TimeSeries,


### PR DESCRIPTION
## Summary
- add a dedicated `integration-tests` subproject and run it in CI
- add end-to-end Monte Carlo + CSV integration coverage for `McRunner.runZIO`
- replace hidden `McRunner` output/runtime defects with typed `SimError` failures

## Testing
- `sbt scalafmtAll "root / Test / compile" "integrationTests / Test / testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"`
- `sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly com.boombustgroup.amorfati.engine.McRunnerSpec com.boombustgroup.amorfati.montecarlo.McRunConfigSpec"`

Closes #335
Closes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite validating deterministic CSV output and error scenarios.

* **Improvements**
  * Improved error reporting for runtime and output-related failures with clearer, typed messages.

* **Chores**
  * Refactored build configuration for maintainability.
  * Added a dedicated integration-tests project and separated unit vs. integration test execution in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->