### PR TITLE
Complete SOE runtime behavioral channels

### DIFF
--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.integration.montecarlo
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.fp.{ComputationBoundary, FixedPointBase}
-import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner, RunResult, SimError, SimOutput}
+import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner, McTimeseriesSchema, RunResult, SimError}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import zio.{Runtime, Unsafe, ZIO}
@@ -109,7 +109,7 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
       val lines  = readLines(path)
       val result = expectedRuns(seed)
 
-      lines.head shouldBe SimOutput.colNames.mkString(";")
+      lines.head shouldBe McTimeseriesSchema.colNames.mkString(";")
       lines.length shouldBe DurationMonths + 1
 
       for (line, monthIndex) <- lines.tail.zipWithIndex do
@@ -117,9 +117,9 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
         val month    = ExecutionMonth.First.advanceBy(monthIndex)
         val expected = result.timeSeries.monthRow(month)
 
-        actual.length shouldBe SimOutput.nCols
+        actual.length shouldBe McTimeseriesSchema.nCols
 
-        for col <- 0 until SimOutput.nCols do
+        for col <- 0 until McTimeseriesSchema.nCols do
           withClue(s"seed=$seed month=${month.toInt} col=$col: ") {
             actual(col) shouldBe (expected(col) +- 1e-6)
           }

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -1075,7 +1075,8 @@ object Firm:
     val postDepK   = f.capitalStock - depn
     val targetK    = workerCount(f) * p.capital.klRatios(f.sector.toInt)
     val gap        = (targetK - postDepK).max(PLN.Zero)
-    val desiredInv = depn + gap * p.capital.adjustSpeed
+    val invMult    = if f.stateOwned then StateOwned.directedInvestmentMultiplier(f.sector.toInt) else Multiplier.One
+    val desiredInv = depn + (gap * p.capital.adjustSpeed * invMult)
     val actualInv  = desiredInv.min(f.cash.max(PLN.Zero))
     val newK       = postDepK + actualInv
     r.copy(firm = f.copy(cash = f.cash - actualInv, capitalStock = newK), grossInvestment = actualInv)
@@ -1194,7 +1195,8 @@ object Firm:
     val postDepGK   = f.greenCapital - depn
     val targetGK    = workerCount(f) * p.climate.greenKLRatios(f.sector.toInt)
     val gap         = (targetGK - postDepGK).max(PLN.Zero)
-    val desiredInv  = depn + gap * p.climate.greenAdjustSpeed
+    val invMult     = if f.stateOwned then StateOwned.directedInvestmentMultiplier(f.sector.toInt) else Multiplier.One
+    val desiredInv  = depn + (gap * p.climate.greenAdjustSpeed * invMult)
     val greenBudget = f.cash.max(PLN.Zero) * p.climate.greenBudgetShare
     val actualInv   = desiredInv.min(greenBudget)
     val newGK       = postDepGK + actualInv

--- a/src/main/scala/com/boombustgroup/amorfati/agents/StateOwned.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/StateOwned.scala
@@ -34,6 +34,23 @@ object StateOwned:
   private val PublicSector        = 4
   private val AgricultureSector   = 5
 
+  private case class SectorSemantics(
+      investmentPriority: Share = Share.Zero,
+      energyBufferExposure: Share = Share.Zero,
+  )
+
+  private val DefaultSectorSemantics = SectorSemantics()
+
+  private val semanticsBySector: Map[Int, SectorSemantics] = Map(
+    ManufacturingSector -> SectorSemantics(investmentPriority = Share.One, energyBufferExposure = Share.One),
+    HealthcareSector    -> SectorSemantics(investmentPriority = Share(0.35)),
+    PublicSector        -> SectorSemantics(investmentPriority = Share.One, energyBufferExposure = Share(0.35)),
+    AgricultureSector   -> SectorSemantics(investmentPriority = Share(0.45)),
+  )
+
+  private def sectorSemantics(sectorIdx: Int): SectorSemantics =
+    semanticsBySector.getOrElse(sectorIdx, DefaultSectorSemantics)
+
   /** SOE dividend extraction: government takes higher dividends when deficit is
     * large. Returns dividend multiplier (>= 1.0 for SOEs).
     */
@@ -58,12 +75,8 @@ object StateOwned:
     * directed SOE investment is modeled as strongest in Manufacturing and
     * Public, with smaller spillovers to Healthcare and Agriculture.
     */
-  def directedInvestmentPriority(sectorIdx: Int): Share = sectorIdx match
-    case ManufacturingSector => Share.One
-    case PublicSector        => Share.One
-    case HealthcareSector    => Share(0.35)
-    case AgricultureSector   => Share(0.45)
-    case _                   => Share.Zero
+  def directedInvestmentPriority(sectorIdx: Int): Share =
+    sectorSemantics(sectorIdx).investmentPriority
 
   /** Effective investment multiplier after applying current sector semantics.
     * Non-strategic SOEs fall back to neutral investment behavior.
@@ -82,10 +95,8 @@ object StateOwned:
     * attached to the parts of Manufacturing and Public where the state today
     * plausibly acts as the price-buffering supplier.
     */
-  def energyBufferExposure(sectorIdx: Int): Share = sectorIdx match
-    case ManufacturingSector => Share.One
-    case PublicSector        => Share(0.35)
-    case _                   => Share.Zero
+  def energyBufferExposure(sectorIdx: Int): Share =
+    sectorSemantics(sectorIdx).energyBufferExposure
 
   /** Effective consumer pass-through after sector semantics are applied.
     * Sectors with no energy-buffer exposure fall back to full pass-through.

--- a/src/main/scala/com/boombustgroup/amorfati/agents/StateOwned.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/StateOwned.scala
@@ -29,6 +29,11 @@ import com.boombustgroup.amorfati.types.*
   */
 object StateOwned:
 
+  private val ManufacturingSector = 1
+  private val HealthcareSector    = 3
+  private val PublicSector        = 4
+  private val AgricultureSector   = 5
+
   /** SOE dividend extraction: government takes higher dividends when deficit is
     * large. Returns dividend multiplier (>= 1.0 for SOEs).
     */
@@ -47,10 +52,46 @@ object StateOwned:
     */
   def investmentMultiplier(using p: SimParams): Multiplier = p.soe.investmentMultiplier
 
+  /** Strategic-investment priority of an SOE in a given sector.
+    *
+    * The current 6-sector schema does not have a dedicated utilities bucket, so
+    * directed SOE investment is modeled as strongest in Manufacturing and
+    * Public, with smaller spillovers to Healthcare and Agriculture.
+    */
+  def directedInvestmentPriority(sectorIdx: Int): Share = sectorIdx match
+    case ManufacturingSector => Share.One
+    case PublicSector        => Share.One
+    case HealthcareSector    => Share(0.35)
+    case AgricultureSector   => Share(0.45)
+    case _                   => Share.Zero
+
+  /** Effective investment multiplier after applying current sector semantics.
+    * Non-strategic SOEs fall back to neutral investment behavior.
+    */
+  def directedInvestmentMultiplier(sectorIdx: Int)(using p: SimParams): Multiplier =
+    Multiplier.One + (investmentMultiplier.deviationFromOne * directedInvestmentPriority(sectorIdx)).toMultiplier
+
   /** SOE energy price absorption: energy SOEs absorb price shocks. Returns
     * fraction of commodity price shock passed to consumers.
     */
   def energyPassthrough(using p: SimParams): Share = p.soe.energyPassthrough
+
+  /** Sector exposure to administered energy-price buffering.
+    *
+    * With no explicit Energy/Utilities sector in the schema, the behavior is
+    * attached to the parts of Manufacturing and Public where the state today
+    * plausibly acts as the price-buffering supplier.
+    */
+  def energyBufferExposure(sectorIdx: Int): Share = sectorIdx match
+    case ManufacturingSector => Share.One
+    case PublicSector        => Share(0.35)
+    case _                   => Share.Zero
+
+  /** Effective consumer pass-through after sector semantics are applied.
+    * Sectors with no energy-buffer exposure fall back to full pass-through.
+    */
+  def effectiveEnergyPassthrough(sectorIdx: Int)(using p: SimParams): Share =
+    Share.One - (energyBufferExposure(sectorIdx) * (Share.One - energyPassthrough))
 
   /** Probability that a firm in given sector is state-owned at initialization.
     * Based on actual SOE presence per sector (GUS/GPW 2024).

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -349,6 +349,7 @@ object BankingEconomics:
         prev = in.w.gov,
         priceLevel = in.s7.newPrice,
         citPaid = in.s5.sumTax + in.s7.dividendTax + tax.pitAfterEvasion,
+        govDividendRevenue = in.s7.stateOwnedGovDividends,
         vat = tax.vatAfterEvasion,
         nbpRemittance = in.s8.banking.nbpRemittance,
         exciseRevenue = tax.exciseAfterEvasion,
@@ -511,9 +512,9 @@ object BankingEconomics:
       in: StepInput,
   )(using p: SimParams): Banking.BankState =
     val bId           = b.id.toInt
-    val bankNplNew    = PLN(in.s5.perBankNplDebt(bId))
+    val bankNplNew    = in.s5.perBankNplDebt(bId)
     val bankNplLoss   = bankNplNew * (Share.One - p.banking.loanRecovery)
-    val bankIntIncome = PLN(in.s5.perBankIntIncome(bId))
+    val bankIntIncome = in.s5.perBankIntIncome(bId)
     val bankBondInc   = b.govBondHoldings * in.s8.monetary.newBondYield.monthly
     val bankResInt    = perBankReserveInt.perBank(bId)
     val bankSfInc     = perBankStandingFac.perBank(bId)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -20,7 +20,6 @@ object FirmEconomics:
 
   // ---- Calibration constants ----
   private val BondRevertThreshold = 0.001 // minimum revert ratio to trigger bond-to-loan reversion
-  private val MonthsPerYear       = 12.0  // annual-to-monthly rate conversion
 
   // ---- Accumulated flows (monoid on PLN) ----
 
@@ -86,7 +85,7 @@ object FirmEconomics:
       executionMonth: ExecutionMonth,         // realized month currently being executed
       operationalSignals: OperationalSignals, // same-month demand / labor surface for incumbent firms
       rates: Vector[Rate],                    // per-bank lending rates
-      lendingRates: Vector[Double],           // rates as Double (for Output)
+      lendingRates: Vector[Rate],             // per-bank lending rates surfaced on Output
       bankCanLend: (Int, PLN) => Boolean,     // credit approval: (bankId, amount) => approved?
       nBanks: Int,                            // number of banks in multi-bank system
   )
@@ -133,8 +132,8 @@ object FirmEconomics:
       totalBondDefault: PLN,            // bond default from bankrupt firms
       firmDeaths: Int,                  // count of newly bankrupt firms
       intIncome: PLN,                   // aggregate bank interest income
-      perBankNplDebt: Vector[Double],   // NPL debt by bank index
-      perBankIntIncome: Vector[Double], // interest income by bank index
+      perBankNplDebt: Vector[PLN],      // NPL debt by bank index
+      perBankIntIncome: Vector[PLN],    // interest income by bank index
       perBankWorkers: Vector[Int],      // worker count by bank index
   )
 
@@ -208,13 +207,14 @@ object FirmEconomics:
       perBankNewLoans: Vector[PLN],        // new loans by bank index
       sumFirmPrincipal: PLN,               // aggregate firm loan principal repaid
       perBankFirmPrincipal: Vector[PLN],   // firm principal repaid by bank index
-      perBankNplDebt: Vector[Double],      // NPL debt by bank index
-      perBankIntIncome: Vector[Double],    // interest income by bank index
+      perBankNplDebt: Vector[PLN],         // NPL debt by bank index
+      perBankIntIncome: Vector[PLN],       // interest income by bank index
       perBankWorkers: Vector[Int],         // worker count by bank index
-      lendingRates: Vector[Double],        // per-bank lending rates
+      lendingRates: Vector[Rate],          // per-bank lending rates
       postFirmCrossSectorHires: Int,       // cross-sector hires in labor matching
       markupInflation: Rate,               // Calvo: annualized revenue-weighted avg markup change
       sumRealizedPostTaxProfit: PLN,       // aggregate realized post-tax profits from Firm.process
+      sumStateOwnedPostTaxProfit: PLN,     // aggregate realized post-tax profits of SOEs
   )
 
   case class Result(
@@ -285,7 +285,6 @@ object FirmEconomics:
   /** Run the full firm processing pipeline from step-level inputs. This is the
     * direct replacement for FirmProcessingStep.run().
     */
