### PR TITLE
Reduce Monte Carlo runner result retention

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -259,9 +259,7 @@ object MechanismsState:
     expectations = Expectations.initial,
   )
 
-/** NBP monetary plumbing — single-step flows from S8/S9, surfaced for
-  * SimOutput.
-  */
+/** NBP monetary plumbing */
 case class MonetaryPlumbingState(
     reserveInterestTotal: PLN = PLN.Zero, // NBP interest on required reserves
     standingFacilityNet: PLN = PLN.Zero,  // net standing facility income (deposit − Lombard)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -337,7 +337,6 @@ object WorldAssemblyEconomics:
 
     InformalResult(taxEvasionLoss, realizedTaxShadowShare, cyclicalAdj, nextTaxShadowShare)
 
-  /** Pre-compute observable values surfaced on World for SimOutput. */
   @boundaryEscape
   private def computeObservables(in: StepInput)(using p: SimParams): Observables =
     import ComputationBoundary.toDouble

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalRules.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalRules.scala
@@ -30,7 +30,7 @@ object FiscalRules:
       status: RuleStatus,           // which rules are binding + diagnostics
   )
 
-  /** Rule compliance status for observability (surfaced in SimOutput). */
+  /** Rule compliance status for observability */
   case class RuleStatus(
       debtToGdp: Share,       // current debt/GDP ratio
       deficitToGdp: Share,    // current deficit/GDP ratio (annualized)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McCsvSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McCsvSchema.scala
@@ -1,0 +1,12 @@
+package com.boombustgroup.amorfati.montecarlo
+
+/** Shared CSV row contract used by Monte Carlo output schemas. */
+private[montecarlo] final case class McCsvSchema[-Row](
+    header: String,
+    render: Row => String,
+):
+  def contramap[Source](f: Source => Row): McCsvSchema[Source] =
+    McCsvSchema(
+      header = header,
+      render = source => render(f(source)),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
@@ -1,0 +1,35 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import zio.ZIO
+
+import java.io.File
+
+private[montecarlo] object McOutputFiles:
+
+  def prepareOutputDir(outputDir: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        if outputDir.exists() then
+          if !outputDir.isDirectory then throw java.io.IOException(s"path exists but is not a directory: ${outputDir.getPath}")
+        else if !outputDir.mkdirs() && (!outputDir.exists() || !outputDir.isDirectory) then
+          throw java.io.IOException(s"failed to create output directory: ${outputDir.getPath}")
+      .mapError(outputFailure("prepare output directory", outputDir))
+
+  def seedFile(outputDir: File, seed: Long, rc: McRunConfig): File =
+    new File(outputDir, f"${filePrefix(rc)}_seed${seed}%03d.csv")
+
+  def householdFile(outputDir: File, rc: McRunConfig): File =
+    new File(outputDir, s"${filePrefix(rc)}_hh.csv")
+
+  def bankFile(outputDir: File, rc: McRunConfig): File =
+    new File(outputDir, s"${filePrefix(rc)}_banks.csv")
+
+  def savedFiles(outputDir: File, rc: McRunConfig): Vector[File] =
+    (1L to rc.nSeeds.toLong).map(seed => seedFile(outputDir, seed, rc)).toVector ++
+      Vector(householdFile(outputDir, rc), bankFile(outputDir, rc))
+
+  private def filePrefix(rc: McRunConfig): String =
+    s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -7,9 +7,10 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.montecarlo.McRunnerConsole.Event
 import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema.Col
 import zio.stream.ZStream
-import zio.{Clock, Console, ZIO}
+import zio.{Clock, ZIO}
 
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -31,7 +32,7 @@ object McRunner:
     val parallelism = scala.math.max(1, scala.math.min(java.lang.Runtime.getRuntime.availableProcessors(), rc.nSeeds))
     for
       _         <- McOutputFiles.prepareOutputDir(outputDir)
-      _         <- Console.printLine(s"  run-id: ${rc.runId}").mapError(runtimeFailure("print run id"))
+      _         <- McRunnerConsole.emit(Event.RunId(rc.runId))
       t0        <- Clock.currentTime(TimeUnit.MILLISECONDS)
       summaries <- ZStream
         .fromIterable(1L to rc.nSeeds.toLong)
@@ -39,10 +40,10 @@ object McRunner:
           runSeed(seed, rc, outputDir)
         .runCollect
       _         <- McTerminalSummaryCsv.writeAll(rc, outputDir, summaries)
-      _         <- Console.printLine("").mapError(runtimeFailure("print separator"))
-      _         <- printSavedZIO(rc, outputDir)
+      _         <- McRunnerConsole.emit(Event.BlankLine)
+      _         <- McRunnerConsole.emitAll(McOutputFiles.savedFiles(outputDir, rc).map(file => Event.SavedFile(file.getPath)))
       t1        <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _         <- Console.printLine(f"\nTotal time: ${(t1 - t0) / 1000.0}%.1f seconds").mapError(runtimeFailure("print total time"))
+      _         <- McRunnerConsole.emit(Event.TotalTime((t1 - t0) / 1000.0))
     yield ()
 
   /** Pure simulation — returns Either, no side effects. For tests. */
@@ -120,7 +121,7 @@ object McRunner:
       terminal <- McTimeseriesCsv.writeStreaming(
         McOutputFiles.seedFile(outputDir, seed, rc),
         seedStream(seed, rc.runDurationMonths)
-          .tap(snapshot => printMonthProgressZIO(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))
+          .tap(snapshot => McRunnerConsole.emit(monthProgressEvent(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths)))
           .map(snapshot => SeedTerminalSnapshot(snapshot.executionMonth, snapshot.monthData, snapshot.state)),
         McTimeseriesSchema.csvSchema.contramap(snapshot => (snapshot.executionMonth, snapshot.lastMonthData)),
         SimError.RuntimeFailure(
@@ -129,46 +130,18 @@ object McRunner:
         ),
       )
       et       <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _        <- printSeedDone(seed, rc.nSeeds, terminal.lastMonthData, et - st)
+      _        <- McRunnerConsole.emit(seedDoneEvent(seed, rc.nSeeds, terminal.lastMonthData, et - st))
     yield McTerminalSummarySchema.fromTerminalState(seed, terminal.terminalState)
 
-  // $COVERAGE-OFF$
-  // I/O: CSV writers, progress, banner
-  private def runtimeFailure(operation: String)(err: Throwable): SimError =
-    SimError.RuntimeFailure(operation, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))
+  private def monthProgressEvent(seed: Long, totalSeeds: Int, month: ExecutionMonth, durationMonths: Int): Event =
+    Event.MonthProgress(seed = seed, totalSeeds = totalSeeds, month = month, durationMonths = durationMonths)
 
-  // ---------------------------------------------------------------------------
-  //  Progress
-  // ---------------------------------------------------------------------------
-
-  private val BarWidth = 20
-
-  private def printMonthProgressZIO(seed: Long, total: Int, month: ExecutionMonth, duration: Int): ZIO[Any, SimError, Unit] =
-    ZIO.attempt(printMonthProgress(seed, total, month, duration)).mapError(runtimeFailure("print month progress"))
-
-  private def printMonthProgress(seed: Long, total: Int, month: ExecutionMonth, duration: Int): Unit =
-    val frac   = month.toInt.toDouble / duration
-    val filled = (frac * BarWidth).toInt
-    val bar    = "\u2588" * filled + "\u2591" * (BarWidth - filled)
-    val pct    = (frac * 100).toInt
-    print(f"\r  Seed $seed%3d/$total [$bar] ${month.toInt}%3d/${duration}m ($pct%3d%%)")
-
-  private def printSeedDone(seed: Long, total: Int, last: Array[Double], dt: Long) =
-    val adopt = last(Col.TotalAdoption.ordinal)
-    val pi    = last(Col.Inflation.ordinal)
-    val unemp = last(Col.Unemployment.ordinal)
-    val bar   = "\u2588" * BarWidth
-    Console
-      .printLine(
-        f"\r  Seed $seed%3d/$total [$bar] done (${dt}ms) | " +
-          f"Adopt=${adopt * 100}%5.1f%% | pi=${pi * 100}%5.1f%% | " +
-          f"Unemp=${unemp * 100}%5.1f%%",
-      )
-      .mapError(runtimeFailure("print seed summary"))
-
-  private def printSavedZIO(rc: McRunConfig, outputDir: File) =
-    ZIO
-      .foreachDiscard(McOutputFiles.savedFiles(outputDir, rc))(file => Console.printLine(s"Saved: ${file.getPath}"))
-      .mapError(runtimeFailure("print saved file paths"))
-
-  // $COVERAGE-ON$
+  private def seedDoneEvent(seed: Long, totalSeeds: Int, lastMonthData: Array[Double], elapsedMillis: Long): Event =
+    Event.SeedDone(
+      seed = seed,
+      totalSeeds = totalSeeds,
+      elapsedMillis = elapsedMillis,
+      adoption = lastMonthData(Col.TotalAdoption.ordinal),
+      inflation = lastMonthData(Col.Inflation.ordinal),
+      unemployment = lastMonthData(Col.Unemployment.ordinal),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -15,7 +15,9 @@ import com.boombustgroup.amorfati.util.CsvWriter
 import zio.stream.ZStream
 import zio.{Clock, Console, ZIO}
 
+import java.io.BufferedWriter
 import java.io.File
+import java.nio.file.{Files, StandardCopyOption}
 import java.util.concurrent.TimeUnit
 
 /** Monte Carlo runner: simulation loop, per-seed CSV output. */
@@ -23,6 +25,14 @@ object McRunner:
 
   /** Single month snapshot emitted by [[seedStream]]. */
   private case class MonthSnapshot(executionMonth: ExecutionMonth, state: FlowSimulation.SimState, monthData: Array[Double])
+  private enum TerminalSummaryCsv:
+    case Household, Banks
+
+  private case class SeedTerminalOutputs(seed: Long, rowsByCsv: Map[TerminalSummaryCsv, Vector[String]]):
+    def rowsFor(csv: TerminalSummaryCsv): Vector[String] =
+      rowsByCsv.getOrElse(csv, Vector.empty)
+
+  private case class SeedTerminalSnapshot(lastMonthData: Array[Double], terminalState: FlowSimulation.SimState)
 
   /** Run N seeds in parallel, each streaming months via [[seedStream]]. Writes
     * per-seed CSV + aggregated HH/bank CSVs. Fails with [[SimError]].
@@ -31,28 +41,22 @@ object McRunner:
     runZIO(rc, new File("mc"))
 
   private[amorfati] def runZIO(rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, Unit] =
-    val parallelism = java.lang.Runtime.getRuntime.availableProcessors()
+    val parallelism = scala.math.max(1, scala.math.min(java.lang.Runtime.getRuntime.availableProcessors(), rc.nSeeds))
     for
-      _       <- prepareOutputDir(outputDir)
-      _       <- Console.printLine(s"  run-id: ${rc.runId}").mapError(runtimeFailure("print run id"))
-      t0      <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      results <- ZStream
+      _         <- prepareOutputDir(outputDir)
+      _         <- Console.printLine(s"  run-id: ${rc.runId}").mapError(runtimeFailure("print run id"))
+      t0        <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      summaries <- ZStream
         .fromIterable(1L to rc.nSeeds.toLong)
         .mapZIOPar(parallelism): seed =>
-          for
-            st        <- Clock.currentTime(TimeUnit.MILLISECONDS)
-            runResult <- materializeSeed(seed, rc)
-            et        <- Clock.currentTime(TimeUnit.MILLISECONDS)
-            _         <- printSeedDone(seed, rc.nSeeds, runResult, et - st)
-            _         <- writeSeedCsv(seed, rc, outputDir, runResult)
-          yield (seed, runResult)
+          runSeed(seed, rc, outputDir)
         .runCollect
-      _       <- writeHhCsv(rc, outputDir, results)
-      _       <- writeBankCsv(rc, outputDir, results)
-      _       <- Console.printLine("").mapError(runtimeFailure("print separator"))
-      _       <- printSavedZIO(rc, outputDir)
-      t1      <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _       <- Console.printLine(f"\nTotal time: ${(t1 - t0) / 1000.0}%.1f seconds").mapError(runtimeFailure("print total time"))
+      _         <- writeHhCsv(rc, outputDir, summaries)
+      _         <- writeBankCsv(rc, outputDir, summaries)
+      _         <- Console.printLine("").mapError(runtimeFailure("print separator"))
+      _         <- printSavedZIO(rc, outputDir)
+      t1        <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      _         <- Console.printLine(f"\nTotal time: ${(t1 - t0) / 1000.0}%.1f seconds").mapError(runtimeFailure("print total time"))
     yield ()
 
   /** Pure simulation — returns Either, no side effects. For tests. */
@@ -121,21 +125,52 @@ object McRunner:
 
     collect(steps, initState)
 
-  /** Consume a seed stream into RunResult, collecting monthly data. */
-  private def materializeSeed(seed: Long, rc: McRunConfig)(using p: SimParams) =
-    seedStream(seed, rc.runDurationMonths)
-      .tap(s => printMonthProgressZIO(seed, rc.nSeeds, s.executionMonth, rc.runDurationMonths))
-      .runFold((Option.empty[FlowSimulation.SimState], Vector.empty[Array[Double]])):
-        case ((_, series), snapshot) => (Some(snapshot.state), series :+ snapshot.monthData)
-      .flatMap:
-        case (Some(state), series) => ZIO.succeed(RunResult(TimeSeries.wrap(series.toArray), state))
-        case _                     =>
-          ZIO.fail(
-            SimError.RuntimeFailure(
-              "materialize seed",
-              s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
-            ),
-          )
+  /** Stream a seed directly to its CSV and retain only the terminal summary
+    * slice needed for aggregate outputs.
+    */
+  private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, SeedTerminalOutputs] =
+    val finalOutputFile = new File(outputDir, seedFileName(seed, rc))
+    val tempOutputFile  = new File(outputDir, s"${seedFileName(seed, rc)}.tmp")
+    val operation       = "write per-seed CSV"
+
+    val writeSeedFile = for
+      st       <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      terminal <- ZIO.scoped {
+        for
+          writer        <- openCsvWriter(tempOutputFile, operation)
+          _             <- writeCsvLine(writer, seedCsvHeader, tempOutputFile, operation)
+          maybeTerminal <- seedStream(seed, rc.runDurationMonths)
+            .tap(snapshot => printMonthProgressZIO(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))
+            .runFoldZIO(Option.empty[SeedTerminalSnapshot]): (_, snapshot) =>
+              writeCsvLine(
+                writer,
+                renderSeedCsvRow(snapshot.executionMonth, snapshot.monthData),
+                tempOutputFile,
+                operation,
+              ).as(Some(SeedTerminalSnapshot(snapshot.monthData, snapshot.state)))
+          terminal      <- maybeTerminal match
+            case Some(value) => ZIO.succeed(value)
+            case None        =>
+              ZIO.fail(
+                SimError.RuntimeFailure(
+                  "materialize seed",
+                  s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
+                ),
+              )
+        yield terminal
+      }
+      _        <- moveOutputFile(tempOutputFile, finalOutputFile, operation)
+      et       <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      _        <- printSeedDone(seed, rc.nSeeds, terminal.lastMonthData, et - st)
+    yield SeedTerminalOutputs(
+      seed,
+      Map(
+        TerminalSummaryCsv.Household -> Vector(renderHouseholdSummaryRow(seed, terminal.terminalState.householdAggregates)),
+        TerminalSummaryCsv.Banks     -> renderBankSummaryRows(seed, terminal.terminalState.banks),
+      ),
+    )
+
+    writeSeedFile.onError(_ => deleteIfExists(tempOutputFile, operation).ignore)
 
   // ---------------------------------------------------------------------------
   //  Per-seed CSV writer
@@ -163,23 +198,40 @@ object McRunner:
   private def seedFileName(seed: Long, rc: McRunConfig) =
     f"${filePrefix(rc)}_seed${seed}%03d.csv"
 
-  private def writeSeedCsv(seed: Long, rc: McRunConfig, outputDir: File, result: RunResult) =
-    val outputFile = new File(outputDir, seedFileName(seed, rc))
+  private val seedCsvHeader = SimOutput.colNames.mkString(";")
+
+  private def openCsvWriter(outputFile: File, operation: String): ZIO[zio.Scope, SimError, BufferedWriter] =
+    ZIO.fromAutoCloseable(
+      ZIO
+        .attemptBlocking(Files.newBufferedWriter(outputFile.toPath))
+        .mapError(outputFailure(s"open $operation writer", outputFile)),
+    )
+
+  private def writeCsvLine(writer: BufferedWriter, line: String, outputFile: File, operation: String): ZIO[Any, SimError, Unit] =
     ZIO
       .attemptBlocking:
-        val nCols    = SimOutput.nCols
-        val colNames = SimOutput.colNames
-        CsvWriter.write(
-          outputFile,
-          colNames.mkString(";"),
-          result.timeSeries.executionMonths,
-        ): month =>
-          val row = result.timeSeries.monthRow(month)
-          val sb  = new StringBuilder
-          sb.append(month.toInt)
-          for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
-          sb.toString
-      .mapError(outputFailure("write per-seed CSV", outputFile))
+        writer.write(line)
+        writer.newLine()
+      .mapError(outputFailure(operation, outputFile))
+
+  private def moveOutputFile(tempFile: File, outputFile: File, operation: String): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        Files.move(tempFile.toPath, outputFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+      .unit
+      .mapError(outputFailure(s"finalize $operation", outputFile))
+
+  private def deleteIfExists(file: File, operation: String): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking(Files.deleteIfExists(file.toPath))
+      .unit
+      .mapError(outputFailure(s"cleanup $operation temp file", file))
+
+  private def renderSeedCsvRow(month: ExecutionMonth, row: Array[Double]) =
+    val sb = new StringBuilder
+    sb.append(month.toInt)
+    for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
+    sb.toString
 
   // ---------------------------------------------------------------------------
   //  HH + Bank CSV writers (from collected results)
@@ -211,13 +263,14 @@ object McRunner:
 
   private val hhHeader = "Seed;" + hhSchema.map(_._1).mkString(";")
 
-  private def writeHhCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[(Long, RunResult)]) =
+  private def renderHouseholdSummaryRow(seed: Long, agg: Household.Aggregates): String =
+    s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
+
+  private def writeHhCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
     val outputFile = new File(outputDir, s"${filePrefix(rc)}_hh.csv")
     ZIO
       .attemptBlocking:
-        val rows = results.map: (seed, r) =>
-          val agg = r.terminalState.householdAggregates
-          s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
+        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(TerminalSummaryCsv.Household))
         CsvWriter.write(outputFile, hhHeader, rows)(identity)
       .mapError(outputFailure("write household summary CSV", outputFile))
 
@@ -235,13 +288,15 @@ object McRunner:
 
   private val bankHeader = "Seed;" + bankSchema.map(_._1).mkString(";")
 
-  private def writeBankCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[(Long, RunResult)]) =
+  private def renderBankSummaryRows(seed: Long, banks: Vector[BankState]): Vector[String] =
+    banks.map: b =>
+      s"$seed;" + bankSchema.map(_._2(b)).mkString(";")
+
+  private def writeBankCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
     val outputFile = new File(outputDir, s"${filePrefix(rc)}_banks.csv")
     ZIO
       .attemptBlocking:
