### PR TITLE
Split foreign settlement shells from persisted stocks

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/AggregateBatchContract.scala
@@ -54,7 +54,11 @@ object AggregateBatchContract:
     val Healthcare  = 10
 
   object ForeignIndex:
-    val Aggregate = 0
+    val GovBondHolder      = 0
+    val TradeSettlement    = 1
+    val IncomeSettlement   = 2
+    val CapitalSettlement  = 3
+    val TransferSettlement = 4
 
   val sectorSizes: Map[EntitySector, Int] = Map(
     EntitySector.Households -> 4,
@@ -64,7 +68,7 @@ object AggregateBatchContract:
     EntitySector.NBP        -> 1,
     EntitySector.Insurance  -> 1,
     EntitySector.Funds      -> 11,
-    EntitySector.Foreign    -> 1,
+    EntitySector.Foreign    -> 5,
   )
 
   private val sectorOrder: Vector[EntitySector] = Vector(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
-import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
+import com.boombustgroup.amorfati.engine.ledger.{ForeignRuntimeContract, TreasuryRuntimeContract}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -42,7 +42,7 @@ object EquityFlows:
         EntitySector.Firms,
         FirmIndex.Aggregate,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.IncomeSettlement.index,
         input.foreignDividends,
         AssetType.Cash,
         FlowMechanism.EquityForDividend,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
-import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
+import com.boombustgroup.amorfati.engine.ledger.{ForeignRuntimeContract, TreasuryRuntimeContract}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -129,7 +129,7 @@ object FirmFlows:
         EntitySector.Firms,
         FirmIndex.Aggregate,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.IncomeSettlement.index,
         input.profitShifting,
         AssetType.Cash,
         FlowMechanism.FirmProfitShifting,
@@ -138,7 +138,7 @@ object FirmFlows:
         EntitySector.Firms,
         FirmIndex.Aggregate,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.IncomeSettlement.index,
         input.fdiRepatriation,
         AssetType.Cash,
         FlowMechanism.FirmFdiRepatriation,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/HouseholdFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
+import com.boombustgroup.amorfati.engine.ledger.ForeignRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -90,7 +91,7 @@ object HouseholdFlows:
         EntitySector.Households,
         HouseholdIndex.Aggregate,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TransferSettlement.index,
         input.remittances,
         AssetType.Cash,
         FlowMechanism.HhRemittance,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlows.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
-import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
+import com.boombustgroup.amorfati.engine.ledger.{ForeignRuntimeContract, TreasuryRuntimeContract}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -37,7 +37,7 @@ object OpenEconFlows:
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TradeSettlement.index,
         EntitySector.Firms,
         FirmIndex.DomesticDemand,
         input.exports,
@@ -48,14 +48,14 @@ object OpenEconFlows:
         EntitySector.Firms,
         FirmIndex.DomesticDemand,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TradeSettlement.index,
         input.imports,
         AssetType.Cash,
         FlowMechanism.TradeImports,
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TradeSettlement.index,
         EntitySector.Firms,
         FirmIndex.DomesticDemand,
         input.tourismExport,
@@ -66,17 +66,25 @@ object OpenEconFlows:
         EntitySector.Firms,
         FirmIndex.DomesticDemand,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TradeSettlement.index,
         input.tourismImport,
         AssetType.Cash,
         FlowMechanism.TourismImport,
       ),
       AggregateBatchedEmission