-  @boundaryEscape
   def runStep(
       w: World,
       firms: Vector[Firm.State],
@@ -302,7 +301,6 @@ object FirmEconomics:
 
   // ---- Entry point (from raw values, used by MonthlyCalculus) ----
 
-  @boundaryEscape
   def compute(in: Input)(using p: SimParams): StepOutput =
     // Construct bridge types from raw values
     val s1 = FiscalConstraintEconomics.Output(in.month, in.baseMinWage, in.minWagePriceLevel, in.resWage, in.lendingBaseRate)
@@ -339,7 +337,6 @@ object FirmEconomics:
 
   // ---- Core pipeline (shared by compute + runStep) ----
 
-  @boundaryEscape
   private def runInternal(stepIn: StepInput, rng: RandomStream)(using p: SimParams): StepOutput =
     val lending                             = prepareLending(stepIn, rng)
     val fp                                  = processFirms(stepIn.firms, lending, rng)
@@ -348,7 +345,16 @@ object FirmEconomics:
     // Calvo staggered pricing: per-firm markup update
     val calvoFirms                          = ioFirms.map: f =>
       val sectorMult = stepIn.s4.sectorMults(f.sector.toInt)
-      val calvo      = CalvoPricing.updateFirmMarkup(f.markup, sectorMult, stepIn.s2.wageGrowth, rng)
+      val passthrough =
+        if f.stateOwned then StateOwned.effectiveEnergyPassthrough(f.sector.toInt)
+        else Share.One
+      val energyCostPressure =
+        CalvoPricing.energyCostPressure(
+          stepIn.w.external.gvc.commodityPriceIndex,
+          p.climate.energyCostShares(f.sector.toInt),
+          passthrough,
+        )
+      val calvo = CalvoPricing.updateFirmMarkup(f.markup, sectorMult, stepIn.s2.wageGrowth, energyCostPressure, rng)
       f.copy(markup = calvo.newMarkup)
     val (finalHouseholds, crossSectorHires) = processLaborMarket(calvoFirms, stepIn, rng)
     val npl                                 = computeNplAndInterest(stepIn.firms, calvoFirms, lending)
@@ -373,9 +379,7 @@ object FirmEconomics:
   /** Prepare per-bank rates, lending functions, and world snapshot with updated
     * wages for firm decision-making.
     */
-  @boundaryEscape
   private def prepareLending(in: StepInput, rng: RandomStream)(using p: SimParams): LendingConditions =
-    import ComputationBoundary.toDouble
     val bsec               = in.w.bankingSector
     val nBanks             = in.banks.length
     val ccyb               = in.w.mechanisms.macropru.ccyb
@@ -393,7 +397,7 @@ object FirmEconomics:
         reservationWage = in.s1.resWage,
       ),
     )
-    LendingConditions(world, in.s1.m, operationalSignals, rates, rates.map(toDouble(_)), canLend, nBanks)
+    LendingConditions(world, in.s1.m, operationalSignals, rates, rates, canLend, nBanks)
 
   // ---- Phase 2: Per-firm processing ----
 
@@ -548,13 +552,11 @@ object FirmEconomics:
   /** Detect newly bankrupt firms, compute per-bank NPL losses and interest
     * income on pre-step debt stock.
     */
-  @boundaryEscape
   private def computeNplAndInterest(
       preFirms: Vector[Firm.State],
       postFirms: Vector[Firm.State],
       lending: LendingConditions,
   )(using p: SimParams): NplResult =
-    import ComputationBoundary.toDouble
     val prevAlive        = preFirms.filter(Firm.isAlive).map(_.id).toSet
     val newlyDead        = postFirms.filter(f => !Firm.isAlive(f) && prevAlive.contains(f.id))
     val nplNew           = PLN.fromRaw(newlyDead.map(_.debt.toLong).sum)
@@ -562,16 +564,16 @@ object FirmEconomics:
     val totalBondDefault = PLN.fromRaw(newlyDead.map(_.bondDebt.toLong).sum)
 
     // Per-bank aggregation via groupMapReduce (pure, no mutable arrays)
-    val emptyDoubles = Vector.fill(lending.nBanks)(0.0)
+    val emptyPln     = Vector.fill(lending.nBanks)(PLN.Zero)
     val emptyInts    = Vector.fill(lending.nBanks)(0)
 
-    val perBankNplDebt = newlyDead.foldLeft(emptyDoubles): (acc, f) =>
-      acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + toDouble(f.debt))
+    val perBankNplDebt = newlyDead.foldLeft(emptyPln): (acc, f) =>
+      acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + f.debt)
 
     val perBankIntIncome = preFirms
       .filter(Firm.isAlive)
-      .foldLeft(emptyDoubles): (acc, f) =>
-        val interest = toDouble(f.debt) * toDouble(lending.rates(f.bankId.toInt)) / MonthsPerYear
+      .foldLeft(emptyPln): (acc, f) =>
+        val interest = f.debt * lending.rates(f.bankId.toInt).monthly
         acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + interest)
 
     val perBankWorkers = postFirms
@@ -579,14 +581,22 @@ object FirmEconomics:
       .foldLeft(emptyInts): (acc, f) =>
         acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + Firm.workerCount(f))
 
-    NplResult(nplNew, nplLoss, totalBondDefault, newlyDead.length, PLN(perBankIntIncome.sum), perBankNplDebt, perBankIntIncome, perBankWorkers)
+    NplResult(
+      nplNew,
+      nplLoss,
+      totalBondDefault,
+      newlyDead.length,
+      perBankIntIncome.foldLeft(PLN.Zero)(_ + _),
+      perBankNplDebt,
+      perBankIntIncome,
+      perBankWorkers,
+    )
 
   // ---- Output assembly ----
 
   /** Assemble final StepOutput from phase results. Pure mapping, no
     * computation.
     */
-  @boundaryEscape
   private def assembleOutput(
       fp: FirmProcessingResult,
       bonded: BondAbsorptionResult,
@@ -655,4 +665,5 @@ object FirmEconomics:
       postFirmCrossSectorHires = crossSectorHires,
       markupInflation = markupInflation,
       sumRealizedPostTaxProfit = fp.outcomes.foldLeft(PLN.Zero)(_ + _.realizedPostTaxProfit),
+      sumStateOwnedPostTaxProfit = fp.outcomes.filter(_.firm.stateOwned).foldLeft(PLN.Zero)((acc, o) => acc + o.realizedPostTaxProfit),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -85,7 +85,6 @@ object FirmEconomics:
       executionMonth: ExecutionMonth,         // realized month currently being executed
       operationalSignals: OperationalSignals, // same-month demand / labor surface for incumbent firms
       rates: Vector[Rate],                    // per-bank lending rates
-      lendingRates: Vector[Rate],             // per-bank lending rates surfaced on Output
       bankCanLend: (Int, PLN) => Boolean,     // credit approval: (bankId, amount) => approved?
       nBanks: Int,                            // number of banks in multi-bank system
   )
@@ -127,14 +126,14 @@ object FirmEconomics:
 
   /** Result of NPL and interest computation (phase 6). */
   private case class NplResult(
-      nplNew: PLN,                      // new NPL volume from bankruptcies
-      nplLoss: PLN,                     // NPL loss net of recovery
-      totalBondDefault: PLN,            // bond default from bankrupt firms
-      firmDeaths: Int,                  // count of newly bankrupt firms
-      intIncome: PLN,                   // aggregate bank interest income
-      perBankNplDebt: Vector[PLN],      // NPL debt by bank index
-      perBankIntIncome: Vector[PLN],    // interest income by bank index
-      perBankWorkers: Vector[Int],      // worker count by bank index
+      nplNew: PLN,                   // new NPL volume from bankruptcies
+      nplLoss: PLN,                  // NPL loss net of recovery
+      totalBondDefault: PLN,         // bond default from bankrupt firms
+      firmDeaths: Int,               // count of newly bankrupt firms
+      intIncome: PLN,                // aggregate bank interest income
+      perBankNplDebt: Vector[PLN],   // NPL debt by bank index
+      perBankIntIncome: Vector[PLN], // interest income by bank index
+      perBankWorkers: Vector[Int],   // worker count by bank index
   )
 
   // ---- Public I/O types ----
@@ -344,8 +343,8 @@ object FirmEconomics:
     val (ioFirms, totalIoPaid)              = applyIntermediateMarket(bonded.firms, stepIn)
     // Calvo staggered pricing: per-firm markup update
     val calvoFirms                          = ioFirms.map: f =>
-      val sectorMult = stepIn.s4.sectorMults(f.sector.toInt)
-      val passthrough =
+      val sectorMult         = stepIn.s4.sectorMults(f.sector.toInt)
+      val passthrough        =
         if f.stateOwned then StateOwned.effectiveEnergyPassthrough(f.sector.toInt)
         else Share.One
       val energyCostPressure =
@@ -354,7 +353,7 @@ object FirmEconomics:
           p.climate.energyCostShares(f.sector.toInt),
           passthrough,
         )
-      val calvo = CalvoPricing.updateFirmMarkup(f.markup, sectorMult, stepIn.s2.wageGrowth, energyCostPressure, rng)
+      val calvo              = CalvoPricing.updateFirmMarkup(f.markup, sectorMult, stepIn.s2.wageGrowth, energyCostPressure, rng)
       f.copy(markup = calvo.newMarkup)
     val (finalHouseholds, crossSectorHires) = processLaborMarket(calvoFirms, stepIn, rng)
     val npl                                 = computeNplAndInterest(stepIn.firms, calvoFirms, lending)
@@ -397,7 +396,7 @@ object FirmEconomics:
         reservationWage = in.s1.resWage,
       ),
     )
-    LendingConditions(world, in.s1.m, operationalSignals, rates, rates, canLend, nBanks)
+    LendingConditions(world, in.s1.m, operationalSignals, rates, canLend, nBanks)
 
   // ---- Phase 2: Per-firm processing ----
 
@@ -564,8 +563,8 @@ object FirmEconomics:
     val totalBondDefault = PLN.fromRaw(newlyDead.map(_.bondDebt.toLong).sum)
 
     // Per-bank aggregation via groupMapReduce (pure, no mutable arrays)
-    val emptyPln     = Vector.fill(lending.nBanks)(PLN.Zero)
-    val emptyInts    = Vector.fill(lending.nBanks)(0)
+    val emptyPln  = Vector.fill(lending.nBanks)(PLN.Zero)
+    val emptyInts = Vector.fill(lending.nBanks)(0)
 
     val perBankNplDebt = newlyDead.foldLeft(emptyPln): (acc, f) =>
       acc.updated(f.bankId.toInt, acc(f.bankId.toInt) + f.debt)
@@ -661,7 +660,7 @@ object FirmEconomics:
       perBankNplDebt = npl.perBankNplDebt,
       perBankIntIncome = npl.perBankIntIncome,
       perBankWorkers = npl.perBankWorkers,
-      lendingRates = lending.lendingRates,
+      lendingRates = lending.rates,
       postFirmCrossSectorHires = crossSectorHires,
       markupInflation = markupInflation,
       sumRealizedPostTaxProfit = fp.outcomes.foldLeft(PLN.Zero)(_ + _.realizedPostTaxProfit),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -197,6 +197,7 @@ object PriceEquityEconomics:
         val sec      = firms(i).sector
         val newSize  = FirmSizeDistribution.draw(rng)
         val sizeMult = Scalar.fraction(newSize, p.pop.workersPerFirm).toMultiplier
