### PR TITLE
Define treasury runtime settlement contract

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.flows.AggregateBatchContract
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
+import com.boombustgroup.amorfati.engine.ledger.{LedgerStateAdapter, TreasuryRuntimeContract}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
 
@@ -480,8 +480,11 @@ object Sfc:
     val publicCashErrors =
       runtimeCashIdentity(
         SfcIdentity.GovBudgetCash,
-        "government budget cash",
-        AccountRef(EntitySector.Government, ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget)),
+        "treasury budget settlement cash",
+        AccountRef(
+          TreasuryRuntimeContract.TreasuryBudgetSettlement.sector,
+          ExecutionIndex(TreasuryRuntimeContract.TreasuryBudgetSettlement.index),
+        ),
         batches,
         executionDeltaLedger,
       ) ++

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/BankingFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/BankingFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -39,7 +40,7 @@ object BankingFlows:
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Banks,
         BankIndex.Aggregate,
         input.govBondIncome,
@@ -89,7 +90,7 @@ object BankingFlows:
         EntitySector.Banks,
         BankIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.bfgLevy,
         AssetType.Cash,
         FlowMechanism.BankBfgLevy,
@@ -98,7 +99,7 @@ object BankingFlows:
         EntitySector.Banks,
         BankIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.unrealizedBondLoss,
         AssetType.Cash,
         FlowMechanism.BankUnrealizedLoss,
@@ -116,7 +117,7 @@ object BankingFlows:
         EntitySector.Banks,
         BankIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.nbpRemittance,
         AssetType.Cash,
         FlowMechanism.BankNbpRemittance,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -48,7 +49,15 @@ object EarmarkedFlows:
       AggregateBatchedEmission
         .transfer(EntitySector.Funds, FundIndex.Fp, EntitySector.Firms, FirmIndex.Services, fpSpend, AssetType.Cash, FlowMechanism.FpSpending),
       AggregateBatchedEmission
-        .transfer(EntitySector.Government, GovernmentIndex.Budget, EntitySector.Funds, FundIndex.Fp, fpDeficit, AssetType.Cash, FlowMechanism.FpGovSubvention),
+        .transfer(
+          EntitySector.Government,
+          TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+          EntitySector.Funds,
+          FundIndex.Fp,
+          fpDeficit,
+          AssetType.Cash,
+          FlowMechanism.FpGovSubvention,
+        ),
       AggregateBatchedEmission.transfer(
         EntitySector.Households,
         HouseholdIndex.Aggregate,
@@ -62,7 +71,7 @@ object EarmarkedFlows:
         .transfer(EntitySector.Funds, FundIndex.Pfron, EntitySector.Firms, FirmIndex.Services, pfronSpend, AssetType.Cash, FlowMechanism.PfronSpending),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         FundIndex.Pfron,
         pfronDeficit,
@@ -82,7 +91,7 @@ object EarmarkedFlows:
         .transfer(EntitySector.Funds, FundIndex.Fgsp, EntitySector.Firms, FirmIndex.Services, fgspSpend, AssetType.Cash, FlowMechanism.FgspSpending),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         FundIndex.Fgsp,
         fgspDeficit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -50,7 +51,7 @@ object EquityFlows:
         EntitySector.Households,
         HouseholdIndex.Investors,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.dividendTax,
         AssetType.Cash,
         FlowMechanism.EquityDividendTax,
@@ -59,7 +60,7 @@ object EquityFlows:
         EntitySector.Firms,
         FirmIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.govDividends,
         AssetType.Cash,
         FlowMechanism.EquityGovDividend,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -50,7 +51,15 @@ object FirmFlows:
         FlowMechanism.FirmWages,
       ),
       AggregateBatchedEmission