-        val rows = results.flatMap: (seed, r) =>
-          r.terminalState.banks.map: b =>
-            s"$seed;" + bankSchema.map(_._2(b)).mkString(";")
+        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(TerminalSummaryCsv.Banks))
         CsvWriter.write(outputFile, bankHeader, rows)(identity)
       .mapError(outputFailure("write bank summary CSV", outputFile))
 
@@ -261,8 +316,7 @@ object McRunner:
     val pct    = (frac * 100).toInt
     print(f"\r  Seed $seed%3d/$total [$bar] ${month.toInt}%3d/${duration}m ($pct%3d%%)")
 
-  private def printSeedDone(seed: Long, total: Int, result: RunResult, dt: Long) =
-    val last  = result.timeSeries.lastMonth
+  private def printSeedDone(seed: Long, total: Int, last: Array[Double], dt: Long) =
     val adopt = last(Col.TotalAdoption.ordinal)
     val pi    = last(Col.Inflation.ordinal)
     val unemp = last(Col.Unemployment.ordinal)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
-import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
+import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema.Col
 import zio.stream.ZStream
 import zio.{Clock, Console, ZIO}
 
@@ -83,7 +83,7 @@ object McRunner:
       case Left(errors) =>
         Left(SimError.SfcViolation(result.executionMonth, errors))
       case Right(())    =>
