### PR TITLE
Make SimOutput schema/config invariants explicit

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
@@ -83,6 +83,15 @@ case class HousingConfig(
     regionalMarkets.map(_.market) == HousingConfig.RegionalMarket.all,
     s"regionalMarkets must preserve region order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionalMarkets.map(_.market.label).mkString(" -> ")}",
   )
+  regionalMarkets.foreach: marketConfig =>
+    require(
+      marketConfig.valueShare >= Share.Zero && marketConfig.valueShare <= Share.One,
+      s"regionalMarkets valueShare for ${marketConfig.market.label} must be in [0,1], got ${marketConfig.valueShare}",
+    )
+    require(
+      marketConfig.mortgageShare >= Share.Zero && marketConfig.mortgageShare <= Share.One,
+      s"regionalMarkets mortgageShare for ${marketConfig.market.label} must be in [0,1], got ${marketConfig.mortgageShare}",
+    )
 
   private val regionalValueShareSum    = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.valueShare)
   private val regionalMortgageShareSum = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.mortgageShare)

--- a/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
@@ -9,7 +9,7 @@ import com.boombustgroup.amorfati.types.*
   * mortgage origination subject to LTV limits (KNF Recommendation S), mortgage
   * default with unemployment sensitivity, housing wealth effects on
   * consumption, and 7-region disaggregation (Warsaw, Krakow, Wroclaw, Gdansk,
-  * Poznan, Lodz, rest-of-Poland). Calibrated to NBP residential price survey
+  * Lodz, Poznan, rest-of-Poland). Calibrated to NBP residential price survey
   * 2024, KNF Recommendation S, and GUS wage surveys 2024.
   *
   * Stock values (`initValue`, `initMortgage`) are in raw PLN — scaled by
@@ -50,8 +50,8 @@ import com.boombustgroup.amorfati.types.*
   * @param rentalYield
   *   annual rental yield as fraction of property value (Otodom/NBP: ~4.5%)
   * @param regionalHpi
-  *   initial HPI by region (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Poznan,
-  *   Lodz, rest)
+  *   initial HPI by region (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Lodz,
+  *   Poznan, rest)
   * @param regionalValueShares
   *   share of total housing value by region (NBP/GUS 2024)
   * @param regionalMortgageShares
@@ -77,7 +77,7 @@ case class HousingConfig(
     mortgageRecovery: Share = Share(0.70),
     wealthMpc: Share = Share(0.05),
     rentalYield: Rate = Rate(0.045),
-    // Regional housing (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Poznan, Lodz, rest)
+    // Regional housing (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Lodz, Poznan, rest)
     regionalHpi: Vector[PriceIndex] =
       Vector(PriceIndex(230.0), PriceIndex(190.0), PriceIndex(170.0), PriceIndex(175.0), PriceIndex(110.0), PriceIndex(140.0), PriceIndex(100.0)),
     regionalValueShares: Vector[Share] = Vector(Share(0.25), Share(0.08), Share(0.07), Share(0.08), Share(0.04), Share(0.05), Share(0.43)),
@@ -90,3 +90,40 @@ case class HousingConfig(
   require(ltvMax > Share.Zero && ltvMax <= Share.One, s"ltvMax must be in (0,1]: $ltvMax")
   require(mortgageMaturity > 0, s"mortgageMaturity must be positive: $mortgageMaturity")
   require(initValue >= PLN.Zero, s"initValue must be non-negative: $initValue")
+
+  private def requireRegionalShape[A](label: String, values: Vector[A]): Unit =
+    require(
+      values.length == HousingConfig.RegionalMarketCount,
+      s"$label must have ${HousingConfig.RegionalMarketCount} regions in order ${HousingConfig.RegionalMarketLabels.mkString(" -> ")}, got ${values.length}",
+    )
+
+  requireRegionalShape("regionalHpi", regionalHpi)
+  requireRegionalShape("regionalValueShares", regionalValueShares)
+  requireRegionalShape("regionalMortgageShares", regionalMortgageShares)
+  requireRegionalShape("regionalGammas", regionalGammas)
+  requireRegionalShape("regionalIncomeMult", regionalIncomeMult)
+
+  private val regionalValueShareSum    = regionalValueShares.foldLeft(Share.Zero)(_ + _)
+  private val regionalMortgageShareSum = regionalMortgageShares.foldLeft(Share.Zero)(_ + _)
+
+  require(regionalValueShareSum == Share.One, s"regionalValueShares must sum to 1.0, got $regionalValueShareSum")
+  require(regionalMortgageShareSum == Share.One, s"regionalMortgageShares must sum to 1.0, got $regionalMortgageShareSum")
+
+object HousingConfig:
+
+  private[amorfati] final case class RegionalMarket(columnPrefix: String, label: String):
+    def hpiColName: String = s"${columnPrefix}Hpi"
+
+  private[amorfati] val RegionalMarketSchema: Vector[RegionalMarket] =
+    Vector(
+      RegionalMarket("Waw", "Warsaw"),
+      RegionalMarket("Krk", "Krakow"),
+      RegionalMarket("Wro", "Wroclaw"),
+      RegionalMarket("Gdn", "Gdansk"),
+      RegionalMarket("Ldz", "Lodz"),
+      RegionalMarket("Poz", "Poznan"),
+      RegionalMarket("Rest", "Rest of Poland"),
+    )
+
+  private[amorfati] val RegionalMarketCount: Int             = RegionalMarketSchema.length
+  private[amorfati] val RegionalMarketLabels: Vector[String] = RegionalMarketSchema.map(_.label)

--- a/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
@@ -96,8 +96,8 @@ case class HousingConfig(
   private val regionalValueShareSum    = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.valueShare)
   private val regionalMortgageShareSum = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.mortgageShare)
 
-  require(regionalValueShareSum == Share.One, s"regionalValueShares must sum to 1.0, got $regionalValueShareSum")
-  require(regionalMortgageShareSum == Share.One, s"regionalMortgageShares must sum to 1.0, got $regionalMortgageShareSum")
+  require(regionalValueShareSum == Share.One, s"regionalMarkets value shares must sum to 1.0, got $regionalValueShareSum")
+  require(regionalMortgageShareSum == Share.One, s"regionalMarkets mortgage shares must sum to 1.0, got $regionalMortgageShareSum")
 
 object HousingConfig:
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
@@ -49,17 +49,9 @@ import com.boombustgroup.amorfati.types.*
   *   Shiller 2005)
   * @param rentalYield
   *   annual rental yield as fraction of property value (Otodom/NBP: ~4.5%)
-  * @param regionalHpi
-  *   initial HPI by region (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Lodz,
-  *   Poznan, rest)
-  * @param regionalValueShares
-  *   share of total housing value by region (NBP/GUS 2024)
-  * @param regionalMortgageShares
-  *   share of total mortgage stock by region (NBP 2024)
-  * @param regionalGammas
-  *   region-specific mean-reversion speeds
-  * @param regionalIncomeMult
-  *   regional income multiplier vs. national average (GUS wage surveys 2024)
+  * @param regionalMarkets
+  *   keyed regional configuration preserving market identity for Warsaw,
+  *   Krakow, Wroclaw, Gdansk, Lodz, Poznan, and rest-of-Poland
   */
 case class HousingConfig(
     initHpi: PriceIndex = PriceIndex(100.0),
@@ -77,53 +69,61 @@ case class HousingConfig(
     mortgageRecovery: Share = Share(0.70),
     wealthMpc: Share = Share(0.05),
     rentalYield: Rate = Rate(0.045),
-    // Regional housing (7 regions: Warsaw, Krakow, Wroclaw, Gdansk, Lodz, Poznan, rest)
-    regionalHpi: Vector[PriceIndex] =
-      Vector(PriceIndex(230.0), PriceIndex(190.0), PriceIndex(170.0), PriceIndex(175.0), PriceIndex(110.0), PriceIndex(140.0), PriceIndex(100.0)),
-    regionalValueShares: Vector[Share] = Vector(Share(0.25), Share(0.08), Share(0.07), Share(0.08), Share(0.04), Share(0.05), Share(0.43)),
-    regionalMortgageShares: Vector[Share] = Vector(Share(0.30), Share(0.10), Share(0.08), Share(0.09), Share(0.04), Share(0.06), Share(0.33)),
-    regionalGammas: Vector[Coefficient] =
-      Vector(Coefficient(0.03), Coefficient(0.04), Coefficient(0.04), Coefficient(0.04), Coefficient(0.06), Coefficient(0.05), Coefficient(0.06)),
-    regionalIncomeMult: Vector[Multiplier] =
-      Vector(Multiplier(1.35), Multiplier(1.15), Multiplier(1.10), Multiplier(1.12), Multiplier(0.95), Multiplier(1.05), Multiplier(0.82)),
+    regionalMarkets: Vector[HousingConfig.RegionalMarketConfig] = HousingConfig.DefaultRegionalMarkets,
 ):
   require(ltvMax > Share.Zero && ltvMax <= Share.One, s"ltvMax must be in (0,1]: $ltvMax")
   require(mortgageMaturity > 0, s"mortgageMaturity must be positive: $mortgageMaturity")
   require(initValue >= PLN.Zero, s"initValue must be non-negative: $initValue")
 
-  private def requireRegionalShape[A](label: String, values: Vector[A]): Unit =
-    require(
-      values.length == HousingConfig.RegionalMarketCount,
-      s"$label must have ${HousingConfig.RegionalMarketCount} regions in order ${HousingConfig.RegionalMarketLabels.mkString(" -> ")}, got ${values.length}",
-    )
+  require(
+    regionalMarkets.length == HousingConfig.RegionalMarket.count,
+    s"regionalMarkets must have ${HousingConfig.RegionalMarket.count} regions in order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionalMarkets.length}",
+  )
+  require(
+    regionalMarkets.map(_.market) == HousingConfig.RegionalMarket.all,
+    s"regionalMarkets must preserve region order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionalMarkets.map(_.market.label).mkString(" -> ")}",
+  )
 
-  requireRegionalShape("regionalHpi", regionalHpi)
-  requireRegionalShape("regionalValueShares", regionalValueShares)
-  requireRegionalShape("regionalMortgageShares", regionalMortgageShares)
-  requireRegionalShape("regionalGammas", regionalGammas)
-  requireRegionalShape("regionalIncomeMult", regionalIncomeMult)
-
-  private val regionalValueShareSum    = regionalValueShares.foldLeft(Share.Zero)(_ + _)
-  private val regionalMortgageShareSum = regionalMortgageShares.foldLeft(Share.Zero)(_ + _)
+  private val regionalValueShareSum    = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.valueShare)
+  private val regionalMortgageShareSum = regionalMarkets.foldLeft(Share.Zero)((acc, market) => acc + market.mortgageShare)
 
   require(regionalValueShareSum == Share.One, s"regionalValueShares must sum to 1.0, got $regionalValueShareSum")
   require(regionalMortgageShareSum == Share.One, s"regionalMortgageShares must sum to 1.0, got $regionalMortgageShareSum")
 
 object HousingConfig:
 