-        .transfer(EntitySector.Firms, FirmIndex.Aggregate, EntitySector.Government, GovernmentIndex.Budget, input.cit, AssetType.Cash, FlowMechanism.FirmCit),
+        .transfer(
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          EntitySector.Government,
+          TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+          input.cit,
+          AssetType.Cash,
+          FlowMechanism.FirmCit,
+        ),
       AggregateBatchedEmission.transfer(
         EntitySector.Firms,
         FirmIndex.Aggregate,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/GovBudgetFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -42,16 +43,16 @@ object GovBudgetFlows:
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.TaxpayerPool,
+        TreasuryRuntimeContract.TaxpayerCollection.index,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.taxRevenue,
         AssetType.Cash,
         FlowMechanism.GovTaxRevenue,
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Firms,
         FirmIndex.Aggregate,
         input.govPurchases,
@@ -60,7 +61,7 @@ object GovBudgetFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         FundIndex.Bondholders,
         input.debtService,
@@ -69,7 +70,7 @@ object GovBudgetFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Households,
         HouseholdIndex.Aggregate,
         input.unempBenefitSpend,
@@ -78,7 +79,7 @@ object GovBudgetFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Households,
         HouseholdIndex.Aggregate,
         input.socialTransferSpend,
@@ -87,7 +88,7 @@ object GovBudgetFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Firms,
         FirmIndex.CapitalGoods,
         input.euCofinancing,
@@ -96,7 +97,7 @@ object GovBudgetFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Firms,
         FirmIndex.CapitalGoods,
         input.govCapitalSpend,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -62,7 +63,7 @@ object HouseholdFlows:
         EntitySector.Households,
         HouseholdIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.pit,
         AssetType.Cash,
         FlowMechanism.HhPit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -39,7 +40,7 @@ object JstFlows:
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.TaxpayerPool,
+        TreasuryRuntimeContract.TaxpayerCollection.index,
         EntitySector.Funds,
         FundIndex.Jst,
         totalRevenue,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -47,7 +48,7 @@ object NfzFlows:
         .transfer(EntitySector.Funds, FundIndex.Nfz, EntitySector.Firms, FirmIndex.Services, spending, AssetType.Cash, FlowMechanism.NfzSpending),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         FundIndex.Nfz,
         deficit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -118,7 +119,7 @@ object OpenEconFlows:
         EntitySector.Foreign,
         ForeignIndex.Aggregate,
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.euFunds,
         AssetType.Cash,
         FlowMechanism.EuFunds,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -48,7 +49,7 @@ object ZusFlows:
         .transfer(EntitySector.Funds, FundIndex.Zus, EntitySector.Households, HouseholdIndex.Aggregate, pensions, AssetType.Cash, FlowMechanism.ZusPension),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        GovernmentIndex.Budget,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         FundIndex.Zus,
         deficit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
@@ -384,15 +384,15 @@ object AssetOwnershipContract:
       RuntimeShellCategory.ExecutionShell,
     ),
     RuntimeShell(
-      EntitySector.Government,
-      AggregateBatchContract.GovernmentIndex.Budget,
-      "Government.Budget",
+      TreasuryRuntimeContract.TreasuryBudgetSettlement.sector,
+      TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+      TreasuryRuntimeContract.TreasuryBudgetSettlement.name,
       RuntimeShellCategory.SettlementShell,
     ),
     RuntimeShell(
-      EntitySector.Government,
-      AggregateBatchContract.GovernmentIndex.TaxpayerPool,
-      "Government.TaxpayerPool",
+      TreasuryRuntimeContract.TaxpayerCollection.sector,
+      TreasuryRuntimeContract.TaxpayerCollection.index,
+      TreasuryRuntimeContract.TaxpayerCollection.name,
       RuntimeShellCategory.SettlementShell,
     ),
     RuntimeShell(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/TreasuryRuntimeContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/TreasuryRuntimeContract.scala
@@ -1,0 +1,58 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.engine.flows.AggregateBatchContract
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+
+/** Explicit runtime contract for government treasury settlement shells.
+  *
+  * The engine currently uses synthetic aggregate government nodes during batch
+  * execution. This contract makes the distinction explicit:
+  *   - sovereign issuer stock is the persisted `Government / GovBondHTM` slot
+  *   - treasury budget settlement is a non-persisted runtime cash shell
+  *   - taxpayer collection is a non-persisted runtime routing shell
+  */
+object TreasuryRuntimeContract:
+
+  enum RuntimeRole:
+    case SovereignIssuerStock
+    case TreasuryBudgetSettlementShell
+    case TaxpayerCollectionShell
+
+  case class RuntimeNode(
+      name: String,
+      sector: EntitySector,
+      index: Int,
+      role: RuntimeRole,
+      persistedAsStock: Boolean,
+  )
+
+  val IssuerStockAsset: AssetType = AssetType.GovBondHTM
+
+  val SovereignIssuerGovBondStock: RuntimeNode =
+    RuntimeNode(
+      name = "Government.GovBondOutstanding",
+      sector = EntitySector.Government,
+      index = 0,
+      role = RuntimeRole.SovereignIssuerStock,
+      persistedAsStock = true,
+    )
+
+  val TreasuryBudgetSettlement: RuntimeNode =
+    RuntimeNode(
+      name = "Government.TreasuryBudgetSettlement",
+      sector = EntitySector.Government,
+      index = AggregateBatchContract.GovernmentIndex.Budget,
+      role = RuntimeRole.TreasuryBudgetSettlementShell,
+      persistedAsStock = false,
+    )
+
+  val TaxpayerCollection: RuntimeNode =
+    RuntimeNode(
+      name = "Government.TaxpayerCollectionShell",
+      sector = EntitySector.Government,
+      index = AggregateBatchContract.GovernmentIndex.TaxpayerPool,
+      role = RuntimeRole.TaxpayerCollectionShell,
+      persistedAsStock = false,
+    )
+
+end TreasuryRuntimeContract

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/SfcSpec.scala
@@ -9,6 +9,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.markets.{FiscalBudget, OpenEconomy}
 import com.boombustgroup.amorfati.engine.flows.{AggregateBatchContract, AggregateBatchedEmission, FlowMechanism}
+import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector}
 