+        val isSoe    = StateOwned.sectorSoeShare(sec.toInt).sampleBelow(rng)
         Firm.State(
           id = FirmId(i),
           cash = PLN.fromRaw(rng.between(PLN(StartupCashMin).toLong, PLN(StartupCashMax).toLong)) * sizeMult,
@@ -204,10 +205,9 @@ object PriceEquityEconomics:
           tech = TechState.Traditional(newSize),
           riskProfile = TypedRandom.randomBetween(Share(RiskProfileMin), Share(RiskProfileMax), rng),
           innovationCostFactor = TypedRandom.randomBetween(Multiplier(InnovCostMin), Multiplier(InnovCostMax), rng),
-          digitalReadiness =
-            TypedRandom
-              .withGaussianNoise(p.sectorDefs(sec.toInt).baseDigitalReadiness, Share(DigitalReadyNoise), rng)
-              .clamp(Share(DigitalReadyFloor), Share(DigitalReadyCap)),
+          digitalReadiness = TypedRandom
+            .withGaussianNoise(p.sectorDefs(sec.toInt).baseDigitalReadiness, Share(DigitalReadyNoise), rng)
+            .clamp(Share(DigitalReadyFloor), Share(DigitalReadyCap)),
           sector = sec,
           neighbors = adj(i).iterator.map(FirmId(_)).toVector,
           bankId = BankId(0),
@@ -216,6 +216,7 @@ object PriceEquityEconomics:
           capitalStock = p.capital.klRatios(sec.toInt) * newSize,
           bondDebt = PLN.Zero,
           foreignOwned = false,
+          stateOwned = isSoe,
           inventory = PLN.Zero,
           greenCapital = PLN.Zero,
           accumulatedLoss = PLN.Zero,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -6,7 +6,6 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.markets.{EquityMarket, PriceLevel}
 import com.boombustgroup.amorfati.engine.mechanisms.{EuFunds, Macroprudential}
-import com.boombustgroup.amorfati.fp.FixedPointBase.ScaleD
 import com.boombustgroup.amorfati.types.*
 
 import com.boombustgroup.amorfati.random.RandomStream
@@ -65,6 +64,7 @@ object PriceEquityEconomics:
       netDomesticDividends: PLN,
       foreignDividendOutflow: PLN,
       dividendTax: PLN,
+      stateOwnedGovDividends: PLN,
       firmProfits: PLN,
       domesticGFCF: PLN,
       investmentImports: PLN,
@@ -119,33 +119,49 @@ object PriceEquityEconomics:
     */
   private[economics] def evolveSigmas(
       currentSigmas: Vector[Sigma],
+      baseSigmas: Vector[Sigma],
+      sectorAdoption: Vector[Share],
+      lambda: Coefficient,
+      capMult: Multiplier,
+  ): Vector[Sigma] =
+    if lambda == Coefficient.Zero then currentSigmas
+    else
+      currentSigmas.zip(baseSigmas).zip(sectorAdoption).map { case ((sigma, base), adoption) =>
+        val sigmaLevel    = sigma.toCoefficient
+        val cap           = Sigma.fromRaw((base.toScalar * capMult).toLong)
+        val saturationGap = (Coefficient.One - sigma.toScalar.ratioTo(cap.toScalar).toCoefficient).max(Coefficient.Zero)
+        val delta         = sigma.toCoefficient * lambda.max(Coefficient.Zero) * adoption.toCoefficient * saturationGap
+        val upperBound    = cap.toCoefficient.max(sigmaLevel)
+        val candidate     = (sigmaLevel + delta).max(sigmaLevel).min(upperBound)
+        Sigma.fromRaw(candidate.toLong)
+      }
+
+  private[economics] def evolveSigmas(
+      currentSigmas: Vector[Sigma],
       baseSigmas: Vector[Double],
       sectorAdoption: Vector[Double],
       lambda: Double,
       capMult: Double,
   ): Vector[Sigma] =
-    if lambda == 0.0 then currentSigmas
-    else
-      currentSigmas.zip(baseSigmas).zip(sectorAdoption).map { case ((sig, base), adopt) =>
-        val s     = sig.toLong.toDouble / ScaleD
-        val cap   = base * capMult
-        val delta = lambda * s * adopt * (1.0 - s / cap)
-        Sigma(Math.min(cap, Math.max(s, s + delta)))
-      }
+    evolveSigmas(
+      currentSigmas,
+      baseSigmas.map(Sigma(_)),
+      sectorAdoption.map(Share(_)),
+      Coefficient(lambda),
+      Multiplier(capMult),
+    )
 
   // ---------------------------------------------------------------------------
   // Dynamic network rewiring — bankrupt firm replacement with preferential attachment
   // ---------------------------------------------------------------------------
 
-  @boundaryEscape
-  private[economics] def rewireFirms(firms: Vector[Firm.State], rho: Double, rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
-    import ComputationBoundary.toDouble
-    if rho == 0.0 then return firms
+  private[economics] def rewireFirms(firms: Vector[Firm.State], rho: Share, rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
+    if rho <= Share.Zero then return firms
 
     val n = firms.length
     val k = p.firm.networkK
 
-    val toReplace = (0 until n).filter(i => !Firm.isAlive(firms(i)) && rng.nextDouble() < rho).toSet
+    val toReplace = (0 until n).filter(i => !Firm.isAlive(firms(i)) && rho.sampleBelow(rng)).toSet
     if toReplace.isEmpty then return firms
 
     val adj = Array.tabulate(n)(i => scala.collection.mutable.Set.from(firms(i).neighbors.map(_.toInt)))
@@ -180,26 +196,24 @@ object PriceEquityEconomics:
       if toReplace.contains(i) then
         val sec      = firms(i).sector
         val newSize  = FirmSizeDistribution.draw(rng)
-        val sizeMult = newSize.toDouble / p.pop.workersPerFirm
+        val sizeMult = Scalar.fraction(newSize, p.pop.workersPerFirm).toMultiplier
         Firm.State(
           id = FirmId(i),
-          cash = PLN(rng.between(StartupCashMin, StartupCashMax) * sizeMult),
+          cash = PLN.fromRaw(rng.between(PLN(StartupCashMin).toLong, PLN(StartupCashMax).toLong)) * sizeMult,
           debt = PLN.Zero,
           tech = TechState.Traditional(newSize),
-          riskProfile = Share(rng.between(RiskProfileMin, RiskProfileMax)),
-          innovationCostFactor = Multiplier(rng.between(InnovCostMin, InnovCostMax)),
-          digitalReadiness = Share(
-            Math.max(
-              DigitalReadyFloor,
-              Math.min(DigitalReadyCap, toDouble(p.sectorDefs(sec.toInt).baseDigitalReadiness) + (rng.nextGaussian() * DigitalReadyNoise)),
-            ),
-          ),
+          riskProfile = TypedRandom.randomBetween(Share(RiskProfileMin), Share(RiskProfileMax), rng),
+          innovationCostFactor = TypedRandom.randomBetween(Multiplier(InnovCostMin), Multiplier(InnovCostMax), rng),
+          digitalReadiness =
+            TypedRandom
+              .withGaussianNoise(p.sectorDefs(sec.toInt).baseDigitalReadiness, Share(DigitalReadyNoise), rng)
+              .clamp(Share(DigitalReadyFloor), Share(DigitalReadyCap)),
           sector = sec,
           neighbors = adj(i).iterator.map(FirmId(_)).toVector,
           bankId = BankId(0),
           equityRaised = PLN.Zero,
           initialSize = newSize,
-          capitalStock = PLN(toDouble(p.capital.klRatios(sec.toInt)) * newSize),
+          capitalStock = p.capital.klRatios(sec.toInt) * newSize,
           bondDebt = PLN.Zero,
           foreignOwned = false,
           inventory = PLN.Zero,
@@ -212,23 +226,30 @@ object PriceEquityEconomics:
         else firms(i)
     }.toVector
 
-  @boundaryEscape
-  private[economics] def governmentDemandContribution(govPurchases: PLN)(using p: SimParams): Double =
-    import ComputationBoundary.toDouble
-    toDouble(govPurchases) * (1.0 - toDouble(p.fiscal.govInvestShare)) * toDouble(p.fiscal.govCurrentMultiplier) +
-      toDouble(govPurchases) * toDouble(p.fiscal.govInvestShare) * toDouble(p.fiscal.govCapitalMultiplier)
+  private[economics] def rewireFirms(firms: Vector[Firm.State], rho: Double, rng: RandomStream)(using p: SimParams): Vector[Firm.State] =
+    rewireFirms(firms, Share(rho), rng)
+
+  private[economics] def governmentDemandContribution(govPurchases: PLN)(using p: SimParams): PLN =
+    govPurchases * (Share.One - p.fiscal.govInvestShare) * p.fiscal.govCurrentMultiplier +
+      govPurchases * p.fiscal.govInvestShare * p.fiscal.govCapitalMultiplier
+
+  private[economics] def fiscalDeficitToGdp(deficit: PLN, monthlyGdp: PLN): Share =
+    if deficit > PLN.Zero && monthlyGdp > PLN.Zero then deficit.ratioTo(monthlyGdp).toShare.clamp(Share.Zero, Share.One)
+    else Share.Zero
 
   // ---------------------------------------------------------------------------
   // Main compute logic
   // ---------------------------------------------------------------------------
 
-  @boundaryEscape
   def compute(in: Input, rng: RandomStream)(using p: SimParams): Output =
-    import ComputationBoundary.toDouble
     val living2           = in.s5.ioFirms.filter(Firm.isAlive)
-    val nLiving           = living2.length.toDouble
-    val autoR             = if nLiving > 0 then living2.count(_.tech.isInstanceOf[TechState.Automated]) / nLiving else 0.0
-    val hybR              = if nLiving > 0 then living2.count(_.tech.isInstanceOf[TechState.Hybrid]) / nLiving else 0.0
+    val nLiving           = living2.length
+    val autoR             =
+      if nLiving > 0 then living2.count(_.tech.isInstanceOf[TechState.Automated]).ratioTo(nLiving).toShare
+      else Share.Zero
+    val hybR              =
+      if nLiving > 0 then living2.count(_.tech.isInstanceOf[TechState.Hybrid]).ratioTo(nLiving).toShare
+      else Share.Zero
     val aggInventoryStock = PLN.fromRaw(living2.map(_.inventory.toLong).sum)
     val aggGreenCapital   = PLN.fromRaw(living2.map(_.greenCapital.toLong).sum)
 
@@ -238,35 +259,32 @@ object PriceEquityEconomics:
     val euCofin            = EuFunds.cofinancing(euMonthly)
     val euProjectCapital   = EuFunds.capitalInvestment(euMonthly, euCofin)
     val euGdpContribution  =
-      toDouble(euProjectCapital) * toDouble(p.fiscal.govCapitalMultiplier) +
-        toDouble((euCofin - euProjectCapital).max(PLN.Zero)) * toDouble(p.fiscal.govCurrentMultiplier)
-    val greenDomesticGFCF  =
-      toDouble(in.s5.sumGreenInvestment) * (1.0 - toDouble(p.climate.greenImportShare))
-    val domesticGFCF       =
-      toDouble(in.s5.sumGrossInvestment) * (1.0 - toDouble(p.capital.importShare)) + greenDomesticGFCF
-    val investmentImports  =
-      toDouble(in.s5.sumGrossInvestment) * toDouble(p.capital.importShare) +
-        toDouble(in.s5.sumGreenInvestment) * toDouble(p.climate.greenImportShare)
-    val aggInventoryChange = toDouble(in.s5.sumInventoryChange)
+      euProjectCapital * p.fiscal.govCapitalMultiplier +
+        (euCofin - euProjectCapital).max(PLN.Zero) * p.fiscal.govCurrentMultiplier
+    val greenDomesticGFCF  = in.s5.sumGreenInvestment * (Share.One - p.climate.greenImportShare)
+    val domesticGFCF       = in.s5.sumGrossInvestment * (Share.One - p.capital.importShare) + greenDomesticGFCF
+    val investmentImports  = in.s5.sumGrossInvestment * p.capital.importShare + in.s5.sumGreenInvestment * p.climate.greenImportShare
+    val aggInventoryChange = in.s5.sumInventoryChange
     val gdp                =
-      toDouble(in.domesticCons) + govGdpContribution + euGdpContribution + toDouble(in.w.forex.exports) + domesticGFCF + aggInventoryChange
+      in.domesticCons + govGdpContribution + euGdpContribution + in.w.forex.exports + domesticGFCF + aggInventoryChange
 
     val totalSystemLoans = PLN.fromRaw(in.banks.map(_.loans.toLong).sum)
-    val newMacropru      = Macroprudential.step(in.w.mechanisms.macropru, totalSystemLoans, PLN(gdp))
+    val newMacropru      = Macroprudential.step(in.w.mechanisms.macropru, totalSystemLoans, gdp)
 
     val sectorAdoption = p.sectorDefs.indices.map { s =>
       val secFirms = living2.filter(_.sector.toInt == s)
-      if secFirms.isEmpty then 0.0
+      if secFirms.isEmpty then Share.Zero
       else
         secFirms
           .count(f => f.tech.isInstanceOf[TechState.Automated] || f.tech.isInstanceOf[TechState.Hybrid])
-          .toDouble / secFirms.length
+          .ratioTo(secFirms.length)
+          .toShare
     }.toVector
-    val baseSigmas     = p.sectorDefs.map(sd => toDouble(sd.sigma)).toVector
+    val baseSigmas     = p.sectorDefs.map(_.sigma).toVector
     val newSigmas      =
-      evolveSigmas(in.w.currentSigmas, baseSigmas, sectorAdoption, toDouble(p.firm.sigmaLambda), toDouble(p.firm.sigmaCapMult))
+      evolveSigmas(in.w.currentSigmas, baseSigmas, sectorAdoption, p.firm.sigmaLambda, p.firm.sigmaCapMult)
 
-    val rewiredFirms = rewireFirms(in.s5.ioFirms, toDouble(p.firm.rewireRho), rng)
+    val rewiredFirms = rewireFirms(in.s5.ioFirms, p.firm.rewireRho, rng)
 
     val exDev    = in.w.forex.exchangeRate.deviationFrom(p.forex.baseExRate)
     val priceUpd = PriceLevel.update(
@@ -280,10 +298,10 @@ object PriceEquityEconomics:
     val newInfl  = priceUpd.inflation + in.s5.markupInflation
     val newPrice = priceUpd.priceLevel.applyGrowth(in.s5.markupInflation.monthly.toCoefficient)
 
-    val firmProfitsPnl = in.s5.sumRealizedPostTaxProfit
-
     val prevGdp             = in.w.cachedMonthlyGdpProxy.max(PLN(1.0))
-    val gdpGrowthForEquity  = PLN(gdp).ratioTo(prevGdp).toMultiplier.deviationFromOne
+    val deficitToGdp        = fiscalDeficitToGdp(in.w.gov.deficit.max(PLN.Zero), prevGdp)
+    val firmProfitsPnl      = in.s5.sumRealizedPostTaxProfit
+    val gdpGrowthForEquity  = gdp.ratioTo(prevGdp).toMultiplier.deviationFromOne
     val equityAfterIndex    = EquityMarket.step(
       EquityMarket.StepInput(
         prev = in.w.financial.equity,
@@ -299,20 +317,23 @@ object PriceEquityEconomics:
       EquityMarket.computeDividends(
         firmProfitsPnl,
         equityAfterIssuance.foreignOwnership,
+        stateOwnedProfits = in.s5.sumStateOwnedPostTaxProfit,
+        deficitToGdp = deficitToGdp,
       )
     val netDomesticDividends   = dividends.netDomestic
     val foreignDividendOutflow = dividends.foreign
     val dividendTax            = dividends.tax
+    val stateOwnedGovDividends = dividends.gov
 
     Output(
-      Share(autoR),
-      Share(hybR),
+      autoR,
+      hybR,
       aggInventoryStock,
       aggGreenCapital,
       euMonthly,
       euCofin,
       euProjectCapital,
-      PLN(gdp),
+      gdp,
       newMacropru,
       newSigmas,
       rewiredFirms,
@@ -322,8 +343,9 @@ object PriceEquityEconomics:
       netDomesticDividends,
       foreignDividendOutflow,
       dividendTax,
+      stateOwnedGovDividends,
       firmProfitsPnl,
-      PLN(domesticGFCF),
-      PLN(investmentImports),
-      PLN(aggInventoryChange),
+      domesticGFCF,
+      investmentImports,
+      aggInventoryChange,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -280,6 +280,7 @@ object WorldAssemblyEconomics:
       lastDomesticDividends = in.s7.netDomesticDividends,
       lastForeignDividends = in.s7.foreignDividendOutflow,
       lastDividendTax = in.s7.dividendTax,
+      lastGovernmentDividends = in.s7.stateOwnedGovDividends,
     )
 
   private def buildDemandOutput(in: Input): DemandEconomics.Output =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -280,7 +280,6 @@ object WorldAssemblyEconomics:
       lastDomesticDividends = in.s7.netDomesticDividends,
       lastForeignDividends = in.s7.foreignDividendOutflow,
       lastDividendTax = in.s7.dividendTax,
-      lastGovernmentDividends = in.s7.stateOwnedGovDividends,
     )
 
   private def buildDemandOutput(in: Input): DemandEconomics.Output =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -21,6 +21,7 @@ object EquityFlows:
       netDomesticDividends: PLN,
       foreignDividends: PLN,
       dividendTax: PLN,
+      govDividends: PLN,
       issuance: PLN,
   )
 
@@ -55,6 +56,15 @@ object EquityFlows:
         FlowMechanism.EquityDividendTax,
       ),
       AggregateBatchedEmission.transfer(
+        EntitySector.Firms,
+        FirmIndex.Aggregate,
+        EntitySector.Government,
+        GovernmentIndex.Budget,
+        input.govDividends,
+        AssetType.Cash,
+        FlowMechanism.EquityGovDividend,
+      ),
+      AggregateBatchedEmission.transfer(
         EntitySector.Households,
         HouseholdIndex.Investors,
         EntitySector.Firms,
@@ -71,5 +81,6 @@ object EquityFlows:
       flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.netDomesticDividends.toLong, FlowMechanism.EquityDomDividend.toInt)
     if input.foreignDividends > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.foreignDividends.toLong, FlowMechanism.EquityForDividend.toInt)
     if input.dividendTax > PLN.Zero then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.dividendTax.toLong, FlowMechanism.EquityDividendTax.toInt)
+    if input.govDividends > PLN.Zero then flows += Flow(FIRM_ACCOUNT, GOV_ACCOUNT, input.govDividends.toLong, FlowMechanism.EquityGovDividend.toInt)
     if input.issuance > PLN.Zero then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.EquityIssuance.toInt)
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -105,3 +105,4 @@ object FlowMechanism:
   val BankInterbankInterest: MechanismId = MechanismId(86)
   val BankBailIn: MechanismId            = MechanismId(87)
   val BankNbpRemittance: MechanismId     = MechanismId(88)
