### PR TITLE
Clarify runtime execution as delta ledger

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -50,17 +50,23 @@ object Sfc:
       index: ExecutionIndex,
   )
 
-  case class ExecutionSnapshot(
+  /** Executed batch deltas accumulated on the empty aggregate runtime ledger.
+    *
+    * This is not a closing stock state. Each stored value is the net month
+    * delta for one synthetic `(sector, asset, index)` slot after executing the
+    * emitted batches against an empty aggregate state.
+    */
+  case class ExecutionDeltaLedger(
       balances: Map[ExecutionBalanceKey, PLN],
   ):
-    def balance(key: ExecutionBalanceKey): PLN =
+    def delta(key: ExecutionBalanceKey): PLN =
       balances.getOrElse(key, PLN.Zero)
 
-  object ExecutionSnapshot:
+  object ExecutionDeltaLedger:
     def fromRaw(
         balances: Map[(EntitySector, AssetType, Int), Long],
-    ): ExecutionSnapshot =
-      ExecutionSnapshot(
+    ): ExecutionDeltaLedger =
+      ExecutionDeltaLedger(
         balances.iterator.map { case ((sector, asset, index), amount) =>
           ExecutionBalanceKey(sector, asset, ExecutionIndex(index)) -> PLN.fromRaw(amount)
         }.toMap,
@@ -449,8 +455,8 @@ object Sfc:
       curr: RuntimeState,
       flows: SemanticFlows,
       batches: Vector[BatchedFlow],
-      executionSnapshot: ExecutionSnapshot,
-      totalWealth: Long,
+      executionDeltaLedger: ExecutionDeltaLedger,
+      deltaLedgerNet: Long,
   )(using p: SimParams): SfcResult =
     // In the runtime API, Flow-of-Funds is checked from executed ledger
     // batches. Keep the stock-side identities from the legacy oracle, but
@@ -463,13 +469,13 @@ object Sfc:
     // `metricDiagnostics`.
     val baseErrors    =
       validateStockExactness(snapshot(prev), snapshot(curr), flows.copy(fofResidual = PLN.Zero)).left.toOption.getOrElse(Vector.empty)
-    val runtimeErrors = runtimeIdentityErrors(batches, executionSnapshot, totalWealth)
+    val runtimeErrors = runtimeIdentityErrors(batches, executionDeltaLedger, deltaLedgerNet)
     merge(baseErrors ++ runtimeErrors)
 
   private def runtimeIdentityErrors(
       batches: Vector[BatchedFlow],
-      executionSnapshot: ExecutionSnapshot,
-      totalWealth: Long,
+      executionDeltaLedger: ExecutionDeltaLedger,
+      deltaLedgerNet: Long,
   ): Vector[SfcIdentityError] =
     val publicCashErrors =
       runtimeCashIdentity(
@@ -477,59 +483,59 @@ object Sfc:
         "government budget cash",
         AccountRef(EntitySector.Government, ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget)),
         batches,
-        executionSnapshot,
+        executionDeltaLedger,
       ) ++
         runtimeCashIdentity(
           SfcIdentity.JstCash,
           "JST cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Jst)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         ) ++
         runtimeCashIdentity(
           SfcIdentity.ZusCash,
           "ZUS cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Zus)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         ) ++
         runtimeCashIdentity(
           SfcIdentity.NfzCash,
           "NFZ cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Nfz)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         ) ++
         runtimeCashIdentity(
           SfcIdentity.FpCash,
           "FP cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Fp)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         ) ++
         runtimeCashIdentity(
           SfcIdentity.PfronCash,
           "PFRON cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Pfron)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         ) ++
         runtimeCashIdentity(
           SfcIdentity.FgspCash,
           "FGSP cash",
           AccountRef(EntitySector.Funds, ExecutionIndex(AggregateBatchContract.FundIndex.Fgsp)),
           batches,
-          executionSnapshot,
+          executionDeltaLedger,
         )
     val fofErrors        =
-      if totalWealth == 0L then Vector.empty
+      if deltaLedgerNet == 0L then Vector.empty
       else
         Vector(
           SfcIdentityError(
             SfcIdentity.FlowOfFunds,
-            s"ledger execution totalWealth=$totalWealth across ${batches.size} batches",
+            s"ledger execution delta-ledger net=$deltaLedgerNet across ${batches.size} batches",
             expected = PLN.Zero,
-            actual = PLN.fromRaw(totalWealth),
+            actual = PLN.fromRaw(deltaLedgerNet),
           ),
         )
     publicCashErrors ++ fofErrors
@@ -546,26 +552,26 @@ object Sfc:
       label: String,
       account: AccountRef,
       batches: Vector[BatchedFlow],
-      executionSnapshot: ExecutionSnapshot,
+      executionDeltaLedger: ExecutionDeltaLedger,
   ): Vector[SfcIdentityError] =
     val expected = cashAccountNetFlow(account, batches)
-    val actual   = cashAccountBalance(account, executionSnapshot)
+    val actual   = cashAccountDelta(account, executionDeltaLedger)
     if actual != expected then
       Vector(
         SfcIdentityError(
           identity,
-          s"$label [expected net=$expected, actual closing=$actual]",
+          s"$label [expected net delta=$expected, actual delta-ledger=$actual]",
           expected = expected,
           actual = actual,
         ),
       )
     else Vector.empty
 
-  private def cashAccountBalance(
+  private def cashAccountDelta(
       account: AccountRef,
-      executionSnapshot: ExecutionSnapshot,
+      executionDeltaLedger: ExecutionDeltaLedger,
   ): PLN =
-    executionSnapshot.balance(
+    executionDeltaLedger.delta(
       ExecutionBalanceKey(account.sector, AssetType.Cash, account.index),
     )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
@@ -87,11 +87,12 @@ object AggregateBatchContract:
   def emptyExecutionState(): MutableWorldState =
     new MutableWorldState(sectorSizes)
 
-  def totalWealth(snapshot: Map[(EntitySector, AssetType, Int), Long]): Long =
+  /** Net delta across the executed aggregate runtime ledger. */
+  def netDelta(snapshot: Map[(EntitySector, AssetType, Int), Long]): Long =
     snapshot.valuesIterator.sum
 
-  def totalWealth(state: MutableWorldState): Long =
-    totalWealth(state.snapshot)
+  def netDelta(state: MutableWorldState): Long =
+    netDelta(state.snapshot)
 
   def toLegacyFlows(batches: Vector[BatchedFlow]): Vector[Flow] =
     batches.flatMap(toLegacyFlows)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -39,9 +39,15 @@ object FlowSimulation:
     def fromInit(init: com.boombustgroup.amorfati.init.WorldInit.InitResult): SimState =
       SimState(CompletedMonth.Zero, init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
+  /** Executed aggregate batch deltas on top of an empty runtime ledger shell.
+    *
+    * This is not a closing stock snapshot. `deltaLedger` stores the net monthly
+    * delta per synthetic runtime slot, and `netDelta` is the conservation check
+    * over that delta space.
+    */
   case class ExecutionResult(
-      snapshot: Map[(EntitySector, AssetType, Int), Long],
-      totalWealth: Long,
+      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
+      netDelta: Long,
   )
 
   /** All calculus results needed to feed flow mechanisms. */
@@ -354,8 +360,8 @@ object FlowSimulation:
       curr = runtimeState(nextState.world, nextState.firms, nextState.households, nextState.banks),
       flows = sfcFlows,
       batches = flows,
-      executionSnapshot = Sfc.ExecutionSnapshot.fromRaw(execution.snapshot),
-      totalWealth = execution.totalWealth,
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger.fromRaw(execution.deltaLedger),
+      deltaLedgerNet = execution.netDelta,
     )
     val monthTrace = buildMonthTrace(
       input = input,
@@ -650,10 +656,10 @@ object FlowSimulation:
     ImperativeInterpreter
       .planAndApplyAll(state, flows)
       .map: _ =>
-        val snapshot = state.snapshot
+        val deltaLedger = state.snapshot
         ExecutionResult(
-          snapshot = snapshot,
-          totalWealth = AggregateBatchContract.totalWealth(snapshot),
+          deltaLedger = deltaLedger,
+          netDelta = AggregateBatchContract.netDelta(deltaLedger),
         )
 
   private def runtimeState(

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -956,10 +956,10 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     result shouldBe Right(())
   }
 
-  // ---- Runtime-only public cash identity ----
+  // ---- Runtime-only public cash delta-ledger identity ----
 
-  "Sfc.validate (runtime government budget cash)" should "pass when execution budget cash matches batch net flow" in {
-    val batches  = Vector.concat(
+  "Sfc.validate (runtime government budget cash delta ledger)" should "pass when execution budget cash delta matches batch net flow" in {
+    val batches     = Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Aggregate,
@@ -979,7 +979,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         FlowMechanism.GovPurchases,
       ),
     )
-    val snapshot = Sfc.ExecutionSnapshot(
+    val deltaLedger = Sfc.ExecutionDeltaLedger(
       Map(
         Sfc.ExecutionBalanceKey(
           EntitySector.Government,
@@ -988,18 +988,18 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         ) -> PLN(60.0),
       ),
     )
-    val result   = Sfc.validate(
+    val result      = Sfc.validate(
       prev = zeroRuntime,
       curr = zeroRuntime,
       flows = zeroFlows,
       batches = batches,
-      executionSnapshot = snapshot,
-      totalWealth = 0L,
+      executionDeltaLedger = deltaLedger,
+      deltaLedgerNet = 0L,
     )
     result shouldBe Right(())
   }
 
-  it should "detect mismatch between budget cash batches and execution snapshot" in {
+  it should "detect mismatch between budget cash batches and execution delta ledger" in {
     val batches = Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Firms,
@@ -1025,7 +1025,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       curr = zeroRuntime,
       flows = zeroFlows,
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1034,7 +1034,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(55.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result shouldBe a[Left[?, ?]]
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.GovBudgetCash) shouldBe true
@@ -1068,7 +1068,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       curr = currRuntime,
       flows = zeroFlows.copy(govSpending = PLN(10_000.0), govRevenue = PLN.Zero),
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1077,7 +1077,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(60.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result shouldBe Right(())
   }
@@ -1162,7 +1162,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       curr = zeroRuntime,
       flows = zeroFlows,
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1186,7 +1186,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(10.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result shouldBe Right(())
   }
@@ -1234,7 +1234,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       flows = zeroFlows.copy(zusContributions = PLN.Zero, zusPensionPayments = PLN(9999.0)),
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1248,7 +1248,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(49.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result.shouldBe(a[Left[?, ?]])
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.ZusCash).shouldBe(true)
@@ -1343,7 +1343,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       curr = zeroRuntime,
       flows = zeroFlows,
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1367,7 +1367,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(15.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result.shouldBe(Right(()))
   }
@@ -1407,7 +1407,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       curr = zeroRuntime,
       flows = zeroFlows,
       batches = batches,
-      executionSnapshot = Sfc.ExecutionSnapshot(
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger(
         Map(
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
@@ -1421,7 +1421,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           ) -> PLN(14.0),
         ),
       ),
-      totalWealth = 0L,
+      deltaLedgerNet = 0L,
     )
     result.shouldBe(a[Left[?, ?]])
     result.swap.getOrElse(Vector.empty).exists(_.identity == Sfc.SfcIdentity.FgspCash).shouldBe(true)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/AutonomousPipelineSpec.scala
@@ -27,7 +27,7 @@ class AutonomousPipelineSpec extends AnyFlatSpec with Matchers:
       val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
 
       withClue(s"Month $month: ") {
-        result.execution.totalWealth.shouldBe(0L)
+        result.execution.netDelta.shouldBe(0L)
       }
 
       state = result.nextState

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -140,5 +140,5 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
     result.flows should not be empty
     result.flows.forall(_.isInstanceOf[BatchedFlow]) shouldBe true
     batchedMechanismTotals(result.flows) shouldBe legacyMechanismTotals(legacy)
-    result.execution.totalWealth shouldBe 0L
+    result.execution.netDelta shouldBe 0L
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -25,7 +25,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
-    result.execution.totalWealth shouldBe 0L
+    result.execution.netDelta shouldBe 0L
     AggregateBatchContract.totalTransferred(flows) should be > 0L
   }
 
@@ -38,7 +38,7 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
       val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
       withClue(s"Month $month: ") {
-        result.execution.totalWealth shouldBe 0L
+        result.execution.netDelta shouldBe 0L
         AggregateBatchContract.totalTransferred(flows) should be > 0L
       }
 
@@ -52,6 +52,6 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val flows  = FlowSimulation.emitAllBatches(result.calculus)
 
-    result.execution.totalWealth shouldBe 0L
+    result.execution.netDelta shouldBe 0L
     flows.map(_.mechanism).toSet.size should be > 30
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -45,7 +45,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state  = FlowSimulation.SimState.fromInit(init)
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
-    result.execution.totalWealth shouldBe 0L
+    result.execution.netDelta shouldBe 0L
     result.sfcResult shouldBe Right(())
     result.calculus.employed should be > 0
   }
@@ -152,7 +152,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     results.foreach { result =>
       val month = result.executionMonth.toInt
       withClue(s"Month $month: ") {
-        result.execution.totalWealth shouldBe 0L
+        result.execution.netDelta shouldBe 0L
         result.sfcResult shouldBe Right(())
       }
     }
@@ -171,8 +171,8 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
       MonthRandomness.Contract.fromSeed(42L),
     )
 
-    lowShadowRun.execution.totalWealth shouldBe 0L
-    highShadowRun.execution.totalWealth shouldBe 0L
+    lowShadowRun.execution.netDelta shouldBe 0L
+    highShadowRun.execution.netDelta shouldBe 0L
     lowShadowRun.sfcResult shouldBe Right(())
     highShadowRun.sfcResult shouldBe Right(())
 
@@ -294,14 +294,14 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     trace.seedTransition.provenance.sectorHiringSignal.value shouldBe trace.timing.demandSignals.sectorHiringSignal
   }
 
-  it should "match the legacy pure interpreter on aggregate execution balances" in {
+  it should "match the legacy pure interpreter on aggregate execution deltas" in {
     val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val initState = FlowSimulation.SimState.fromInit(init)
     val result    = FlowSimulation.step(initState, MonthRandomness.Contract.fromSeed(42L))
     val state     = AggregateBatchContract.emptyExecutionState()
 
     ImperativeInterpreter.planAndApplyAll(state, result.flows) shouldBe Right(())
-    AggregateBatchContract.totalWealth(state) shouldBe Interpreter.totalWealth(
+    AggregateBatchContract.netDelta(state) shouldBe Interpreter.totalWealth(
       Interpreter.applyAll(Map.empty[Int, Long], AggregateBatchContract.toLegacyFlows(result.flows)),
     )
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiMonthFlowSpec.scala
@@ -25,7 +25,7 @@ class MultiMonthFlowSpec extends AnyFlatSpec with Matchers:
       val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L * 1000 + month))
 
       withClue(s"SFC violated at month $month: ") {
-        result.execution.totalWealth shouldBe 0L
+        result.execution.netDelta shouldBe 0L
       }
 
       state = result.nextState

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/MultiSeedValidationSpec.scala
@@ -29,7 +29,7 @@ class MultiSeedValidationSpec extends AnyFlatSpec with Matchers:
       (1 to months).foreach { month =>
         val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(seed * 1000 + month))
         withClue(s"Seed $seed, month $month: ") {
-          result.execution.totalWealth.shouldBe(0L)
+          result.execution.netDelta.shouldBe(0L)
         }
         state = result.nextState
       }


### PR DESCRIPTION
## Summary

Implements the minimal semantics cleanup for `#362` by making the current
runtime execution artifact explicit as a delta ledger rather than something
that looks like a closing stock snapshot.

This PR:

- renames flow-pipeline execution output from snapshot/balance language to
  `deltaLedger` / `netDelta`
- renames SFC runtime execution input from `ExecutionSnapshot` to
  `ExecutionDeltaLedger`
- updates SFC runtime cash validation messages so they refer to net deltas and
  delta-ledger semantics instead of closing balances
- renames the aggregate execution helper from `totalWealth` to `netDelta`

## Scope

This PR intentionally clarifies semantics only.

Included:

- execution artifact rename and comments
- SFC validation rename/message cleanup
- test updates for the new delta-ledger terminology

Not included:

- stock-based execution against a populated runtime ledger
- next-world materialization redesign
- settlement topology redesign

## Why

The current execution state is produced by applying batches to an empty
aggregate runtime state. That makes it a delta ledger on synthetic nodes, not a
closing balance snapshot. The code now says that directly.

## Follow-up

- Refs #362 
- A future redesign can still move execution to a true stock-based runtime
  state, but this PR removes the current semantic ambiguity first.

## Verification

- `sbt "Test/compile" "testOnly com.boombustgroup.amorfati.accounting.SfcSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.flows.BatchedEmissionContractSpec"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal accounting logic terminology and structure for greater consistency across validation and simulation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->