@@ -16,6 +17,9 @@ class SfcSpec extends AnyFlatSpec with Matchers:
 
   given SimParams          = SimParams.defaults
   private val p: SimParams = summon[SimParams]
+
+  private val treasuryBudgetIndex     = TreasuryRuntimeContract.TreasuryBudgetSettlement.index
+  private val taxpayerCollectionIndex = TreasuryRuntimeContract.TaxpayerCollection.index
 
   private def errorDelta(result: Either[Vector[Sfc.SfcIdentityError], Unit], id: Sfc.SfcIdentity): BigDecimal =
     result.swap.getOrElse(Vector.empty).find(_.identity == id).map(e => (e.actual - e.expected).bd).getOrElse(BigDecimal(0))
@@ -964,14 +968,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Aggregate,
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         PLN(100.0),
         AssetType.Cash,
         FlowMechanism.FirmCit,
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Services,
         PLN(40.0),
@@ -984,7 +988,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         Sfc.ExecutionBalanceKey(
           EntitySector.Government,
           AssetType.Cash,
-          Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+          Sfc.ExecutionIndex(treasuryBudgetIndex),
         ) -> PLN(60.0),
       ),
     )
@@ -1005,14 +1009,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Aggregate,
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         PLN(100.0),
         AssetType.Cash,
         FlowMechanism.FirmCit,
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Services,
         PLN(40.0),
@@ -1030,7 +1034,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(55.0),
         ),
       ),
@@ -1048,14 +1052,14 @@ class SfcSpec extends AnyFlatSpec with Matchers:
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Aggregate,
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         PLN(100.0),
         AssetType.Cash,
         FlowMechanism.FirmCit,
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Firms,
         AggregateBatchContract.FirmIndex.Services,
         PLN(40.0),
@@ -1073,7 +1077,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(60.0),
         ),
       ),
@@ -1086,7 +1090,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     val batches = Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.TaxpayerPool,
+        taxpayerCollectionIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Jst,
         PLN(100.0),
@@ -1122,7 +1126,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Zus,
         PLN(20.0),
@@ -1149,7 +1153,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Nfz,
         PLN(30.0),