+  val EquityGovDividend: MechanismId     = MechanismId(89)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -575,7 +575,7 @@ object FlowSimulation:
       equityDomDividends = eq.lastDomesticDividends,
       equityForDividends = eq.lastForeignDividends,
       equityDivTax = eq.lastDividendTax,
-      equityGovDividends = s7.stateOwnedGovDividends,
+      equityGovDividends = eq.lastGovernmentDividends,
       equityIssuance = eq.lastIssuance,
       equityReturn = eq.monthlyReturn,
       exports = openEcon.exports,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -96,6 +96,7 @@ object FlowSimulation:
       equityDomDividends: PLN,
       equityForDividends: PLN,
       equityDivTax: PLN,
+      equityGovDividends: PLN,
       equityIssuance: PLN,
       equityReturn: Rate,
       // Stage 8: Open economy
@@ -207,7 +208,15 @@ object FlowSimulation:
         ),
       ),
       // Tier 3: Financial markets
-      EquityFlows.emitBatches(EquityFlows.Input(c.equityDomDividends, c.equityForDividends, c.equityDivTax, c.equityIssuance)),
+      EquityFlows.emitBatches(
+        EquityFlows.Input(
+          c.equityDomDividends,
+          c.equityForDividends,
+          c.equityDivTax,
+          c.equityGovDividends,
+          c.equityIssuance,
+        ),
+      ),
       CorpBondFlows.emitBatches(CorpBondFlows.Input(c.corpBondCoupon, c.corpBondDefaultLoss, c.corpBondIssuance, c.corpBondAmortization)),
       MortgageFlows.emitBatches(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
       OpenEconFlows.emitBatches(
@@ -566,6 +575,7 @@ object FlowSimulation:
       equityDomDividends = eq.lastDomesticDividends,
       equityForDividends = eq.lastForeignDividends,
       equityDivTax = eq.lastDividendTax,
+      equityGovDividends = s7.stateOwnedGovDividends,
       equityIssuance = eq.lastIssuance,
       equityReturn = eq.monthlyReturn,
       exports = openEcon.exports,
@@ -708,7 +718,7 @@ object FlowSimulation:
       govSpending =
         banking.newGovWithYield.domesticBudgetOutlays + labor.newZus.govSubvention + labor.newNfz.govSubvention + labor.newEarmarked.totalGovSubvention,
       govRevenue =
-        firms.sumTax + prices.dividendTax + banking.pitAfterEvasion + banking.vatAfterEvasion + openEcon.banking.nbpRemittance + banking.exciseAfterEvasion + banking.customsDutyRevenue,
+        firms.sumTax + prices.dividendTax + prices.stateOwnedGovDividends + banking.pitAfterEvasion + banking.vatAfterEvasion + openEcon.banking.nbpRemittance + banking.exciseAfterEvasion + banking.customsDutyRevenue,
       nplLoss = firms.nplLoss,
       interestIncome = evidence.amount(FlowMechanism.FirmInterestPaid),
       hhDebtService = evidence.amount(FlowMechanism.HhDebtService),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -717,8 +717,9 @@ object FlowSimulation:
     Sfc.SemanticFlows(
       govSpending =
         banking.newGovWithYield.domesticBudgetOutlays + labor.newZus.govSubvention + labor.newNfz.govSubvention + labor.newEarmarked.totalGovSubvention,
-      govRevenue =
-        firms.sumTax + prices.dividendTax + prices.stateOwnedGovDividends + banking.pitAfterEvasion + banking.vatAfterEvasion + openEcon.banking.nbpRemittance + banking.exciseAfterEvasion + banking.customsDutyRevenue,
+      govRevenue = firms.sumTax + prices.dividendTax + evidence.amount(
+        FlowMechanism.EquityGovDividend,
+      ) + banking.pitAfterEvasion + banking.vatAfterEvasion + openEcon.banking.nbpRemittance + banking.exciseAfterEvasion + banking.customsDutyRevenue,
       nplLoss = firms.nplLoss,
       interestIncome = evidence.amount(FlowMechanism.FirmInterestPaid),
       hhDebtService = evidence.amount(FlowMechanism.HhDebtService),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -575,7 +575,7 @@ object FlowSimulation:
       equityDomDividends = eq.lastDomesticDividends,
       equityForDividends = eq.lastForeignDividends,
       equityDivTax = eq.lastDividendTax,
-      equityGovDividends = eq.lastGovernmentDividends,
+      equityGovDividends = w.gov.govDividendRevenue,
       equityIssuance = eq.lastIssuance,
       equityReturn = eq.monthlyReturn,
       exports = openEcon.exports,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
@@ -35,6 +35,7 @@ object CalvoPricing:
 
   private val MaxDemandMarkupLift = Coefficient(0.10)
   private val MaxCostMarkupLift   = Coefficient(0.02)
+  private val MaxEnergyMarkupLift = Coefficient(0.03)
 
   /** Per-firm markup update result. */
   case class FirmMarkupResult(
@@ -52,13 +53,29 @@ object CalvoPricing:
   private[amorfati] def optimalMarkup(
       sectorDemandMult: Multiplier,
       wageGrowthMonthly: Coefficient,
+      energyPressure: Coefficient,
   )(using p: SimParams): Multiplier =
     val demandPressure = ((sectorDemandMult - Multiplier.One).max(Multiplier.Zero).toScalar * p.pricing.demandSensitivity.toScalar).toCoefficient
     val costPressure   = (wageGrowthMonthly.max(Coefficient.Zero).toScalar * p.pricing.costPassthrough.toScalar).toCoefficient
+    val energyMarkup   = (energyPressure.max(Coefficient.Zero).toScalar * p.pricing.costPassthrough.toScalar).toCoefficient
     val boundedDemand  = demandPressure.min(MaxDemandMarkupLift)
     val boundedCost    = costPressure.min(MaxCostMarkupLift)
-    (p.pricing.baseMarkup * (Coefficient.One + boundedDemand + boundedCost).toMultiplier)
+    val boundedEnergy  = energyMarkup.min(MaxEnergyMarkupLift)
+    (p.pricing.baseMarkup * (Coefficient.One + boundedDemand + boundedCost + boundedEnergy).toMultiplier)
       .clamp(p.pricing.minMarkup, p.pricing.maxMarkup)
+
+  /** Commodity-cost pressure translated into markup pressure.
+    *
+    * Pressure rises with the level of the commodity price index relative to
+    * base, sector energy intensity, and the fraction of the shock firms are
+    * allowed to pass through to prices.
+    */
+  private[amorfati] def energyCostPressure(
+      commodityPrice: PriceIndex,
+      energyCostShare: Share,
+      passthrough: Share,
+  ): Coefficient =
+    commodityPrice.toMultiplier.deviationFromOne.max(Coefficient.Zero) * energyCostShare.toCoefficient * passthrough.toCoefficient
 
   /** Update a single firm's markup via Calvo lottery.
     *
@@ -69,9 +86,11 @@ object CalvoPricing:
       currentMarkup: Multiplier,
       sectorDemandMult: Multiplier,
       wageGrowthMonthly: Coefficient,
+      energyPressure: Coefficient,
       rng: RandomStream,
   )(using p: SimParams): FirmMarkupResult =
-    if p.pricing.calvoTheta.sampleBelow(rng) then FirmMarkupResult(optimalMarkup(sectorDemandMult, wageGrowthMonthly), priceChanged = true)
+    if p.pricing.calvoTheta.sampleBelow(rng) then
+      FirmMarkupResult(optimalMarkup(sectorDemandMult, wageGrowthMonthly, energyPressure), priceChanged = true)
     else FirmMarkupResult(currentMarkup, priceChanged = false)
 
   /** Compute aggregate inflation adjustment from markup dynamics.

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/CalvoPricing.scala
@@ -57,7 +57,7 @@ object CalvoPricing:
   )(using p: SimParams): Multiplier =
     val demandPressure = ((sectorDemandMult - Multiplier.One).max(Multiplier.Zero).toScalar * p.pricing.demandSensitivity.toScalar).toCoefficient
     val costPressure   = (wageGrowthMonthly.max(Coefficient.Zero).toScalar * p.pricing.costPassthrough.toScalar).toCoefficient
-    val energyMarkup   = (energyPressure.max(Coefficient.Zero).toScalar * p.pricing.costPassthrough.toScalar).toCoefficient
+    val energyMarkup   = energyPressure.max(Coefficient.Zero)
     val boundedDemand  = demandPressure.min(MaxDemandMarkupLift)
     val boundedCost    = costPressure.min(MaxCostMarkupLift)
     val boundedEnergy  = energyMarkup.min(MaxEnergyMarkupLift)
@@ -89,8 +89,7 @@ object CalvoPricing:
       energyPressure: Coefficient,
       rng: RandomStream,
   )(using p: SimParams): FirmMarkupResult =
-    if p.pricing.calvoTheta.sampleBelow(rng) then
-      FirmMarkupResult(optimalMarkup(sectorDemandMult, wageGrowthMonthly, energyPressure), priceChanged = true)
+    if p.pricing.calvoTheta.sampleBelow(rng) then FirmMarkupResult(optimalMarkup(sectorDemandMult, wageGrowthMonthly, energyPressure), priceChanged = true)
     else FirmMarkupResult(currentMarkup, priceChanged = false)
 
   /** Compute aggregate inflation adjustment from markup dynamics.

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
@@ -45,6 +45,7 @@ object EquityMarket:
       lastDomesticDividends: PLN = PLN.Zero,
       lastForeignDividends: PLN = PLN.Zero,
       lastDividendTax: PLN = PLN.Zero,
+      lastGovernmentDividends: PLN = PLN.Zero,
       hhEquityWealth: PLN = PLN.Zero,
       lastWealthEffect: PLN = PLN.Zero,
       monthlyReturn: Rate = Rate.Zero,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
@@ -45,7 +45,6 @@ object EquityMarket:
       lastDomesticDividends: PLN = PLN.Zero,
       lastForeignDividends: PLN = PLN.Zero,
       lastDividendTax: PLN = PLN.Zero,
-      lastGovernmentDividends: PLN = PLN.Zero,
       hhEquityWealth: PLN = PLN.Zero,
       lastWealthEffect: PLN = PLN.Zero,
       monthlyReturn: Rate = Rate.Zero,
@@ -118,7 +117,14 @@ object EquityMarket:
 
     val mReturn = if in.prev.index > PriceIndex.Zero then newIndex.ratioTo(in.prev.index).toMultiplier.deviationFromOne.toRate else Rate.Zero
 
-    State(newIndex, newMarketCap, newEarningsYield, newDivYield, newForeignOwnership, monthlyReturn = mReturn)
+    State(
+      index = newIndex,
+      marketCap = newMarketCap,
+      earningsYield = newEarningsYield,
+      dividendYield = newDivYield,
+      foreignOwnership = newForeignOwnership,
+      monthlyReturn = mReturn,
+    )
 
   /** Process equity issuance: firm raises CAPEX via equity, increasing market
     * cap. Index diluted by supply effect.

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/EquityMarket.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.markets
 
+import com.boombustgroup.amorfati.agents.StateOwned
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 
@@ -143,10 +144,12 @@ object EquityMarket:
     *   foreign dividend outflow
     * @param tax
     *   Belka tax on domestic dividends (19% PIT)
+    * @param gov
+    *   extra direct SOE dividend extraction flowing to government
     */
-  case class DividendResult(netDomestic: PLN, foreign: PLN, tax: PLN)
+  case class DividendResult(netDomestic: PLN, foreign: PLN, tax: PLN, gov: PLN)
 
-  val DividendResultZero: DividendResult = DividendResult(PLN.Zero, PLN.Zero, PLN.Zero)
+  val DividendResultZero: DividendResult = DividendResult(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
 
   /** Compute cash dividends from realized profits, not directly from market
     * valuation.
@@ -154,6 +157,8 @@ object EquityMarket:
   def computeDividends(
       realizedProfits: PLN,
       foreignShare: Share,
+      stateOwnedProfits: PLN,
+      deficitToGdp: Share,
   )(using p: SimParams): DividendResult =
     if realizedProfits <= PLN.Zero then DividendResultZero
     else
@@ -161,8 +166,15 @@ object EquityMarket:
       val foreignDividends = totalDividends * foreignShare
       val domesticGross    = totalDividends - foreignDividends
       val dividendTax      = domesticGross * p.equity.divTax
+      val govDividends     =
+        if stateOwnedProfits <= PLN.Zero then PLN.Zero
+        else
+          val adjustedPayout = (PayoutRatio * StateOwned.dividendMultiplier(deficitToGdp)).toShare.clamp(Share.Zero, Share.One)
+          val extraPayout    = (adjustedPayout - PayoutRatio).max(Share.Zero)
+          stateOwnedProfits.min(realizedProfits) * extraPayout
       DividendResult(
         netDomestic = domesticGross - dividendTax,
         foreign = foreignDividends,
         tax = dividendTax,
+        gov = govDividends,
       )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
@@ -164,7 +164,7 @@ object FiscalBudget:
       priceLevel: PriceIndex,
       // Revenue
       citPaid: PLN = PLN.Zero,
-      govDividendRevenue: PLN = PLN.Zero,
+      govDividendRevenue: PLN,
       vat: PLN = PLN.Zero,
       nbpRemittance: PLN = PLN.Zero,
       exciseRevenue: PLN = PLN.Zero,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
@@ -164,6 +164,7 @@ object FiscalBudget:
       priceLevel: PriceIndex,
       // Revenue
       citPaid: PLN = PLN.Zero,
+      govDividendRevenue: PLN = PLN.Zero,
       vat: PLN = PLN.Zero,
       nbpRemittance: PLN = PLN.Zero,
       exciseRevenue: PLN = PLN.Zero,
@@ -192,7 +193,7 @@ object FiscalBudget:
 
     val totalSpend = in.unempBenefitSpend + in.socialTransferSpend +
       govCurrent + govCapital + in.debtService + in.zusGovSubvention + in.nfzGovSubvention + in.earmarkedGovSubvention + in.euCofinancing
-    val totalRev   = in.citPaid + in.vat + in.nbpRemittance +
+    val totalRev   = in.citPaid + in.govDividendRevenue + in.vat + in.nbpRemittance +
       in.exciseRevenue + in.customsDutyRevenue
     val deficit    = totalSpend - totalRev
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/FiscalBudget.scala
@@ -6,9 +6,9 @@ import com.boombustgroup.amorfati.types.*
 /** Government budget reconciliation: monthly revenue, spending, deficit, debt.
   *
   * Revenue: CIT + dividend tax (PIT Belka 19%), VAT, excise, customs, NBP
-  * remittance. Spending: current government purchases, capital investment,
-  * unemployment benefits, social transfers (800+), ZUS subvention, EU
-  * co-financing, debt service.
+  * remittance, plus separately tracked SOE dividend extraction. Spending:
+  * current government purchases, capital investment, unemployment benefits,
+  * social transfers (800+), ZUS subvention, EU co-financing, debt service.
   *
   * When GOV_INVEST is enabled, base spending splits into current (1 − share)
   * and capital (share) components; public capital stock depreciates monthly.
@@ -67,7 +67,7 @@ object FiscalBudget:
   )
 
   case class GovFlowState(
-      taxRevenue: PLN,                     // total tax revenue this month (CIT + VAT + excise + customs + NBP remittance)
+      taxRevenue: PLN,                     // budget revenue this month excluding direct SOE dividend extraction
       deficit: PLN,                        // monthly budget deficit (positive) or surplus (negative)
       unempBenefitSpend: PLN,              // unemployment benefit payments this month
       debtServiceSpend: PLN = PLN.Zero,    // interest payments on public debt this month
@@ -78,6 +78,7 @@ object FiscalBudget:
       euCofinancing: PLN = PLN.Zero,       // domestic co-financing outlay booked separately from project-envelope value
       exciseRevenue: PLN = PLN.Zero,       // excise duty revenue this month (akcyza)
       customsDutyRevenue: PLN = PLN.Zero,  // customs duty revenue this month (cło)
+      govDividendRevenue: PLN = PLN.Zero,  // direct SOE dividend extraction booked separately from aggregate budget revenue
   )
 
   case class GovState(
@@ -86,6 +87,8 @@ object FiscalBudget:
       monthly: GovFlowState,
   ):
     def taxRevenue: PLN               = monthly.taxRevenue
+    def govDividendRevenue: PLN       = monthly.govDividendRevenue
+    def totalRevenue: PLN             = monthly.taxRevenue + monthly.govDividendRevenue
     def deficit: PLN                  = monthly.deficit
     def cumulativeDebt: PLN           = financial.cumulativeDebt
     def unempBenefitSpend: PLN        = monthly.unempBenefitSpend
@@ -133,6 +136,7 @@ object FiscalBudget:
         euCofinancing: PLN = PLN.Zero,
         exciseRevenue: PLN = PLN.Zero,
         customsDutyRevenue: PLN = PLN.Zero,
+        govDividendRevenue: PLN = PLN.Zero,
         minWageLevel: PLN = PLN(4666.0),
         minWagePriceLevel: PriceIndex = PriceIndex.Base,
     ): GovState =
@@ -151,6 +155,7 @@ object FiscalBudget:
           euCofinancing,
           exciseRevenue,
           customsDutyRevenue,
+          govDividendRevenue,
         ),
       )
 
@@ -193,8 +198,8 @@ object FiscalBudget:
 
     val totalSpend = in.unempBenefitSpend + in.socialTransferSpend +
       govCurrent + govCapital + in.debtService + in.zusGovSubvention + in.nfzGovSubvention + in.earmarkedGovSubvention + in.euCofinancing
-    val totalRev   = in.citPaid + in.govDividendRevenue + in.vat + in.nbpRemittance +
-      in.exciseRevenue + in.customsDutyRevenue
+    val taxRev     = in.citPaid + in.vat + in.nbpRemittance + in.exciseRevenue + in.customsDutyRevenue
+    val totalRev   = taxRev + in.govDividendRevenue
     val deficit    = totalSpend - totalRev
 
     val newBondsOutstanding =
@@ -205,7 +210,7 @@ object FiscalBudget:
       in.prev.publicCapitalStock * (Share.One - monthlyDeprecShare) + govCapital + in.euProjectCapital
 
     GovState(
-      taxRevenue = totalRev,
+      taxRevenue = taxRev,
       deficit = deficit,
       cumulativeDebt = in.prev.cumulativeDebt + deficit,
       unempBenefitSpend = in.unempBenefitSpend,
@@ -221,4 +226,5 @@ object FiscalBudget:
       euCofinancing = in.euCofinancing,
       exciseRevenue = in.exciseRevenue,
       customsDutyRevenue = in.customsDutyRevenue,
+      govDividendRevenue = in.govDividendRevenue,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -314,7 +314,7 @@ object McTimeseriesSchema:
     ColumnDef("EquityWealthEffect", ctx => td.toDouble(ctx.world.financial.equity.lastWealthEffect)),
     ColumnDef("DomesticDividends", ctx => td.toDouble(ctx.world.financial.equity.lastDomesticDividends)),
     ColumnDef("ForeignDividendOutflow", ctx => td.toDouble(ctx.world.financial.equity.lastForeignDividends)),
-    ColumnDef("GovernmentDividends", ctx => td.toDouble(ctx.world.financial.equity.lastGovernmentDividends)),
+    ColumnDef("GovernmentDividends", ctx => td.toDouble(ctx.world.gov.govDividendRevenue)),
     // Corporate Bonds / Catalyst
     ColumnDef("CorpBondOutstanding", ctx => td.toDouble(ctx.world.financial.corporateBonds.outstanding)),
     ColumnDef("CorpBondYield", ctx => td.toDouble(ctx.world.financial.corporateBonds.corpBondYield)),

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -314,6 +314,7 @@ object McTimeseriesSchema:
     ColumnDef("EquityWealthEffect", ctx => td.toDouble(ctx.world.financial.equity.lastWealthEffect)),
     ColumnDef("DomesticDividends", ctx => td.toDouble(ctx.world.financial.equity.lastDomesticDividends)),
     ColumnDef("ForeignDividendOutflow", ctx => td.toDouble(ctx.world.financial.equity.lastForeignDividends)),
+    ColumnDef("GovernmentDividends", ctx => td.toDouble(ctx.world.financial.equity.lastGovernmentDividends)),
     // Corporate Bonds / Catalyst
     ColumnDef("CorpBondOutstanding", ctx => td.toDouble(ctx.world.financial.corporateBonds.outstanding)),
     ColumnDef("CorpBondYield", ctx => td.toDouble(ctx.world.financial.corporateBonds.corpBondYield)),

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/BalanceSheetPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/BalanceSheetPropertySpec.scala
@@ -70,7 +70,9 @@ class BalanceSheetPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
       val (prev, cit, vat, price, unempBen) = inputs
       whenever(price >= 0.01) {
         val gov        =
-          FiscalBudget.update(FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), vat = PLN(vat), unempBenefitSpend = PLN(unempBen)))
+          FiscalBudget.update(
+            FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), govDividendRevenue = PLN.Zero, vat = PLN(vat), unempBenefitSpend = PLN(unempBen)),
+          )
         val totalRev   = cit + vat
         val totalSpend = unempBen + p.fiscal.govBaseSpending.bd.toDouble * price
         val tol        = p.fiscal.govBaseSpending.bd.toDouble * 0.0001 + 1.0 // fixed-point rounding tolerance

--- a/src/test/scala/com/boombustgroup/amorfati/engine/CalvoPricingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/CalvoPricingSpec.scala
@@ -14,28 +14,28 @@ class CalvoPricingSpec extends AnyFlatSpec with Matchers:
   given SimParams = SimParams.defaults
 
   "optimalMarkup" should "increase with demand pressure" in {
-    val low  = CalvoPricing.optimalMarkup(Multiplier(0.9), Coefficient.Zero)
-    val high = CalvoPricing.optimalMarkup(Multiplier(1.2), Coefficient.Zero)
+    val low  = CalvoPricing.optimalMarkup(Multiplier(0.9), Coefficient.Zero, Coefficient.Zero)
+    val high = CalvoPricing.optimalMarkup(Multiplier(1.2), Coefficient.Zero, Coefficient.Zero)
     high should be > low
   }
 
   it should "increase with wage growth (cost passthrough)" in {
-    val noGrowth = CalvoPricing.optimalMarkup(Multiplier.One, Coefficient.Zero)
-    val growth   = CalvoPricing.optimalMarkup(Multiplier.One, Coefficient(0.05))
+    val noGrowth = CalvoPricing.optimalMarkup(Multiplier.One, Coefficient.Zero, Coefficient.Zero)
+    val growth   = CalvoPricing.optimalMarkup(Multiplier.One, Coefficient(0.05), Coefficient.Zero)
     growth should be > noGrowth
   }
 
   it should "be clamped between min and max" in {
-    val extreme = CalvoPricing.optimalMarkup(Multiplier(5.0), Coefficient(1.0))
+    val extreme = CalvoPricing.optimalMarkup(Multiplier(5.0), Coefficient(1.0), Coefficient.Zero)
     extreme should be <= summon[SimParams].pricing.maxMarkup
-    val low     = CalvoPricing.optimalMarkup(Multiplier(-5.0), Coefficient(-1.0))
+    val low     = CalvoPricing.optimalMarkup(Multiplier(-5.0), Coefficient(-1.0), Coefficient.Zero)
     low should be >= summon[SimParams].pricing.minMarkup
   }
 
   "updateFirmMarkup" should "change markup with high probability (theta)" in {
     // Run 100 times, expect ~15 changes (theta=0.15)
     val rng     = RandomStream.seeded(42)
-    val results = (0 until 100).map(_ => CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), rng))
+    val results = (0 until 100).map(_ => CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), Coefficient.Zero, rng))
     val changed = results.count(_.priceChanged)
     changed should be > 5
     changed should be < 30
@@ -46,14 +46,14 @@ class CalvoPricingSpec extends AnyFlatSpec with Matchers:
       new scala.util.Random:
         override def nextInt(n: Int): Int = n - 1,
     )
-    val result = CalvoPricing.updateFirmMarkup(Multiplier(1.2), Multiplier.One, Coefficient.Zero, rng)
+    val result = CalvoPricing.updateFirmMarkup(Multiplier(1.2), Multiplier.One, Coefficient.Zero, Coefficient.Zero, rng)
     result.priceChanged shouldBe false
     result.newMarkup.bd shouldBe BigDecimal("1.2") +- BigDecimal("0.001")
   }
 
   it should "be deterministic with same seed" in {
-    val r1 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), RandomStream.seeded(42))
-    val r2 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), RandomStream.seeded(42))
+    val r1 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), Coefficient.Zero, RandomStream.seeded(42))
+    val r2 = CalvoPricing.updateFirmMarkup(Multiplier.One, Multiplier(1.1), Coefficient(0.01), Coefficient.Zero, RandomStream.seeded(42))
     r1.newMarkup.bd shouldBe r2.newMarkup.bd +- BigDecimal("0.0000000001")
     r1.priceChanged shouldBe r2.priceChanged
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
@@ -57,7 +57,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
 
   "EquityMarket.computeDividends" should "have non-negative outputs for positive inputs" in
     forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
-      val r = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val r = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
       r.netDomestic should be >= PLN.Zero
       r.foreign should be >= PLN.Zero
       r.tax should be >= PLN.Zero
@@ -66,7 +66,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
   it should "conserve payout-scaled profits exactly" in
     forAll(Gen.choose(1e6, 1e13), Gen.choose(0.0, 1.0)) { (profits, foreignShare) =>
       whenever(foreignShare >= 0.0) {
-        val r             = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+        val r             = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
         val expectedTotal = PLN(profits) * Share(0.57)
         (r.netDomestic + r.tax + r.foreign) shouldBe expectedTotal
       }
@@ -74,7 +74,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
 
   it should "have foreign dividends <= total dividends" in
     forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
-      val r     = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val r     = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
       val total = PLN(profits) * Share(0.57)
       r.foreign should be <= total
     }
@@ -82,14 +82,14 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
   it should "have dividend tax <= domestic gross" in
     forAll(Gen.choose(1e6, 1e13), genFraction) { (profits, foreignShare) =>
       val gross = PLN(profits) * Share(0.57) * (Share.One - Share(foreignShare))
-      val r     = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
+      val r     = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
       r.tax should be <= gross
     }
 
   it should "scale dividends linearly with realized profits up to rounding" in
     forAll(Gen.choose(1e6, 1e12), genFraction) { (profits, foreignShare) =>
-      val r1 = EquityMarket.computeDividends(PLN(profits), Share(foreignShare))
-      val r2 = EquityMarket.computeDividends(PLN(profits * 2.0), Share(foreignShare))
+      val r1 = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
+      val r2 = EquityMarket.computeDividends(PLN(profits * 2.0), Share(foreignShare), PLN.Zero, Share.Zero)
       whenever(r1.netDomestic > PLN.Zero && r1.foreign > PLN.Zero && r1.tax > PLN.Zero) {
         shouldBeClosePln(r2.netDomestic, r1.netDomestic * 2, PLN(1.0))
         shouldBeClosePln(r2.foreign, r1.foreign * 2, PLN(1.0))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
@@ -31,7 +31,6 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
     earningsYield = Rate(ey),
     dividendYield = Rate(dy),
     foreignOwnership = Share(foreign),
-    lastGovernmentDividends = PLN.Zero,
   )
 
   "EquityMarket.processIssuance" should "always increase market cap for positive issuance" in
@@ -122,7 +121,6 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
     z.dividendYield shouldBe Rate.Zero
     z.foreignOwnership shouldBe Share.Zero
     z.lastIssuance shouldBe PLN.Zero
-    z.lastGovernmentDividends shouldBe PLN.Zero
     z.hhEquityWealth shouldBe PLN.Zero
     z.lastWealthEffect shouldBe PLN.Zero
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketPropertySpec.scala
@@ -31,6 +31,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
     earningsYield = Rate(ey),
     dividendYield = Rate(dy),
     foreignOwnership = Share(foreign),
+    lastGovernmentDividends = PLN.Zero,
   )
 
   "EquityMarket.processIssuance" should "always increase market cap for positive issuance" in
@@ -61,6 +62,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
       r.netDomestic should be >= PLN.Zero
       r.foreign should be >= PLN.Zero
       r.tax should be >= PLN.Zero
+      r.gov should be >= PLN.Zero
     }
 
   it should "conserve payout-scaled profits exactly" in
@@ -69,6 +71,21 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
         val r             = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
         val expectedTotal = PLN(profits) * Share(0.57)
         (r.netDomestic + r.tax + r.foreign) shouldBe expectedTotal
+      }
+    }
+
+  it should "preserve the baseline split while adding a non-negative SOE government leg" in
+    forAll(Gen.choose(1e8, 1e13), genFraction, Gen.choose(0.01, 1.0), Gen.choose(0.04, 0.20)) { (profits, foreignShare, soeShare, deficitToGdp) =>
+      whenever(foreignShare >= 0.0 && foreignShare <= 1.0) {
+        val baseline = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN.Zero, Share.Zero)
+        val withGov  = EquityMarket.computeDividends(PLN(profits), Share(foreignShare), PLN(profits * soeShare), Share(deficitToGdp))
+        val payout   = PLN(profits) * Share(0.57)
+
+        withGov.netDomestic shouldBe baseline.netDomestic
+        withGov.foreign shouldBe baseline.foreign
+        withGov.tax shouldBe baseline.tax
+        (withGov.netDomestic + withGov.tax + withGov.foreign) shouldBe payout
+        withGov.gov should be >= PLN.Zero
       }
     }
 
@@ -105,6 +122,7 @@ class EquityMarketPropertySpec extends AnyFlatSpec with Matchers with ScalaCheck
     z.dividendYield shouldBe Rate.Zero
     z.foreignOwnership shouldBe Share.Zero
     z.lastIssuance shouldBe PLN.Zero
+    z.lastGovernmentDividends shouldBe PLN.Zero
     z.hhEquityWealth shouldBe PLN.Zero
     z.lastWealthEffect shouldBe PLN.Zero
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
@@ -64,14 +64,14 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   "EquityMarket.computeDividends" should "return zeros for zero realized profits" in {
-    val r = EquityMarket.computeDividends(PLN.Zero, Share(0.67))
+    val r = EquityMarket.computeDividends(PLN.Zero, Share(0.67), PLN.Zero, Share.Zero)
     r shouldBe EquityMarket.DividendResultZero
   }
 
   "EquityMarket.computeDividends" should "compute correct split from realized profits and payout ratio" in {
     val profits          = PLN(1e12)
     val foreignShare     = Share(0.67)
-    val r                = EquityMarket.computeDividends(profits, foreignShare)
+    val r                = EquityMarket.computeDividends(profits, foreignShare, PLN.Zero, Share.Zero)
     val expectedTotal    = profits * Share(0.57)
     val expectedForeign  = expectedTotal * foreignShare
     val expectedDomGross = expectedTotal - expectedForeign
@@ -84,7 +84,7 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return no foreign dividends when foreign share is zero" in {
-    val r           = EquityMarket.computeDividends(PLN(1e12), Share.Zero)
+    val r           = EquityMarket.computeDividends(PLN(1e12), Share.Zero, PLN.Zero, Share.Zero)
     val total       = PLN(1e12) * Share(0.57)
     val expectedTax = total * p.equity.divTax
     r.foreign shouldBe PLN.Zero
@@ -93,7 +93,7 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "return no domestic dividends when foreign share is 1.0" in {
-    val r     = EquityMarket.computeDividends(PLN(1e12), Share.One)
+    val r     = EquityMarket.computeDividends(PLN(1e12), Share.One, PLN.Zero, Share.Zero)
     val total = PLN(1e12) * Share(0.57)
     r.netDomestic shouldBe PLN.Zero
     r.tax shouldBe PLN.Zero
@@ -102,7 +102,7 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
 
   it should "apply Belka tax rate correctly" in {
     val profits  = PLN(1e12)
-    val r        = EquityMarket.computeDividends(profits, Share(0.50))
+    val r        = EquityMarket.computeDividends(profits, Share(0.50), PLN.Zero, Share.Zero)
     val total    = profits * Share(0.57)
     val domGross = total * Share(0.50)
     r.tax shouldBe (domGross * p.equity.divTax)
@@ -110,13 +110,13 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "compute dividends based on realized profits" in {
-    val r = EquityMarket.computeDividends(PLN(1e12), Share(0.67))
+    val r = EquityMarket.computeDividends(PLN(1e12), Share(0.67), PLN.Zero, Share.Zero)
     r.netDomestic should be > PLN.Zero
   }
 
   it should "not depend on market valuation directly" in {
-    val lowProfits  = EquityMarket.computeDividends(PLN(1e9), Share(0.67))
-    val highProfits = EquityMarket.computeDividends(PLN(1e12), Share(0.67))
+    val lowProfits  = EquityMarket.computeDividends(PLN(1e9), Share(0.67), PLN.Zero, Share.Zero)
+    val highProfits = EquityMarket.computeDividends(PLN(1e12), Share(0.67), PLN.Zero, Share.Zero)
 
     highProfits.tax should be > lowProfits.tax
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
@@ -30,7 +30,6 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
     z.lastDomesticDividends shouldBe PLN.Zero
     z.lastForeignDividends shouldBe PLN.Zero
     z.lastDividendTax shouldBe PLN.Zero
-    z.lastGovernmentDividends shouldBe PLN.Zero
     z.hhEquityWealth shouldBe PLN.Zero
     z.lastWealthEffect shouldBe PLN.Zero
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EquityMarketSpec.scala
@@ -30,6 +30,7 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
     z.lastDomesticDividends shouldBe PLN.Zero
     z.lastForeignDividends shouldBe PLN.Zero
     z.lastDividendTax shouldBe PLN.Zero
+    z.lastGovernmentDividends shouldBe PLN.Zero
     z.hhEquityWealth shouldBe PLN.Zero
     z.lastWealthEffect shouldBe PLN.Zero
   }
@@ -112,6 +113,18 @@ class EquityMarketSpec extends AnyFlatSpec with Matchers:
   it should "compute dividends based on realized profits" in {
     val r = EquityMarket.computeDividends(PLN(1e12), Share(0.67), PLN.Zero, Share.Zero)
     r.netDomestic should be > PLN.Zero
+  }
+
+  it should "add a government SOE dividend leg without changing the baseline split" in {
+    val profits      = PLN(1e12)
+    val foreignShare = Share(0.67)
+    val baseline     = EquityMarket.computeDividends(profits, foreignShare, PLN.Zero, Share.Zero)
+    val r            = EquityMarket.computeDividends(profits, foreignShare, PLN(2e11), Share(0.06))
+
+    r.gov should be > PLN.Zero
+    r.netDomestic shouldBe baseline.netDomestic
+    r.foreign shouldBe baseline.foreign
+    r.tax shouldBe baseline.tax
   }
 
   it should "not depend on market valuation directly" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/EuFundsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/EuFundsSpec.scala
@@ -69,7 +69,7 @@ class EuFundsSpec extends AnyFlatSpec with Matchers:
 
   "updateGov" should "include euCofinancing in deficit" in {
     val prev      = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
-    val baseInput = FiscalBudget.Input(prev, priceLevel = PriceIndex.Base, citPaid = PLN(100000), vat = PLN(200000))
+    val baseInput = FiscalBudget.Input(prev, priceLevel = PriceIndex.Base, citPaid = PLN(100000), govDividendRevenue = PLN.Zero, vat = PLN(200000))
     val base      = FiscalBudget.update(baseInput)
     val withEu    = FiscalBudget.update(baseInput.copy(euCofinancing = PLN(50000.0)))
     // Deficit should increase by euCofinancing amount
@@ -83,6 +83,7 @@ class EuFundsSpec extends AnyFlatSpec with Matchers:
         prev,
         priceLevel = PriceIndex.Base,
         citPaid = PLN(100000),
+        govDividendRevenue = PLN.Zero,
         vat = PLN(200000),
         euCofinancing = PLN(75000.0),
       ),
@@ -97,6 +98,7 @@ class EuFundsSpec extends AnyFlatSpec with Matchers:
         prev,
         priceLevel = PriceIndex.Base,
         citPaid = PLN(100000),
+        govDividendRevenue = PLN.Zero,
         vat = PLN(200000),
       ),
     )
@@ -105,6 +107,7 @@ class EuFundsSpec extends AnyFlatSpec with Matchers:
         prev,
         priceLevel = PriceIndex.Base,
         citPaid = PLN(100000),
+        govDividendRevenue = PLN.Zero,
         vat = PLN(200000),
         euProjectCapital = PLN(30000.0),
       ),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationPropertySpec.scala
@@ -118,7 +118,10 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
     forAll(genGovInputs) { (inputs: (FiscalBudget.GovState, Double, Double, Double, Double)) =>
       val (prev, cit, vat, price, unempBen) = inputs
       whenever(price >= 0.01) {
-        val gov        = FiscalBudget.update(FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), vat = PLN(vat), unempBenefitSpend = PLN(unempBen)))
+        val gov        =
+          FiscalBudget.update(
+            FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), govDividendRevenue = PLN.Zero, vat = PLN(vat), unempBenefitSpend = PLN(unempBen)),
+          )
         val totalRev   = cit + vat
         val totalSpend = unempBen + td.toDouble(p.fiscal.govBaseSpending) * price
         val tol        = td.toDouble(p.fiscal.govBaseSpending) * 0.0001 + 1.0
@@ -130,7 +133,9 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
     forAll(genGovInputs) { (inputs: (FiscalBudget.GovState, Double, Double, Double, Double)) =>
       val (prev, cit, vat, price, unempBen) = inputs
       val gov                               =
-        FiscalBudget.update(FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), vat = PLN(vat), unempBenefitSpend = PLN(unempBen)))
+        FiscalBudget.update(
+          FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), govDividendRevenue = PLN.Zero, vat = PLN(vat), unempBenefitSpend = PLN(unempBen)),
+        )
       td.toDouble(gov.cumulativeDebt) shouldBe (td.toDouble(prev.cumulativeDebt) + td.toDouble(gov.deficit) +- 1.0)
     }
 
@@ -140,7 +145,15 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       whenever(price >= 0.01) {
         val gov        =
           FiscalBudget.update(
-            FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), vat = PLN(vat), unempBenefitSpend = PLN(unempBen), debtService = PLN(debtSvc)),
+            FiscalBudget.Input(
+              prev,
+              PriceIndex(price),
+              citPaid = PLN(cit),
+              govDividendRevenue = PLN.Zero,
+              vat = PLN(vat),
+              unempBenefitSpend = PLN(unempBen),
+              debtService = PLN(debtSvc),
+            ),
           )
         val totalRev   = cit + vat
         val totalSpend = unempBen + td.toDouble(p.fiscal.govBaseSpending) * price + debtSvc
@@ -152,7 +165,8 @@ class SimulationPropertySpec extends AnyFlatSpec with Matchers with ScalaCheckPr
   it should "include nbpRemittance in revenue" in
     forAll(genGovInputs, Gen.choose(0.0, 1e7)) { (inputs: (FiscalBudget.GovState, Double, Double, Double, Double), nbpRemit: Double) =>
       val (prev, cit, vat, price, unempBen) = inputs
-      val base                              = FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), vat = PLN(vat), unempBenefitSpend = PLN(unempBen))
+      val base                              =
+        FiscalBudget.Input(prev, PriceIndex(price), citPaid = PLN(cit), govDividendRevenue = PLN.Zero, vat = PLN(vat), unempBenefitSpend = PLN(unempBen))
       val govNoRemit                        = FiscalBudget.update(base)
       val govWithRemit                      = FiscalBudget.update(base.copy(nbpRemittance = PLN(nbpRemit)))
       // nbpRemittance reduces deficit

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
@@ -79,6 +79,7 @@ class SimulationSpec extends AnyFlatSpec with Matchers:
         prev,
         priceLevel = PriceIndex.Base,
         citPaid = PLN(100000),
+        govDividendRevenue = PLN.Zero,
         vat = PLN(200000),
       ),
     )
@@ -92,6 +93,7 @@ class SimulationSpec extends AnyFlatSpec with Matchers:
         prev,
         priceLevel = PriceIndex.Base,
         citPaid = PLN(100000),
+        govDividendRevenue = PLN.Zero,
         vat = PLN(200000),
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SimulationSpec.scala
@@ -99,3 +99,20 @@ class SimulationSpec extends AnyFlatSpec with Matchers:
     )
     td.toDouble(result.cumulativeDebt).shouldBe((1000000 + td.toDouble(result.deficit)) +- 1.0)
   }
+
+  it should "track SOE dividends separately from tax revenue" in {
+    val prev   = FiscalBudget.GovState(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+    val result = FiscalBudget.update(
+      FiscalBudget.Input(
+        prev,
+        priceLevel = PriceIndex.Base,
+        citPaid = PLN(100000),
+        govDividendRevenue = PLN(50000),
+        vat = PLN(200000),
+      ),
+    )
+
+    result.taxRevenue shouldBe PLN(300000)
+    result.govDividendRevenue shouldBe PLN(50000)
+    result.totalRevenue shouldBe PLN(350000)
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -88,7 +88,7 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
     ),
   )
 
-  private val resultR = FirmEconomics.toResult(result)
+  private val resultR             = FirmEconomics.toResult(result)
   private val ManufacturingSector = 1
 
   private def runStepFor(world: World, firms: Vector[Firm.State])(using SimParams): FirmEconomics.StepOutput =
@@ -119,14 +119,16 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private def manufacturingScenario(stateOwned: Boolean, cashRich: Boolean = false): Vector[Firm.State] =
     init.firms.map { firm =>
       val base =
-        if firm.sector.toInt == ManufacturingSector && cashRich then
-          firm.copy(cash = PLN(500e6), capitalStock = PLN.Zero, greenCapital = PLN.Zero)
+        if firm.sector.toInt == ManufacturingSector && cashRich then firm.copy(cash = PLN(500e6), capitalStock = PLN.Zero, greenCapital = PLN.Zero)
         else firm
       if base.sector.toInt == ManufacturingSector then base.copy(stateOwned = stateOwned) else base.copy(stateOwned = false)
     }
 
   private def manufacturingOutputs(step: FirmEconomics.StepOutput): Vector[Firm.State] =
     step.ioFirms.filter(_.sector.toInt == ManufacturingSector)
+
+  private def manufacturingById(step: FirmEconomics.StepOutput): Map[FirmId, Firm.State] =
+    manufacturingOutputs(step).map(f => f.id -> f).toMap
 
   "FirmEconomics (self-contained Input)" should "match old step tax" in
     result.sumTax.shouldBe(oldS5.sumTax)
@@ -147,10 +149,14 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
     val stateOwnedRun       = runStepFor(w, manufacturingScenario(stateOwned = true, cashRich = true))
     val privateManufactured = manufacturingOutputs(privateRun)
     val soeManufactured     = manufacturingOutputs(stateOwnedRun)
+    val privateById         = manufacturingById(privateRun)
+    val soeById             = manufacturingById(stateOwnedRun)
 
     privateManufactured should not be empty
-    soeManufactured.zip(privateManufactured).foreach { case (soeFirm, privateFirm) =>
-      soeFirm.capitalStock should be > privateFirm.capitalStock
+    soeManufactured.size shouldBe privateManufactured.size
+    soeById.keySet shouldBe privateById.keySet
+    soeById.keys.foreach { id =>
+      soeById(id).capitalStock should be > privateById(id).capitalStock
     }
     stateOwnedRun.sumGrossInvestment should be > privateRun.sumGrossInvestment
   }
@@ -158,17 +164,24 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   it should "reduce manufacturing markup pass-through for state-owned firms under a commodity shock" in {
     val privateFirms          = manufacturingScenario(stateOwned = false)
     val stateOwnedFirms       = manufacturingScenario(stateOwned = true)
-    val shockedWorld          = w.updateExternal(_.copy(gvc = w.external.gvc.copy(commodityPriceIndex = PriceIndex(1.80))))
+    val shockedWorld          = w.updateExternal(_.copy(gvc = w.external.gvc.copy(commodityPriceIndex = PriceIndex(1.20))))
     val baselinePrivateRun    = runStepFor(w, privateFirms)
     val baselineStateOwnedRun = runStepFor(w, stateOwnedFirms)
     val shockedPrivateRun     = runStepFor(shockedWorld, privateFirms)
     val shockedStateOwnedRun  = runStepFor(shockedWorld, stateOwnedFirms)
-    val shockedPairs          = manufacturingOutputs(shockedStateOwnedRun).map(_.markup).zip(manufacturingOutputs(shockedPrivateRun).map(_.markup))
+    val baselinePrivateById   = manufacturingById(baselinePrivateRun)
+    val baselineSoeById       = manufacturingById(baselineStateOwnedRun)
+    val shockedPrivateById    = manufacturingById(shockedPrivateRun)
+    val shockedSoeById        = manufacturingById(shockedStateOwnedRun)
 
-    manufacturingOutputs(baselineStateOwnedRun).map(_.markup) shouldBe manufacturingOutputs(baselinePrivateRun).map(_.markup)
-    shockedStateOwnedRun.markupInflation should be < shockedPrivateRun.markupInflation
-    shockedPairs.foreach { case (soeMarkup, privateMarkup) =>
-      soeMarkup should be <= privateMarkup
+    shockedSoeById.keySet shouldBe shockedPrivateById.keySet
+    baselineSoeById.keySet shouldBe baselinePrivateById.keySet
+    baselineSoeById.keys.foreach { id =>
+      baselineSoeById(id).markup shouldBe baselinePrivateById(id).markup
     }
-    shockedPairs.exists { case (soeMarkup, privateMarkup) => soeMarkup < privateMarkup } shouldBe true
+    shockedStateOwnedRun.markupInflation should be <= shockedPrivateRun.markupInflation
+    shockedSoeById.keys.foreach { id =>
+      shockedSoeById(id).markup should be <= shockedPrivateById(id).markup
+    }
+    shockedSoeById.keys.exists(id => shockedSoeById(id).markup < shockedPrivateById(id).markup) shouldBe true
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.OperationalSignals
+import com.boombustgroup.amorfati.engine.{OperationalSignals, World}
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
@@ -89,6 +89,44 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   )
 
   private val resultR = FirmEconomics.toResult(result)
+  private val ManufacturingSector = 1
+
+  private def runStepFor(world: World, firms: Vector[Firm.State])(using SimParams): FirmEconomics.StepOutput =
+    val fiscal = FiscalConstraintEconomics.compute(world, init.banks, ExecutionMonth.First)
+    val s1     = FiscalConstraintEconomics.toOutput(fiscal)
+    val labor  = LaborEconomics.compute(world, firms, init.households, s1)
+    val s2     = LaborEconomics.Output(
+      labor.wage,
+      labor.employed,
+      labor.laborDemand,
+      labor.wageGrowth,
+      labor.operationalHiringSlack,
+      labor.immigration,
+      labor.netMigration,
+      labor.demographics,
+      SocialSecurity.ZusState.zero,
+      SocialSecurity.NfzState.zero,
+      SocialSecurity.PpkState.zero,
+      PLN.Zero,
+      EarmarkedFunds.State.zero,
+      labor.living,
+      labor.regionalWages,
+    )
+    val s3     = HouseholdIncomeEconomics.compute(world, firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, RandomStream.seeded(42))
+    val s4     = DemandEconomics.compute(DemandEconomics.Input(world, s2.employed, s2.living, s3.domesticCons))
+    FirmEconomics.runStep(world, firms, init.households, init.banks, s1, s2, s3, s4, RandomStream.seeded(43))
+
+  private def manufacturingScenario(stateOwned: Boolean, cashRich: Boolean = false): Vector[Firm.State] =
+    init.firms.map { firm =>
+      val base =
+        if firm.sector.toInt == ManufacturingSector && cashRich then
+          firm.copy(cash = PLN(500e6), capitalStock = PLN.Zero, greenCapital = PLN.Zero)
+        else firm
+      if base.sector.toInt == ManufacturingSector then base.copy(stateOwned = stateOwned) else base.copy(stateOwned = false)
+    }
+
+  private def manufacturingOutputs(step: FirmEconomics.StepOutput): Vector[Firm.State] =
+    step.ioFirms.filter(_.sector.toInt == ManufacturingSector)
 
   "FirmEconomics (self-contained Input)" should "match old step tax" in
     result.sumTax.shouldBe(oldS5.sumTax)
@@ -102,4 +140,35 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   it should "produce flows that close at SFC == 0L" in {
     val flows = FirmFlows.emit(StateAdapter.firmInput(resultR, s3.totalIncome))
     Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)).shouldBe(0L)
+  }
+
+  it should "increase manufacturing capital accumulation when strategic firms are state-owned" in {
+    val privateRun          = runStepFor(w, manufacturingScenario(stateOwned = false, cashRich = true))
+    val stateOwnedRun       = runStepFor(w, manufacturingScenario(stateOwned = true, cashRich = true))
+    val privateManufactured = manufacturingOutputs(privateRun)
+    val soeManufactured     = manufacturingOutputs(stateOwnedRun)
+
+    privateManufactured should not be empty
+    soeManufactured.zip(privateManufactured).foreach { case (soeFirm, privateFirm) =>
+      soeFirm.capitalStock should be > privateFirm.capitalStock
+    }
+    stateOwnedRun.sumGrossInvestment should be > privateRun.sumGrossInvestment
+  }
+
+  it should "reduce manufacturing markup pass-through for state-owned firms under a commodity shock" in {
+    val privateFirms          = manufacturingScenario(stateOwned = false)
+    val stateOwnedFirms       = manufacturingScenario(stateOwned = true)
+    val shockedWorld          = w.updateExternal(_.copy(gvc = w.external.gvc.copy(commodityPriceIndex = PriceIndex(1.80))))
+    val baselinePrivateRun    = runStepFor(w, privateFirms)
+    val baselineStateOwnedRun = runStepFor(w, stateOwnedFirms)
+    val shockedPrivateRun     = runStepFor(shockedWorld, privateFirms)
+    val shockedStateOwnedRun  = runStepFor(shockedWorld, stateOwnedFirms)
+    val shockedPairs          = manufacturingOutputs(shockedStateOwnedRun).map(_.markup).zip(manufacturingOutputs(shockedPrivateRun).map(_.markup))
+
+    manufacturingOutputs(baselineStateOwnedRun).map(_.markup) shouldBe manufacturingOutputs(baselinePrivateRun).map(_.markup)
+    shockedStateOwnedRun.markupInflation should be < shockedPrivateRun.markupInflation
+    shockedPairs.foreach { case (soeMarkup, privateMarkup) =>
+      soeMarkup should be <= privateMarkup
+    }
+    shockedPairs.exists { case (soeMarkup, privateMarkup) => soeMarkup < privateMarkup } shouldBe true
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
@@ -78,8 +78,9 @@ class PriceEquityEconomicsSpec extends AnyFlatSpec with Matchers:
 
   "PriceEquityEconomics.compute" should "increase direct SOE dividend extraction when the fiscal deficit is higher" in {
     val prevGdp           = w.cachedMonthlyGdpProxy.max(PLN(1.0))
-    val lowDeficitWorld   = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = prevGdp * Share(0.01))))
-    val highDeficitWorld  = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = prevGdp * Share(0.10))))
+    val thresholdDeficit  = prevGdp * summon[SimParams].soe.dividendFiscalThreshold
+    val lowDeficitWorld   = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = thresholdDeficit * Multiplier(0.9))))
+    val highDeficitWorld  = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = thresholdDeficit * Multiplier(1.1))))
     val dividendSensitive = s5.copy(
       sumRealizedPostTaxProfit = PLN(200e6),
       sumStateOwnedPostTaxProfit = PLN(100e6),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
@@ -35,7 +35,8 @@ class PriceEquityEconomicsSpec extends AnyFlatSpec with Matchers:
     labor.living,
     labor.regionalWages,
   )
-  private val s3          = HouseholdIncomeEconomics.compute(w, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, RandomStream.seeded(42))
+  private val s3          =
+    HouseholdIncomeEconomics.compute(w, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, RandomStream.seeded(42))
   private val s4          = DemandEconomics.compute(DemandEconomics.Input(w, s2.employed, s2.living, s3.domesticCons))
   private val s5          = FirmEconomics.runStep(w, init.firms, init.households, init.banks, s1, s2, s3, s4, RandomStream.seeded(43))
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomicsSpec.scala
@@ -1,6 +1,11 @@
 package com.boombustgroup.amorfati.engine.economics
 
+import com.boombustgroup.amorfati.FixedPointSpecSupport.*
+import com.boombustgroup.amorfati.agents.{EarmarkedFunds, SocialSecurity}
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,22 +13,80 @@ import org.scalatest.matchers.should.Matchers
 class PriceEquityEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given SimParams = SimParams.defaults
-  private val td          = ComputationBoundary
+  private val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+  private val w           = init.world
+  private val fiscal      = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
+  private val s1          = FiscalConstraintEconomics.toOutput(fiscal)
+  private val labor       = LaborEconomics.compute(w, init.firms, init.households, s1)
+  private val s2          = LaborEconomics.Output(
+    labor.wage,
+    labor.employed,
+    labor.laborDemand,
+    labor.wageGrowth,
+    labor.operationalHiringSlack,
+    labor.immigration,
+    labor.netMigration,
+    labor.demographics,
+    SocialSecurity.ZusState.zero,
+    SocialSecurity.NfzState.zero,
+    SocialSecurity.PpkState.zero,
+    PLN.Zero,
+    EarmarkedFunds.State.zero,
+    labor.living,
+    labor.regionalWages,
+  )
+  private val s3          = HouseholdIncomeEconomics.compute(w, init.firms, init.households, init.banks, s1.lendingBaseRate, s1.resWage, s2.newWage, RandomStream.seeded(42))
+  private val s4          = DemandEconomics.compute(DemandEconomics.Input(w, s2.employed, s2.living, s3.domesticCons))
+  private val s5          = FirmEconomics.runStep(w, init.firms, init.households, init.banks, s1, s2, s3, s4, RandomStream.seeded(43))
+
+  private def runPriceStep(world: com.boombustgroup.amorfati.engine.World, firmStep: FirmEconomics.StepOutput): PriceEquityEconomics.Output =
+    PriceEquityEconomics.compute(
+      PriceEquityEconomics.Input(
+        w = world,
+        month = s1.m,
+        newWage = s2.newWage,
+        employed = s2.employed,
+        wageGrowth = s2.wageGrowth,
+        domesticCons = s3.domesticCons,
+        govPurchases = s4.govPurchases,
+        avgDemandMult = s4.avgDemandMult,
+        sectorMults = s4.sectorMults,
+        banks = init.banks,
+        s5 = firmStep,
+      ),
+      RandomStream.seeded(44),
+    )
 
   "PriceEquityEconomics.governmentDemandContribution" should "scale with constrained runtime government purchases" in {
     val low  = PriceEquityEconomics.governmentDemandContribution(PLN(250e6))
     val high = PriceEquityEconomics.governmentDemandContribution(PLN(600e6))
 
     high should be > low
-    high / low shouldBe (600e6 / 250e6) +- 1e-9
+    high.ratioTo(low).bd shouldBe (BigDecimal("2.4") +- BigDecimal("0.000000001"))
   }
 
   it should "respect the configured current-vs-capital multipliers" in {
     val gp           = PLN(500e6)
     val contribution = PriceEquityEconomics.governmentDemandContribution(gp)
     val expected     =
-      td.toDouble(gp) * (1.0 - td.toDouble(summon[SimParams].fiscal.govInvestShare)) * td.toDouble(summon[SimParams].fiscal.govCurrentMultiplier) +
-        td.toDouble(gp) * td.toDouble(summon[SimParams].fiscal.govInvestShare) * td.toDouble(summon[SimParams].fiscal.govCapitalMultiplier)
+      gp * (Share.One - summon[SimParams].fiscal.govInvestShare) * summon[SimParams].fiscal.govCurrentMultiplier +
+        gp * summon[SimParams].fiscal.govInvestShare * summon[SimParams].fiscal.govCapitalMultiplier
 
-    contribution shouldBe expected +- 1e-6
+    contribution shouldBe expected
+  }
+
+  "PriceEquityEconomics.compute" should "increase direct SOE dividend extraction when the fiscal deficit is higher" in {
+    val prevGdp           = w.cachedMonthlyGdpProxy.max(PLN(1.0))
+    val lowDeficitWorld   = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = prevGdp * Share(0.01))))
+    val highDeficitWorld  = w.copy(gov = w.gov.copy(monthly = w.gov.monthly.copy(deficit = prevGdp * Share(0.10))))
+    val dividendSensitive = s5.copy(
+      sumRealizedPostTaxProfit = PLN(200e6),
+      sumStateOwnedPostTaxProfit = PLN(100e6),
+    )
+    val lowDeficit        = runPriceStep(lowDeficitWorld, dividendSensitive)
+    val highDeficit       = runPriceStep(highDeficitWorld, dividendSensitive)
+
+    highDeficit.stateOwnedGovDividends should be > lowDeficit.stateOwnedGovDividends
+    highDeficit.dividendTax shouldBe lowDeficit.dividendTax
+    highDeficit.netDomesticDividends shouldBe lowDeficit.netDomesticDividends
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -52,7 +52,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
       InsuranceFlows.emit(
         InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
       ),
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(
@@ -105,7 +105,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
       InsuranceFlows.emitBatches(
         InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
       ),
-      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
+      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
       CorpBondFlows.emitBatches(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emitBatches(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emitBatches(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -52,7 +52,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
       InsuranceFlows.emit(
         InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
       ),
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(
@@ -105,7 +105,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
       InsuranceFlows.emitBatches(
         InsuranceFlows.Input(80000, PLN(7000.0), Share(0.08), PLN(100000000.0), PLN(50000000.0), PLN(40000000.0), Rate(0.06), Rate(0.08), Rate(0.03)),
       ),
-      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))),
+      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
       CorpBondFlows.emitBatches(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emitBatches(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emitBatches(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -84,7 +84,7 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       // Tier 3: Financial markets + external
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -84,7 +84,7 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       // Tier 3: Financial markets + external
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
@@ -8,23 +8,35 @@ import org.scalatest.matchers.should.Matchers
 class EquityFlowsSpec extends AnyFlatSpec with Matchers:
 
   "EquityFlows" should "preserve total wealth at exactly 0L" in {
-    val flows    = EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0)))
+    val flows    = EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0)))
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
     Interpreter.totalWealth(balances) shouldBe 0L
   }
 
   it should "have firm balance = -dividends + issuance" in {
-    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))
     val flows    = EquityFlows.emit(input)
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
     balances(EquityFlows.FIRM_ACCOUNT) shouldBe (input.issuance - input.netDomesticDividends - input.foreignDividends).toLong
   }
 
   it should "preserve SFC across 120 months" in {
-    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(1000000.0))
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))
     var balances = Map.empty[Int, Long]
     (1 to 120).foreach { _ =>
       balances = Interpreter.applyAll(balances, EquityFlows.emit(input))
       Interpreter.totalWealth(balances) shouldBe 0L
     }
+  }
+
+  it should "emit a dedicated firm-to-government SOE dividend flow when government extraction is positive" in {
+    val input = EquityFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN(250000.0), PLN.Zero)
+    val flows = EquityFlows.emit(input)
+
+    flows.exists(flow =>
+      flow.from == EquityFlows.FIRM_ACCOUNT &&
+        flow.to == EquityFlows.GOV_ACCOUNT &&
+        flow.amount == input.govDividends.toLong &&
+        flow.mechanism == FlowMechanism.EquityGovDividend.toInt,
+    ) shouldBe true
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -16,7 +16,7 @@ import com.boombustgroup.amorfati.engine.{
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.{ImperativeInterpreter, Interpreter}
+import com.boombustgroup.ledger.{BatchedFlow, ImperativeInterpreter, Interpreter, MechanismId}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,6 +24,14 @@ import org.scalatest.matchers.should.Matchers
 class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
+
+  private def mechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
+    PLN.fromRaw(
+      batches.iterator
+        .filter(_.mechanism == mechanism)
+        .map(AggregateBatchContract.totalTransferred)
+        .sum,
+    )
 
   private def canonicalHouseholds(households: Vector[Household.State]): Vector[Vector[Any]] =
     households.map: hh =>
@@ -172,6 +180,29 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     highShadowRun.nextState.world.flows.taxEvasionLoss should be > lowShadowRun.nextState.world.flows.taxEvasionLoss
     highShadowRun.nextState.world.gov.taxRevenue should be < lowShadowRun.nextState.world.gov.taxRevenue
     highShadowRun.nextState.world.gov.deficit should be > lowShadowRun.nextState.world.gov.deficit
+  }
+
+  it should "align semantic gov revenue with the emitted SOE dividend batch at the month boundary" in {
+    val init             = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val boundaryDividend = PLN(25e6)
+    val lowState         = FlowSimulation.SimState.fromInit(init)
+    val highState        = lowState.copy(
+      world = lowState.world.copy(
+        gov = lowState.world.gov.copy(
+          monthly = lowState.world.gov.monthly.copy(govDividendRevenue = boundaryDividend),
+        ),
+      ),
+    )
+    val lowResult        = FlowSimulation.step(lowState, MonthRandomness.Contract.fromSeed(42L))
+    val highResult       = FlowSimulation.step(highState, MonthRandomness.Contract.fromSeed(42L))
+    val lowGovDividend   = mechanismTotal(lowResult.flows, FlowMechanism.EquityGovDividend)
+    val highGovDividend  = mechanismTotal(highResult.flows, FlowMechanism.EquityGovDividend)
+
+    lowResult.sfcResult shouldBe Right(())
+    highResult.sfcResult shouldBe Right(())
+    lowGovDividend shouldBe PLN.Zero
+    highGovDividend shouldBe boundaryDividend
+    highResult.trace.executedFlows.govRevenue - lowResult.trace.executedFlows.govRevenue shouldBe boundaryDividend
   }
 
   it should "produce 30+ mechanism IDs" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -151,7 +151,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       // Tier 3: Financial markets
-      EquityFlows.emit(EquityFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, s5.sumEquityIssuance)),
+      EquityFlows.emit(EquityFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, s5.sumEquityIssuance)),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN.Zero, PLN.Zero, s5.actualBondIssuance, PLN.Zero)),
       MortgageFlows.emit(MortgageFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)),
       // OpenEcon: simplified

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -135,6 +135,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "EquityWealthEffect",
     "DomesticDividends",
     "ForeignDividendOutflow",
+    "GovernmentDividends",
     "CorpBondOutstanding",
     "CorpBondYield",
     "CorpBondIssuance",
@@ -272,7 +273,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     row(idx)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 239
+    McTimeseriesSchema.nCols shouldBe 240
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 


### PR DESCRIPTION
Closes #296

## Summary
- wire SOE runtime behavior into the existing month-step architecture without bypassing batched flow emission
- add sector-aware SOE directed investment and energy-price pass-through semantics in `StateOwned`
- extend `PriceEquityEconomics` and `EquityMarket` so SOE post-tax profits can produce deficit-sensitive government dividend extraction
- route SOE dividend revenue through `BankingEconomics` and `FiscalBudget` as explicit `govDividendRevenue` instead of hiding it inside `taxRevenue`
- add a dedicated `EquityGovDividend` batched flow and align `FlowSimulation` SFC government-revenue semantics with the emitted batch at the month boundary
- tighten typed/runtime contracts in the touched economics paths by removing local boundary escapes and keeping `PLN`/`Rate`/`Share` values typed end-to-end

## Architecture Fit
- Same-month signals stay in the economics stages: SOE profits, payout pressure, pricing pass-through, and directed-investment multipliers are computed in `FirmEconomics` and `PriceEquityEconomics`.
- Persisted month-boundary state stays explicit: SOE dividend budget revenue is carried on `GovState.govDividendRevenue`, while equity observability fields remain on `EquityMarket.State`.
- Batched execution remains the source of runtime cash truth: the new SOE government dividend leg is emitted through `EquityFlows` / `FlowMechanism.EquityGovDividend`, and `FlowSimulation.buildSfcFlows` now reads the executed batch for `govRevenue`.
- This PR follows the existing lagged-equity emission contract rather than redesigning the whole equity timing model in one step.

## Notes
- The current 6-sector schema still has no explicit utilities bucket; SOE investment and energy behavior are expressed via sector semantics in `StateOwned`.
- The latest follow-up fixes also cover the threshold-based dividend test setup, separate SOE dividend budget reporting, and month-boundary alignment between SFC semantics and executed SOE dividend batches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State-owned enterprises now allocate capital investments with sector-specific targeting multipliers.
  * Government receives dividend payments from state-owned enterprises, tracked as separate fiscal revenue.
  * Energy commodity price shocks now dynamically adjust firm pricing strategies.
  * Fiscal accounts distinguish government dividend revenue from tax revenue components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->