-  private[amorfati] final case class RegionalMarket(columnPrefix: String, label: String):
+  enum RegionalMarket(val columnPrefix: String, val label: String):
+    case Warsaw        extends RegionalMarket("Waw", "Warsaw")
+    case Krakow        extends RegionalMarket("Krk", "Krakow")
+    case Wroclaw       extends RegionalMarket("Wro", "Wroclaw")
+    case Gdansk        extends RegionalMarket("Gdn", "Gdansk")
+    case Lodz          extends RegionalMarket("Ldz", "Lodz")
+    case Poznan        extends RegionalMarket("Poz", "Poznan")
+    case RestOfPoland  extends RegionalMarket("Rest", "Rest of Poland")
+
     def hpiColName: String = s"${columnPrefix}Hpi"
 
-  private[amorfati] val RegionalMarketSchema: Vector[RegionalMarket] =
-    Vector(
-      RegionalMarket("Waw", "Warsaw"),
-      RegionalMarket("Krk", "Krakow"),
-      RegionalMarket("Wro", "Wroclaw"),
-      RegionalMarket("Gdn", "Gdansk"),
-      RegionalMarket("Ldz", "Lodz"),
-      RegionalMarket("Poz", "Poznan"),
-      RegionalMarket("Rest", "Rest of Poland"),
-    )
+  object RegionalMarket:
+    val all: Vector[RegionalMarket]     = values.toVector
+    val count: Int                      = all.length
+    val labels: Vector[String]          = all.map(_.label)
 