@@ -1167,7 +1171,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(-50.0),
           Sfc.ExecutionBalanceKey(
             EntitySector.Funds,
@@ -1195,7 +1199,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
     val batches = Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Zus,
         PLN(20.0),
@@ -1239,7 +1243,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(-20.0),
           Sfc.ExecutionBalanceKey(
             EntitySector.Funds,
@@ -1276,7 +1280,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Fp,
         PLN(20.0),
@@ -1303,7 +1307,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Pfron,
         PLN(15.0),
@@ -1330,7 +1334,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Fgsp,
         PLN(25.0),
@@ -1348,7 +1352,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(-60.0),
           Sfc.ExecutionBalanceKey(
             EntitySector.Funds,
@@ -1394,7 +1398,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
-        AggregateBatchContract.GovernmentIndex.Budget,
+        treasuryBudgetIndex,
         EntitySector.Funds,
         AggregateBatchContract.FundIndex.Fgsp,
         PLN(25.0),
@@ -1412,7 +1416,7 @@ class SfcSpec extends AnyFlatSpec with Matchers:
           Sfc.ExecutionBalanceKey(
             EntitySector.Government,
             AssetType.Cash,
-            Sfc.ExecutionIndex(AggregateBatchContract.GovernmentIndex.Budget),
+            Sfc.ExecutionIndex(treasuryBudgetIndex),
           ) -> PLN(-25.0),
           Sfc.ExecutionBalanceKey(
             EntitySector.Funds,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
@@ -52,8 +52,8 @@ class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
       .toSet
 
     settlementShells shouldBe Set(
-      (EntitySector.Government, "Government.Budget"),
-      (EntitySector.Government, "Government.TaxpayerPool"),
+      (EntitySector.Government, TreasuryRuntimeContract.TreasuryBudgetSettlement.name),
+      (EntitySector.Government, TreasuryRuntimeContract.TaxpayerCollection.name),
       (EntitySector.NBP, "NBP.Aggregate"),
       (EntitySector.Foreign, "Foreign.Aggregate"),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/TreasuryRuntimeContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/TreasuryRuntimeContractSpec.scala
@@ -1,0 +1,54 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.engine.ledger.AssetOwnershipContract.RuntimeShellCategory
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TreasuryRuntimeContractSpec extends AnyFlatSpec with Matchers:
+
+  "TreasuryRuntimeContract" should "separate issuer stock from treasury settlement shells" in {
+    TreasuryRuntimeContract.SovereignIssuerGovBondStock.persistedAsStock shouldBe true
+    TreasuryRuntimeContract.SovereignIssuerGovBondStock.sector shouldBe EntitySector.Government
+    TreasuryRuntimeContract.IssuerStockAsset shouldBe AssetType.GovBondHTM
+
+    TreasuryRuntimeContract.TreasuryBudgetSettlement.persistedAsStock shouldBe false
+    TreasuryRuntimeContract.TaxpayerCollection.persistedAsStock shouldBe false
+  }
+
+  it should "align with the engine ownership contract" in {
+    AssetOwnershipContract.isSupportedPersistedPair(
+      TreasuryRuntimeContract.SovereignIssuerGovBondStock.sector,
+      TreasuryRuntimeContract.IssuerStockAsset,
+      TreasuryRuntimeContract.SovereignIssuerGovBondStock.index,
+    ) shouldBe true
+
+    AssetOwnershipContract.isSupportedPersistedPair(
+      TreasuryRuntimeContract.TreasuryBudgetSettlement.sector,
+      AssetType.Cash,
+      TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+    ) shouldBe false
+
+    AssetOwnershipContract.isSupportedPersistedPair(
+      TreasuryRuntimeContract.TaxpayerCollection.sector,
+      AssetType.Cash,
+      TreasuryRuntimeContract.TaxpayerCollection.index,
+    ) shouldBe false
+
+    AssetOwnershipContract.nonPersistedRuntimeShells should contain allOf (
+      AssetOwnershipContract.RuntimeShell(
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.sector,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.name,
+        RuntimeShellCategory.SettlementShell,
+      ),
+      AssetOwnershipContract.RuntimeShell(
+        TreasuryRuntimeContract.TaxpayerCollection.sector,
+        TreasuryRuntimeContract.TaxpayerCollection.index,
+        TreasuryRuntimeContract.TaxpayerCollection.name,
+        RuntimeShellCategory.SettlementShell,
+      ),
+    )
+  }
+
+end TreasuryRuntimeContractSpec


### PR DESCRIPTION
## Summary
- add an explicit TreasuryRuntimeContract that separates persisted sovereign issuer stock from treasury budget settlement and taxpayer collection runtime shells
- route government cash batches and SFC runtime identities through the named treasury contract instead of raw synthetic government indices
- extend ownership/contract tests to prove treasury shells stay non-persisted while government bond issuer stock remains supported

Closes #369