-        val monthData = SimOutput.compute(
+        val monthData = McTimeseriesSchema.compute(
           result.executionMonth,
           result.nextState.world,
           result.nextState.firms,
@@ -114,15 +114,15 @@ object McRunner:
   /** Stream a seed directly to its CSV and retain only the terminal summary
     * slice needed for aggregate outputs.
     */
-  private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, SeedTerminalOutputs] =
+  private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, McTerminalSummaryRows] =
     for
       st       <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      terminal <- McSeedCsv.writeStreaming(
+      terminal <- McTimeseriesCsv.writeStreaming(
         McOutputFiles.seedFile(outputDir, seed, rc),
         seedStream(seed, rc.runDurationMonths)
           .tap(snapshot => printMonthProgressZIO(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))
           .map(snapshot => SeedTerminalSnapshot(snapshot.executionMonth, snapshot.monthData, snapshot.state)),
-        snapshot => McSeedCsv.renderMonthRow(snapshot.executionMonth, snapshot.lastMonthData),
+        McTimeseriesSchema.csvSchema.contramap(snapshot => (snapshot.executionMonth, snapshot.lastMonthData)),
         SimError.RuntimeFailure(
           "materialize seed",
           s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
@@ -130,7 +130,7 @@ object McRunner:
       )
       et       <- Clock.currentTime(TimeUnit.MILLISECONDS)
       _        <- printSeedDone(seed, rc.nSeeds, terminal.lastMonthData, et - st)
-    yield McTerminalSummaryCsv.fromTerminalState(seed, terminal.terminalState)
+    yield McTerminalSummarySchema.fromTerminalState(seed, terminal.terminalState)
 
   // $COVERAGE-OFF$
   // I/O: CSV writers, progress, banner

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -2,22 +2,16 @@ package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.*
 import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
-import com.boombustgroup.amorfati.agents.Banking.BankState
-import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
-import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.amorfati.util.CsvWriter
 import zio.stream.ZStream
 import zio.{Clock, Console, ZIO}
 
-import java.io.BufferedWriter
 import java.io.File
-import java.nio.file.{Files, StandardCopyOption}
 import java.util.concurrent.TimeUnit
 
 /** Monte Carlo runner: simulation loop, per-seed CSV output. */
@@ -25,14 +19,7 @@ object McRunner:
 
   /** Single month snapshot emitted by [[seedStream]]. */
   private case class MonthSnapshot(executionMonth: ExecutionMonth, state: FlowSimulation.SimState, monthData: Array[Double])
-  private enum TerminalSummaryCsv:
-    case Household, Banks
-
-  private case class SeedTerminalOutputs(seed: Long, rowsByCsv: Map[TerminalSummaryCsv, Vector[String]]):
-    def rowsFor(csv: TerminalSummaryCsv): Vector[String] =
-      rowsByCsv.getOrElse(csv, Vector.empty)
-
-  private case class SeedTerminalSnapshot(lastMonthData: Array[Double], terminalState: FlowSimulation.SimState)
+  private case class SeedTerminalSnapshot(executionMonth: ExecutionMonth, lastMonthData: Array[Double], terminalState: FlowSimulation.SimState)
 
   /** Run N seeds in parallel, each streaming months via [[seedStream]]. Writes
     * per-seed CSV + aggregated HH/bank CSVs. Fails with [[SimError]].
@@ -43,7 +30,7 @@ object McRunner:
   private[amorfati] def runZIO(rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, Unit] =
     val parallelism = scala.math.max(1, scala.math.min(java.lang.Runtime.getRuntime.availableProcessors(), rc.nSeeds))
     for
-      _         <- prepareOutputDir(outputDir)
+      _         <- McOutputFiles.prepareOutputDir(outputDir)
       _         <- Console.printLine(s"  run-id: ${rc.runId}").mapError(runtimeFailure("print run id"))
       t0        <- Clock.currentTime(TimeUnit.MILLISECONDS)
       summaries <- ZStream
@@ -51,8 +38,7 @@ object McRunner:
         .mapZIOPar(parallelism): seed =>
           runSeed(seed, rc, outputDir)
         .runCollect
-      _         <- writeHhCsv(rc, outputDir, summaries)
-      _         <- writeBankCsv(rc, outputDir, summaries)
+      _         <- McTerminalSummaryCsv.writeAll(rc, outputDir, summaries)
       _         <- Console.printLine("").mapError(runtimeFailure("print separator"))
       _         <- printSavedZIO(rc, outputDir)
       t1        <- Clock.currentTime(TimeUnit.MILLISECONDS)
@@ -129,176 +115,27 @@ object McRunner:
     * slice needed for aggregate outputs.
     */
   private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, SeedTerminalOutputs] =
-    val finalOutputFile = new File(outputDir, seedFileName(seed, rc))
-    val tempOutputFile  = new File(outputDir, s"${seedFileName(seed, rc)}.tmp")
-    val operation       = "write per-seed CSV"
-
-    val writeSeedFile = for
+    for
       st       <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      terminal <- ZIO.scoped {
-        for
-          writer        <- openCsvWriter(tempOutputFile, operation)
-          _             <- writeCsvLine(writer, seedCsvHeader, tempOutputFile, operation)
-          maybeTerminal <- seedStream(seed, rc.runDurationMonths)
-            .tap(snapshot => printMonthProgressZIO(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))
-            .runFoldZIO(Option.empty[SeedTerminalSnapshot]): (_, snapshot) =>
-              writeCsvLine(
-                writer,
-                renderSeedCsvRow(snapshot.executionMonth, snapshot.monthData),
-                tempOutputFile,
-                operation,
-              ).as(Some(SeedTerminalSnapshot(snapshot.monthData, snapshot.state)))
-          terminal      <- maybeTerminal match
-            case Some(value) => ZIO.succeed(value)
-            case None        =>
-              ZIO.fail(
-                SimError.RuntimeFailure(
-                  "materialize seed",
-                  s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
-                ),
-              )
-        yield terminal
-      }
-      _        <- moveOutputFile(tempOutputFile, finalOutputFile, operation)
+      terminal <- McSeedCsv.writeStreaming(
+        McOutputFiles.seedFile(outputDir, seed, rc),
+        seedStream(seed, rc.runDurationMonths)
+          .tap(snapshot => printMonthProgressZIO(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))
+          .map(snapshot => SeedTerminalSnapshot(snapshot.executionMonth, snapshot.monthData, snapshot.state)),
+        snapshot => McSeedCsv.renderMonthRow(snapshot.executionMonth, snapshot.lastMonthData),
+        SimError.RuntimeFailure(
+          "materialize seed",
+          s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
+        ),
+      )
       et       <- Clock.currentTime(TimeUnit.MILLISECONDS)
       _        <- printSeedDone(seed, rc.nSeeds, terminal.lastMonthData, et - st)
-    yield SeedTerminalOutputs(
-      seed,
-      Map(
-        TerminalSummaryCsv.Household -> Vector(renderHouseholdSummaryRow(seed, terminal.terminalState.householdAggregates)),
-        TerminalSummaryCsv.Banks     -> renderBankSummaryRows(seed, terminal.terminalState.banks),
-      ),
-    )
+    yield McTerminalSummaryCsv.fromTerminalState(seed, terminal.terminalState)
 
-    writeSeedFile.onError(_ => deleteIfExists(tempOutputFile, operation).ignore)
-
-  // ---------------------------------------------------------------------------
-  //  Per-seed CSV writer
-  // ---------------------------------------------------------------------------
-
-  // $COVERAGE-OFF$ I/O: CSV writers, progress, banner
+  // $COVERAGE-OFF$
+  // I/O: CSV writers, progress, banner
   private def runtimeFailure(operation: String)(err: Throwable): SimError =
     SimError.RuntimeFailure(operation, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))