-        .transfer(EntitySector.Foreign, ForeignIndex.Aggregate, EntitySector.Firms, FirmIndex.Aggregate, input.fdi, AssetType.Cash, FlowMechanism.Fdi),
+        .transfer(
+          EntitySector.Foreign,
+          ForeignRuntimeContract.CapitalSettlement.index,
+          EntitySector.Firms,
+          FirmIndex.Aggregate,
+          input.fdi,
+          AssetType.Cash,
+          FlowMechanism.Fdi,
+        ),
       if input.portfolioFlows > PLN.Zero then
         AggregateBatchedEmission.transfer(
           EntitySector.Foreign,
-          ForeignIndex.Aggregate,
+          ForeignRuntimeContract.CapitalSettlement.index,
           EntitySector.Firms,
           FirmIndex.Aggregate,
           input.portfolioFlows,
@@ -88,7 +96,7 @@ object OpenEconFlows:
           EntitySector.Firms,
           FirmIndex.Aggregate,
           EntitySector.Foreign,
-          ForeignIndex.Aggregate,
+          ForeignRuntimeContract.CapitalSettlement.index,
           -input.portfolioFlows,
           AssetType.Cash,
           FlowMechanism.PortfolioFlow,
@@ -97,7 +105,7 @@ object OpenEconFlows:
       if input.primaryIncome > PLN.Zero then
         AggregateBatchedEmission.transfer(
           EntitySector.Foreign,
-          ForeignIndex.Aggregate,
+          ForeignRuntimeContract.IncomeSettlement.index,
           EntitySector.Firms,
           FirmIndex.Aggregate,
           input.primaryIncome,
@@ -109,7 +117,7 @@ object OpenEconFlows:
           EntitySector.Firms,
           FirmIndex.Aggregate,
           EntitySector.Foreign,
-          ForeignIndex.Aggregate,
+          ForeignRuntimeContract.IncomeSettlement.index,
           -input.primaryIncome,
           AssetType.Cash,
           FlowMechanism.PrimaryIncome,
@@ -117,7 +125,7 @@ object OpenEconFlows:
       else Vector.empty,
       AggregateBatchedEmission.transfer(
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TransferSettlement.index,
         EntitySector.Government,
         TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         input.euFunds,
@@ -126,7 +134,7 @@ object OpenEconFlows:
       ),
       AggregateBatchedEmission.transfer(
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.TransferSettlement.index,
         EntitySector.Households,
         HouseholdIndex.Aggregate,
         input.diasporaInflow,
@@ -137,7 +145,7 @@ object OpenEconFlows:
         EntitySector.Firms,
         FirmIndex.Aggregate,
         EntitySector.Foreign,
-        ForeignIndex.Aggregate,
+        ForeignRuntimeContract.CapitalSettlement.index,
         input.capitalFlightOutflow,
         AssetType.Cash,
         FlowMechanism.CapitalFlight,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
@@ -433,8 +433,26 @@ object AssetOwnershipContract:
     ),
     RuntimeShell(
       EntitySector.Foreign,
-      AggregateBatchContract.ForeignIndex.Aggregate,
-      "Foreign.Aggregate",
+      ForeignRuntimeContract.TradeSettlement.index,
+      ForeignRuntimeContract.TradeSettlement.name,
+      RuntimeShellCategory.SettlementShell,
+    ),
+    RuntimeShell(
+      EntitySector.Foreign,
+      ForeignRuntimeContract.IncomeSettlement.index,
+      ForeignRuntimeContract.IncomeSettlement.name,
+      RuntimeShellCategory.SettlementShell,
+    ),
+    RuntimeShell(
+      EntitySector.Foreign,
+      ForeignRuntimeContract.CapitalSettlement.index,
+      ForeignRuntimeContract.CapitalSettlement.name,
+      RuntimeShellCategory.SettlementShell,
+    ),
+    RuntimeShell(
+      EntitySector.Foreign,
+      ForeignRuntimeContract.TransferSettlement.index,
+      ForeignRuntimeContract.TransferSettlement.name,
       RuntimeShellCategory.SettlementShell,
     ),
   )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/ForeignRuntimeContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/ForeignRuntimeContract.scala
@@ -1,0 +1,84 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.engine.flows.AggregateBatchContract
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+
+/** Explicit runtime contract for foreign-sector stock ownership and settlement
+  * shells.
+  *
+  * The engine persists only one foreign stock-bearing slice: non-resident
+  * government bond holdings. All other foreign-facing monthly cash channels are
+  * delta-only settlement shells grouped by economic role.
+  */
+object ForeignRuntimeContract:
+
+  enum RuntimeRole:
+    case GovBondHolderStock
+    case TradeSettlementShell
+    case IncomeSettlementShell
+    case CapitalSettlementShell
+    case TransferSettlementShell
+
+  case class RuntimeNode(
+      name: String,
+      sector: EntitySector,
+      index: Int,
+      role: RuntimeRole,
+      persistedAsStock: Boolean,
+      asset: AssetType,
+  )
+
+  val GovBondHolderStock: RuntimeNode =
+    RuntimeNode(
+      name = "Foreign.GovBondPortfolio",
+      sector = EntitySector.Foreign,
+      index = AggregateBatchContract.ForeignIndex.GovBondHolder,
+      role = RuntimeRole.GovBondHolderStock,
+      persistedAsStock = true,
+      asset = AssetType.GovBondHTM,
+    )
+
+  val TradeSettlement: RuntimeNode =
+    RuntimeNode(
+      name = "Foreign.TradeSettlement",
+      sector = EntitySector.Foreign,
+      index = AggregateBatchContract.ForeignIndex.TradeSettlement,
+      role = RuntimeRole.TradeSettlementShell,
+      persistedAsStock = false,
+      asset = AssetType.Cash,
+    )
+
+  val IncomeSettlement: RuntimeNode =
+    RuntimeNode(
+      name = "Foreign.IncomeSettlement",
+      sector = EntitySector.Foreign,
+      index = AggregateBatchContract.ForeignIndex.IncomeSettlement,
+      role = RuntimeRole.IncomeSettlementShell,
+      persistedAsStock = false,
+      asset = AssetType.Cash,
+    )
+
+  val CapitalSettlement: RuntimeNode =
+    RuntimeNode(
+      name = "Foreign.CapitalSettlement",
+      sector = EntitySector.Foreign,
+      index = AggregateBatchContract.ForeignIndex.CapitalSettlement,
+      role = RuntimeRole.CapitalSettlementShell,
+      persistedAsStock = false,
+      asset = AssetType.Cash,
+    )
+
+  val TransferSettlement: RuntimeNode =
+    RuntimeNode(
+      name = "Foreign.TransferSettlement",
+      sector = EntitySector.Foreign,
+      index = AggregateBatchContract.ForeignIndex.TransferSettlement,
+      role = RuntimeRole.TransferSettlementShell,
+      persistedAsStock = false,
+      asset = AssetType.Cash,
+    )
+
+  val RuntimeShells: Vector[RuntimeNode] =
+    Vector(TradeSettlement, IncomeSettlement, CapitalSettlement, TransferSettlement)
+
+end ForeignRuntimeContract

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.ledger
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
-import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.engine.flows.{AggregateBatchContract, FlowSimulation}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
 
@@ -34,7 +34,7 @@ object LedgerStateAdapter:
     val Count: Int = 10
 
   private val SingletonSectorSize = 1
-  private val ForeignSectorSize   = 1
+  private val ForeignSectorSize   = AggregateBatchContract.ForeignIndex.TransferSettlement + 1
 
   case class HouseholdBalances(
       demandDeposit: PLN,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/OpenEconFlowsSpec.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.ledger.ForeignRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
@@ -52,6 +53,31 @@ class OpenEconFlowsSpec extends AnyFlatSpec with Matchers:
     val flows    = OpenEconFlows.emit(payment)
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
     Interpreter.totalWealth(balances) shouldBe 0L
+  }
+
+  it should "route trade, income, capital, and transfer channels through distinct foreign settlement shells" in {
+    val batches                                      = OpenEconFlows.emitBatches(baseInput.copy(primaryIncome = PLN(300000.0)))
+    def onlyFromIndex(mechanism: MechanismId): Int   =
+      batches.find(_.mechanism == mechanism).get match
+        case broadcast: BatchedFlow.Broadcast => broadcast.fromIndex
+        case other                            => fail(s"expected broadcast batch for $mechanism but got $other")
+    def onlyTargetIndex(mechanism: MechanismId): Int =
+      batches.find(_.mechanism == mechanism).get match
+        case broadcast: BatchedFlow.Broadcast => broadcast.targetIndices.head
+        case other                            => fail(s"expected broadcast batch for $mechanism but got $other")
+
+    onlyFromIndex(FlowMechanism.TradeExports) shouldBe ForeignRuntimeContract.TradeSettlement.index
+    onlyTargetIndex(FlowMechanism.TradeImports) shouldBe ForeignRuntimeContract.TradeSettlement.index
+    onlyFromIndex(FlowMechanism.TourismExport) shouldBe ForeignRuntimeContract.TradeSettlement.index
+    onlyTargetIndex(FlowMechanism.TourismImport) shouldBe ForeignRuntimeContract.TradeSettlement.index
+
+    onlyFromIndex(FlowMechanism.Fdi) shouldBe ForeignRuntimeContract.CapitalSettlement.index
+    onlyFromIndex(FlowMechanism.PortfolioFlow) shouldBe ForeignRuntimeContract.CapitalSettlement.index
+    onlyTargetIndex(FlowMechanism.CapitalFlight) shouldBe ForeignRuntimeContract.CapitalSettlement.index
+
+    onlyFromIndex(FlowMechanism.PrimaryIncome) shouldBe ForeignRuntimeContract.IncomeSettlement.index
+    onlyFromIndex(FlowMechanism.EuFunds) shouldBe ForeignRuntimeContract.TransferSettlement.index
+    onlyFromIndex(FlowMechanism.DiasporaInflow) shouldBe ForeignRuntimeContract.TransferSettlement.index
   }
 
   it should "preserve SFC across 120 months" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
@@ -55,7 +55,10 @@ class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
       (EntitySector.Government, TreasuryRuntimeContract.TreasuryBudgetSettlement.name),
       (EntitySector.Government, TreasuryRuntimeContract.TaxpayerCollection.name),
       (EntitySector.NBP, NbpRuntimeContract.ReserveSettlementLiability.name),
-      (EntitySector.Foreign, "Foreign.Aggregate"),
+      (EntitySector.Foreign, ForeignRuntimeContract.TradeSettlement.name),
+      (EntitySector.Foreign, ForeignRuntimeContract.IncomeSettlement.name),
+      (EntitySector.Foreign, ForeignRuntimeContract.CapitalSettlement.name),
+      (EntitySector.Foreign, ForeignRuntimeContract.TransferSettlement.name),
     )
     nonPersistedRuntimeShells.map(shell => (shell.sector, shell.index)).toSet.size shouldBe nonPersistedRuntimeShells.size
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/ForeignRuntimeContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/ForeignRuntimeContractSpec.scala
@@ -1,0 +1,40 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.engine.ledger.AssetOwnershipContract.RuntimeShellCategory
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ForeignRuntimeContractSpec extends AnyFlatSpec with Matchers:
+
+  "ForeignRuntimeContract" should "separate foreign bond stock ownership from settlement shells" in {
+    ForeignRuntimeContract.GovBondHolderStock.persistedAsStock shouldBe true
+    ForeignRuntimeContract.GovBondHolderStock.sector shouldBe EntitySector.Foreign
+    ForeignRuntimeContract.GovBondHolderStock.asset shouldBe AssetType.GovBondHTM
+
+    all(ForeignRuntimeContract.RuntimeShells.map(_.persistedAsStock)) shouldBe false
+    all(ForeignRuntimeContract.RuntimeShells.map(_.asset)) shouldBe AssetType.Cash
+  }
+
+  it should "align with the engine ownership contract" in {
+    AssetOwnershipContract.isSupportedPersistedPair(
+      ForeignRuntimeContract.GovBondHolderStock.sector,
+      ForeignRuntimeContract.GovBondHolderStock.asset,
+      ForeignRuntimeContract.GovBondHolderStock.index,
+    ) shouldBe true
+
+    ForeignRuntimeContract.RuntimeShells.foreach { shell =>
+      AssetOwnershipContract.isSupportedPersistedPair(shell.sector, shell.asset, shell.index) shouldBe false
+
+      AssetOwnershipContract.nonPersistedRuntimeShells should contain(
+        AssetOwnershipContract.RuntimeShell(
+          shell.sector,
+          shell.index,
+          shell.name,
+          RuntimeShellCategory.SettlementShell,
+        ),
+      )
+    }
+  }
+
+end ForeignRuntimeContractSpec

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -20,7 +20,7 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
       EntitySector.NBP        -> 1,
       EntitySector.Insurance  -> 1,
       EntitySector.Funds      -> LedgerStateAdapter.FundIndex.Count,
-      EntitySector.Foreign    -> 1,
+      EntitySector.Foreign    -> 5,
     )
   }
 


### PR DESCRIPTION
## Summary
- add ForeignRuntimeContract to separate persisted foreign SPW holdings from delta-only trade, income, capital, and transfer settlement shells
- rewire foreign-facing batched emitters to the appropriate settlement shell instead of one overloaded foreign runtime bucket
- update ownership and ledger specs so the foreign runtime contract is explicit and validated

## Testing
- sbt test

Closes #366