### PR TITLE
Unify McRunConfig and McRunner runtime contracts

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/Main.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/Main.scala
@@ -41,21 +41,26 @@ object Main extends ZIOAppDefault:
       val idx = args.indexOf(name)
       if idx >= 0 && idx + 1 < args.length then Some(args(idx + 1)) else None
 
-    def parsePositiveInt(value: String, flag: String): Either[String, Int] =
-      scala.util.Try(value.toInt).toOption.filter(_ > 0).toRight(s"$flag must be a positive integer")
+    def parseInt(value: String, label: String): Either[String, Int] =
+      scala.util.Try(value.toInt).toOption.toRight(s"$label must be an integer")
 
     ZIO
       .fromEither(for
         _           <- Either.cond(args.length >= 2, (), usage)
-        nSeeds      <- args.headOption.flatMap(s => scala.util.Try(s.toInt).toOption).filter(_ > 0).toRight(usage)
+        nSeedsValue <- args.headOption.toRight(usage)
+        nSeeds      <- parseInt(nSeedsValue, "<nSeeds>")
         prefix      <- args.lift(1).toRight(usage)
         runDuration <- findFlag("--duration") match
-          case Some(value) => parsePositiveInt(value, "--duration")
+          case Some(value) => parseInt(value, "--duration")
           case None        => Right(McRunConfig.DefaultRunDuration)
-      yield
-        val runId = findFlag("--run-id")
-        runId match
-          case Some(id) => McRunConfig(nSeeds, prefix, runDuration, id)
-          case None     => McRunConfig(nSeeds, prefix, runDuration))
+        mcRunConfig <- scala.util
+          .Try:
+            findFlag("--run-id") match
+              case Some(id) => McRunConfig(nSeeds, prefix, runDuration, id)
+              case None     => McRunConfig(nSeeds, prefix, runDuration)
+          .toEither
+          .left
+          .map(_.getMessage)
+      yield mcRunConfig)
       .mapError(err => new IllegalArgumentException(if err == usage then usage else s"$err\n$usage"))
 // $COVERAGE-ON$

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
@@ -11,10 +11,28 @@ case class McRunConfig(
     outputPrefix: String,
     runDurationMonths: Int = McRunConfig.DefaultRunDuration,
     runId: String = McRunConfig.autoRunId(),
-)
+):
+  McRunConfig.requirePositiveSeeds(nSeeds)
+  McRunConfig.requireNonBlankOutputPrefix(outputPrefix)
+  McRunConfig.requirePositiveDuration(runDurationMonths)
+  McRunConfig.requireNonBlankRunId(runId)
 
 object McRunConfig:
   val DefaultRunDuration: Int        = 120
   private val fmt: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm")
 
-  def autoRunId(): String = LocalDateTime.now().format(fmt)
+  def autoRunId(): String = autoRunId(LocalDateTime.now())
+
+  def autoRunId(at: LocalDateTime): String = at.format(fmt)
+
+  def requirePositiveSeeds(nSeeds: Int): Unit =
+    require(nSeeds > 0, s"nSeeds must be > 0, got $nSeeds")
+
+  def requireNonBlankOutputPrefix(outputPrefix: String): Unit =
+    require(outputPrefix != null && outputPrefix.trim.nonEmpty, "outputPrefix must be non-blank")
+
+  def requirePositiveDuration(runDurationMonths: Int): Unit =
+    require(runDurationMonths > 0, s"runDurationMonths must be > 0, got $runDurationMonths")
+
+  def requireNonBlankRunId(runId: String): Unit =
+    require(runId != null && runId.trim.nonEmpty, "runId must be non-blank")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -57,6 +57,7 @@ object McRunner:
 
   /** Pure simulation — returns Either, no side effects. For tests. */
   def runSingle(seed: Long, durationMonths: Int = McRunConfig.DefaultRunDuration)(using p: SimParams): Either[SimError, RunResult] =
+    McRunConfig.requirePositiveDuration(durationMonths)
     initSeed(seed).flatMap: initState =>
       materializeRun(initState, runtimeSteps(seed, initState).take(durationMonths))
 
@@ -128,7 +129,13 @@ object McRunner:
         case ((_, series), snapshot) => (Some(snapshot.state), series :+ snapshot.monthData)
       .flatMap:
         case (Some(state), series) => ZIO.succeed(RunResult(TimeSeries.wrap(series.toArray), state))
-        case _                     => ZIO.fail(SimError.Init(Vector.empty))
+        case _                     =>
+          ZIO.fail(
+            SimError.RuntimeFailure(
+              "materialize seed",
+              s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
+            ),
+          )
 
   // ---------------------------------------------------------------------------
   //  Per-seed CSV writer

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -27,6 +27,16 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   // --- Basic output sanity ---
 
+  "runSingle" should "reject non-positive durations" in {
+    val zeroDuration = intercept[IllegalArgumentException]:
+      runSingle(42, 0)
+    zeroDuration.getMessage should include("runDurationMonths must be > 0")
+
+    val negativeDuration = intercept[IllegalArgumentException]:
+      runSingle(42, -1)
+    negativeDuration.getMessage should include("runDurationMonths must be > 0")
+  }
+
   "runSingle" should "produce 60 rows x 227 columns" in {
     ts.nMonths shouldBe duration
     for row <- ts do row.length shouldBe SimOutput.nCols

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunConfigSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunConfigSpec.scala
@@ -1,5 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
+import java.time.LocalDateTime
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -7,4 +9,27 @@ class McRunConfigSpec extends AnyFlatSpec with Matchers:
 
   "McRunConfig" should "default runtime duration to 120 months" in {
     McRunConfig(nSeeds = 2, outputPrefix = "baseline").runDurationMonths shouldBe 120
+  }
+
+  it should "preserve an injected runId" in {
+    McRunConfig(nSeeds = 2, outputPrefix = "baseline", runId = "manual-run").runId shouldBe "manual-run"
+  }
+
+  it should "format generated runIds deterministically for a supplied timestamp" in {
+    McRunConfig.autoRunId(LocalDateTime.of(2026, 4, 12, 9, 7)) shouldBe "20260412T0907"
+  }
+
+  it should "reject non-positive seed counts" in {
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = 0, outputPrefix = "baseline")
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = -1, outputPrefix = "baseline")
+  }
+
+  it should "reject non-positive run durations" in {
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = 2, outputPrefix = "baseline", runDurationMonths = 0)
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = 2, outputPrefix = "baseline", runDurationMonths = -1)
+  }
+
+  it should "reject blank output prefixes and runIds" in {
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = 2, outputPrefix = "   ")
+    an[IllegalArgumentException] should be thrownBy McRunConfig(nSeeds = 2, outputPrefix = "baseline", runId = "   ")
   }


### PR DESCRIPTION
## Summary
- centralize Monte Carlo runtime validation in `McRunConfig`
- make `Main` and `McRunner.runSingle` honor the same positive-duration contract
- add focused tests for invalid runtime inputs and deterministic/generated `runId` behavior

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration parameter validation now enforces stricter constraints with improved error messages for invalid inputs.
  * Error reporting during initialization provides more specific diagnostic information about failures.
  * Validation logic has been centralized and made more consistent across system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->