-
-  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
-    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))
-
-  private def prepareOutputDir(outputDir: File): ZIO[Any, SimError, Unit] =
-    ZIO
-      .attemptBlocking:
-        if outputDir.exists() then
-          if !outputDir.isDirectory then throw java.io.IOException(s"path exists but is not a directory: ${outputDir.getPath}")
-        else if !outputDir.mkdirs() && (!outputDir.exists() || !outputDir.isDirectory) then
-          throw java.io.IOException(s"failed to create output directory: ${outputDir.getPath}")
-      .mapError(outputFailure("prepare output directory", outputDir))
-
-  private def filePrefix(rc: McRunConfig) =
-    s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"
-
-  private def seedFileName(seed: Long, rc: McRunConfig) =
-    f"${filePrefix(rc)}_seed${seed}%03d.csv"
-
-  private val seedCsvHeader = SimOutput.colNames.mkString(";")
-
-  private def openCsvWriter(outputFile: File, operation: String): ZIO[zio.Scope, SimError, BufferedWriter] =
-    ZIO.fromAutoCloseable(
-      ZIO
-        .attemptBlocking(Files.newBufferedWriter(outputFile.toPath))
-        .mapError(outputFailure(s"open $operation writer", outputFile)),
-    )
-
-  private def writeCsvLine(writer: BufferedWriter, line: String, outputFile: File, operation: String): ZIO[Any, SimError, Unit] =
-    ZIO
-      .attemptBlocking:
-        writer.write(line)
-        writer.newLine()
-      .mapError(outputFailure(operation, outputFile))
-
-  private def moveOutputFile(tempFile: File, outputFile: File, operation: String): ZIO[Any, SimError, Unit] =
-    ZIO
-      .attemptBlocking:
-        Files.move(tempFile.toPath, outputFile.toPath, StandardCopyOption.REPLACE_EXISTING)
-      .unit
-      .mapError(outputFailure(s"finalize $operation", outputFile))
-
-  private def deleteIfExists(file: File, operation: String): ZIO[Any, SimError, Unit] =
-    ZIO
-      .attemptBlocking(Files.deleteIfExists(file.toPath))
-      .unit
-      .mapError(outputFailure(s"cleanup $operation temp file", file))
-
-  private def renderSeedCsvRow(month: ExecutionMonth, row: Array[Double]) =
-    val sb = new StringBuilder
-    sb.append(month.toInt)
-    for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
-    sb.toString
-
-  // ---------------------------------------------------------------------------
-  //  HH + Bank CSV writers (from collected results)
-  // ---------------------------------------------------------------------------
-
-  private val td = ComputationBoundary
-
-  private val hhSchema: Vector[(String, Household.Aggregates => String)] = Vector(
-    ("HH_Employed", a => s"${a.employed}"),
-    ("HH_Unemployed", a => s"${a.unemployed}"),
-    ("HH_Retraining", a => s"${a.retraining}"),
-    ("HH_Bankrupt", a => s"${a.bankrupt}"),
-    ("MeanSavings", a => f"${td.toDouble(a.meanSavings)}%.2f"),
-    ("MedianSavings", a => f"${td.toDouble(a.medianSavings)}%.2f"),
-    ("Gini_Individual", a => f"${td.toDouble(a.giniIndividual)}%.6f"),
-    ("Gini_Wealth", a => f"${td.toDouble(a.giniWealth)}%.6f"),
-    ("MeanSkill", a => f"${td.toDouble(a.meanSkill)}%.6f"),
-    ("MeanHealthPenalty", a => f"${td.toDouble(a.meanHealthPenalty)}%.6f"),
-    ("RetrainingAttempts", a => s"${a.retrainingAttempts}"),
-    ("RetrainingSuccesses", a => s"${a.retrainingSuccesses}"),
-    ("ConsumptionP10", a => f"${td.toDouble(a.consumptionP10)}%.2f"),
-    ("ConsumptionP50", a => f"${td.toDouble(a.consumptionP50)}%.2f"),
-    ("ConsumptionP90", a => f"${td.toDouble(a.consumptionP90)}%.2f"),
-    ("BankruptcyRate", a => f"${td.toDouble(a.bankruptcyRate)}%.6f"),
-    ("MeanMonthsToRuin", a => f"${a.meanMonthsToRuin.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD}%.2f"),
-    ("PovertyRate_50pct", a => f"${td.toDouble(a.povertyRate50)}%.6f"),
-    ("PovertyRate_30pct", a => f"${td.toDouble(a.povertyRate30)}%.6f"),
-  )
-
-  private val hhHeader = "Seed;" + hhSchema.map(_._1).mkString(";")
-
-  private def renderHouseholdSummaryRow(seed: Long, agg: Household.Aggregates): String =
-    s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
-
-  private def writeHhCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
-    val outputFile = new File(outputDir, s"${filePrefix(rc)}_hh.csv")
-    ZIO
-      .attemptBlocking:
-        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(TerminalSummaryCsv.Household))
-        CsvWriter.write(outputFile, hhHeader, rows)(identity)
-      .mapError(outputFailure("write household summary CSV", outputFile))
-
-  private val bankSchema: Vector[(String, BankState => String)] = Vector(
-    ("BankId", b => s"${b.id}"),
-    ("Deposits", b => f"${td.toDouble(b.deposits)}%.2f"),
-    ("Loans", b => f"${td.toDouble(b.loans)}%.2f"),
-    ("Capital", b => f"${td.toDouble(b.capital)}%.2f"),
-    ("NPL", b => f"${td.toDouble(b.nplRatio)}%.6f"),
-    ("CAR", b => f"${td.toDouble(b.car)}%.6f"),
-    ("GovBonds", b => f"${td.toDouble(b.govBondHoldings)}%.2f"),
-    ("InterbankNet", b => f"${td.toDouble(b.interbankNet)}%.2f"),
-    ("Failed", b => s"${b.failed}"),
-  )
-
-  private val bankHeader = "Seed;" + bankSchema.map(_._1).mkString(";")
-
-  private def renderBankSummaryRows(seed: Long, banks: Vector[BankState]): Vector[String] =
-    banks.map: b =>
-      s"$seed;" + bankSchema.map(_._2(b)).mkString(";")
-
-  private def writeBankCsv(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
-    val outputFile = new File(outputDir, s"${filePrefix(rc)}_banks.csv")
-    ZIO
-      .attemptBlocking:
-        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(TerminalSummaryCsv.Banks))
-        CsvWriter.write(outputFile, bankHeader, rows)(identity)
-      .mapError(outputFailure("write bank summary CSV", outputFile))
 
   // ---------------------------------------------------------------------------
   //  Progress
@@ -330,10 +167,8 @@ object McRunner:
       .mapError(runtimeFailure("print seed summary"))
 
   private def printSavedZIO(rc: McRunConfig, outputDir: File) =