-  private[amorfati] val RegionalMarketCount: Int             = RegionalMarketSchema.length
-  private[amorfati] val RegionalMarketLabels: Vector[String] = RegionalMarketSchema.map(_.label)
+  final case class RegionalMarketConfig(
+      market: RegionalMarket,
+      initHpi: PriceIndex,
+      valueShare: Share,
+      mortgageShare: Share,
+      gamma: Coefficient,
+      incomeMultiplier: Multiplier,
+  )
+
+  private[amorfati] val DefaultRegionalMarkets: Vector[RegionalMarketConfig] =
+    Vector(
+      RegionalMarketConfig(RegionalMarket.Warsaw, PriceIndex(230.0), Share(0.25), Share(0.30), Coefficient(0.03), Multiplier(1.35)),
+      RegionalMarketConfig(RegionalMarket.Krakow, PriceIndex(190.0), Share(0.08), Share(0.10), Coefficient(0.04), Multiplier(1.15)),
+      RegionalMarketConfig(RegionalMarket.Wroclaw, PriceIndex(170.0), Share(0.07), Share(0.08), Coefficient(0.04), Multiplier(1.10)),
+      RegionalMarketConfig(RegionalMarket.Gdansk, PriceIndex(175.0), Share(0.08), Share(0.09), Coefficient(0.04), Multiplier(1.12)),
+      RegionalMarketConfig(RegionalMarket.Lodz, PriceIndex(110.0), Share(0.04), Share(0.04), Coefficient(0.06), Multiplier(0.95)),
+      RegionalMarketConfig(RegionalMarket.Poznan, PriceIndex(140.0), Share(0.05), Share(0.06), Coefficient(0.05), Multiplier(1.05)),
+      RegionalMarketConfig(RegionalMarket.RestOfPoland, PriceIndex(100.0), Share(0.43), Share(0.33), Coefficient(0.06), Multiplier(0.82)),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HousingConfig.scala
@@ -93,20 +93,20 @@ case class HousingConfig(
 object HousingConfig:
 
   enum RegionalMarket(val columnPrefix: String, val label: String):
-    case Warsaw        extends RegionalMarket("Waw", "Warsaw")
-    case Krakow        extends RegionalMarket("Krk", "Krakow")
-    case Wroclaw       extends RegionalMarket("Wro", "Wroclaw")
-    case Gdansk        extends RegionalMarket("Gdn", "Gdansk")
-    case Lodz          extends RegionalMarket("Ldz", "Lodz")
-    case Poznan        extends RegionalMarket("Poz", "Poznan")
-    case RestOfPoland  extends RegionalMarket("Rest", "Rest of Poland")
+    case Warsaw       extends RegionalMarket("Waw", "Warsaw")
+    case Krakow       extends RegionalMarket("Krk", "Krakow")
+    case Wroclaw      extends RegionalMarket("Wro", "Wroclaw")
+    case Gdansk       extends RegionalMarket("Gdn", "Gdansk")
+    case Lodz         extends RegionalMarket("Ldz", "Lodz")
+    case Poznan       extends RegionalMarket("Poz", "Poznan")
+    case RestOfPoland extends RegionalMarket("Rest", "Rest of Poland")
 
     def hpiColName: String = s"${columnPrefix}Hpi"
 
   object RegionalMarket:
-    val all: Vector[RegionalMarket]     = values.toVector
-    val count: Int                      = all.length
-    val labels: Vector[String]          = all.map(_.label)
+    val all: Vector[RegionalMarket] = values.toVector
+    val count: Int                  = all.length
+    val labels: Vector[String]      = all.map(_.label)
 
   final case class RegionalMarketConfig(
       market: RegionalMarket,

--- a/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
@@ -83,13 +83,36 @@ case class SimParams private (
     sectorDefs: Vector[SectorDef] = SimParams.DefaultSectorDefs,
     topology: Topology = Topology.Ws,
     gdpRatio: Scalar = SimParams.DefaultGdpRatio, // scaling coefficient — computation boundary, not SFC flow
-)
+):
+  SimParams.validateSectorSchema(sectorDefs)
 
 object SimParams:
 
   // ── Sector definitions (6-sector Polish economy, GUS 2024) ──
 
   import com.boombustgroup.amorfati.types.*
+
+  private[amorfati] val SchemaSectorNames: Vector[String] =
+    Vector(
+      "BPO/SSC",
+      "Manufacturing",
+      "Retail/Services",
+      "Healthcare",
+      "Public",
+      "Agriculture",
+    )
+
+  private[amorfati] val SchemaSectorCount: Int = SchemaSectorNames.length
+
+  private[amorfati] def validateSectorSchema(sectorDefs: Vector[SectorDef]): Unit =
+    require(
+      sectorDefs.length == SchemaSectorCount,
+      s"sectorDefs must have $SchemaSectorCount schema sectors in order ${SchemaSectorNames.mkString(" -> ")}, got ${sectorDefs.length}",
+    )
+    require(
+      sectorDefs.map(_.name) == SchemaSectorNames,
+      s"sectorDefs must preserve schema order ${SchemaSectorNames.mkString(" -> ")}, got ${sectorDefs.map(_.name).mkString(" -> ")}",
+    )
 
   /** Default 6-sector definitions calibrated to GUS 2024.
     *

--- a/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala
@@ -29,8 +29,8 @@ case class SectorDef(
   * economy.
   *
   * Hierarchical, immutable, and testable configuration threaded via Scala 3
-  * `using` context parameters. Constructor is private — use
-  * `SimParams.defaults`.
+  * `using` context parameters. Constructor remains package-scoped for config
+  * tests; production code should use `SimParams.defaults`.
   *
   * Sub-configs are grouped by economic domain:
   *   - `pop` — simulation structure
@@ -49,8 +49,7 @@ case class SectorDef(
   * Polish GDP (~3.5 bln PLN). Do NOT construct SimParams directly with unscaled
   * values — always start from `defaults` and use `.copy()`.
   */
-@annotation.nowarn("msg=unused private member") // Scala 3.8 false positive: defaults used via copy()
-case class SimParams private (
+case class SimParams private[config] (
     pop: PopulationConfig = PopulationConfig(),
     firm: FirmConfig = FirmConfig(),
     household: HouseholdConfig = HouseholdConfig(),
@@ -92,17 +91,20 @@ object SimParams:
 
   import com.boombustgroup.amorfati.types.*
 
-  private[amorfati] val SchemaSectorNames: Vector[String] =
+  private[amorfati] final case class SchemaSector(name: String, outputStem: String)
+
+  private[amorfati] val SchemaSectors: Vector[SchemaSector] =
     Vector(
-      "BPO/SSC",
-      "Manufacturing",
-      "Retail/Services",
-      "Healthcare",
-      "Public",
-      "Agriculture",
+      SchemaSector("BPO/SSC", "BPO"),
+      SchemaSector("Manufacturing", "Manuf"),
+      SchemaSector("Retail/Services", "Retail"),
+      SchemaSector("Healthcare", "Health"),
+      SchemaSector("Public", "Public"),
+      SchemaSector("Agriculture", "Agri"),
     )
 
-  private[amorfati] val SchemaSectorCount: Int = SchemaSectorNames.length
+  private[amorfati] val SchemaSectorNames: Vector[String] = SchemaSectors.map(_.name)
+  private[amorfati] val SchemaSectorCount: Int            = SchemaSectors.length
 
   private[amorfati] def validateSectorSchema(sectorDefs: Vector[SectorDef]): Unit =
     require(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -26,6 +26,7 @@ object HousingMarket:
   val NRegions = HousingConfig.RegionalMarket.count
 
   case class RegionalState(
+      market: HousingConfig.RegionalMarket,
       priceIndex: PriceIndex,
       totalValue: PLN,
       mortgageStock: PLN,
@@ -54,6 +55,15 @@ object HousingMarket:
         rs.length == NRegions,
         s"HousingMarket.State.regions must have $NRegions entries in order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${rs.length}",
       )
+      val regionMarkets = rs.map(_.market)
+      require(
+        regionMarkets.distinct.length == rs.length,
+        s"HousingMarket.State.regions must contain unique markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
+      )
+      require(
+        regionMarkets.toSet == HousingConfig.RegionalMarket.all.toSet,
+        s"HousingMarket.State.regions must cover markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
+      )
 
   case class MortgageFlows(
       interest: PLN,
@@ -72,6 +82,9 @@ object HousingMarket:
   )
 
   private case class PriceUpdate(value: PLN, hpi: PriceIndex, monthlyReturn: Rate)
+
+  private def regionsByMarket(regs: Vector[RegionalState]): Map[HousingConfig.RegionalMarket, RegionalState] =
+    regs.iterator.map(region => region.market -> region).toMap
 
   def zero: State = State(
     priceIndex = PriceIndex.Zero,
@@ -105,11 +118,12 @@ object HousingMarket:
     )
 
   private def initRegions(using p: SimParams): Vector[RegionalState] =
-    p.housing.regionalMarkets.map: market =>
+    p.housing.regionalMarkets.map: marketConfig =>
       RegionalState(
-        priceIndex = market.initHpi,
-        totalValue = p.housing.initValue * market.valueShare,
-        mortgageStock = p.housing.initMortgage * market.mortgageShare,
+        market = marketConfig.market,
+        priceIndex = marketConfig.initHpi,
+        totalValue = p.housing.initValue * marketConfig.valueShare,
+        mortgageStock = p.housing.initMortgage * marketConfig.mortgageShare,
         lastOrigination = PLN.Zero,
         lastRepayment = PLN.Zero,
         lastDefault = PLN.Zero,
@@ -127,13 +141,13 @@ object HousingMarket:
       regs: Vector[RegionalState],
       rateChange: Rate,
   )(using p: SimParams): State =
-    val updatedRegions = regs
-      .zip(p.housing.regionalMarkets)
-      .map: (reg, market) =>
-        val gamma          = market.gamma
-        val regionalGrowth = in.incomeGrowth * market.incomeMultiplier
-        val update         = meenPriceUpdate(reg.totalValue, reg.priceIndex, gamma, regionalGrowth, rateChange, in.mortgageRate)
-        reg.copy(priceIndex = update.hpi, totalValue = update.value, monthlyReturn = update.monthlyReturn)
+    val priorRegionsByMarket = regionsByMarket(regs)
+    val updatedRegions       = p.housing.regionalMarkets.map: marketConfig =>
+      val reg            = priorRegionsByMarket(marketConfig.market)
+      val gamma          = marketConfig.gamma
+      val regionalGrowth = in.incomeGrowth * marketConfig.incomeMultiplier
+      val update         = meenPriceUpdate(reg.totalValue, reg.priceIndex, gamma, regionalGrowth, rateChange, in.mortgageRate)
+      reg.copy(priceIndex = update.hpi, totalValue = update.value, monthlyReturn = update.monthlyReturn)
     aggregateFromRegions(in.prev, updatedRegions, in.mortgageRate)
 
   private def stepAggregate(in: StepInput, rateChange: Rate)(using p: SimParams): State =
@@ -157,17 +171,16 @@ object HousingMarket:
       regions: Vector[RegionalState],
       mortgageRate: Rate,
   )(using p: SimParams): State =
-    val aggValue  = sumPln(regions.map(_.totalValue))
-    val aggHpi    =
+    val aggValue            = sumPln(regions.map(_.totalValue))
+    val valueSharesByMarket = p.housing.regionalMarkets.iterator.map(marketConfig => marketConfig.market -> marketConfig.valueShare).toMap
+    val aggHpi              =
       if aggValue > PLN.Zero then
         regions
-          .zip(p.housing.regionalMarkets)
-          .foldLeft(Multiplier.Zero): (acc, regMarket) =>
-            val (reg, market) = regMarket
-            acc + (market.valueShare * reg.priceIndex.toMultiplier)
+          .foldLeft(Multiplier.Zero): (acc, reg) =>
+            acc + (valueSharesByMarket(reg.market) * reg.priceIndex.toMultiplier)
           .toPriceIndex
       else prev.priceIndex
-    val aggReturn =
+    val aggReturn           =
       if prev.priceIndex > PriceIndex.Zero then aggHpi.ratioTo(prev.priceIndex).toMultiplier.deviationFromOne.toRate
       else Rate.Zero
     prev.copy(
@@ -249,18 +262,23 @@ object HousingMarket:
       regs: Vector[RegionalState],
       origination: PLN,
   )(using p: SimParams): State =
-    val distributed         = Distribute.distribute(origination.distributeRaw, p.housing.regionalMarkets.map(_.valueShare.distributeRaw).toArray)
-    val updatedRegions      = regs
+    val distributed          = Distribute.distribute(origination.distributeRaw, p.housing.regionalMarkets.map(_.valueShare.distributeRaw).toArray)
+    val priorRegionsByMarket = regionsByMarket(regs)
+    val allocatedByMarket    = p.housing.regionalMarkets.iterator
       .zip(distributed.iterator)
-      .map: (reg, allocatedRaw) =>
-        val regionalRaw      = PLN.fromRaw(allocatedRaw)
-        val regionalHeadroom = (reg.totalValue * p.housing.ltvMax - reg.mortgageStock).max(PLN.Zero)
-        val regionalOrig     = regionalRaw.min(regionalHeadroom)
-        reg.copy(
-          mortgageStock = reg.mortgageStock + regionalOrig,
-          lastOrigination = regionalOrig,
-        )
-    val realizedOrigination = updatedRegions.foldLeft(PLN.Zero)(_ + _.lastOrigination)
+      .map: (marketConfig, allocatedRaw) =>
+        marketConfig.market -> PLN.fromRaw(allocatedRaw)
+      .toMap
+    val updatedRegions       = p.housing.regionalMarkets.map: marketConfig =>
+      val reg              = priorRegionsByMarket(marketConfig.market)
+      val regionalRaw      = allocatedByMarket(marketConfig.market)
+      val regionalHeadroom = (reg.totalValue * p.housing.ltvMax - reg.mortgageStock).max(PLN.Zero)
+      val regionalOrig     = regionalRaw.min(regionalHeadroom)
+      reg.copy(
+        mortgageStock = reg.mortgageStock + regionalOrig,
+        lastOrigination = regionalOrig,
+      )
+    val realizedOrigination  = updatedRegions.foldLeft(PLN.Zero)(_ + _.lastOrigination)
     prev.copy(
       mortgageStock = prev.mortgageStock + realizedOrigination,
       lastOrigination = realizedOrigination,
@@ -308,16 +326,21 @@ object HousingMarket:
       val weights         = regs.map(_.mortgageStock.distributeRaw).toArray
       val distributedPrin = Distribute.distribute(flows.principal.distributeRaw, weights)
       val distributedDef  = Distribute.distribute(flows.defaultAmount.distributeRaw, weights)
-      regs.zip(distributedPrin.iterator).zip(distributedDef.iterator).map { case ((reg, principalRaw), defaultRaw) =>
-        val rPrincipal = PLN.fromRaw(principalRaw)
-        val rDefault   = PLN.fromRaw(defaultRaw)
-        val rStock     = (reg.mortgageStock - rPrincipal - rDefault).max(PLN.Zero)
-        reg.copy(
-          mortgageStock = rStock,
-          lastRepayment = rPrincipal,
-          lastDefault = rDefault,
-        )
-      }
+      val updatedByMarket = regs
+        .zip(distributedPrin.iterator)
+        .zip(distributedDef.iterator)
+        .map { case ((reg, principalRaw), defaultRaw) =>
+          val rPrincipal = PLN.fromRaw(principalRaw)
+          val rDefault   = PLN.fromRaw(defaultRaw)
+          val rStock     = (reg.mortgageStock - rPrincipal - rDefault).max(PLN.Zero)
+          reg.market -> reg.copy(
+            mortgageStock = rStock,
+            lastRepayment = rPrincipal,
+            lastDefault = rDefault,
+          )
+        }
+        .toMap
+      HousingConfig.RegionalMarket.all.map(updatedByMarket)
 
   private def sumPln(values: Vector[PLN]): PLN =
     values.foldLeft(PLN.Zero)(_ + _)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -53,16 +53,16 @@ object HousingMarket:
     regions.foreach: rs =>
       require(
         rs.length == NRegions,
-        s"HousingMarket.State.regions must have $NRegions entries in order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${rs.length}",
+        s"HousingMarket.State.regions must contain $NRegions entries covering markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${rs.length}",
       )
       val regionMarkets = rs.map(_.market)
       require(
         regionMarkets.distinct.length == rs.length,
-        s"HousingMarket.State.regions must contain unique markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
+        s"HousingMarket.State.regions must contain unique markets covering ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
       )
       require(
         regionMarkets.toSet == HousingConfig.RegionalMarket.all.toSet,
-        s"HousingMarket.State.regions must cover markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
+        s"HousingMarket.State.regions must cover all markets ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${regionMarkets.map(_.label).mkString(" -> ")}",
       )
 
   case class MortgageFlows(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -23,7 +23,7 @@ object HousingMarket:
 
   private val MinHousingValueForIncomeRatio = PLN.fromLong(1000)
 
-  val NRegions = HousingConfig.RegionalMarketCount
+  val NRegions = HousingConfig.RegionalMarket.count
 
   case class RegionalState(
       priceIndex: PriceIndex,
@@ -52,7 +52,7 @@ object HousingMarket:
     regions.foreach: rs =>
       require(
         rs.length == NRegions,
-        s"HousingMarket.State.regions must have $NRegions entries in order ${HousingConfig.RegionalMarketLabels.mkString(" -> ")}, got ${rs.length}",
+        s"HousingMarket.State.regions must have $NRegions entries in order ${HousingConfig.RegionalMarket.labels.mkString(" -> ")}, got ${rs.length}",
       )
 
   case class MortgageFlows(
@@ -105,18 +105,16 @@ object HousingMarket:
     )
 
   private def initRegions(using p: SimParams): Vector[RegionalState] =
-    (0 until NRegions)
-      .map: r =>
+    p.housing.regionalMarkets.map: market =>
         RegionalState(
-          priceIndex = p.housing.regionalHpi(r),
-          totalValue = p.housing.initValue * p.housing.regionalValueShares(r),
-          mortgageStock = p.housing.initMortgage * p.housing.regionalMortgageShares(r),
+          priceIndex = market.initHpi,
+          totalValue = p.housing.initValue * market.valueShare,
+          mortgageStock = p.housing.initMortgage * market.mortgageShare,
           lastOrigination = PLN.Zero,
           lastRepayment = PLN.Zero,
           lastDefault = PLN.Zero,
           monthlyReturn = Rate.Zero,
         )
-      .toVector
 
   def step(in: StepInput)(using p: SimParams): State =
     val rateChange = in.mortgageRate - in.prevMortgageRate
@@ -129,9 +127,9 @@ object HousingMarket:
       regs: Vector[RegionalState],
       rateChange: Rate,
   )(using p: SimParams): State =
-    val updatedRegions = regs.zipWithIndex.map: (reg, r) =>
-      val gamma          = p.housing.regionalGammas(r)
-      val regionalGrowth = in.incomeGrowth * p.housing.regionalIncomeMult(r)
+    val updatedRegions = regs.zip(p.housing.regionalMarkets).map: (reg, market) =>
+      val gamma          = market.gamma
+      val regionalGrowth = in.incomeGrowth * market.incomeMultiplier
       val update         = meenPriceUpdate(reg.totalValue, reg.priceIndex, gamma, regionalGrowth, rateChange, in.mortgageRate)
       reg.copy(priceIndex = update.hpi, totalValue = update.value, monthlyReturn = update.monthlyReturn)
     aggregateFromRegions(in.prev, updatedRegions, in.mortgageRate)
@@ -160,10 +158,10 @@ object HousingMarket:
     val aggValue  = sumPln(regions.map(_.totalValue))
     val aggHpi    =
       if aggValue > PLN.Zero then
-        regions.zipWithIndex
-          .foldLeft(Multiplier.Zero): (acc, regR) =>
-            val (reg, r) = regR
-            acc + (p.housing.regionalValueShares(r) * reg.priceIndex.toMultiplier)
+        regions.zip(p.housing.regionalMarkets)
+          .foldLeft(Multiplier.Zero): (acc, regMarket) =>
+            val (reg, market) = regMarket
+            acc + (market.valueShare * reg.priceIndex.toMultiplier)
           .toPriceIndex
       else prev.priceIndex
     val aggReturn =
@@ -248,7 +246,7 @@ object HousingMarket:
       regs: Vector[RegionalState],
       origination: PLN,
   )(using p: SimParams): State =
-    val distributed         = Distribute.distribute(origination.distributeRaw, p.housing.regionalValueShares.map(_.distributeRaw).toArray)
+    val distributed         = Distribute.distribute(origination.distributeRaw, p.housing.regionalMarkets.map(_.valueShare.distributeRaw).toArray)
     val updatedRegions      = regs
       .zip(distributed.iterator)
       .map: (reg, allocatedRaw) =>

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.markets
 
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.Distribute
 
@@ -23,7 +23,7 @@ object HousingMarket:
 
   private val MinHousingValueForIncomeRatio = PLN.fromLong(1000)
 
-  val NRegions = 7
+  val NRegions = HousingConfig.RegionalMarketCount
 
   case class RegionalState(
       priceIndex: PriceIndex,
@@ -48,7 +48,12 @@ object HousingMarket:
       monthlyReturn: Rate,
       mortgageInterestIncome: PLN,
       regions: Option[Vector[RegionalState]] = None,
-  )
+  ):
+    regions.foreach: rs =>
+      require(
+        rs.length == NRegions,
+        s"HousingMarket.State.regions must have $NRegions entries in order ${HousingConfig.RegionalMarketLabels.mkString(" -> ")}, got ${rs.length}",
+      )
 
   case class MortgageFlows(
       interest: PLN,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -106,15 +106,15 @@ object HousingMarket:
 
   private def initRegions(using p: SimParams): Vector[RegionalState] =
     p.housing.regionalMarkets.map: market =>
-        RegionalState(
-          priceIndex = market.initHpi,
-          totalValue = p.housing.initValue * market.valueShare,
-          mortgageStock = p.housing.initMortgage * market.mortgageShare,
-          lastOrigination = PLN.Zero,
-          lastRepayment = PLN.Zero,
-          lastDefault = PLN.Zero,
-          monthlyReturn = Rate.Zero,
-        )
+      RegionalState(
+        priceIndex = market.initHpi,
+        totalValue = p.housing.initValue * market.valueShare,
+        mortgageStock = p.housing.initMortgage * market.mortgageShare,
+        lastOrigination = PLN.Zero,
+        lastRepayment = PLN.Zero,
+        lastDefault = PLN.Zero,
+        monthlyReturn = Rate.Zero,
+      )
 
   def step(in: StepInput)(using p: SimParams): State =
     val rateChange = in.mortgageRate - in.prevMortgageRate
@@ -127,11 +127,13 @@ object HousingMarket:
       regs: Vector[RegionalState],
       rateChange: Rate,
   )(using p: SimParams): State =
-    val updatedRegions = regs.zip(p.housing.regionalMarkets).map: (reg, market) =>
-      val gamma          = market.gamma
-      val regionalGrowth = in.incomeGrowth * market.incomeMultiplier
-      val update         = meenPriceUpdate(reg.totalValue, reg.priceIndex, gamma, regionalGrowth, rateChange, in.mortgageRate)
-      reg.copy(priceIndex = update.hpi, totalValue = update.value, monthlyReturn = update.monthlyReturn)
+    val updatedRegions = regs
+      .zip(p.housing.regionalMarkets)
+      .map: (reg, market) =>
+        val gamma          = market.gamma
+        val regionalGrowth = in.incomeGrowth * market.incomeMultiplier
+        val update         = meenPriceUpdate(reg.totalValue, reg.priceIndex, gamma, regionalGrowth, rateChange, in.mortgageRate)
+        reg.copy(priceIndex = update.hpi, totalValue = update.value, monthlyReturn = update.monthlyReturn)
     aggregateFromRegions(in.prev, updatedRegions, in.mortgageRate)
 
   private def stepAggregate(in: StepInput, rateChange: Rate)(using p: SimParams): State =
@@ -158,7 +160,8 @@ object HousingMarket:
     val aggValue  = sumPln(regions.map(_.totalValue))
     val aggHpi    =
       if aggValue > PLN.Zero then
-        regions.zip(p.housing.regionalMarkets)
+        regions
+          .zip(p.housing.regionalMarkets)
           .foldLeft(Multiplier.Zero): (acc, regMarket) =>
             val (reg, market) = regMarket
             acc + (market.valueShare * reg.priceIndex.toMultiplier)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -6,12 +6,12 @@ schema, summary statistics, and CSV I/O. It is the only consumer of
 
 ## Files
 
-| File | Object | Role |
-|------|--------|------|
-| `McRunner.scala` | `McRunner` | MC loop: runs N seeds, collects results, writes CSV, prints summary |
-| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId` |
-| `SimOutput.scala` | `SimOutput` | 197-column output schema — typed `Col` definitions, `compute` function |
-| `McTypes.scala` | `RunResult`, `TimeSeries`, `DescriptiveStats`, `McResults` | Zero-cost typed wrappers for simulation output and summary statistics |
+| File | Object | Role                                                                                                       |
+|------|--------|------------------------------------------------------------------------------------------------------------|
+| `McRunner.scala` | `McRunner` | MC loop: runs N seeds, collects results, writes CSV, prints summary                                        |
+| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId`                       |
+| `SimOutput.scala` | `SimOutput` | 239-column output schema with explicit sector/region contracts — typed `Col` definitions, `compute` function |
+| `McTypes.scala` | `RunResult`, `TimeSeries`, `DescriptiveStats`, `McResults` | Zero-cost typed wrappers for simulation output and summary statistics                                      |
 
 ## Data flow
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -63,15 +63,15 @@ object SimOutput:
       s"SimOutput requires world.currentSigmas to have ${p.sectorDefs.length} entries to match sectorDefs, got ${world.currentSigmas.length}",
     )
 
-    given SimParams                                          = p
-    private val sectorIndexByName: Map[String, Int]          = p.sectorDefs.iterator.map(_.name).zipWithIndex.map((name, idx) => name -> idx).toMap
-    lazy val bankAgg: Banking.Aggregate                      = Banking.aggregateFromBanks(banks)
-    lazy val hhAgg: Household.Aggregates                     = householdAggregates
-    lazy val monetaryAgg: Option[Banking.MonetaryAggregates] = Some(
+    given SimParams                                                                                 = p
+    private val sectorIndexByName: Map[String, Int]                                                 = p.sectorDefs.iterator.map(_.name).zipWithIndex.map((name, idx) => name -> idx).toMap
+    lazy val bankAgg: Banking.Aggregate                                                             = Banking.aggregateFromBanks(banks)
+    lazy val hhAgg: Household.Aggregates                                                            = householdAggregates
+    lazy val monetaryAgg: Option[Banking.MonetaryAggregates]                                        = Some(
       Banking.MonetaryAggregates.compute(banks, world.financial.nbfi.tfiAum, world.financial.corporateBonds.outstanding),
     )
-    lazy val monthlyGdp: PLN                                 = world.cachedMonthlyGdpProxy
-    lazy val sectorAuto: Vector[Double]                      = sectorColumns.map { sector =>
+    lazy val monthlyGdp: PLN                                                                        = world.cachedMonthlyGdpProxy
+    lazy val sectorAuto: Vector[Double]                                                             = sectorColumns.map { sector =>
       val sectorIdx = sectorIndexByName(sector.expectedSectorName)
       val secFirms  = living.filter(_.sector.toInt == sectorIdx)
       if secFirms.isEmpty then 0.0
@@ -85,7 +85,7 @@ object SimOutput:
         .map(_.zip(HousingConfig.RegionalMarket.all).map((state, market) => market -> state).toMap)
         .getOrElse(Map.empty)
 
-    def sectorSigma(idx: Int): Double      = td.toDouble(world.currentSigmas(idx))
+    def sectorSigma(idx: Int): Double                                  = td.toDouble(world.currentSigmas(idx))
     def housingRegionHpi(market: HousingConfig.RegionalMarket): Double =
       housingRegionsByMarket.get(market).map(regionState => td.toDouble(regionState.priceIndex)).getOrElse(0.0)
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.engine.markets.HousingMarket
 import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
 import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
@@ -24,15 +25,18 @@ object SimOutput:
     def autoColName: String  = s"${columnStem}_Auto"
     def sigmaColName: String = s"${columnStem}_Sigma"
 
-  private val sectorColumnStems: Vector[String] = Vector("BPO", "Manuf", "Retail", "Health", "Public", "Agri")
+  private val sectorSchemaPairs: Vector[(String, String)] =
+    SimParams.SchemaSectors.map(schemaSector => schemaSector.name -> schemaSector.outputStem)
 
   require(
-    sectorColumnStems.length == SimParams.SchemaSectorCount,
-    s"SimOutput sector schema must define ${SimParams.SchemaSectorCount} column stems, got ${sectorColumnStems.length}",
+    sectorSchemaPairs.length == SimParams.SchemaSectorCount &&
+      sectorSchemaPairs.map(_._1) == SimParams.SchemaSectorNames &&
+      sectorSchemaPairs.map(_._2).distinct.length == sectorSchemaPairs.length,
+    s"SimOutput sector schema must define ${SimParams.SchemaSectorCount} unique (name, stem) pairs, got ${sectorSchemaPairs.mkString(", ")}",
   )
 
   private val sectorColumns: Vector[SectorColumns] =
-    SimParams.SchemaSectorNames.zip(sectorColumnStems).map((sectorName, columnStem) => SectorColumns(sectorName, columnStem))
+    SimParams.SchemaSectors.map(schemaSector => SectorColumns(schemaSector.name, schemaSector.outputStem))
 
   // -------------------------------------------------------------------------
   //  ColumnDef + Ctx
@@ -76,9 +80,14 @@ object SimOutput:
           .count(f => f.tech.isInstanceOf[TechState.Automated] || f.tech.isInstanceOf[TechState.Hybrid])
           .toDouble / secFirms.length
     }
+    lazy val housingRegionsByMarket: Map[HousingConfig.RegionalMarket, HousingMarket.RegionalState] =
+      world.real.housing.regions
+        .map(_.zip(HousingConfig.RegionalMarket.all).map((state, market) => market -> state).toMap)
+        .getOrElse(Map.empty)
 
     def sectorSigma(idx: Int): Double      = td.toDouble(world.currentSigmas(idx))
-    def housingRegionHpi(idx: Int): Double = world.real.housing.regions.map(rs => td.toDouble(rs(idx).priceIndex)).getOrElse(0.0)
+    def housingRegionHpi(market: HousingConfig.RegionalMarket): Double =
+      housingRegionsByMarket.get(market).map(regionState => td.toDouble(regionState.priceIndex)).getOrElse(0.0)
 
     inline def unemployPct: Double = td.toDouble(world.unemploymentRate(hhAgg.employed))
 
@@ -353,8 +362,8 @@ object SimOutput:
   )
 
   private def realGroup: Vector[ColumnDef] =
-    val regionalHousingColumns = HousingConfig.RegionalMarketSchema.zipWithIndex.map: (region, idx) =>
-      ColumnDef(region.hpiColName, ctx => ctx.housingRegionHpi(idx))
+    val regionalHousingColumns = HousingConfig.RegionalMarket.all.map: market =>
+      ColumnDef(market.hpiColName, ctx => ctx.housingRegionHpi(market))
 
     (Vector(
       // Housing Market

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.agents.*
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
@@ -19,6 +19,20 @@ object SimOutput:
   private val td                                          = ComputationBoundary
   private def exchangeRateValue(er: ExchangeRate): Double = er.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
   private def priceIndexValue(pi: PriceIndex): Double     = pi.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
+
+  private case class SectorColumns(expectedSectorName: String, columnStem: String):
+    def autoColName: String  = s"${columnStem}_Auto"
+    def sigmaColName: String = s"${columnStem}_Sigma"
+
+  private val sectorColumnStems: Vector[String] = Vector("BPO", "Manuf", "Retail", "Health", "Public", "Agri")
+
+  require(
+    sectorColumnStems.length == SimParams.SchemaSectorCount,
+    s"SimOutput sector schema must define ${SimParams.SchemaSectorCount} column stems, got ${sectorColumnStems.length}",
+  )
+
+  private val sectorColumns: Vector[SectorColumns] =
+    SimParams.SchemaSectorNames.zip(sectorColumnStems).map((sectorName, columnStem) => SectorColumns(sectorName, columnStem))
 
   // -------------------------------------------------------------------------
   //  ColumnDef + Ctx
@@ -40,21 +54,31 @@ object SimOutput:
       val aliveBanks: Vector[Banking.BankState],
       val p: SimParams,
   ):
+    require(
+      world.currentSigmas.length == p.sectorDefs.length,
+      s"SimOutput requires world.currentSigmas to have ${p.sectorDefs.length} entries to match sectorDefs, got ${world.currentSigmas.length}",
+    )
+
     given SimParams                                          = p
+    private val sectorIndexByName: Map[String, Int]          = p.sectorDefs.iterator.map(_.name).zipWithIndex.map((name, idx) => name -> idx).toMap
     lazy val bankAgg: Banking.Aggregate                      = Banking.aggregateFromBanks(banks)
     lazy val hhAgg: Household.Aggregates                     = householdAggregates
     lazy val monetaryAgg: Option[Banking.MonetaryAggregates] = Some(
       Banking.MonetaryAggregates.compute(banks, world.financial.nbfi.tfiAum, world.financial.corporateBonds.outstanding),
     )
     lazy val monthlyGdp: PLN                                 = world.cachedMonthlyGdpProxy
-    lazy val sectorAuto: IndexedSeq[Double]                  = p.sectorDefs.indices.map { s =>
-      val secFirms = living.filter(_.sector.toInt == s)
+    lazy val sectorAuto: Vector[Double]                      = sectorColumns.map { sector =>
+      val sectorIdx = sectorIndexByName(sector.expectedSectorName)
+      val secFirms  = living.filter(_.sector.toInt == sectorIdx)
       if secFirms.isEmpty then 0.0
       else
         secFirms
           .count(f => f.tech.isInstanceOf[TechState.Automated] || f.tech.isInstanceOf[TechState.Hybrid])
           .toDouble / secFirms.length
     }
+
+    def sectorSigma(idx: Int): Double      = td.toDouble(world.currentSigmas(idx))
+    def housingRegionHpi(idx: Int): Double = world.real.housing.regions.map(rs => td.toDouble(rs(idx).priceIndex)).getOrElse(0.0)
 
     inline def unemployPct: Double = td.toDouble(world.unemploymentRate(hhAgg.employed))
 
@@ -97,28 +121,20 @@ object SimOutput:
     ColumnDef("HybridRatio", ctx => td.toDouble(ctx.world.real.hybridRatio)),
   )
 
-  private def sectoralGroup: Vector[ColumnDef] = Vector(
-    // per-sector automation ratios
-    ColumnDef("BPO_Auto", ctx => ctx.sectorAuto(0)),
-    ColumnDef("Manuf_Auto", ctx => ctx.sectorAuto(1)),
-    ColumnDef("Retail_Auto", ctx => ctx.sectorAuto(2)),
-    ColumnDef("Health_Auto", ctx => ctx.sectorAuto(3)),
-    ColumnDef("Public_Auto", ctx => ctx.sectorAuto(4)),
-    ColumnDef("Agri_Auto", ctx => ctx.sectorAuto(5)),
-    // per-sector current sigma
-    ColumnDef("BPO_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(0))),
-    ColumnDef("Manuf_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(1))),
-    ColumnDef("Retail_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(2))),
-    ColumnDef("Health_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(3))),
-    ColumnDef("Public_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(4))),
-    ColumnDef("Agri_Sigma", ctx => td.toDouble(ctx.world.currentSigmas(5))),
-    ColumnDef("MeanDegree", ctx => ctx.firms.map(_.neighbors.length.toDouble).sum / ctx.firms.length),
-    ColumnDef("IoFlows", ctx => td.toDouble(ctx.world.flows.ioFlows)),
-    ColumnDef(
-      "IoGdpRatio",
-      ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.ioFlows) / td.toDouble(ctx.monthlyGdp) else 0.0,
-    ),
-  )
+  private def sectoralGroup: Vector[ColumnDef] =
+    val autoColumns  = sectorColumns.zipWithIndex.map: (sector, idx) =>
+      ColumnDef(sector.autoColName, ctx => ctx.sectorAuto(idx))
+    val sigmaColumns = sectorColumns.zipWithIndex.map: (sector, idx) =>
+      ColumnDef(sector.sigmaColName, ctx => ctx.sectorSigma(idx))
+
+    (autoColumns ++ sigmaColumns ++ Vector(
+      ColumnDef("MeanDegree", ctx => ctx.firms.map(_.neighbors.length.toDouble).sum / ctx.firms.length),
+      ColumnDef("IoFlows", ctx => td.toDouble(ctx.world.flows.ioFlows)),
+      ColumnDef(
+        "IoGdpRatio",
+        ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.ioFlows) / td.toDouble(ctx.monthlyGdp) else 0.0,
+      ),
+    )).toVector
 
   private def externalGroup: Vector[ColumnDef] = Vector(
     ColumnDef("NFA", ctx => td.toDouble(ctx.world.bop.nfa)),
@@ -336,65 +352,65 @@ object SimOutput:
     ColumnDef("BailInLoss", ctx => td.toDouble(ctx.world.flows.bailInLoss)),
   )
 
-  private def realGroup: Vector[ColumnDef] = Vector(
-    // Housing Market
-    ColumnDef("HousingPriceIndex", ctx => td.toDouble(ctx.world.real.housing.priceIndex)),
-    ColumnDef("HousingMarketValue", ctx => td.toDouble(ctx.world.real.housing.totalValue)),
-    ColumnDef("MortgageStock", ctx => td.toDouble(ctx.world.real.housing.mortgageStock)),
-    ColumnDef("AvgMortgageRate", ctx => td.toDouble(ctx.world.real.housing.avgMortgageRate)),
-    ColumnDef("MortgageOrigination", ctx => td.toDouble(ctx.world.real.housing.lastOrigination)),
-    ColumnDef("MortgageRepayment", ctx => td.toDouble(ctx.world.real.housing.lastRepayment)),
-    ColumnDef("MortgageDefault", ctx => td.toDouble(ctx.world.real.housing.lastDefault)),
-    ColumnDef("MortgageInterestIncome", ctx => td.toDouble(ctx.world.real.housing.mortgageInterestIncome)),
-    ColumnDef("HhHousingWealth", ctx => td.toDouble(ctx.world.real.housing.hhHousingWealth)),
-    ColumnDef("HousingWealthEffect", ctx => td.toDouble(ctx.world.real.housing.lastWealthEffect)),
-    ColumnDef(
-      "MortgageToGdp",
-      ctx =>
-        if ctx.monthlyGdp > PLN.Zero && ctx.world.real.housing.mortgageStock > PLN.Zero
-        then td.toDouble(ctx.world.real.housing.mortgageStock) / (td.toDouble(ctx.monthlyGdp) * 12.0)
-        else 0.0,
-    ),
-    // Regional Housing Market
-    ColumnDef("WawHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(0).priceIndex)).getOrElse(0.0)),
-    ColumnDef("KrkHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(1).priceIndex)).getOrElse(0.0)),
-    ColumnDef("WroHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(2).priceIndex)).getOrElse(0.0)),
-    ColumnDef("GdnHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(3).priceIndex)).getOrElse(0.0)),
-    ColumnDef("LdzHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(4).priceIndex)).getOrElse(0.0)),
-    ColumnDef("PozHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(5).priceIndex)).getOrElse(0.0)),
-    ColumnDef("RestHpi", ctx => ctx.world.real.housing.regions.map(rs => td.toDouble(rs(6).priceIndex)).getOrElse(0.0)),
-    // Sectoral Labor Mobility
-    ColumnDef("SectorMobilityRate", ctx => td.toDouble(ctx.world.real.sectoralMobility.sectorMobilityRate)),
-    ColumnDef("CrossSectorHires", ctx => ctx.world.real.sectoralMobility.crossSectorHires.toDouble),
-    ColumnDef("VoluntaryQuits", ctx => ctx.world.real.sectoralMobility.voluntaryQuits.toDouble),
-    // Physical Capital
-    ColumnDef("AggCapitalStock", ctx => ctx.living.map(f => td.toDouble(f.capitalStock)).sum),
-    ColumnDef("GrossInvestment", ctx => td.toDouble(ctx.world.real.grossInvestment)),
-    ColumnDef("CapitalDepreciation", ctx => ctx.living.map(f => td.toDouble(f.capitalStock) * td.toDouble(ctx.p.capital.depRates(f.sector.toInt).monthly)).sum),
-    // Inventories
-    ColumnDef("AggInventoryStock", ctx => td.toDouble(ctx.world.flows.aggInventoryStock)),
-    ColumnDef("InventoryChange", ctx => td.toDouble(ctx.world.flows.aggInventoryChange)),
-    ColumnDef(
-      "InventoryToGdp",
-      ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.aggInventoryStock) / td.toDouble(ctx.monthlyGdp) else 0.0,
-    ),
-    // Energy / Climate
-    ColumnDef("AggEnergyCost", ctx => td.toDouble(ctx.world.flows.aggEnergyCost)),
-    ColumnDef(
-      "EnergyCostToGdp",
-      ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.aggEnergyCost) / td.toDouble(ctx.monthlyGdp) else 0.0,
-    ),
-    ColumnDef("EtsPrice", ctx => ctx.world.real.etsPrice),
-    ColumnDef("AggGreenCapital", ctx => td.toDouble(ctx.world.real.aggGreenCapital)),
-    ColumnDef("GreenInvestment", ctx => td.toDouble(ctx.world.real.aggGreenInvestment)),
-    ColumnDef(
-      "GreenCapitalRatio",
-      ctx => {
-        val aggK = ctx.living.map(f => td.toDouble(f.capitalStock)).sum
-        if ctx.world.real.aggGreenCapital > PLN.Zero && aggK > 0 then td.toDouble(ctx.world.real.aggGreenCapital) / aggK else 0.0
-      },
-    ),
-  )
+  private def realGroup: Vector[ColumnDef] =
+    val regionalHousingColumns = HousingConfig.RegionalMarketSchema.zipWithIndex.map: (region, idx) =>
+      ColumnDef(region.hpiColName, ctx => ctx.housingRegionHpi(idx))
+
+    (Vector(
+      // Housing Market
+      ColumnDef("HousingPriceIndex", ctx => td.toDouble(ctx.world.real.housing.priceIndex)),
+      ColumnDef("HousingMarketValue", ctx => td.toDouble(ctx.world.real.housing.totalValue)),
+      ColumnDef("MortgageStock", ctx => td.toDouble(ctx.world.real.housing.mortgageStock)),
+      ColumnDef("AvgMortgageRate", ctx => td.toDouble(ctx.world.real.housing.avgMortgageRate)),
+      ColumnDef("MortgageOrigination", ctx => td.toDouble(ctx.world.real.housing.lastOrigination)),
+      ColumnDef("MortgageRepayment", ctx => td.toDouble(ctx.world.real.housing.lastRepayment)),
+      ColumnDef("MortgageDefault", ctx => td.toDouble(ctx.world.real.housing.lastDefault)),
+      ColumnDef("MortgageInterestIncome", ctx => td.toDouble(ctx.world.real.housing.mortgageInterestIncome)),
+      ColumnDef("HhHousingWealth", ctx => td.toDouble(ctx.world.real.housing.hhHousingWealth)),
+      ColumnDef("HousingWealthEffect", ctx => td.toDouble(ctx.world.real.housing.lastWealthEffect)),
+      ColumnDef(
+        "MortgageToGdp",
+        ctx =>
+          if ctx.monthlyGdp > PLN.Zero && ctx.world.real.housing.mortgageStock > PLN.Zero
+          then td.toDouble(ctx.world.real.housing.mortgageStock) / (td.toDouble(ctx.monthlyGdp) * 12.0)
+          else 0.0,
+      ),
+    ) ++ regionalHousingColumns ++ Vector(
+      // Sectoral Labor Mobility
+      ColumnDef("SectorMobilityRate", ctx => td.toDouble(ctx.world.real.sectoralMobility.sectorMobilityRate)),
+      ColumnDef("CrossSectorHires", ctx => ctx.world.real.sectoralMobility.crossSectorHires.toDouble),
+      ColumnDef("VoluntaryQuits", ctx => ctx.world.real.sectoralMobility.voluntaryQuits.toDouble),
+      // Physical Capital
+      ColumnDef("AggCapitalStock", ctx => ctx.living.map(f => td.toDouble(f.capitalStock)).sum),
+      ColumnDef("GrossInvestment", ctx => td.toDouble(ctx.world.real.grossInvestment)),
+      ColumnDef(
+        "CapitalDepreciation",
+        ctx => ctx.living.map(f => td.toDouble(f.capitalStock) * td.toDouble(ctx.p.capital.depRates(f.sector.toInt).monthly)).sum,
+      ),
+      // Inventories
+      ColumnDef("AggInventoryStock", ctx => td.toDouble(ctx.world.flows.aggInventoryStock)),
+      ColumnDef("InventoryChange", ctx => td.toDouble(ctx.world.flows.aggInventoryChange)),
+      ColumnDef(
+        "InventoryToGdp",
+        ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.aggInventoryStock) / td.toDouble(ctx.monthlyGdp) else 0.0,
+      ),
+      // Energy / Climate
+      ColumnDef("AggEnergyCost", ctx => td.toDouble(ctx.world.flows.aggEnergyCost)),
+      ColumnDef(
+        "EnergyCostToGdp",
+        ctx => if ctx.monthlyGdp > PLN.Zero then td.toDouble(ctx.world.flows.aggEnergyCost) / td.toDouble(ctx.monthlyGdp) else 0.0,
+      ),
+      ColumnDef("EtsPrice", ctx => ctx.world.real.etsPrice),
+      ColumnDef("AggGreenCapital", ctx => td.toDouble(ctx.world.real.aggGreenCapital)),
+      ColumnDef("GreenInvestment", ctx => td.toDouble(ctx.world.real.aggGreenInvestment)),
+      ColumnDef(
+        "GreenCapitalRatio",
+        ctx => {
+          val aggK = ctx.living.map(f => td.toDouble(f.capitalStock)).sum
+          if ctx.world.real.aggGreenCapital > PLN.Zero && aggK > 0 then td.toDouble(ctx.world.real.aggGreenCapital) / aggK else 0.0
+        },
+      ),
+    )).toVector
 
   private def socialGroup: Vector[ColumnDef] = Vector(
     // JST
@@ -579,11 +595,17 @@ object SimOutput:
     val DepositFacilityUsage: Col   = lookup("DepositFacilityUsage")
     val InterbankInterestNet: Col   = lookup("InterbankInterestNet")
 
-    private val sectorAutoNames  = Vector("BPO_Auto", "Manuf_Auto", "Retail_Auto", "Health_Auto", "Public_Auto", "Agri_Auto")
-    private val sectorSigmaNames = Vector("BPO_Sigma", "Manuf_Sigma", "Retail_Sigma", "Health_Sigma", "Public_Sigma", "Agri_Sigma")
+    private val sectorAutoNames  = sectorColumns.map(_.autoColName)
+    private val sectorSigmaNames = sectorColumns.map(_.sigmaColName)
 
-    def sectorAuto(s: Int): Col  = lookup(sectorAutoNames(s))
-    def sectorSigma(s: Int): Col = lookup(sectorSigmaNames(s))
+    private def sectorCol(names: Vector[String], sectorIndex: Int, kind: String): Col =
+      names
+        .lift(sectorIndex)
+        .map(lookup)
+        .getOrElse(throw new IndexOutOfBoundsException(s"$kind sector index must be between 0 and ${names.length - 1}, got $sectorIndex"))
+
+    def sectorAuto(s: Int): Col  = sectorCol(sectorAutoNames, s, "sectorAuto")
+    def sectorSigma(s: Int): Col = sectorCol(sectorSigmaNames, s, "sectorSigma")
 
   extension (c: Col) def ordinal: Int = c
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/SimOutput.scala
@@ -82,7 +82,7 @@ object SimOutput:
     }
     lazy val housingRegionsByMarket: Map[HousingConfig.RegionalMarket, HousingMarket.RegionalState] =
       world.real.housing.regions
-        .map(_.zip(HousingConfig.RegionalMarket.all).map((state, market) => market -> state).toMap)
+        .map(_.iterator.map(state => state.market -> state).toMap)
         .getOrElse(Map.empty)
 
     def sectorSigma(idx: Int): Double                                  = td.toDouble(world.currentSigmas(idx))

--- a/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
@@ -36,7 +36,7 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
 
   it should "reject schema-breaking sector count changes" in {
     val err = intercept[IllegalArgumentException]:
-      SimParams.validateSectorSchema(p.sectorDefs.dropRight(1))
+      p.copy(sectorDefs = p.sectorDefs.dropRight(1))
 
     err.getMessage.should(include("sectorDefs must have 6 schema sectors"))
   }
@@ -44,16 +44,38 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
   it should "reject schema-breaking sector reordering" in {
     val reordered = Vector(p.sectorDefs(1), p.sectorDefs(0)) ++ p.sectorDefs.drop(2)
     val err       = intercept[IllegalArgumentException]:
-      SimParams.validateSectorSchema(reordered)
+      p.copy(sectorDefs = reordered)
 
     err.getMessage.should(include("sectorDefs must preserve schema order"))
   }
 
-  "HousingConfig" should "reject malformed regional vectors" in {
+  "HousingConfig" should "reject malformed regional market vectors" in {
     val err = intercept[IllegalArgumentException]:
-      p.housing.copy(regionalHpi = p.housing.regionalHpi.dropRight(1))
+      p.housing.copy(regionalMarkets = p.housing.regionalMarkets.dropRight(1))
 
-    err.getMessage.should(include("regionalHpi must have 7 regions"))
+    err.getMessage.should(include("regionalMarkets must have 7 regions"))
+  }
+
+  it should "reject regional value shares that do not sum to 1.0" in {
+    val malformed = p.housing.regionalMarkets.updated(
+      0,
+      p.housing.regionalMarkets.head.copy(valueShare = Share(0.20)),
+    )
+    val err       = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalMarkets = malformed)
+
+    err.getMessage.should(include("regionalValueShares must sum to 1.0"))
+  }
+
+  it should "reject regional mortgage shares that do not sum to 1.0" in {
+    val malformed = p.housing.regionalMarkets.updated(
+      0,
+      p.housing.regionalMarkets.head.copy(mortgageShare = Share(0.20)),
+    )
+    val err       = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalMarkets = malformed)
+
+    err.getMessage.should(include("regionalMortgageShares must sum to 1.0"))
   }
 
   "Config" should "have FirmsCount = 10000 by default" in {

--- a/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
@@ -95,7 +95,7 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
     val err       = intercept[IllegalArgumentException]:
       p.housing.copy(regionalMarkets = malformed)
 
-    err.getMessage.should(include("regionalValueShares must sum to 1.0"))
+    err.getMessage.should(include("regionalMarkets value shares must sum to 1.0"))
   }
 
   it should "reject regional mortgage shares that do not sum to 1.0" in {
@@ -106,7 +106,7 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
     val err       = intercept[IllegalArgumentException]:
       p.housing.copy(regionalMarkets = malformed)
 
-    err.getMessage.should(include("regionalMortgageShares must sum to 1.0"))
+    err.getMessage.should(include("regionalMarkets mortgage shares must sum to 1.0"))
   }
 
   "Config" should "have FirmsCount = 10000 by default" in {

--- a/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
@@ -34,6 +34,28 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
     )
   }
 
+  it should "reject schema-breaking sector count changes" in {
+    val err = intercept[IllegalArgumentException]:
+      SimParams.validateSectorSchema(p.sectorDefs.dropRight(1))
+
+    err.getMessage.should(include("sectorDefs must have 6 schema sectors"))
+  }
+
+  it should "reject schema-breaking sector reordering" in {
+    val reordered = Vector(p.sectorDefs(1), p.sectorDefs(0)) ++ p.sectorDefs.drop(2)
+    val err       = intercept[IllegalArgumentException]:
+      SimParams.validateSectorSchema(reordered)
+
+    err.getMessage.should(include("sectorDefs must preserve schema order"))
+  }
+
+  "HousingConfig" should "reject malformed regional vectors" in {
+    val err = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalHpi = p.housing.regionalHpi.dropRight(1))
+
+    err.getMessage.should(include("regionalHpi must have 7 regions"))
+  }
+
   "Config" should "have FirmsCount = 10000 by default" in {
     // Only true when FIRMS_COUNT env var is unset
     if sys.env.get("FIRMS_COUNT").isEmpty then p.pop.firmsCount shouldBe 10000

--- a/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/SimConfigSpec.scala
@@ -56,6 +56,37 @@ class SimConfigSpec extends AnyFlatSpec with Matchers:
     err.getMessage.should(include("regionalMarkets must have 7 regions"))
   }
 
+  it should "reject reordered regional markets" in {
+    val regionalMarkets = p.housing.regionalMarkets
+    val swapped         = regionalMarkets.updated(0, regionalMarkets(1)).updated(1, regionalMarkets(0))
+    val err             = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalMarkets = swapped)
+
+    err.getMessage.should(include("regionalMarkets must preserve region order"))
+  }
+
+  it should "reject out-of-range regional value shares" in {
+    val malformed = p.housing.regionalMarkets.updated(
+      0,
+      p.housing.regionalMarkets.head.copy(valueShare = Share(-0.01)),
+    )
+    val err       = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalMarkets = malformed)
+
+    err.getMessage.should(include("regionalMarkets valueShare for Warsaw must be in [0,1]"))
+  }
+
+  it should "reject out-of-range regional mortgage shares" in {
+    val malformed = p.housing.regionalMarkets.updated(
+      0,
+      p.housing.regionalMarkets.head.copy(mortgageShare = Share(1.01)),
+    )
+    val err       = intercept[IllegalArgumentException]:
+      p.housing.copy(regionalMarkets = malformed)
+
+    err.getMessage.should(include("regionalMarkets mortgageShare for Warsaw must be in [0,1]"))
+  }
+
   it should "reject regional value shares that do not sum to 1.0" in {
     val malformed = p.housing.regionalMarkets.updated(
       0,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/FdiCompositionSpec.scala
@@ -114,13 +114,6 @@ class FdiCompositionSpec extends AnyFlatSpec with Matchers:
     Firm.isAlive(r.firm) || !Firm.isAlive(r.firm) shouldBe true // always true, no crash
   }
 
-  // --- Integration: output column count ---
-
-  "Output columns" should "have 171 entries in colNames" in
-    // Verify the colNames array in Main matches nCols
-    // We test this indirectly through the integration spec (nCols = 171)
-    succeed
-
   // --- FDI foreign shares calibration ---
 
   "FDI foreign shares" should "have Manufacturing as highest share" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/HousingMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/HousingMarketPropertySpec.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine
 
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.markets.HousingMarket
 import com.boombustgroup.amorfati.types.*
 import org.scalacheck.Gen
@@ -147,6 +147,7 @@ class HousingMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaChec
   private def makeRegionalState(aggValue: PLN, aggMortgage: PLN): HousingMarket.State =
     val regions = (0 until 7).map { r =>
       HousingMarket.RegionalState(
+        market = HousingConfig.RegionalMarket.all(r),
         priceIndex = priceIndex(hpis(r)),
         totalValue = valueShares(r) * aggValue,
         mortgageStock = mortgageShares(r) * aggMortgage,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/HousingMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/HousingMarketSpec.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine
 
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.markets.HousingMarket
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,10 +16,10 @@ class HousingMarketSpec extends AnyFlatSpec with Matchers:
   private def pln(units: Long): PLN                                                  = PLN.fromLong(units)
   private def rateBps(bps: Long): Rate                                               = Rate.fromRaw(bps)
   private def priceIndex(points: Long): PriceIndex                                   = PriceIndex.fromRaw(points * 10000L)
-  private def shouldBeClosePln(actual: PLN, expected: PLN, tolerance: PLN): Unit     =
-    (actual - expected).abs should be <= tolerance
-  private def shouldBeCloseRate(actual: Rate, expected: Rate, tolerance: Rate): Unit =
-    (actual - expected).abs should be <= tolerance
+  private def shouldBeClosePln(actual: PLN, expected: PLN, tolerance: PLN): Unit     = (actual - expected).abs should be <= tolerance
+  private def shouldBeCloseRate(actual: Rate, expected: Rate, tolerance: Rate): Unit = (actual - expected).abs should be <= tolerance
+  private def regionsByMarket(state: HousingMarket.State)                            = state.regions.get.iterator.map(region => region.market -> region).toMap
+  private def swapFirstTwo[A](items: Vector[A]): Vector[A]                           = items.updated(0, items(1)).updated(1, items(0))
 
   private val initState = HousingMarket.State(
     priceIndex = priceIndex(100),
@@ -163,6 +163,7 @@ class HousingMarketSpec extends AnyFlatSpec with Matchers:
     val hpis           = Vector(230L, 190L, 170L, 175L, 110L, 140L, 100L)
     val regions        = (0 until 7).map { r =>
       HousingMarket.RegionalState(
+        market = HousingConfig.RegionalMarket.all(r),
         priceIndex = priceIndex(hpis(r)),
         totalValue = valueShares(r) * aggValue,
         mortgageStock = mortgageShares(r) * aggMortgage,
@@ -285,4 +286,46 @@ class HousingMarketSpec extends AnyFlatSpec with Matchers:
     )
 
     result.regions.get.map(_.lastOrigination).sum shouldBe result.lastOrigination
+  }
+
+  it should "align regional price updates by market identity when input order changes" in {
+    val state         = makeRegionalState(pln(1_000_000_000), pln(400_000_000))
+    val shuffledState = state.copy(regions = Some(swapFirstTwo(state.regions.get)))
+    val input         = HousingMarket.StepInput(
+      prev = state,
+      mortgageRate = rateBps(760),
+      inflation = Rate.Zero,
+      incomeGrowth = rateBps(60),
+      employed = 1,
+      prevMortgageRate = rateBps(800),
+    )
+    val baseline      = HousingMarket.step(input)
+    val shuffled      = HousingMarket.step(input.copy(prev = shuffledState))
+
+    val baselineByMarket = regionsByMarket(baseline)
+    val shuffledByMarket = regionsByMarket(shuffled)
+    HousingConfig.RegionalMarket.all.foreach { market =>
+      shuffledByMarket(market).priceIndex shouldBe baselineByMarket(market).priceIndex
+      shuffledByMarket(market).totalValue shouldBe baselineByMarket(market).totalValue
+      shuffledByMarket(market).monthlyReturn shouldBe baselineByMarket(market).monthlyReturn
+    }
+    shuffled.priceIndex shouldBe baseline.priceIndex
+    shuffled.totalValue shouldBe baseline.totalValue
+  }
+
+  "HousingMarket.processOrigination" should "align regional allocations by market identity when input order changes" in {
+    val state         = makeRegionalState(pln(1_000_000_000), pln(400_000_000))
+    val shuffledState = state.copy(regions = Some(swapFirstTwo(state.regions.get)))
+    val totalIncome   = pln(100_000_000)
+    val baseline      = HousingMarket.processOrigination(state, totalIncome, rateBps(800), bankCapacity = true)
+    val shuffled      = HousingMarket.processOrigination(shuffledState, totalIncome, rateBps(800), bankCapacity = true)
+
+    val baselineByMarket = regionsByMarket(baseline)
+    val shuffledByMarket = regionsByMarket(shuffled)
+    HousingConfig.RegionalMarket.all.foreach { market =>
+      shuffledByMarket(market).lastOrigination shouldBe baselineByMarket(market).lastOrigination
+      shuffledByMarket(market).mortgageStock shouldBe baselineByMarket(market).mortgageStock
+    }
+    shuffled.lastOrigination shouldBe baseline.lastOrigination
+    shuffled.mortgageStock shouldBe baseline.mortgageStock
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -37,7 +37,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
     negativeDuration.getMessage should include("runDurationMonths must be > 0")
   }
 
-  "runSingle" should "produce 60 rows x 227 columns" in {
+  "runSingle" should s"produce 60 rows x ${SimOutput.nCols} columns" in {
     ts.nMonths shouldBe duration
     for row <- ts do row.length shouldBe SimOutput.nCols
   }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
@@ -283,6 +283,15 @@ class SimOutputSpec extends AnyFlatSpec with Matchers:
     err.getMessage.should(include("world.currentSigmas"))
   }
 
+  it should "keep sector sigma columns aligned with the schema" in {
+    val updatedSigma = Sigma(17.0)
+    val updatedWorld = init.world.copy(currentSigmas = init.world.currentSigmas.updated(1, updatedSigma))
+    val updatedRow   = computeRow(updatedWorld)
+
+    valueAt(updatedRow, "Manuf_Sigma") shouldBe 17.0
+    valueAt(updatedRow, "BPO_Sigma") shouldBe valueAt(computeRow(init.world), "BPO_Sigma")
+  }
+
   it should "map regional HPI columns using the documented Lodz-before-Poznan order" in {
     val regions    = init.world.real.housing.regions.getOrElse(fail("expected initialized regional housing data"))
     val updated    = regions.zipWithIndex.map: (region, idx) =>

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
@@ -1,0 +1,307 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SimOutputSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private lazy val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+
+  private val expectedColNames = Vector(
+    "Month",
+    "Inflation",
+    "Unemployment",
+    "PermanentShare",
+    "ZlecenieShare",
+    "B2BShare",
+    "TotalAdoption",
+    "ExRate",
+    "MarketWage",
+    "GovDebt",
+    "NPL",
+    "RefRate",
+    "PriceLevel",
+    "AutoRatio",
+    "HybridRatio",
+    "BPO_Auto",
+    "Manuf_Auto",
+    "Retail_Auto",
+    "Health_Auto",
+    "Public_Auto",
+    "Agri_Auto",
+    "BPO_Sigma",
+    "Manuf_Sigma",
+    "Retail_Sigma",
+    "Health_Sigma",
+    "Public_Sigma",
+    "Agri_Sigma",
+    "MeanDegree",
+    "IoFlows",
+    "IoGdpRatio",
+    "NFA",
+    "CurrentAccount",
+    "CapitalAccount",
+    "TradeBalance_OE",
+    "Exports_OE",
+    "TotalImports_OE",
+    "ImportedInterm",
+    "FDI",
+    "GvcDisruptionIndex",
+    "ForeignPriceIndex",
+    "GvcTradeConcentration",
+    "GvcExportDemandShock",
+    "GvcImportCostIndex",
+    "CommodityPriceIndex",
+    "ImmigrantStock",
+    "MonthlyImmigInflow",
+    "RemittanceOutflow",
+    "ImmigrantUnempRate",
+    "FxReserves",
+    "FxInterventionAmt",
+    "FxInterventionActive",
+    "DiasporaRemittanceInflow",
+    "NetRemittances",
+    "TourismExport",
+    "TourismImport",
+    "NetTourismBalance",
+    "TourismSeasonalFactor",
+    "UnempBenefitSpend",
+    "OutputGap",
+    "EffectivePitRate",
+    "SocialTransferSpend",
+    "GovCurrentSpend",
+    "GovCapitalSpendDomestic",
+    "GovDomesticBudgetDemand",
+    "GovDomesticBudgetOutlays",
+    "EuProjectCapitalTotal",
+    "PublicCapitalStock",
+    "EuCofinancingDomestic",
+    "EuFundsMonthly",
+    "EuCumulativeAbsorption",
+    "MinWageLevel",
+    "ExciseRevenue",
+    "CustomsDutyRevenue",
+    "DebtToGdp",
+    "DeficitToGdp",
+    "FiscalRuleBinding",
+    "GovSpendingCutRatio",
+    "BondYield",
+    "WeightedCoupon",
+    "BondsOutstanding",
+    "BankBondHoldings",
+    "ForeignBondHoldings",
+    "NbpBondHoldings",
+    "QeActive",
+    "DebtService",
+    "NbpRemittance",
+    "ReserveInterest",
+    "StandingFacilityNet",
+    "DepositFacilityUsage",
+    "InterbankInterestNet",
+    "M0",
+    "M1",
+    "M2",
+    "M3",
+    "CreditMultiplier",
+    "FofResidual",
+    "InterbankRate",
+    "MinBankCAR",
+    "MaxBankNPL",
+    "BankFailures",
+    "MinBankLCR",
+    "MinBankNSFR",
+    "AvgTermDepositFrac",
+    "WIBOR_1M",
+    "WIBOR_3M",
+    "WIBOR_6M",
+    "ConsumerLoans",
+    "ConsumerNplRatio",
+    "ConsumerOrigination",
+    "ConsumerDebtService",
+    "GpwIndex",
+    "GpwMarketCap",
+    "GpwPE",
+    "GpwDivYield",
+    "EquityIssuanceTotal",
+    "EquityFinancedFrac",
+    "HhEquityWealth",
+    "EquityWealthEffect",
+    "DomesticDividends",
+    "ForeignDividendOutflow",
+    "CorpBondOutstanding",
+    "CorpBondYield",
+    "CorpBondIssuance",
+    "CorpBondSpread",
+    "BankCorpBondHoldings",
+    "PpkCorpBondHoldings",
+    "CorpBondAbsorptionRate",
+    "InsLifeReserves",
+    "InsNonLifeReserves",
+    "InsGovBondHoldings",
+    "InsLifePremium",
+    "InsNonLifePremium",
+    "InsLifeClaims",
+    "InsNonLifeClaims",
+    "NbfiTfiAum",
+    "NbfiTfiGovBondHoldings",
+    "NbfiLoanStock",
+    "NbfiOrigination",
+    "NbfiDefaults",
+    "NbfiBankTightness",
+    "QfBondsOutstanding",
+    "QfNbpHoldings",
+    "QfLoanPortfolio",
+    "QfIssuance",
+    "Esa2010DebtToGdp",
+    "NbfiDepositDrain",
+    "BankAfsBonds",
+    "BankHtmBonds",
+    "EclStage1",
+    "EclStage2",
+    "EclStage3",
+    "BfgLevyTotal",
+    "BfgFundBalance",
+    "BailInLoss",
+    "HousingPriceIndex",
+    "HousingMarketValue",
+    "MortgageStock",
+    "AvgMortgageRate",
+    "MortgageOrigination",
+    "MortgageRepayment",
+    "MortgageDefault",
+    "MortgageInterestIncome",
+    "HhHousingWealth",
+    "HousingWealthEffect",
+    "MortgageToGdp",
+    "WawHpi",
+    "KrkHpi",
+    "WroHpi",
+    "GdnHpi",
+    "LdzHpi",
+    "PozHpi",
+    "RestHpi",
+    "SectorMobilityRate",
+    "CrossSectorHires",
+    "VoluntaryQuits",
+    "AggCapitalStock",
+    "GrossInvestment",
+    "CapitalDepreciation",
+    "AggInventoryStock",
+    "InventoryChange",
+    "InventoryToGdp",
+    "AggEnergyCost",
+    "EnergyCostToGdp",
+    "EtsPrice",
+    "AggGreenCapital",
+    "GreenInvestment",
+    "GreenCapitalRatio",
+    "JstRevenue",
+    "JstSpending",
+    "JstDebt",
+    "JstDeposits",
+    "JstDeficit",
+    "ZusContributions",
+    "ZusPensionPayments",
+    "ZusGovSubvention",
+    "FusBalance",
+    "NfzContributions",
+    "NfzSpending",
+    "NfzBalance",
+    "NfzGovSubvention",
+    "PpkContributions",
+    "PpkBondHoldings",
+    "NRetirees",
+    "WorkingAgePop",
+    "MonthlyRetirements",
+    "FpBalance",
+    "FpContributions",
+    "PfronBalance",
+    "FgspBalance",
+    "FgspSpending",
+    "EarmarkedGovSubvention",
+    "ExpectedInflation",
+    "NbpCredibility",
+    "ForwardGuidanceRate",
+    "InflationForecastError",
+    "CCyB",
+    "CreditToGdpGap",
+    "EffectiveMinCar",
+    "FdiProfitShifting",
+    "FdiRepatriation",
+    "FdiGrossOutflow",
+    "ForeignOwnedFrac",
+    "FdiCitLoss",
+    "FirmBirths",
+    "FirmDeaths",
+    "NetEntry",
+    "LivingFirmCount",
+    "NetFirmBirths",
+    "TotalFirmCount",
+    "RealizedTaxShadowShare",
+    "NextTaxShadowShare",
+    "TaxEvasionLoss",
+    "EvasionToGdpRatio",
+    "Unemp_Central",
+    "Unemp_South",
+    "Unemp_East",
+    "Unemp_Northwest",
+    "Unemp_Southwest",
+    "Unemp_North",
+  )
+
+  private def computeRow(world: World): Array[Double] =
+    SimOutput.compute(
+      executionMonth = ExecutionMonth.First,
+      world = world,
+      firms = init.firms,
+      households = init.households,
+      banks = init.banks,
+      householdAggregates = init.householdAggregates,
+    )
+
+  private def valueAt(row: Array[Double], name: String): Double =
+    val idx = SimOutput.colNames.indexOf(name)
+    idx.should(be >= 0)
+    row(idx)
+
+  "SimOutput" should "expose the stable schema contract" in {
+    SimOutput.nCols shouldBe 239
+    SimOutput.colNames.toVector shouldBe expectedColNames
+  }
+
+  it should "fail fast when currentSigmas does not match the sector schema" in {
+    val err = intercept[IllegalArgumentException]:
+      computeRow(init.world.copy(currentSigmas = init.world.currentSigmas.dropRight(1)))
+
+    err.getMessage.should(include("world.currentSigmas"))
+  }
+
+  it should "map regional HPI columns using the documented Lodz-before-Poznan order" in {
+    val regions    = init.world.real.housing.regions.getOrElse(fail("expected initialized regional housing data"))
+    val updated    = regions.zipWithIndex.map: (region, idx) =>
+      region.copy(priceIndex = PriceIndex(101.0 + idx.toDouble))
+    val updatedRow = computeRow(init.world.copy(real = init.world.real.copy(housing = init.world.real.housing.copy(regions = Some(updated)))))
+
+    valueAt(updatedRow, "WawHpi") shouldBe 101.0
+    valueAt(updatedRow, "KrkHpi") shouldBe 102.0
+    valueAt(updatedRow, "WroHpi") shouldBe 103.0
+    valueAt(updatedRow, "GdnHpi") shouldBe 104.0
+    valueAt(updatedRow, "LdzHpi") shouldBe 105.0
+    valueAt(updatedRow, "PozHpi") shouldBe 106.0
+    valueAt(updatedRow, "RestHpi") shouldBe 107.0
+  }
+
+  it should "reject malformed regional housing state shapes before output indexing" in {
+    val regions = init.world.real.housing.regions.getOrElse(fail("expected initialized regional housing data"))
+    val err     = intercept[IllegalArgumentException]:
+      init.world.real.housing.copy(regions = Some(regions.dropRight(1)))
+
+    err.getMessage.should(include("HousingMarket.State.regions must have 7 entries"))
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
@@ -320,5 +320,5 @@ class SimOutputSpec extends AnyFlatSpec with Matchers:
     val err     = intercept[IllegalArgumentException]:
       init.world.real.housing.copy(regions = Some(regions.dropRight(1)))
 
-    err.getMessage.should(include("HousingMarket.State.regions must have 7 entries"))
+    err.getMessage.should(include("HousingMarket.State.regions must contain 7 entries covering markets"))
   }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/SimOutputSpec.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.montecarlo
 
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -292,11 +292,19 @@ class SimOutputSpec extends AnyFlatSpec with Matchers:
     valueAt(updatedRow, "BPO_Sigma") shouldBe valueAt(computeRow(init.world), "BPO_Sigma")
   }
 
-  it should "map regional HPI columns using the documented Lodz-before-Poznan order" in {
-    val regions    = init.world.real.housing.regions.getOrElse(fail("expected initialized regional housing data"))
-    val updated    = regions.zipWithIndex.map: (region, idx) =>
-      region.copy(priceIndex = PriceIndex(101.0 + idx.toDouble))
-    val updatedRow = computeRow(init.world.copy(real = init.world.real.copy(housing = init.world.real.housing.copy(regions = Some(updated)))))
+  it should "map regional HPI columns by market identity and preserve schema order" in {
+    val regions     = init.world.real.housing.regions.getOrElse(fail("expected initialized regional housing data"))
+    val hpiByMarket = Map(
+      HousingConfig.RegionalMarket.Warsaw       -> 101.0,
+      HousingConfig.RegionalMarket.Krakow       -> 102.0,
+      HousingConfig.RegionalMarket.Wroclaw      -> 103.0,
+      HousingConfig.RegionalMarket.Gdansk       -> 104.0,
+      HousingConfig.RegionalMarket.Lodz         -> 105.0,
+      HousingConfig.RegionalMarket.Poznan       -> 106.0,
+      HousingConfig.RegionalMarket.RestOfPoland -> 107.0,
+    )
+    val updated     = regions.reverse.map(region => region.copy(priceIndex = PriceIndex(hpiByMarket(region.market))))
+    val updatedRow  = computeRow(init.world.copy(real = init.world.real.copy(housing = init.world.real.housing.copy(regions = Some(updated)))))
 
     valueAt(updatedRow, "WawHpi") shouldBe 101.0
     valueAt(updatedRow, "KrkHpi") shouldBe 102.0


### PR DESCRIPTION
## Summary
- centralize SimOutput sector and region mappings behind explicit schema contracts
- fail fast on invalid sector and housing config shapes instead of relying on late positional indexing
- add schema contract tests and remove stale column-count references from tests/docs


Fixes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation output expanded to 239 columns with dynamic per-sector metrics and explicit per-region housing price index columns.
  * Regional housing markets now use named, configurable market entries for initialization and updates.

* **Bug Fixes / Validation**
  * Stronger validation enforces sector and regional schema length, order, uniqueness, and share totals with clearer errors.

* **Tests**
  * Added/updated tests for schema validation, output shape, sigma/region mappings, and robustness to reordered inputs.

* **Documentation**
  * Updated output schema docs to reflect the new column structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->