-    val seedFiles = (1L to rc.nSeeds.toLong).map(s => new File(outputDir, seedFileName(s, rc)).getPath)
-    (ZIO.foreachDiscard(seedFiles)(f => Console.printLine(s"Saved: $f")) *>
-      Console.printLine(s"Saved: ${new File(outputDir, s"${filePrefix(rc)}_hh.csv").getPath}") *>
-      Console.printLine(s"Saved: ${new File(outputDir, s"${filePrefix(rc)}_banks.csv").getPath}"))
+    ZIO
+      .foreachDiscard(McOutputFiles.savedFiles(outputDir, rc))(file => Console.printLine(s"Saved: ${file.getPath}"))
       .mapError(runtimeFailure("print saved file paths"))
 
   // $COVERAGE-ON$

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunnerConsole.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunnerConsole.scala
@@ -1,0 +1,74 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import zio.{Console, ZIO}
+
+import java.util.Locale
+
+private[montecarlo] object McRunnerConsole:
+
+  enum Event:
+    case RunId(runId: String)
+    case MonthProgress(seed: Long, totalSeeds: Int, month: ExecutionMonth, durationMonths: Int)
+    case SeedDone(
+        seed: Long,
+        totalSeeds: Int,
+        elapsedMillis: Long,
+        adoption: Double,
+        inflation: Double,
+        unemployment: Double,
+    )
+    case BlankLine
+    case SavedFile(path: String)
+    case TotalTime(seconds: Double)
+
+  private val BarWidth = 20
+
+  def emit(event: Event): ZIO[Any, SimError, Unit] =
+    event match
+      case runId: Event.RunId            => Console.printLine(render(runId)).mapError(runtimeFailure("print run id"))
+      case progress: Event.MonthProgress => Console.print(render(progress)).mapError(runtimeFailure("print month progress"))
+      case done: Event.SeedDone          => Console.printLine(render(done)).mapError(runtimeFailure("print seed summary"))
+      case Event.BlankLine               => Console.printLine("").mapError(runtimeFailure("print separator"))
+      case saved: Event.SavedFile        => Console.printLine(render(saved)).mapError(runtimeFailure("print saved file paths"))
+      case total: Event.TotalTime        => Console.printLine(render(total)).mapError(runtimeFailure("print total time"))
+
+  def emitAll(events: Iterable[Event]): ZIO[Any, SimError, Unit] =
+    ZIO.foreachDiscard(events)(emit)
+
+  private[montecarlo] def render(event: Event): String =
+    event match
+      case runId: Event.RunId            => renderRunId(runId)
+      case progress: Event.MonthProgress => renderMonth(progress)
+      case done: Event.SeedDone          => renderSeedDone(done)
+      case Event.BlankLine               => ""
+      case saved: Event.SavedFile        => renderSaved(saved)
+      case total: Event.TotalTime        => renderTotalTime(total)
+
+  private def renderRunId(runId: Event.RunId): String =
+    s"  run-id: ${runId.runId}"
+
+  private def renderMonth(progress: Event.MonthProgress): String =
+    val frac   = progress.month.toInt.toDouble / progress.durationMonths
+    val filled = (frac * BarWidth).toInt
+    val bar    = "\u2588" * filled + "\u2591" * (BarWidth - filled)
+    val pct    = (frac * 100).toInt
+    f"\r  Seed ${progress.seed}%3d/${progress.totalSeeds} [$bar] ${progress.month.toInt}%3d/${progress.durationMonths}m ($pct%3d%%)"
+
+  private def renderSeedDone(done: Event.SeedDone): String =
+    val bar = "\u2588" * BarWidth
+    f"\r  Seed ${done.seed}%3d/${done.totalSeeds} [$bar] done (${done.elapsedMillis}ms) | " +
+      s"Adopt=${formatPct(done.adoption)} | pi=${formatPct(done.inflation)} | " +
+      s"Unemp=${formatPct(done.unemployment)}"
+
+  private def renderSaved(saved: Event.SavedFile): String =
+    s"Saved: ${saved.path}"
+
+  private def renderTotalTime(total: Event.TotalTime): String =
+    String.format(Locale.US, "\nTotal time: %.1f seconds", Double.box(total.seconds))
+
+  private def formatPct(value: Double): String =
+    String.format(Locale.US, "%5.1f%%", Double.box(value * 100.0))
+
+  private def runtimeFailure(operation: String)(err: Throwable): SimError =
+    SimError.RuntimeFailure(operation, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McSeedCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McSeedCsv.scala
@@ -1,0 +1,72 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import zio.stream.ZStream
+import zio.{Scope, ZIO}
+
+import java.io.BufferedWriter
+import java.io.File
+import java.nio.file.{Files, StandardCopyOption}
+
+private[montecarlo] object McSeedCsv:
+
+  private val operation = "write per-seed CSV"
+  private val header    = SimOutput.colNames.mkString(";")
+
+  def writeStreaming[A](
+      outputFile: File,
+      rows: ZStream[Any, SimError, A],
+      render: A => String,
+      emptyError: => SimError,
+  ): ZIO[Any, SimError, A] =
+    val tempFile  = new File(s"${outputFile.getPath}.tmp")
+    val writeFile = ZIO.scoped:
+      for
+        writer    <- openWriter(tempFile)
+        _         <- writeLine(writer, header, tempFile)
+        maybeLast <- rows.runFoldZIO(Option.empty[A]): (_, row) =>
+          writeLine(writer, render(row), tempFile).as(Some(row))
+        last      <- maybeLast match
+          case Some(value) => ZIO.succeed(value)
+          case None        => ZIO.fail(emptyError)
+      yield last
+
+    writeFile
+      .tap(_ => finalizeFile(tempFile, outputFile))
+      .onError(_ => deleteIfExists(tempFile).ignore)
+
+  def renderMonthRow(month: ExecutionMonth, row: Array[Double]): String =
+    val sb = new StringBuilder
+    sb.append(month.toInt)
+    for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
+    sb.toString
+
+  private def openWriter(outputFile: File): ZIO[Scope, SimError, BufferedWriter] =
+    ZIO.fromAutoCloseable(
+      ZIO
+        .attemptBlocking(Files.newBufferedWriter(outputFile.toPath))
+        .mapError(outputFailure(s"open $operation writer", outputFile)),
+    )
+
+  private def writeLine(writer: BufferedWriter, line: String, outputFile: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        writer.write(line)
+        writer.newLine()
+      .mapError(outputFailure(operation, outputFile))
+
+  private def finalizeFile(tempFile: File, outputFile: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        Files.move(tempFile.toPath, outputFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+      .unit
+      .mapError(outputFailure(s"finalize $operation", outputFile))
+
+  private def deleteIfExists(file: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking(Files.deleteIfExists(file.toPath))
+      .unit
+      .mapError(outputFailure(s"cleanup $operation temp file", file))
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
@@ -1,0 +1,95 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.Banking.BankState
+import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.fp.ComputationBoundary
+import com.boombustgroup.amorfati.util.CsvWriter
+import zio.ZIO
+
+import java.io.File
+
+private[montecarlo] enum TerminalSummaryCsv:
+  case Household, Banks
+
+private[montecarlo] case class SeedTerminalOutputs(seed: Long, rowsByCsv: Map[TerminalSummaryCsv, Vector[String]]):
+  def rowsFor(csv: TerminalSummaryCsv): Vector[String] =
+    rowsByCsv.getOrElse(csv, Vector.empty)
+
+private[montecarlo] object McTerminalSummaryCsv:
+
+  private val td = ComputationBoundary
+
+  private case class SummarySpec(
+      csv: TerminalSummaryCsv,
+      outputFile: (File, McRunConfig) => File,
+      header: String,
+  )
+
+  private val hhSchema: Vector[(String, Household.Aggregates => String)] = Vector(
+    ("HH_Employed", a => s"${a.employed}"),
+    ("HH_Unemployed", a => s"${a.unemployed}"),
+    ("HH_Retraining", a => s"${a.retraining}"),
+    ("HH_Bankrupt", a => s"${a.bankrupt}"),
+    ("MeanSavings", a => f"${td.toDouble(a.meanSavings)}%.2f"),
+    ("MedianSavings", a => f"${td.toDouble(a.medianSavings)}%.2f"),
+    ("Gini_Individual", a => f"${td.toDouble(a.giniIndividual)}%.6f"),
+    ("Gini_Wealth", a => f"${td.toDouble(a.giniWealth)}%.6f"),
+    ("MeanSkill", a => f"${td.toDouble(a.meanSkill)}%.6f"),
+    ("MeanHealthPenalty", a => f"${td.toDouble(a.meanHealthPenalty)}%.6f"),
+    ("RetrainingAttempts", a => s"${a.retrainingAttempts}"),
+    ("RetrainingSuccesses", a => s"${a.retrainingSuccesses}"),
+    ("ConsumptionP10", a => f"${td.toDouble(a.consumptionP10)}%.2f"),
+    ("ConsumptionP50", a => f"${td.toDouble(a.consumptionP50)}%.2f"),
+    ("ConsumptionP90", a => f"${td.toDouble(a.consumptionP90)}%.2f"),
+    ("BankruptcyRate", a => f"${td.toDouble(a.bankruptcyRate)}%.6f"),
+    ("MeanMonthsToRuin", a => f"${a.meanMonthsToRuin.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD}%.2f"),
+    ("PovertyRate_50pct", a => f"${td.toDouble(a.povertyRate50)}%.6f"),
+    ("PovertyRate_30pct", a => f"${td.toDouble(a.povertyRate30)}%.6f"),
+  )
+
+  private val bankSchema: Vector[(String, BankState => String)] = Vector(
+    ("BankId", b => s"${b.id}"),
+    ("Deposits", b => f"${td.toDouble(b.deposits)}%.2f"),
+    ("Loans", b => f"${td.toDouble(b.loans)}%.2f"),
+    ("Capital", b => f"${td.toDouble(b.capital)}%.2f"),
+    ("NPL", b => f"${td.toDouble(b.nplRatio)}%.6f"),
+    ("CAR", b => f"${td.toDouble(b.car)}%.6f"),
+    ("GovBonds", b => f"${td.toDouble(b.govBondHoldings)}%.2f"),
+    ("InterbankNet", b => f"${td.toDouble(b.interbankNet)}%.2f"),
+    ("Failed", b => s"${b.failed}"),
+  )
+
+  private val specs = Vector(
+    SummarySpec(TerminalSummaryCsv.Household, McOutputFiles.householdFile, "Seed;" + hhSchema.map(_._1).mkString(";")),
+    SummarySpec(TerminalSummaryCsv.Banks, McOutputFiles.bankFile, "Seed;" + bankSchema.map(_._1).mkString(";")),
+  )
+
+  def fromTerminalState(seed: Long, terminalState: FlowSimulation.SimState): SeedTerminalOutputs =
+    SeedTerminalOutputs(
+      seed,
+      Map(
+        TerminalSummaryCsv.Household -> Vector(renderHouseholdRow(seed, terminalState.householdAggregates)),
+        TerminalSummaryCsv.Banks     -> terminalState.banks.map(renderBankRow(seed, _)),
+      ),
+    )
+
+  def writeAll(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]): ZIO[Any, SimError, Unit] =
+    ZIO.foreachDiscard(specs)(spec => writeSummaryCsv(spec, rc, outputDir, results))
+
+  private def writeSummaryCsv(spec: SummarySpec, rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
+    val outputFile = spec.outputFile(outputDir, rc)
+    ZIO
+      .attemptBlocking:
+        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(spec.csv))
+        CsvWriter.write(outputFile, spec.header, rows)(identity)
+      .mapError(outputFailure(s"write ${spec.csv.toString.toLowerCase} summary CSV", outputFile))
+
+  private def renderHouseholdRow(seed: Long, agg: Household.Aggregates): String =
+    s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
+
+  private def renderBankRow(seed: Long, bank: BankState): String =
+    s"$seed;" + bankSchema.map(_._2(bank)).mkString(";")
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
@@ -8,18 +8,19 @@ import java.io.File
 private[montecarlo] object McTerminalSummaryCsv:
 
   def writeAll(rc: McRunConfig, outputDir: File, results: zio.Chunk[McTerminalSummaryRows]): ZIO[Any, SimError, Unit] =
-    ZIO.foreachDiscard(McTerminalSummarySchema.specs)(spec => writeSummaryCsv(spec, rc, outputDir, results))
+    val sorted = results.sortBy(_.seed)
+    ZIO.foreachDiscard(McTerminalSummarySchema.specs)(spec => writeSummaryCsv(spec, rc, outputDir, sorted))
 
   private def writeSummaryCsv(
       spec: McTerminalSummarySchema.SummarySpec,
       rc: McRunConfig,
       outputDir: File,
-      results: zio.Chunk[McTerminalSummaryRows],
+      sortedResults: zio.Chunk[McTerminalSummaryRows],
   ) =
     val outputFile = spec.outputFile(outputDir, rc)
     ZIO
       .attemptBlocking:
-        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(spec.id))
+        val rows = sortedResults.flatMap(_.rowsFor(spec.id))
         CsvWriter.write(outputFile, spec.csvSchema.header, rows)(spec.csvSchema.render)
       .mapError(outputFailure(s"write ${spec.id.toString.toLowerCase} summary CSV", outputFile))
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummaryCsv.scala
@@ -1,95 +1,27 @@
 package com.boombustgroup.amorfati.montecarlo
 
-import com.boombustgroup.amorfati.agents.Banking.BankState
-import com.boombustgroup.amorfati.agents.Household
-import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.util.CsvWriter
 import zio.ZIO
 
 import java.io.File
 
-private[montecarlo] enum TerminalSummaryCsv:
-  case Household, Banks
-
-private[montecarlo] case class SeedTerminalOutputs(seed: Long, rowsByCsv: Map[TerminalSummaryCsv, Vector[String]]):
-  def rowsFor(csv: TerminalSummaryCsv): Vector[String] =
-    rowsByCsv.getOrElse(csv, Vector.empty)
-
 private[montecarlo] object McTerminalSummaryCsv:
 
-  private val td = ComputationBoundary
+  def writeAll(rc: McRunConfig, outputDir: File, results: zio.Chunk[McTerminalSummaryRows]): ZIO[Any, SimError, Unit] =
+    ZIO.foreachDiscard(McTerminalSummarySchema.specs)(spec => writeSummaryCsv(spec, rc, outputDir, results))
 
-  private case class SummarySpec(
-      csv: TerminalSummaryCsv,
-      outputFile: (File, McRunConfig) => File,
-      header: String,
-  )
-
-  private val hhSchema: Vector[(String, Household.Aggregates => String)] = Vector(
-    ("HH_Employed", a => s"${a.employed}"),
-    ("HH_Unemployed", a => s"${a.unemployed}"),
-    ("HH_Retraining", a => s"${a.retraining}"),
-    ("HH_Bankrupt", a => s"${a.bankrupt}"),
-    ("MeanSavings", a => f"${td.toDouble(a.meanSavings)}%.2f"),
-    ("MedianSavings", a => f"${td.toDouble(a.medianSavings)}%.2f"),
-    ("Gini_Individual", a => f"${td.toDouble(a.giniIndividual)}%.6f"),
-    ("Gini_Wealth", a => f"${td.toDouble(a.giniWealth)}%.6f"),
-    ("MeanSkill", a => f"${td.toDouble(a.meanSkill)}%.6f"),
-    ("MeanHealthPenalty", a => f"${td.toDouble(a.meanHealthPenalty)}%.6f"),
-    ("RetrainingAttempts", a => s"${a.retrainingAttempts}"),
-    ("RetrainingSuccesses", a => s"${a.retrainingSuccesses}"),
-    ("ConsumptionP10", a => f"${td.toDouble(a.consumptionP10)}%.2f"),
-    ("ConsumptionP50", a => f"${td.toDouble(a.consumptionP50)}%.2f"),
-    ("ConsumptionP90", a => f"${td.toDouble(a.consumptionP90)}%.2f"),
-    ("BankruptcyRate", a => f"${td.toDouble(a.bankruptcyRate)}%.6f"),
-    ("MeanMonthsToRuin", a => f"${a.meanMonthsToRuin.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD}%.2f"),
-    ("PovertyRate_50pct", a => f"${td.toDouble(a.povertyRate50)}%.6f"),
-    ("PovertyRate_30pct", a => f"${td.toDouble(a.povertyRate30)}%.6f"),
-  )
-
-  private val bankSchema: Vector[(String, BankState => String)] = Vector(
-    ("BankId", b => s"${b.id}"),
-    ("Deposits", b => f"${td.toDouble(b.deposits)}%.2f"),
-    ("Loans", b => f"${td.toDouble(b.loans)}%.2f"),
-    ("Capital", b => f"${td.toDouble(b.capital)}%.2f"),
-    ("NPL", b => f"${td.toDouble(b.nplRatio)}%.6f"),
-    ("CAR", b => f"${td.toDouble(b.car)}%.6f"),
-    ("GovBonds", b => f"${td.toDouble(b.govBondHoldings)}%.2f"),
-    ("InterbankNet", b => f"${td.toDouble(b.interbankNet)}%.2f"),
-    ("Failed", b => s"${b.failed}"),
-  )
-
-  private val specs = Vector(
-    SummarySpec(TerminalSummaryCsv.Household, McOutputFiles.householdFile, "Seed;" + hhSchema.map(_._1).mkString(";")),
-    SummarySpec(TerminalSummaryCsv.Banks, McOutputFiles.bankFile, "Seed;" + bankSchema.map(_._1).mkString(";")),
-  )
-
-  def fromTerminalState(seed: Long, terminalState: FlowSimulation.SimState): SeedTerminalOutputs =
-    SeedTerminalOutputs(
-      seed,
-      Map(
-        TerminalSummaryCsv.Household -> Vector(renderHouseholdRow(seed, terminalState.householdAggregates)),
-        TerminalSummaryCsv.Banks     -> terminalState.banks.map(renderBankRow(seed, _)),
-      ),
-    )
-
-  def writeAll(rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]): ZIO[Any, SimError, Unit] =
-    ZIO.foreachDiscard(specs)(spec => writeSummaryCsv(spec, rc, outputDir, results))
-
-  private def writeSummaryCsv(spec: SummarySpec, rc: McRunConfig, outputDir: File, results: zio.Chunk[SeedTerminalOutputs]) =
+  private def writeSummaryCsv(
+      spec: McTerminalSummarySchema.SummarySpec,
+      rc: McRunConfig,
+      outputDir: File,
+      results: zio.Chunk[McTerminalSummaryRows],
+  ) =
     val outputFile = spec.outputFile(outputDir, rc)
     ZIO
       .attemptBlocking:
-        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(spec.csv))
-        CsvWriter.write(outputFile, spec.header, rows)(identity)
-      .mapError(outputFailure(s"write ${spec.csv.toString.toLowerCase} summary CSV", outputFile))
-
-  private def renderHouseholdRow(seed: Long, agg: Household.Aggregates): String =
-    s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
-
-  private def renderBankRow(seed: Long, bank: BankState): String =
-    s"$seed;" + bankSchema.map(_._2(bank)).mkString(";")
+        val rows = results.sortBy(_.seed).flatMap(_.rowsFor(spec.id))
+        CsvWriter.write(outputFile, spec.csvSchema.header, rows)(spec.csvSchema.render)
+      .mapError(outputFailure(s"write ${spec.id.toString.toLowerCase} summary CSV", outputFile))
 
   private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
     SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
@@ -1,0 +1,93 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.Banking.BankState
+import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.fp.ComputationBoundary
+
+import java.io.File
+
+private[montecarlo] enum McTerminalSummaryId:
+  case Household, Banks
+
+private[montecarlo] final case class McTerminalSummaryRows(seed: Long, rowsById: Map[McTerminalSummaryId, Vector[String]]):
+  def rowsFor(id: McTerminalSummaryId): Vector[String] =
+    rowsById.getOrElse(id, Vector.empty)
+
+private[montecarlo] object McTerminalSummarySchema:
+
+  private val td = ComputationBoundary
+
+  private[montecarlo] final case class SummarySpec(
+      id: McTerminalSummaryId,
+      outputFile: (File, McRunConfig) => File,
+      csvSchema: McCsvSchema[String],
+  )
+
+  private val hhSchema: Vector[(String, Household.Aggregates => String)] = Vector(
+    ("HH_Employed", a => s"${a.employed}"),
+    ("HH_Unemployed", a => s"${a.unemployed}"),
+    ("HH_Retraining", a => s"${a.retraining}"),
+    ("HH_Bankrupt", a => s"${a.bankrupt}"),
+    ("MeanSavings", a => f"${td.toDouble(a.meanSavings)}%.2f"),
+    ("MedianSavings", a => f"${td.toDouble(a.medianSavings)}%.2f"),
+    ("Gini_Individual", a => f"${td.toDouble(a.giniIndividual)}%.6f"),
+    ("Gini_Wealth", a => f"${td.toDouble(a.giniWealth)}%.6f"),
+    ("MeanSkill", a => f"${td.toDouble(a.meanSkill)}%.6f"),
+    ("MeanHealthPenalty", a => f"${td.toDouble(a.meanHealthPenalty)}%.6f"),
+    ("RetrainingAttempts", a => s"${a.retrainingAttempts}"),
+    ("RetrainingSuccesses", a => s"${a.retrainingSuccesses}"),
+    ("ConsumptionP10", a => f"${td.toDouble(a.consumptionP10)}%.2f"),
+    ("ConsumptionP50", a => f"${td.toDouble(a.consumptionP50)}%.2f"),
+    ("ConsumptionP90", a => f"${td.toDouble(a.consumptionP90)}%.2f"),
+    ("BankruptcyRate", a => f"${td.toDouble(a.bankruptcyRate)}%.6f"),
+    ("MeanMonthsToRuin", a => f"${a.meanMonthsToRuin.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD}%.2f"),
+    ("PovertyRate_50pct", a => f"${td.toDouble(a.povertyRate50)}%.6f"),
+    ("PovertyRate_30pct", a => f"${td.toDouble(a.povertyRate30)}%.6f"),
+  )
+
+  private val bankSchema: Vector[(String, BankState => String)] = Vector(
+    ("BankId", b => s"${b.id}"),
+    ("Deposits", b => f"${td.toDouble(b.deposits)}%.2f"),
+    ("Loans", b => f"${td.toDouble(b.loans)}%.2f"),
+    ("Capital", b => f"${td.toDouble(b.capital)}%.2f"),
+    ("NPL", b => f"${td.toDouble(b.nplRatio)}%.6f"),
+    ("CAR", b => f"${td.toDouble(b.car)}%.6f"),
+    ("GovBonds", b => f"${td.toDouble(b.govBondHoldings)}%.2f"),
+    ("InterbankNet", b => f"${td.toDouble(b.interbankNet)}%.2f"),
+    ("Failed", b => s"${b.failed}"),
+  )
+
+  private[montecarlo] val specs = Vector(
+    SummarySpec(
+      McTerminalSummaryId.Household,
+      McOutputFiles.householdFile,
+      McCsvSchema(
+        header = "Seed;" + hhSchema.map(_._1).mkString(";"),
+        render = identity,
+      ),
+    ),
+    SummarySpec(
+      McTerminalSummaryId.Banks,
+      McOutputFiles.bankFile,
+      McCsvSchema(
+        header = "Seed;" + bankSchema.map(_._1).mkString(";"),
+        render = identity,
+      ),
+    ),
+  )
+
+  def fromTerminalState(seed: Long, terminalState: FlowSimulation.SimState): McTerminalSummaryRows =
+    McTerminalSummaryRows(
+      seed,
+      Map(
+        McTerminalSummaryId.Household -> Vector(renderHouseholdRow(seed, terminalState.householdAggregates)),
+        McTerminalSummaryId.Banks     -> terminalState.banks.map(renderBankRow(seed, _)),
+      ),
+    )
+
+  private def renderHouseholdRow(seed: Long, agg: Household.Aggregates): String =
+    s"$seed;" + hhSchema.map(_._2(agg)).mkString(";")
+
+  private def renderBankRow(seed: Long, bank: BankState): String =
+    s"$seed;" + bankSchema.map(_._2(bank)).mkString(";")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
@@ -59,6 +59,8 @@ private[montecarlo] object McTerminalSummarySchema:
   )
 
   private[montecarlo] val specs = Vector(
+    // SummarySpec rows are pre-formatted by fromTerminalState, so McCsvSchema only
+    // carries the header contract here and render is intentionally identity.
     SummarySpec(
       McTerminalSummaryId.Household,
       McOutputFiles.householdFile,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesCsv.scala
@@ -1,6 +1,5 @@
 package com.boombustgroup.amorfati.montecarlo
 
-import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import zio.stream.ZStream
 import zio.{Scope, ZIO}
 
@@ -8,24 +7,23 @@ import java.io.BufferedWriter
 import java.io.File
 import java.nio.file.{Files, StandardCopyOption}
 
-private[montecarlo] object McSeedCsv:
+private[montecarlo] object McTimeseriesCsv:
 
   private val operation = "write per-seed CSV"
-  private val header    = SimOutput.colNames.mkString(";")
 
   def writeStreaming[A](
       outputFile: File,
       rows: ZStream[Any, SimError, A],
-      render: A => String,
+      schema: McCsvSchema[A],
       emptyError: => SimError,
   ): ZIO[Any, SimError, A] =
     val tempFile  = new File(s"${outputFile.getPath}.tmp")
     val writeFile = ZIO.scoped:
       for
         writer    <- openWriter(tempFile)
-        _         <- writeLine(writer, header, tempFile)
+        _         <- writeLine(writer, schema.header, tempFile)
         maybeLast <- rows.runFoldZIO(Option.empty[A]): (_, row) =>
-          writeLine(writer, render(row), tempFile).as(Some(row))
+          writeLine(writer, schema.render(row), tempFile).as(Some(row))
         last      <- maybeLast match
           case Some(value) => ZIO.succeed(value)
           case None        => ZIO.fail(emptyError)
@@ -34,12 +32,6 @@ private[montecarlo] object McSeedCsv:
     writeFile
       .tap(_ => finalizeFile(tempFile, outputFile))
       .onError(_ => deleteIfExists(tempFile).ignore)
-
-  def renderMonthRow(month: ExecutionMonth, row: Array[Double]): String =
-    val sb = new StringBuilder
-    sb.append(month.toInt)
-    for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
-    sb.toString
 
   private def openWriter(outputFile: File): ZIO[Scope, SimError, BufferedWriter] =
     ZIO.fromAutoCloseable(

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -10,6 +10,8 @@ import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.agents.Region
 
+import java.util.Locale
+
 /** Typed column schema for Monte Carlo timeseries output.
   *
   * Composable: each group is a `Vector[ColumnDef]`, all composed with `++`.
@@ -634,7 +636,7 @@ object McTimeseriesSchema:
       render = (month, row) =>
         val sb = new StringBuilder
         sb.append(month.toInt)
-        for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
+        for c <- 1 until nCols do sb.append(String.format(Locale.US, ";%.6f", Double.box(row(c))))
         sb.toString,
     )
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -10,12 +10,12 @@ import com.boombustgroup.amorfati.fp.ComputationBoundary
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.agents.Region
 
-/** Typed column schema for simulation output.
+/** Typed column schema for Monte Carlo timeseries output.
   *
   * Composable: each group is a `Vector[ColumnDef]`, all composed with `++`.
   * Column handles (`Col`) are derived by name lookup — no mutable counter.
   */
-object SimOutput:
+object McTimeseriesSchema:
 
   private val td                                          = ComputationBoundary
   private def exchangeRateValue(er: ExchangeRate): Double = er.toLong.toDouble / com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
@@ -32,7 +32,7 @@ object SimOutput:
     sectorSchemaPairs.length == SimParams.SchemaSectorCount &&
       sectorSchemaPairs.map(_._1) == SimParams.SchemaSectorNames &&
       sectorSchemaPairs.map(_._2).distinct.length == sectorSchemaPairs.length,
-    s"SimOutput sector schema must define ${SimParams.SchemaSectorCount} unique (name, stem) pairs, got ${sectorSchemaPairs.mkString(", ")}",
+    s"McTimeseriesSchema sector schema must define ${SimParams.SchemaSectorCount} unique (name, stem) pairs, got ${sectorSchemaPairs.mkString(", ")}",
   )
 
   private val sectorColumns: Vector[SectorColumns] =
@@ -60,7 +60,7 @@ object SimOutput:
   ):
     require(
       world.currentSigmas.length == p.sectorDefs.length,
-      s"SimOutput requires world.currentSigmas to have ${p.sectorDefs.length} entries to match sectorDefs, got ${world.currentSigmas.length}",
+      s"McTimeseriesSchema requires world.currentSigmas to have ${p.sectorDefs.length} entries to match sectorDefs, got ${world.currentSigmas.length}",
     )
 
     given SimParams                                                                                 = p
@@ -627,6 +627,16 @@ object SimOutput:
 
   /** Number of columns — derived from schema. */
   val nCols: Int = schema.length
+
+  private[montecarlo] val csvSchema: McCsvSchema[(ExecutionMonth, Array[Double])] =
+    McCsvSchema(
+      header = colNames.mkString(";"),
+      render = (month, row) =>
+        val sb = new StringBuilder
+        sb.append(month.toInt)
+        for c <- 1 until nCols do sb.append(f";${row(c)}%.6f")
+        sb.toString,
+    )
 
   /** Compute one row. Returns Array[Double] for MC aggregation. */
   def compute(

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.montecarlo
 import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
+import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema.Col
 
 /** Zero-cost typed wrappers for Monte Carlo simulation output. */
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -10,7 +10,10 @@ schema, summary statistics, and CSV I/O. It is the only consumer of
 |------|--------|------------------------------------------------------------------------------------------------------------|
 | `McRunner.scala` | `McRunner` | MC loop: runs N seeds, collects results, writes CSV, prints summary                                        |
 | `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId`                       |
-| `SimOutput.scala` | `SimOutput` | 239-column output schema with explicit sector/region contracts — typed `Col` definitions, `compute` function |
+| `McTimeseriesSchema.scala` | `McTimeseriesSchema` | 239-column timeseries schema with explicit sector/region contracts — typed `Col` definitions, `compute` function |
+| `McTimeseriesCsv.scala` | `McTimeseriesCsv` | Streaming per-seed timeseries CSV sink using the shared timeseries schema                                    |
+| `McTerminalSummarySchema.scala` | `McTerminalSummarySchema` | Terminal summary schema definitions and seed-level row extraction                                             |
+| `McTerminalSummaryCsv.scala` | `McTerminalSummaryCsv` | Terminal summary CSV writers using the shared terminal summary schemas                                        |
 | `McTypes.scala` | `RunResult`, `TimeSeries`, `DescriptiveStats`, `McResults` | Zero-cost typed wrappers for simulation output and summary statistics                                      |
 
 ## Data flow
@@ -21,7 +24,7 @@ Main ──→ McRunner.run(rc)
            ├── for seed ← 1..N:
            │     WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
            │     MonthDriver.unfoldSteps(...).take(runDurationMonths)
-           │     SimOutput.compute  → Array[Double]
+           │     McTimeseriesSchema.compute  → Array[Double]
            │
            ├── McResults.summarize  → DescriptiveStats per column
            └── CSV writers (terminal, timeseries, hh, banks)
@@ -30,7 +33,7 @@ Main ──→ McRunner.run(rc)
 `McRunner.runSingle` is the only bridge between this package and the
 engine — it calls `WorldInit.initialize`, drives the shared
 `MonthDriver.unfoldSteps` iterator, then maps each monthly state
-through `SimOutput.compute`.
+through `McTimeseriesSchema.compute`.
 
 `runDurationMonths` is a Monte Carlo/runtime concern. It controls how
 many monthly snapshots the runner materializes, but it is not part of

--- a/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/McRunnerSpec.scala
@@ -3,8 +3,8 @@ package com.boombustgroup.amorfati.engine
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.montecarlo.McRunner.runSingle
-import com.boombustgroup.amorfati.montecarlo.SimOutput
-import com.boombustgroup.amorfati.montecarlo.SimOutput.Col
+import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema
+import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema.Col
 import com.boombustgroup.amorfati.montecarlo.TimeSeries
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
@@ -37,9 +37,9 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
     negativeDuration.getMessage should include("runDurationMonths must be > 0")
   }
 
-  "runSingle" should s"produce 60 rows x ${SimOutput.nCols} columns" in {
+  "runSingle" should s"produce 60 rows x ${McTimeseriesSchema.nCols} columns" in {
     ts.nMonths shouldBe duration
-    for row <- ts do row.length shouldBe SimOutput.nCols
+    for row <- ts do row.length shouldBe McTimeseriesSchema.nCols
   }
 
   it should "have Month column = 1..60" in {
@@ -85,7 +85,7 @@ class McRunnerSpec extends AnyFlatSpec with Matchers:
 
   it should "be reproducible with the same seed" in {
     val r2 = runSingle(42, duration).fold(e => fail(e.toString), identity)
-    for t <- 0 until duration; c <- 0 until SimOutput.nCols do row(t)(c) shouldBe row(r2.timeSeries, t)(c)
+    for t <- 0 until duration; c <- 0 until McTimeseriesSchema.nCols do row(t)(c) shouldBe row(r2.timeSeries, t)(c)
   }
 
   // --- Terminal state ---

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerConsoleSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerConsoleSpec.scala
@@ -1,0 +1,58 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class McRunnerConsoleSpec extends AnyFlatSpec with Matchers:
+
+  private val fullBlock  = "\u2588"
+  private val emptyBlock = "\u2591"
+
+  "McRunnerConsole.render" should "format month progress consistently" in {
+    val monthProgress = McRunnerConsole.Event.MonthProgress(
+      seed = 7L,
+      totalSeeds = 12,
+      month = ExecutionMonth.First.advanceBy(1),
+      durationMonths = 4,
+    )
+
+    McRunnerConsole.render(monthProgress) shouldBe
+      s"\r  Seed   7/12 [${fullBlock * 10}${emptyBlock * 10}]   2/4m ( 50%)"
+  }
+
+  it should "format run id consistently" in {
+    val runId = McRunnerConsole.Event.RunId("fixed")
+
+    McRunnerConsole.render(runId) shouldBe "  run-id: fixed"
+  }
+
+  it should "format seed completion consistently" in {
+    val seedDone = McRunnerConsole.Event.SeedDone(
+      seed = 7L,
+      totalSeeds = 12,
+      elapsedMillis = 3456L,
+      adoption = 0.123,
+      inflation = 0.045,
+      unemployment = 0.067,
+    )
+
+    McRunnerConsole.render(seedDone) shouldBe
+      s"\r  Seed   7/12 [${fullBlock * 20}] done (3456ms) | Adopt= 12.3% | pi=  4.5% | Unemp=  6.7%"
+  }
+
+  it should "format saved file reporting consistently" in {
+    val savedFile = McRunnerConsole.Event.SavedFile("/tmp/output.csv")
+
+    McRunnerConsole.render(savedFile) shouldBe "Saved: /tmp/output.csv"
+  }
+
+  it should "format a blank separator consistently" in {
+    McRunnerConsole.render(McRunnerConsole.Event.BlankLine) shouldBe ""
+  }
+
+  it should "format total time consistently" in {
+    val totalTime = McRunnerConsole.Event.TotalTime(4.6)
+
+    McRunnerConsole.render(totalTime) shouldBe "\nTotal time: 4.6 seconds"
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
@@ -52,11 +52,8 @@ class McRunnerOutputSpec extends AnyFlatSpec with Matchers:
   private def expectedSeedLines(result: RunResult): Vector[String] =
     val rows = result.timeSeries.executionMonths.map: month =>
       val row = result.timeSeries.monthRow(month)
-      val sb  = new StringBuilder
-      sb.append(month.toInt)
-      for c <- 1 until McTimeseriesSchema.nCols do sb.append(f";${row(c)}%.6f")
-      sb.toString
-    McTimeseriesSchema.colNames.mkString(";") +: rows
+      McTimeseriesSchema.csvSchema.render((month, row))
+    McTimeseriesSchema.csvSchema.header +: rows
 
   private val householdHeader =
     "Seed;HH_Employed;HH_Unemployed;HH_Retraining;HH_Bankrupt;MeanSavings;MedianSavings;Gini_Individual;" +

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
@@ -1,0 +1,141 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.Banking.BankState
+import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.fp.{ComputationBoundary, FixedPointBase}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.{Runtime, Unsafe}
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+class McRunnerOutputSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams = SimParams.defaults
+
+  private val td = ComputationBoundary
+
+  "runZIO" should "match runSingle CSV outputs on a small deterministic run" in
+    withTempDir: outputDir =>
+      val rc       = McRunConfig(nSeeds = 2, outputPrefix = "regression", runDurationMonths = 4, runId = "fixed")
+      val expected = expectedFiles(rc)
+
+      runToDir(rc, outputDir)
+
+      listFileNames(outputDir) shouldBe expected.keySet
+      expected.foreach: (name, lines) =>
+        withClue(s"$name: ") {
+          Files.readAllLines(outputDir.resolve(name), UTF_8).asScala.toVector shouldBe lines
+        }
+
+  private def runToDir(rc: McRunConfig, outputDir: Path): Unit =
+    Unsafe.unsafe: unsafe =>
+      given Unsafe = unsafe
+      Runtime.default.unsafe.run(McRunner.runZIO(rc, outputDir.toFile)).getOrThrowFiberFailure()
+
+  private def expectedFiles(rc: McRunConfig): Map[String, Vector[String]] =
+    val results = (1L to rc.nSeeds.toLong).map: seed =>
+      seed -> McRunner.runSingle(seed, rc.runDurationMonths).fold(err => fail(err.toString), identity)
+
+    results.iterator
+      .map: (seed, result) =>
+        seedFileName(seed, rc) -> expectedSeedLines(result)
+      .toMap ++ Map(
+      hhFileName(rc)   -> expectedHouseholdLines(results.toVector),
+      bankFileName(rc) -> expectedBankLines(results.toVector),
+    )
+
+  private def expectedSeedLines(result: RunResult): Vector[String] =
+    val rows = result.timeSeries.executionMonths.map: month =>
+      val row = result.timeSeries.monthRow(month)
+      val sb  = new StringBuilder
+      sb.append(month.toInt)
+      for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
+      sb.toString
+    SimOutput.colNames.mkString(";") +: rows
+
+  private val householdHeader =
+    "Seed;HH_Employed;HH_Unemployed;HH_Retraining;HH_Bankrupt;MeanSavings;MedianSavings;Gini_Individual;" +
+      "Gini_Wealth;MeanSkill;MeanHealthPenalty;RetrainingAttempts;RetrainingSuccesses;ConsumptionP10;" +
+      "ConsumptionP50;ConsumptionP90;BankruptcyRate;MeanMonthsToRuin;PovertyRate_50pct;PovertyRate_30pct"
+
+  private def expectedHouseholdLines(results: Vector[(Long, RunResult)]): Vector[String] =
+    householdHeader +: results.map: (seed, result) =>
+      householdRow(seed, result.terminalState.householdAggregates)
+
+  private def householdRow(seed: Long, agg: Household.Aggregates): String =
+    Vector(
+      s"$seed",
+      s"${agg.employed}",
+      s"${agg.unemployed}",
+      s"${agg.retraining}",
+      s"${agg.bankrupt}",
+      f"${td.toDouble(agg.meanSavings)}%.2f",
+      f"${td.toDouble(agg.medianSavings)}%.2f",
+      f"${td.toDouble(agg.giniIndividual)}%.6f",
+      f"${td.toDouble(agg.giniWealth)}%.6f",
+      f"${td.toDouble(agg.meanSkill)}%.6f",
+      f"${td.toDouble(agg.meanHealthPenalty)}%.6f",
+      s"${agg.retrainingAttempts}",
+      s"${agg.retrainingSuccesses}",
+      f"${td.toDouble(agg.consumptionP10)}%.2f",
+      f"${td.toDouble(agg.consumptionP50)}%.2f",
+      f"${td.toDouble(agg.consumptionP90)}%.2f",
+      f"${td.toDouble(agg.bankruptcyRate)}%.6f",
+      f"${agg.meanMonthsToRuin.toLong.toDouble / FixedPointBase.ScaleD}%.2f",
+      f"${td.toDouble(agg.povertyRate50)}%.6f",
+      f"${td.toDouble(agg.povertyRate30)}%.6f",
+    ).mkString(";")
+
+  private val bankHeader =
+    "Seed;BankId;Deposits;Loans;Capital;NPL;CAR;GovBonds;InterbankNet;Failed"
+
+  private def expectedBankLines(results: Vector[(Long, RunResult)]): Vector[String] =
+    bankHeader +: results.flatMap: (seed, result) =>
+      result.terminalState.banks.map(bankRow(seed, _))
+
+  private def bankRow(seed: Long, bank: BankState): String =
+    Vector(
+      s"$seed",
+      s"${bank.id}",
+      f"${td.toDouble(bank.deposits)}%.2f",
+      f"${td.toDouble(bank.loans)}%.2f",
+      f"${td.toDouble(bank.capital)}%.2f",
+      f"${td.toDouble(bank.nplRatio)}%.6f",
+      f"${td.toDouble(bank.car)}%.6f",
+      f"${td.toDouble(bank.govBondHoldings)}%.2f",
+      f"${td.toDouble(bank.interbankNet)}%.2f",
+      s"${bank.failed}",
+    ).mkString(";")
+
+  private def filePrefix(rc: McRunConfig): String =
+    s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"
+
+  private def seedFileName(seed: Long, rc: McRunConfig): String =
+    f"${filePrefix(rc)}_seed${seed}%03d.csv"
+
+  private def hhFileName(rc: McRunConfig): String =
+    s"${filePrefix(rc)}_hh.csv"
+
+  private def bankFileName(rc: McRunConfig): String =
+    s"${filePrefix(rc)}_banks.csv"
+
+  private def listFileNames(outputDir: Path): Set[String] =
+    Using.resource(Files.list(outputDir)) { paths =>
+      paths.iterator().asScala.map(_.getFileName.toString).toSet
+    }
+
+  private def withTempDir[A](f: Path => A): A =
+    val outputDir = Files.createTempDirectory("mc-runner-output")
+    try f(outputDir)
+    finally deleteRecursively(outputDir)
+
+  private def deleteRecursively(path: Path): Unit =
+    if Files.exists(path) then
+      Using.resource(Files.walk(path)) { paths =>
+        paths.iterator().asScala.toVector.sortBy(_.getNameCount)(using Ordering.Int.reverse).foreach(Files.deleteIfExists)
+      }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
@@ -54,9 +54,9 @@ class McRunnerOutputSpec extends AnyFlatSpec with Matchers:
       val row = result.timeSeries.monthRow(month)
       val sb  = new StringBuilder
       sb.append(month.toInt)
-      for c <- 1 until SimOutput.nCols do sb.append(f";${row(c)}%.6f")
+      for c <- 1 until McTimeseriesSchema.nCols do sb.append(f";${row(c)}%.6f")
       sb.toString
-    SimOutput.colNames.mkString(";") +: rows
+    McTimeseriesSchema.colNames.mkString(";") +: rows
 
   private val householdHeader =
     "Seed;HH_Employed;HH_Unemployed;HH_Retraining;HH_Bankrupt;MeanSavings;MedianSavings;Gini_Individual;" +

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -8,7 +8,7 @@ import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SimOutputSpec extends AnyFlatSpec with Matchers:
+class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
 
   given SimParams = SimParams.defaults
 
@@ -257,7 +257,7 @@ class SimOutputSpec extends AnyFlatSpec with Matchers:
   )
 
   private def computeRow(world: World): Array[Double] =
-    SimOutput.compute(
+    McTimeseriesSchema.compute(
       executionMonth = ExecutionMonth.First,
       world = world,
       firms = init.firms,
@@ -267,13 +267,13 @@ class SimOutputSpec extends AnyFlatSpec with Matchers:
     )
 
   private def valueAt(row: Array[Double], name: String): Double =
-    val idx = SimOutput.colNames.indexOf(name)
+    val idx = McTimeseriesSchema.colNames.indexOf(name)
     idx.should(be >= 0)
     row(idx)
 
-  "SimOutput" should "expose the stable schema contract" in {
-    SimOutput.nCols shouldBe 239
-    SimOutput.colNames.toVector shouldBe expectedColNames
+  "McTimeseriesSchema" should "expose the stable schema contract" in {
+    McTimeseriesSchema.nCols shouldBe 239
+    McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
   it should "fail fast when currentSigmas does not match the sector schema" in {


### PR DESCRIPTION
Closes #332

## Summary
- stream per-seed Monte Carlo timeseries directly to CSV and retain only terminal summary rows in memory
- split runner output responsibilities into dedicated timeseries, terminal summary, file layout, and console modules
- unify Monte Carlo schema and CSV naming around shared schema/writer conventions
- add deterministic regression coverage for CSV output equivalence and console rendering

## Verification
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McRunnerConsoleSpec"
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McRunnerOutputSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Real-time console progress for multi-seed runs with per-seed metrics (adoption, inflation, unemployment).
  - Streaming per-seed timeseries CSVs and consolidated household/bank summary CSVs with deterministic filenames to reduce memory use and improve reliability.

* **Refactor**
  - Reorganized output layer into dedicated components for timeseries, terminal summaries, and output/file handling.

* **Tests**
  - Added tests validating console rendering and end-to-end output CSV contents.

* **Documentation**
  - Updated package README to reflect the new output flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->