### PR TITLE
Introduce LedgerFinancialState as runtime state

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -73,33 +73,33 @@ object InflationProbe:
     println(s"seed=$seed months=$months")
 
     (1 to months).foreach: month =>
-      val population        = world.derivedTotalPopulation.max(1)
-      val contract          = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
-      val fiscal            = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
-      val s1                = FiscalConstraintEconomics.toOutput(fiscal)
-      val labor             = LaborEconomics.compute(world, firms, hhs, s1)
-      val prevWage          = toDouble(world.householdMarket.marketWage)
-      val rawLaborWage      = toDouble(RegionalClearing.clear(world.regionalWages, s1.resWage, labor.laborDemand, population).nationalWage)
-      val target            = toDouble(summon[SimParams].monetary.targetInfl)
-      val expWagePressure   =
+      val population           = world.derivedTotalPopulation.max(1)
+      val contract             = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
+      val fiscal               = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
+      val s1                   = FiscalConstraintEconomics.toOutput(fiscal)
+      val labor                = LaborEconomics.compute(world, firms, hhs, s1)
+      val prevWage             = toDouble(world.householdMarket.marketWage)
+      val rawLaborWage         = toDouble(RegionalClearing.clear(world.regionalWages, s1.resWage, labor.laborDemand, population).nationalWage)
+      val target               = toDouble(summon[SimParams].monetary.targetInfl)
+      val expWagePressure      =
         toDouble(summon[SimParams].labor.expWagePassthrough) * Math.max(0.0, toDouble(world.mechanisms.expectations.expectedInflation) - target) / 12.0
-      val wageAfterExp      = Math.max(toDouble(s1.resWage), rawLaborWage * (1.0 + expWagePressure))
-      val aggUnionDensity   =
+      val wageAfterExp         = Math.max(toDouble(s1.resWage), rawLaborWage * (1.0 + expWagePressure))
+      val aggUnionDensity      =
         summon[SimParams].sectorDefs.zipWithIndex
           .map((s, i) => toDouble(s.share) * toDouble(summon[SimParams].labor.unionDensity(i)))
           .sum
-      val unionAdjustedWage =
+      val unionAdjustedWage    =
         if wageAfterExp < prevWage then
           val decline = prevWage - wageAfterExp
           Math.max(toDouble(s1.resWage), wageAfterExp + decline * toDouble(summon[SimParams].labor.unionRigidity) * aggUnionDensity)
         else wageAfterExp
-      val supplyAtPrev      = laborSupplyCount(world.householdMarket.marketWage, s1.resWage, population)
-      val newSupply         = laborSupplyCount(PLN(unionAdjustedWage), s1.resWage, population)
-      val excessDemand      = (labor.laborDemand - supplyAtPrev).toDouble / population
-      val phillipsGrowth    = if prevWage > 0.0 then rawLaborWage / prevWage - 1.0 else 0.0
-      val expGrowth         = if rawLaborWage > 0.0 then wageAfterExp / rawLaborWage - 1.0 else 0.0
-      val unionGrowth       = if wageAfterExp > 0.0 then unionAdjustedWage / wageAfterExp - 1.0 else 0.0
-      val s2Pre             = LaborEconomics.Output(
+      val supplyAtPrev         = laborSupplyCount(world.householdMarket.marketWage, s1.resWage, population)
+      val newSupply            = laborSupplyCount(PLN(unionAdjustedWage), s1.resWage, population)
+      val excessDemand         = (labor.laborDemand - supplyAtPrev).toDouble / population
+      val phillipsGrowth       = if prevWage > 0.0 then rawLaborWage / prevWage - 1.0 else 0.0
+      val expGrowth            = if rawLaborWage > 0.0 then wageAfterExp / rawLaborWage - 1.0 else 0.0
+      val unionGrowth          = if wageAfterExp > 0.0 then unionAdjustedWage / wageAfterExp - 1.0 else 0.0
+      val s2Pre                = LaborEconomics.Output(
         labor.wage,
         labor.employed,
         labor.laborDemand,
@@ -116,7 +116,7 @@ object InflationProbe:
         labor.living,
         labor.regionalWages,
       )
-      val s3                =
+      val s3                   =
         HouseholdIncomeEconomics.compute(
           world,
           firms,
@@ -127,13 +127,13 @@ object InflationProbe:
           s2Pre.newWage,
           contract.stages.householdIncomeEconomics.newStream(),
         )
-      val s4                = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
-      val s5                = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
-      val living            = s5.ioFirms.filter(Firm.isAlive)
-      val s2                = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
-      val s6                =
+      val s4                   = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
+      val s5                   = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
+      val living               = s5.ioFirms.filter(Firm.isAlive)
+      val s2                   = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
+      val s6                   =
         HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
-      val s7                = PriceEquityEconomics.compute(
+      val s7                   = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(
           world,
           s1.m,
@@ -149,11 +149,13 @@ object InflationProbe:
         ),
         contract.stages.priceEquityEconomics.newStream(),
       )
-      val s8                =
+      val ledgerFinancialState =
+        LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks)
+      val s8                   =
         OpenEconEconomics.runStep(
           OpenEconEconomics.StepInput(
             world,
-            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            ledgerFinancialState,
             s1,
             s2,
             s3,
@@ -165,11 +167,11 @@ object InflationProbe:
             contract.stages.openEconEconomics.newStream(),
           ),
         )
-      val s9                =
+      val s9                   =
         BankingEconomics.runStep(
           BankingEconomics.StepInput(
             world,
-            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            ledgerFinancialState,
             s1,
             s2,
             s3,
@@ -245,7 +247,7 @@ object InflationProbe:
           firms = firms,
           households = hhs,
           banks = banks,
-          ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+          ledgerFinancialState = ledgerFinancialState,
           month = fiscal.month,
           lendingBaseRate = fiscal.lendingBaseRate,
           resWage = fiscal.resWage,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -6,6 +6,7 @@ import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.markets.RegionalClearing
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
@@ -149,9 +150,38 @@ object InflationProbe:
         contract.stages.priceEquityEconomics.newStream(),
       )
       val s8                =
-        OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, banks, contract.stages.openEconEconomics.newStream()))
+        OpenEconEconomics.runStep(
+          OpenEconEconomics.StepInput(
+            world,
+            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            s1,
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            banks,
+            contract.stages.openEconEconomics.newStream(),
+          ),
+        )
       val s9                =
-        BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, banks, contract.stages.bankingEconomics.newStream()))
+        BankingEconomics.runStep(
+          BankingEconomics.StepInput(
+            world,
+            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            s1,
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            s8,
+            banks,
+            contract.stages.bankingEconomics.newStream(),
+          ),
+        )
 
       val exDev         = exchangeRateValue(world.forex.exchangeRate) / exchangeRateValue(summon[SimParams].forex.baseExRate) - 1.0
       val demandPullM   = toDouble((s4.avgDemandMult.deviationFromOne.toScalar * Scalar(DemandPullWeight)).toCoefficient)
@@ -215,6 +245,7 @@ object InflationProbe:
           firms = firms,
           households = hhs,
           banks = banks,
+          ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
           month = fiscal.month,
           lendingBaseRate = fiscal.lendingBaseRate,
           resWage = fiscal.resWage,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -5,6 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.PLN
 
@@ -215,9 +216,38 @@ object LaborDemandProbe:
         contract.stages.priceEquityEconomics.newStream(),
       )
       val s8     =
-        OpenEconEconomics.runStep(OpenEconEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, banks, contract.stages.openEconEconomics.newStream()))
+        OpenEconEconomics.runStep(
+          OpenEconEconomics.StepInput(
+            world,
+            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            s1,
+            s2Post,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            banks,
+            contract.stages.openEconEconomics.newStream(),
+          ),
+        )
       val s9     =
-        BankingEconomics.runStep(BankingEconomics.StepInput(world, s1, s2Post, s3, s4, s5, s6, s7, s8, banks, contract.stages.bankingEconomics.newStream()))
+        BankingEconomics.runStep(
+          BankingEconomics.StepInput(
+            world,
+            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            s1,
+            s2Post,
+            s3,
+            s4,
+            s5,
+            s6,
+            s7,
+            s8,
+            banks,
+            contract.stages.bankingEconomics.newStream(),
+          ),
+        )
 
       val afterFirm = sectorSnapshots(s5.ioFirms)
       val changes   = sectorChangeSummaries(firms, s5.ioFirms)
@@ -234,6 +264,7 @@ object LaborDemandProbe:
           firms = firms,
           households = hhs,
           banks = banks,
+          ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
           month = fiscal.month,
           lendingBaseRate = fiscal.lendingBaseRate,
           resWage = fiscal.resWage,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -164,10 +164,10 @@ object LaborDemandProbe:
       val beforeAll = sectorSnapshots(firms)
       val hiring    = hiringSummaries(world, firms)
 
-      val fiscal = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
-      val s1     = FiscalConstraintEconomics.toOutput(fiscal)
-      val labor  = LaborEconomics.compute(world, firms, hhs, s1)
-      val s2Pre  = LaborEconomics.Output(
+      val fiscal               = FiscalConstraintEconomics.compute(world, banks, ExecutionMonth(month))
+      val s1                   = FiscalConstraintEconomics.toOutput(fiscal)
+      val labor                = LaborEconomics.compute(world, firms, hhs, s1)
+      val s2Pre                = LaborEconomics.Output(
         labor.wage,
         labor.employed,
         labor.laborDemand,
@@ -184,7 +184,7 @@ object LaborDemandProbe:
         labor.living,
         labor.regionalWages,
       )
-      val s3     =
+      val s3                   =
         HouseholdIncomeEconomics.compute(
           world,
           firms,
@@ -195,11 +195,11 @@ object LaborDemandProbe:
           s2Pre.newWage,
           contract.stages.householdIncomeEconomics.newStream(),
         )
-      val s4     = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
-      val s5     = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
-      val s2Post = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, s5.ioFirms.filter(Firm.isAlive), s5.households)
-      val s6     = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
-      val s7     = PriceEquityEconomics.compute(
+      val s4                   = DemandEconomics.compute(DemandEconomics.Input(world, s2Pre.employed, s2Pre.living, s3.domesticCons))
+      val s5                   = FirmEconomics.runStep(world, firms, hhs, banks, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
+      val s2Post               = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, s5.ioFirms.filter(Firm.isAlive), s5.households)
+      val s6                   = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
+      val s7                   = PriceEquityEconomics.compute(
         PriceEquityEconomics.Input(
           world,
           s1.m,
@@ -215,11 +215,12 @@ object LaborDemandProbe:
         ),
         contract.stages.priceEquityEconomics.newStream(),
       )
-      val s8     =
+      val ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks)
+      val s8                   =
         OpenEconEconomics.runStep(
           OpenEconEconomics.StepInput(
             world,
-            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            ledgerFinancialState,
             s1,
             s2Post,
             s3,
@@ -231,11 +232,11 @@ object LaborDemandProbe:
             contract.stages.openEconEconomics.newStream(),
           ),
         )
-      val s9     =
+      val s9                   =
         BankingEconomics.runStep(
           BankingEconomics.StepInput(
             world,
-            LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+            ledgerFinancialState,
             s1,
             s2Post,
             s3,
@@ -264,7 +265,7 @@ object LaborDemandProbe:
           firms = firms,
           households = hhs,
           banks = banks,
-          ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, firms, hhs, banks),
+          ledgerFinancialState = ledgerFinancialState,
           month = fiscal.month,
           lendingBaseRate = fiscal.lendingBaseRate,
           resWage = fiscal.resWage,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.markets.{BondAuction, FiscalBudget, HousingMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{TaxRevenue, YieldCurve}
 import com.boombustgroup.amorfati.types.*
@@ -30,17 +31,18 @@ object BankingEconomics:
   // ---- Step-level types (formerly BankUpdateStep.Input / BankUpdateStep.Output) ----
 
   case class StepInput(
-      w: World,                               // current world state (pre-step)
-      s1: FiscalConstraintEconomics.Output,   // fiscal constraint (month, lending base rate, res wage)
-      s2: LaborEconomics.Output,              // labor/demographics (employment, wage, immigration)
-      s3: HouseholdIncomeEconomics.Output,    // household income (consumption, PIT, debt service)
-      s4: DemandEconomics.Output,             // demand (sector multipliers, gov purchases)
-      s5: FirmEconomics.StepOutput,           // firm processing (loans, NPL, bonds, I-O firms)
-      s6: HouseholdFinancialEconomics.Output, // household financial (remittances, tourism, consumer credit)
-      s7: PriceEquityEconomics.Output,        // price/equity (inflation, GDP, equity state, macropru)
-      s8: OpenEconEconomics.StepOutput,       // open economy (NBP rate, bond yield, QE, FX, BoP)
-      banks: Vector[Banking.BankState],       // explicit bank population
-      depositRng: RandomStream,               // deterministic RNG for deposit flight decisions
+      w: World,                                   // current world state (pre-step)
+      ledgerFinancialState: LedgerFinancialState, // ledger-backed supported financial state
+      s1: FiscalConstraintEconomics.Output,       // fiscal constraint (month, lending base rate, res wage)
+      s2: LaborEconomics.Output,                  // labor/demographics (employment, wage, immigration)
+      s3: HouseholdIncomeEconomics.Output,        // household income (consumption, PIT, debt service)
+      s4: DemandEconomics.Output,                 // demand (sector multipliers, gov purchases)
+      s5: FirmEconomics.StepOutput,               // firm processing (loans, NPL, bonds, I-O firms)
+      s6: HouseholdFinancialEconomics.Output,     // household financial (remittances, tourism, consumer credit)
+      s7: PriceEquityEconomics.Output,            // price/equity (inflation, GDP, equity state, macropru)
+      s8: OpenEconEconomics.StepOutput,           // open economy (NBP rate, bond yield, QE, FX, BoP)
+      banks: Vector[Banking.BankState],           // explicit bank population
+      depositRng: RandomStream,                   // deterministic RNG for deposit flight decisions
   )
 
   case class StepOutput(
@@ -156,6 +158,7 @@ object BankingEconomics:
 
   case class Input(
       w: World,
+      ledgerFinancialState: LedgerFinancialState,
       // Raw values from earlier calculus (avoids Step.Output dependency)
       month: ExecutionMonth,
       lendingBaseRate: Rate,
@@ -307,6 +310,7 @@ object BankingEconomics:
     val s9 = runStep(
       StepInput(
         in.w,
+        in.ledgerFinancialState,
         s1,
         in.laborOutput,
         in.hhOutput,
@@ -473,9 +477,11 @@ object BankingEconomics:
       in: StepInput,
       newGovWithYield: FiscalBudget.GovState,
   ): BondWaterfallInputs =
-    val actualBondChange = newGovWithYield.bondsOutstanding - in.w.gov.bondsOutstanding
-    val insRequested     = (in.s8.nonBank.newInsurance.govBondHoldings - in.w.financial.insurance.govBondHoldings).max(PLN.Zero)
-    val tfiRequested     = (in.s8.nonBank.newNbfi.tfiGovBondHoldings - in.w.financial.nbfi.tfiGovBondHoldings).max(PLN.Zero)
+    val actualBondChange = newGovWithYield.bondsOutstanding - in.ledgerFinancialState.government.govBondOutstanding
+    val insRequested     =
+      (in.s8.nonBank.newInsurance.govBondHoldings - in.ledgerFinancialState.insurance.govBondHoldings).max(PLN.Zero)
+    val tfiRequested     =
+      (in.s8.nonBank.newNbfi.tfiGovBondHoldings - in.ledgerFinancialState.funds.nbfi.govBondHoldings).max(PLN.Zero)
     val prevEr           = in.w.forex.exchangeRate
     val currEr           = in.s8.external.newForex.exchangeRate
     val erChange         = currEr.deviationFrom(prevEr).toCoefficient
@@ -741,14 +747,18 @@ object BankingEconomics:
         qeCumulative = in.s8.monetary.postFxNbp.qeCumulative + qeSale.actualSold,
       ),
     )
-    val finalPpk                 = in.s2.newPpk.copy(bondHoldings = in.w.social.ppk.bondHoldings + ppkSale.actualSold)
+    val finalPpk                 = in.s2.newPpk.copy(bondHoldings = in.ledgerFinancialState.funds.ppkGovBondHoldings + ppkSale.actualSold)
     val finalInsurance           = in.s8.nonBank.newInsurance.copy(
-      portfolio = in.s8.nonBank.newInsurance.portfolio.copy(govBondHoldings = in.w.financial.insurance.govBondHoldings + insSale.actualSold),
+      portfolio = in.s8.nonBank.newInsurance.portfolio.copy(
+        govBondHoldings = in.ledgerFinancialState.insurance.govBondHoldings + insSale.actualSold,
+      ),
     )
     val finalNbfi                = in.s8.nonBank.newNbfi.copy(
-      tfi = in.s8.nonBank.newNbfi.tfi.copy(tfiGovBondHoldings = in.w.financial.nbfi.tfiGovBondHoldings + tfiSale.actualSold),
+      tfi = in.s8.nonBank.newNbfi.tfi.copy(
+        tfiGovBondHoldings = in.ledgerFinancialState.funds.nbfi.govBondHoldings + tfiSale.actualSold,
+      ),
     )
-    val finalForeignBondHoldings = in.w.gov.foreignBondHoldings + foreignSale.actualSold
+    val finalForeignBondHoldings = in.ledgerFinancialState.foreign.govBondHoldings + foreignSale.actualSold
 
     val failResult =
       Banking.checkFailures(tfiSale.banks, in.s1.m, true, in.s7.newMacropru.ccyb)
@@ -955,8 +965,8 @@ object BankingEconomics:
     Some(
       Banking.MonetaryAggregates.compute(
         finalBanks,
-        in.w.financial.nbfi.tfiAum,
-        in.w.financial.corporateBonds.outstanding,
+        in.ledgerFinancialState.funds.nbfi.tfiUnit,
+        PLN.fromRaw(in.ledgerFinancialState.firms.map(_.corpBond.toLong).sum),
       ),
     )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
-import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+import com.boombustgroup.amorfati.engine.ledger.{LedgerFinancialState, LedgerStateAdapter}
 import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, GvcTrade, OpenEconomy}
 import com.boombustgroup.amorfati.engine.mechanisms.Expectations
 import com.boombustgroup.amorfati.types.*
@@ -286,17 +286,7 @@ object OpenEconEconomics:
     // 8. Insurance
     val unempRate    = in.w.unemploymentRate(in.employed)
     val newInsurance = Insurance.step(
-      in.w.financial.insurance.copy(
-        reserves = in.w.financial.insurance.reserves.copy(
-          lifeReserves = in.ledgerFinancialState.insurance.lifeReserve,
-          nonLifeReserves = in.ledgerFinancialState.insurance.nonLifeReserve,
-        ),
-        portfolio = in.w.financial.insurance.portfolio.copy(
-          govBondHoldings = in.ledgerFinancialState.insurance.govBondHoldings,
-          corpBondHoldings = in.ledgerFinancialState.insurance.corpBondHoldings,
-          equityHoldings = in.ledgerFinancialState.insurance.equityHoldings,
-        ),
-      ),
+      LedgerStateAdapter.projectInsuranceState(in.w.financial.insurance, in.ledgerFinancialState),
       in.employed,
       in.newWage,
       unempRate,
@@ -684,17 +674,7 @@ object OpenEconEconomics:
     val unempRate    = in.w.unemploymentRate(in.s2.employed)
     val newInsurance =
       Insurance.step(
-        in.w.financial.insurance.copy(
-          reserves = in.w.financial.insurance.reserves.copy(
-            lifeReserves = in.ledgerFinancialState.insurance.lifeReserve,
-            nonLifeReserves = in.ledgerFinancialState.insurance.nonLifeReserve,
-          ),
-          portfolio = in.w.financial.insurance.portfolio.copy(
-            govBondHoldings = in.ledgerFinancialState.insurance.govBondHoldings,
-            corpBondHoldings = in.ledgerFinancialState.insurance.corpBondHoldings,
-            equityHoldings = in.ledgerFinancialState.insurance.equityHoldings,
-          ),
-        ),
+        LedgerStateAdapter.projectInsuranceState(in.w.financial.insurance, in.ledgerFinancialState),
         in.s2.employed,
         in.s2.newWage,
         unempRate,
@@ -709,18 +689,7 @@ object OpenEconEconomics:
     val nbfiUnempRate   = in.w.unemploymentRate(in.s2.employed)
     val newNbfi         =
       Nbfi.step(
-        in.w.financial.nbfi.copy(
-          tfi = in.w.financial.nbfi.tfi.copy(
-            tfiAum = in.ledgerFinancialState.funds.nbfi.tfiUnit,
-            tfiGovBondHoldings = in.ledgerFinancialState.funds.nbfi.govBondHoldings,
-            tfiCorpBondHoldings = in.ledgerFinancialState.funds.nbfi.corpBondHoldings,
-            tfiEquityHoldings = in.ledgerFinancialState.funds.nbfi.equityHoldings,
-            tfiCashHoldings = in.ledgerFinancialState.funds.nbfi.cashHoldings,
-          ),
-          credit = in.w.financial.nbfi.credit.copy(
-            nbfiLoanStock = in.ledgerFinancialState.funds.nbfi.nbfiLoanStock,
-          ),
-        ),
+        LedgerStateAdapter.projectNbfiState(in.w.financial.nbfi, in.ledgerFinancialState),
         in.s2.employed,
         in.s2.newWage,
         in.w.priceLevel,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, GvcTrade, OpenEconomy}
 import com.boombustgroup.amorfati.engine.mechanisms.Expectations
 import com.boombustgroup.amorfati.types.*
@@ -134,6 +135,7 @@ object OpenEconEconomics:
   /** Input: everything needed from previous stages. */
   case class Input(
       w: World,
+      ledgerFinancialState: LedgerFinancialState,
       banks: Vector[Banking.BankState],
       employed: Int,
       newWage: PLN,
@@ -202,7 +204,7 @@ object OpenEconEconomics:
         sectorOutputs = sectorOutputs,
         month = in.month,
         inflation = in.w.inflation,
-        nbpFxReserves = in.w.nbp.fxReserves,
+        nbpFxReserves = in.ledgerFinancialState.nbp.foreignAssets,
         gvcExports = gvcExp,
         gvcIntermImports = gvcImp,
         remittanceOutflow = in.remittanceOutflow,
@@ -239,11 +241,17 @@ object OpenEconEconomics:
       Rate(toDouble(deAnchor) * toDouble(p.labor.expBondSensitivity))
     val marketYield       = Nbp.bondYield(newRefRate, debtToGdp, nbpBondGdpShare, in.w.bop.nfa, credPremium)
     val newWeightedCoupon =
-      updateWeightedCoupon(in.w.gov.weightedCoupon, marketYield, in.w.gov.bondsOutstanding, in.w.gov.deficit, p.fiscal.govAvgMaturityMonths)
-    val rawDebtService    = in.w.gov.bondsOutstanding * newWeightedCoupon.monthly
+      updateWeightedCoupon(
+        in.w.gov.weightedCoupon,
+        marketYield,
+        in.ledgerFinancialState.government.govBondOutstanding,
+        in.w.gov.deficit,
+        p.fiscal.govAvgMaturityMonths,
+      )
+    val rawDebtService    = in.ledgerFinancialState.government.govBondOutstanding * newWeightedCoupon.monthly
     val debtService       = rawDebtService.min(in.gdp * MaxDebtServiceGdpShare)
     val bankBondIncome    = bankAgg.govBondHoldings * marketYield.monthly
-    val nbpBondIncome     = in.w.nbp.govBondHoldings * marketYield.monthly
+    val nbpBondIncome     = in.ledgerFinancialState.nbp.govBondHoldings * marketYield.monthly
     val nbpRemittance     = nbpBondIncome - reserveInterest - standingFacility
 
     // QE
@@ -251,7 +259,14 @@ object OpenEconEconomics:
       if Nbp.shouldActivateQe(newRefRate, in.newInflation, newExp.expectedInflation) then true
       else if Nbp.shouldTaperQe(in.newInflation, newExp.expectedInflation) then false
       else in.w.nbp.qeActive
-    val preQeNbp  = Nbp.State(newRefRate, in.w.nbp.govBondHoldings, qeActive, in.w.nbp.qeCumulative, in.w.nbp.fxReserves, in.w.nbp.lastFxTraded)
+    val preQeNbp  = Nbp.State(
+      newRefRate,
+      in.ledgerFinancialState.nbp.govBondHoldings,
+      qeActive,
+      in.w.nbp.qeCumulative,
+      in.ledgerFinancialState.nbp.foreignAssets,
+      in.w.nbp.lastFxTraded,
+    )
     val qeRequest = Nbp.executeQe(preQeNbp, bankAgg.govBondHoldings, in.gdp, in.newInflation, newExp.expectedInflation)
 
     // 7. Corporate bonds
@@ -270,7 +285,25 @@ object OpenEconEconomics:
 
     // 8. Insurance
     val unempRate    = in.w.unemploymentRate(in.employed)
-    val newInsurance = Insurance.step(in.w.financial.insurance, in.employed, in.newWage, unempRate, marketYield, newCorpBonds.corpBondYield, in.equityReturn)
+    val newInsurance = Insurance.step(
+      in.w.financial.insurance.copy(
+        reserves = in.w.financial.insurance.reserves.copy(
+          lifeReserves = in.ledgerFinancialState.insurance.lifeReserve,
+          nonLifeReserves = in.ledgerFinancialState.insurance.nonLifeReserve,
+        ),
+        portfolio = in.w.financial.insurance.portfolio.copy(
+          govBondHoldings = in.ledgerFinancialState.insurance.govBondHoldings,
+          corpBondHoldings = in.ledgerFinancialState.insurance.corpBondHoldings,
+          equityHoldings = in.ledgerFinancialState.insurance.equityHoldings,
+        ),
+      ),
+      in.employed,
+      in.newWage,
+      unempRate,
+      marketYield,
+      newCorpBonds.corpBondYield,
+      in.equityReturn,
+    )
 
     Result(
       exports = bop.exports,
@@ -348,6 +381,7 @@ object OpenEconEconomics:
 
   case class StepInput(
       w: World,
+      ledgerFinancialState: LedgerFinancialState,
       s1: FiscalConstraintEconomics.Output,
       s2: LaborEconomics.Output,
       s3: HouseholdIncomeEconomics.Output,
@@ -495,7 +529,7 @@ object OpenEconEconomics:
         priceLevel = in.w.priceLevel,
         sectorOutputs = sectorOutputs,
         month = in.s1.m,
-        nbpFxReserves = in.w.nbp.fxReserves,
+        nbpFxReserves = in.ledgerFinancialState.nbp.foreignAssets,
         gvcExports = gvcExp,
         gvcIntermImports = gvcImp,
         remittanceOutflow = in.s6.remittanceOutflow,
@@ -590,15 +624,15 @@ object OpenEconEconomics:
     val newWeightedCoupon = updateWeightedCouponPublic(
       prevCoupon = in.w.gov.weightedCoupon,
       marketYield = marketYield,
-      bondsOutstanding = in.w.gov.bondsOutstanding,
+      bondsOutstanding = in.ledgerFinancialState.government.govBondOutstanding,
       deficit = in.w.gov.deficit,
       avgMaturityMonths = p.fiscal.govAvgMaturityMonths,
     )
 
-    val rawDebtService     = in.w.gov.bondsOutstanding * newWeightedCoupon.monthly
+    val rawDebtService     = in.ledgerFinancialState.government.govBondOutstanding * newWeightedCoupon.monthly
     val monthlyDebtService = rawDebtService.min(in.s7.gdp * MaxDebtServiceGdpShare)
     val bankBondIncome     = bankAgg.govBondHoldings * marketYield.monthly
-    val nbpBondIncome      = in.w.nbp.govBondHoldings * marketYield.monthly
+    val nbpBondIncome      = in.ledgerFinancialState.nbp.govBondHoldings * marketYield.monthly
     val nbpRemittance      = nbpBondIncome - interbank.reserveInterest - interbank.standingFacilityIncome
 
     val qeActivate       = Nbp.shouldActivateQe(newRefRate, in.s7.newInfl, newExp.expectedInflation)
@@ -607,7 +641,14 @@ object OpenEconEconomics:
       if qeActivate then true
       else if qeTaper then false
       else in.w.nbp.qeActive
-    val preQeNbp         = Nbp.State(newRefRate, in.w.nbp.govBondHoldings, qeActive, in.w.nbp.qeCumulative, in.w.nbp.fxReserves, in.w.nbp.lastFxTraded)
+    val preQeNbp         = Nbp.State(
+      newRefRate,
+      in.ledgerFinancialState.nbp.govBondHoldings,
+      qeActive,
+      in.w.nbp.qeCumulative,
+      in.ledgerFinancialState.nbp.foreignAssets,
+      in.w.nbp.lastFxTraded,
+    )
     val qeRequest        = Nbp.executeQe(preQeNbp, bankAgg.govBondHoldings, in.s7.gdp, in.s7.newInfl, newExp.expectedInflation)
     val qePurchaseAmount = qeRequest.requestedPurchase
     val postFxNbp        = qeRequest.nbpState.copy(
@@ -643,7 +684,17 @@ object OpenEconEconomics:
     val unempRate    = in.w.unemploymentRate(in.s2.employed)
     val newInsurance =
       Insurance.step(
-        in.w.financial.insurance,
+        in.w.financial.insurance.copy(
+          reserves = in.w.financial.insurance.reserves.copy(
+            lifeReserves = in.ledgerFinancialState.insurance.lifeReserve,
+            nonLifeReserves = in.ledgerFinancialState.insurance.nonLifeReserve,
+          ),
+          portfolio = in.w.financial.insurance.portfolio.copy(
+            govBondHoldings = in.ledgerFinancialState.insurance.govBondHoldings,
+            corpBondHoldings = in.ledgerFinancialState.insurance.corpBondHoldings,
+            equityHoldings = in.ledgerFinancialState.insurance.equityHoldings,
+          ),
+        ),
         in.s2.employed,
         in.s2.newWage,
         unempRate,
@@ -658,7 +709,18 @@ object OpenEconEconomics:
     val nbfiUnempRate   = in.w.unemploymentRate(in.s2.employed)
     val newNbfi         =
       Nbfi.step(
-        in.w.financial.nbfi,
+        in.w.financial.nbfi.copy(
+          tfi = in.w.financial.nbfi.tfi.copy(
+            tfiAum = in.ledgerFinancialState.funds.nbfi.tfiUnit,
+            tfiGovBondHoldings = in.ledgerFinancialState.funds.nbfi.govBondHoldings,
+            tfiCorpBondHoldings = in.ledgerFinancialState.funds.nbfi.corpBondHoldings,
+            tfiEquityHoldings = in.ledgerFinancialState.funds.nbfi.equityHoldings,
+            tfiCashHoldings = in.ledgerFinancialState.funds.nbfi.cashHoldings,
+          ),
+          credit = in.w.financial.nbfi.credit.copy(
+            nbfiLoanStock = in.ledgerFinancialState.funds.nbfi.nbfiLoanStock,
+          ),
+        ),
         in.s2.employed,
         in.s2.newWage,
         in.w.priceLevel,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -492,29 +492,8 @@ object WorldAssemblyEconomics:
           ppkHoldings = corporateBondCircuit.ppkHoldings,
           otherHoldings = corporateBondCircuit.otherHoldings,
         ),
-        insurance = in.s9.finalInsurance.copy(
-          reserves = in.s9.finalInsurance.reserves.copy(
-            lifeReserves = ledgerFinancialState.insurance.lifeReserve,
-            nonLifeReserves = ledgerFinancialState.insurance.nonLifeReserve,
-          ),
-          portfolio = in.s9.finalInsurance.portfolio.copy(
-            govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
-            corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
-            equityHoldings = ledgerFinancialState.insurance.equityHoldings,
-          ),
-        ),
-        nbfi = in.s9.finalNbfi.copy(
-          tfi = in.s9.finalNbfi.tfi.copy(
-            tfiAum = ledgerFinancialState.funds.nbfi.tfiUnit,
-            tfiGovBondHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
-            tfiCorpBondHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
-            tfiEquityHoldings = ledgerFinancialState.funds.nbfi.equityHoldings,
-            tfiCashHoldings = ledgerFinancialState.funds.nbfi.cashHoldings,
-          ),
-          credit = in.s9.finalNbfi.credit.copy(
-            nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
-          ),
-        ),
+        insurance = LedgerStateAdapter.projectInsuranceState(in.s9.finalInsurance, ledgerFinancialState),
+        nbfi = LedgerStateAdapter.projectNbfiState(in.s9.finalNbfi, ledgerFinancialState),
         quasiFiscal = in.s9.newQuasiFiscal.copy(
           bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
           loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -532,50 +532,23 @@ object WorldAssemblyEconomics:
     (world, ledgerFinancialState)
 
   private def buildLedgerFinancialState(in: StepInput): LedgerFinancialState =
+    val social = SocialState(
+      jst = in.s9.newJst,
+      zus = in.s2.newZus,
+      nfz = in.s2.newNfz,
+      ppk = in.s9.finalPpk,
+      demographics = in.s2.newDemographics,
+      earmarked = in.s2.newEarmarked,
+    )
     in.ledgerFinancialState.copy(
       households = in.s9.reassignedHouseholds.map(LedgerStateAdapter.householdBalances),
       firms = in.s9.reassignedFirms.map(LedgerStateAdapter.firmBalances),
       banks = in.s9.banks.map(LedgerStateAdapter.bankBalances),
-      government = LedgerFinancialState.GovernmentBalances(
-        govBondOutstanding = in.s9.newGovWithYield.bondsOutstanding,
-      ),
-      foreign = LedgerFinancialState.ForeignBalances(
-        govBondHoldings = in.s9.newGovWithYield.foreignBondHoldings,
-      ),
-      nbp = LedgerFinancialState.NbpBalances(
-        govBondHoldings = in.s9.finalNbp.govBondHoldings,
-        foreignAssets = in.s9.finalNbp.fxReserves,
-      ),
-      insurance = LedgerFinancialState.InsuranceBalances(
-        lifeReserve = in.s9.finalInsurance.lifeReserves,
-        nonLifeReserve = in.s9.finalInsurance.nonLifeReserves,
-        govBondHoldings = in.s9.finalInsurance.govBondHoldings,
-        corpBondHoldings = in.s9.finalInsurance.corpBondHoldings,
-        equityHoldings = in.s9.finalInsurance.equityHoldings,
-      ),
-      funds = LedgerFinancialState.FundBalances(
-        zusCash = in.s2.newZus.fusBalance,
-        nfzCash = in.s2.newNfz.balance,
-        ppkGovBondHoldings = in.s9.finalPpk.bondHoldings,
-        ppkCorpBondHoldings = in.s8.corpBonds.newCorpBonds.ppkHoldings,
-        fpCash = in.s2.newEarmarked.fpBalance,
-        pfronCash = in.s2.newEarmarked.pfronBalance,
-        fgspCash = in.s2.newEarmarked.fgspBalance,
-        jstCash = in.s9.newJst.deposits,
-        corpBondOtherHoldings = in.s8.corpBonds.newCorpBonds.otherHoldings,
-        nbfi = LedgerFinancialState.NbfiFundBalances(
-          tfiUnit = in.s9.finalNbfi.tfiAum,
-          govBondHoldings = in.s9.finalNbfi.tfiGovBondHoldings,
-          corpBondHoldings = in.s9.finalNbfi.tfiCorpBondHoldings,
-          equityHoldings = in.s9.finalNbfi.tfiEquityHoldings,
-          cashHoldings = in.s9.finalNbfi.tfiCashHoldings,
-          nbfiLoanStock = in.s9.finalNbfi.nbfiLoanStock,
-        ),
-        quasiFiscal = LedgerFinancialState.QuasiFiscalBalances(
-          bondsOutstanding = in.s9.newQuasiFiscal.bondsOutstanding,
-          loanPortfolio = in.s9.newQuasiFiscal.loanPortfolio,
-        ),
-      ),
+      government = LedgerStateAdapter.governmentBalances(in.s9.newGovWithYield),
+      foreign = LedgerStateAdapter.foreignBalances(in.s9.newGovWithYield),
+      nbp = LedgerStateAdapter.nbpBalances(in.s9.finalNbp),
+      insurance = LedgerStateAdapter.insuranceBalances(in.s9.finalInsurance),
+      funds = LedgerStateAdapter.fundBalances(social, in.s8.corpBonds.newCorpBonds, in.s9.finalNbfi, in.s9.newQuasiFiscal),
     )
 
   private def buildPostMonthPipelineState(in: StepInput): PipelineState =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -24,19 +24,20 @@ object WorldAssemblyEconomics:
   // ---------------------------------------------------------------------------
 
   case class StepInput(
-      w: World,                               // current world state
-      firms: Vector[Firm.State],              // pre-step firm population
-      households: Vector[Household.State],    // pre-step household population
-      banks: Vector[Banking.BankState],       // pre-step bank population
-      s1: FiscalConstraintEconomics.Output,   // fiscal constraint (month, reservation wage, lending base rate)
-      s2: LaborEconomics.Output,              // labor/demographics (wage, employment, ZUS, PPK)
-      s3: HouseholdIncomeEconomics.Output,    // household income (consumption, PIT, import propensity)
-      s4: DemandEconomics.Output,             // demand (sector multipliers, gov purchases)
-      s5: FirmEconomics.StepOutput,           // firm processing (loans, NPL, tax, I-O, bond issuance)
-      s6: HouseholdFinancialEconomics.Output, // household financial (debt service, remittances, tourism)
-      s7: PriceEquityEconomics.Output,        // price/equity (inflation, GDP, equity, macropru)
-      s8: OpenEconEconomics.StepOutput,       // open economy (monetary policy, forex, BOP, corp bonds)
-      s9: BankingEconomics.StepOutput,        // bank update (balance sheets, tax revenue, housing flows)
+      w: World,                                   // current world state
+      firms: Vector[Firm.State],                  // pre-step firm population
+      households: Vector[Household.State],        // pre-step household population
+      banks: Vector[Banking.BankState],           // pre-step bank population
+      ledgerFinancialState: LedgerFinancialState, // ledger-backed supported financial source of truth
+      s1: FiscalConstraintEconomics.Output,       // fiscal constraint (month, reservation wage, lending base rate)
+      s2: LaborEconomics.Output,                  // labor/demographics (wage, employment, ZUS, PPK)
+      s3: HouseholdIncomeEconomics.Output,        // household income (consumption, PIT, import propensity)
+      s4: DemandEconomics.Output,                 // demand (sector multipliers, gov purchases)
+      s5: FirmEconomics.StepOutput,               // firm processing (loans, NPL, tax, I-O, bond issuance)
+      s6: HouseholdFinancialEconomics.Output,     // household financial (debt service, remittances, tourism)
+      s7: PriceEquityEconomics.Output,            // price/equity (inflation, GDP, equity, macropru)
+      s8: OpenEconEconomics.StepOutput,           // open economy (monetary policy, forex, BOP, corp bonds)
+      s9: BankingEconomics.StepOutput,            // bank update (balance sheets, tax revenue, housing flows)
   )
 
   case class StepOutput(
@@ -91,6 +92,7 @@ object WorldAssemblyEconomics:
       firms: Vector[Firm.State],
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
+      ledgerFinancialState: LedgerFinancialState,
       // Raw values
       month: ExecutionMonth,
       lendingBaseRate: Rate,
@@ -122,6 +124,7 @@ object WorldAssemblyEconomics:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
+      ledgerFinancialState: LedgerFinancialState,
       signalExtraction: SignalExtraction.Output,
   )
 
@@ -132,6 +135,7 @@ object WorldAssemblyEconomics:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
+      ledgerFinancialState: LedgerFinancialState,
       startupAbsorptionRate: Share,
   )
 
@@ -150,6 +154,7 @@ object WorldAssemblyEconomics:
       in.firms,
       in.households,
       in.banks,
+      in.ledgerFinancialState,
       s1,
       in.laborOutput,
       in.hhOutput,
@@ -211,7 +216,15 @@ object WorldAssemblyEconomics:
     val signalInput = buildSignalExtractionInput(step)
     val post        = computePostMonth(step, in.randomness)
     val seed        = extractSignalExtraction(signalInput, post)
-    Result(advanceToBoundaryWorld(post.world, seed.seedOut), post.firms, post.households, post.banks, post.householdAggregates, seed)
+    Result(
+      advanceToBoundaryWorld(post.world, seed.seedOut),
+      post.firms,
+      post.households,
+      post.banks,
+      post.householdAggregates,
+      post.ledgerFinancialState,
+      seed,
+    )
 
   // ---------------------------------------------------------------------------
   // runStep — migrated from WorldAssemblyStep.run
@@ -237,7 +250,7 @@ object WorldAssemblyEconomics:
     val obs             = computeObservables(in)
     val seedIn          = in.w.seedIn
 
-    val newW = assembleWorld(in, equityAfterStep, fofResidual, informal, obs)
+    val (newW, assembledLedgerFinancialState) = assembleWorld(in, equityAfterStep, fofResidual, informal, obs)
 
     val postFdiFirms = applyFdiMa(in.s9.reassignedFirms, randomness.fdiMa)
     val entryStep    =
@@ -253,9 +266,9 @@ object WorldAssemblyEconomics:
     val startupStaffing = applyStartupStaffing(in, entryStep.firms, in.s9.reassignedHouseholds, randomness.startupStaffing)
 
     // Regional migration: unemployed HH may relocate between NUTS-1 regions
-    val postMigHh  = RegionalMigration(startupStaffing.households, in.s2.regionalWages, randomness.regionalMigration).households
-    val finalFirms = syncStartupStaffing(startupStaffing.firms, postMigHh)
-    val finalW     = newW
+    val postMigHh                 = RegionalMigration(startupStaffing.households, in.s2.regionalWages, randomness.regionalMigration).households
+    val finalFirms                = syncStartupStaffing(startupStaffing.firms, postMigHh)
+    val finalW                    = newW
       .updatePipeline(_ => buildPostMonthPipelineState(in))
       .updateFlows(_.copy(firmBirths = entryStep.firmBirths, firmDeaths = in.s5.firmDeaths, netFirmBirths = entryStep.netBirths))
       .updateReal: r =>
@@ -265,7 +278,20 @@ object WorldAssemblyEconomics:
           ),
         )
       .copy(regionalWages = in.s2.regionalWages)
-    PostResult(finalW, finalFirms, postMigHh, in.s9.banks, startupStaffing.hhAgg, startupStaffing.startupAbsorptionRate)
+    val finalLedgerFinancialState = assembledLedgerFinancialState.copy(
+      households = postMigHh.map(LedgerStateAdapter.householdBalances),
+      firms = finalFirms.map(LedgerStateAdapter.firmBalances),
+      banks = in.s9.banks.map(LedgerStateAdapter.bankBalances),
+    )
+    PostResult(
+      finalW,
+      finalFirms,
+      postMigHh,
+      in.s9.banks,
+      startupStaffing.hhAgg,
+      finalLedgerFinancialState,
+      startupStaffing.startupAbsorptionRate,
+    )
 
   // ---------------------------------------------------------------------------
   // Private helpers — migrated from WorldAssemblyStep
@@ -420,16 +446,17 @@ object WorldAssemblyEconomics:
       fofResidual: PLN,
       informal: InformalResult,
       obs: Observables,
-  ): World =
-    val ledgerFinancialState = buildLedgerFinancialState(in)
-    val provisionalWorld     = World(
+  ): (World, LedgerFinancialState) =
+    val ledgerFinancialState = LedgerStateAdapter.roundTripLedgerFinancialState(buildLedgerFinancialState(in))
+    val corporateBondCircuit = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
+    val world                = World(
       inflation = in.s7.newInfl,
       priceLevel = in.s7.newPrice,
       currentSigmas = in.s7.newSigmas,
       gov = in.s9.newGovWithYield.copy(
         financial = in.s9.newGovWithYield.financial.copy(
-          bondsOutstanding = in.w.gov.bondsOutstanding,
-          foreignBondHoldings = in.w.gov.foreignBondHoldings,
+          bondsOutstanding = ledgerFinancialState.government.govBondOutstanding,
+          foreignBondHoldings = ledgerFinancialState.foreign.govBondHoldings,
         ),
         policy = in.s9.newGovWithYield.policy.copy(
           minWageLevel = in.s1.baseMinWage,
@@ -438,8 +465,8 @@ object WorldAssemblyEconomics:
       ),
       nbp = in.s9.finalNbp.copy(
         balance = in.s9.finalNbp.balance.copy(
-          govBondHoldings = in.w.nbp.govBondHoldings,
-          fxReserves = in.w.nbp.fxReserves,
+          govBondHoldings = ledgerFinancialState.nbp.govBondHoldings,
+          fxReserves = ledgerFinancialState.nbp.foreignAssets,
         ),
       ),
       bankingSector = in.s9.bankingMarket,
@@ -447,34 +474,50 @@ object WorldAssemblyEconomics:
       bop = in.s8.external.newBop,
       householdMarket = HouseholdMarketState.fromAggregates(in.s9.finalHhAgg),
       social = SocialState(
-        jst = in.s9.newJst,
-        zus = in.s2.newZus.copy(fusBalance = in.w.social.zus.fusBalance),
-        nfz = in.s2.newNfz.copy(balance = in.w.social.nfz.balance),
-        ppk = in.s9.finalPpk.copy(bondHoldings = in.w.social.ppk.bondHoldings),
+        jst = in.s9.newJst.copy(deposits = ledgerFinancialState.funds.jstCash),
+        zus = in.s2.newZus.copy(fusBalance = ledgerFinancialState.funds.zusCash),
+        nfz = in.s2.newNfz.copy(balance = ledgerFinancialState.funds.nfzCash),
+        ppk = in.s9.finalPpk.copy(bondHoldings = ledgerFinancialState.funds.ppkGovBondHoldings),
         demographics = in.s2.newDemographics,
         earmarked = in.s2.newEarmarked.copy(
-          fp = in.s2.newEarmarked.fp.copy(balance = in.w.social.earmarked.fpBalance),
-          pfron = in.s2.newEarmarked.pfron.copy(balance = in.w.social.earmarked.pfronBalance),
-          fgsp = in.s2.newEarmarked.fgsp.copy(balance = in.w.social.earmarked.fgspBalance),
+          fp = in.s2.newEarmarked.fp.copy(balance = ledgerFinancialState.funds.fpCash),
+          pfron = in.s2.newEarmarked.pfron.copy(balance = ledgerFinancialState.funds.pfronCash),
+          fgsp = in.s2.newEarmarked.fgsp.copy(balance = ledgerFinancialState.funds.fgspCash),
         ),
       ),
       financial = FinancialMarketsState(
         equity = equityAfterStep,
         corporateBonds = in.s8.corpBonds.newCorpBonds.copy(
-          bankHoldings = in.w.financial.corporateBonds.bankHoldings,
-          ppkHoldings = in.w.financial.corporateBonds.ppkHoldings,
+          bankHoldings = corporateBondCircuit.bankHoldings,
+          ppkHoldings = corporateBondCircuit.ppkHoldings,
+          otherHoldings = corporateBondCircuit.otherHoldings,
         ),
         insurance = in.s9.finalInsurance.copy(
-          reserves = in.w.financial.insurance.reserves,
-          portfolio = in.w.financial.insurance.portfolio,
+          reserves = in.s9.finalInsurance.reserves.copy(
+            lifeReserves = ledgerFinancialState.insurance.lifeReserve,
+            nonLifeReserves = ledgerFinancialState.insurance.nonLifeReserve,
+          ),
+          portfolio = in.s9.finalInsurance.portfolio.copy(
+            govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
+            corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
+            equityHoldings = ledgerFinancialState.insurance.equityHoldings,
+          ),
         ),
         nbfi = in.s9.finalNbfi.copy(
-          tfi = in.w.financial.nbfi.tfi,
-          credit = in.w.financial.nbfi.credit,
+          tfi = in.s9.finalNbfi.tfi.copy(
+            tfiAum = ledgerFinancialState.funds.nbfi.tfiUnit,
+            tfiGovBondHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
+            tfiCorpBondHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
+            tfiEquityHoldings = ledgerFinancialState.funds.nbfi.equityHoldings,
+            tfiCashHoldings = ledgerFinancialState.funds.nbfi.cashHoldings,
+          ),
+          credit = in.s9.finalNbfi.credit.copy(
+            nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
+          ),
         ),
         quasiFiscal = in.s9.newQuasiFiscal.copy(
-          bondsOutstanding = in.w.financial.quasiFiscal.bondsOutstanding,
-          loanPortfolio = in.w.financial.quasiFiscal.loanPortfolio,
+          bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
+          loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,
         ),
       ),
       external = ExternalState(
@@ -513,10 +556,10 @@ object WorldAssemblyEconomics:
       pipeline = in.w.pipeline,
       flows = buildFlowState(in, informal),
     )
-    withLedgerFinancialState(provisionalWorld, LedgerStateAdapter.roundTripLedgerFinancialState(ledgerFinancialState))
+    (world, ledgerFinancialState)
 
   private def buildLedgerFinancialState(in: StepInput): LedgerFinancialState =
-    LedgerFinancialState(
+    in.ledgerFinancialState.copy(
       households = in.s9.reassignedHouseholds.map(LedgerStateAdapter.householdBalances),
       firms = in.s9.reassignedFirms.map(LedgerStateAdapter.firmBalances),
       banks = in.s9.banks.map(LedgerStateAdapter.bankBalances),
@@ -558,71 +601,6 @@ object WorldAssemblyEconomics:
         quasiFiscal = LedgerFinancialState.QuasiFiscalBalances(
           bondsOutstanding = in.s9.newQuasiFiscal.bondsOutstanding,
           loanPortfolio = in.s9.newQuasiFiscal.loanPortfolio,
-        ),
-      ),
-    )
-
-  private[economics] def withLedgerFinancialState(
-      world: World,
-      ledgerFinancialState: LedgerFinancialState,
-  ): World =
-    val corpBonds = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
-    world.copy(
-      gov = world.gov.copy(
-        financial = world.gov.financial.copy(
-          bondsOutstanding = ledgerFinancialState.government.govBondOutstanding,
-          foreignBondHoldings = ledgerFinancialState.foreign.govBondHoldings,
-        ),
-      ),
-      nbp = world.nbp.copy(
-        balance = world.nbp.balance.copy(
-          govBondHoldings = ledgerFinancialState.nbp.govBondHoldings,
-          fxReserves = ledgerFinancialState.nbp.foreignAssets,
-        ),
-      ),
-      social = world.social.copy(
-        jst = world.social.jst.copy(deposits = ledgerFinancialState.funds.jstCash),
-        zus = world.social.zus.copy(fusBalance = ledgerFinancialState.funds.zusCash),
-        nfz = world.social.nfz.copy(balance = ledgerFinancialState.funds.nfzCash),
-        ppk = world.social.ppk.copy(bondHoldings = ledgerFinancialState.funds.ppkGovBondHoldings),
-        earmarked = world.social.earmarked.copy(
-          fp = world.social.earmarked.fp.copy(balance = ledgerFinancialState.funds.fpCash),
-          pfron = world.social.earmarked.pfron.copy(balance = ledgerFinancialState.funds.pfronCash),
-          fgsp = world.social.earmarked.fgsp.copy(balance = ledgerFinancialState.funds.fgspCash),
-        ),
-      ),
-      financial = world.financial.copy(
-        corporateBonds = world.financial.corporateBonds.copy(
-          bankHoldings = corpBonds.bankHoldings,
-          ppkHoldings = corpBonds.ppkHoldings,
-          otherHoldings = corpBonds.otherHoldings,
-        ),
-        insurance = world.financial.insurance.copy(
-          reserves = world.financial.insurance.reserves.copy(
-            lifeReserves = ledgerFinancialState.insurance.lifeReserve,
-            nonLifeReserves = ledgerFinancialState.insurance.nonLifeReserve,
-          ),
-          portfolio = world.financial.insurance.portfolio.copy(
-            govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
-            corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
-            equityHoldings = ledgerFinancialState.insurance.equityHoldings,
-          ),
-        ),
-        nbfi = world.financial.nbfi.copy(
-          tfi = world.financial.nbfi.tfi.copy(
-            tfiAum = ledgerFinancialState.funds.nbfi.tfiUnit,
-            tfiGovBondHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
-            tfiCorpBondHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
-            tfiEquityHoldings = ledgerFinancialState.funds.nbfi.equityHoldings,
-            tfiCashHoldings = ledgerFinancialState.funds.nbfi.cashHoldings,
-          ),
-          credit = world.financial.nbfi.credit.copy(
-            nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
-          ),
-        ),
-        quasiFiscal = world.financial.quasiFiscal.copy(
-          bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
-          loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,
         ),
       ),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.agents.RegionalMigration
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
+import com.boombustgroup.amorfati.engine.ledger.{LedgerFinancialState, LedgerStateAdapter}
 import com.boombustgroup.amorfati.engine.markets.{EquityMarket, LaborMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, InformalEconomy, SectoralMobility}
 import com.boombustgroup.amorfati.types.*
@@ -421,8 +421,8 @@ object WorldAssemblyEconomics:
       informal: InformalResult,
       obs: Observables,
   ): World =
-    val ledgerSupported  = buildLedgerSupportedSnapshot(in)
-    val provisionalWorld = World(
+    val ledgerFinancialState = buildLedgerFinancialState(in)
+    val provisionalWorld     = World(
       inflation = in.s7.newInfl,
       priceLevel = in.s7.newPrice,
       currentSigmas = in.s7.newSigmas,
@@ -513,31 +513,31 @@ object WorldAssemblyEconomics:
       pipeline = in.w.pipeline,
       flows = buildFlowState(in, informal),
     )
-    withLedgerSupportedFinancialState(provisionalWorld, LedgerStateAdapter.roundTripSupported(ledgerSupported))
+    withLedgerFinancialState(provisionalWorld, LedgerStateAdapter.roundTripLedgerFinancialState(ledgerFinancialState))
 
-  private def buildLedgerSupportedSnapshot(in: StepInput): LedgerStateAdapter.SupportedFinancialSnapshot =
-    LedgerStateAdapter.SupportedFinancialSnapshot(
+  private def buildLedgerFinancialState(in: StepInput): LedgerFinancialState =
+    LedgerFinancialState(
       households = in.s9.reassignedHouseholds.map(LedgerStateAdapter.householdBalances),
       firms = in.s9.reassignedFirms.map(LedgerStateAdapter.firmBalances),
       banks = in.s9.banks.map(LedgerStateAdapter.bankBalances),
-      government = LedgerStateAdapter.GovernmentBalances(
+      government = LedgerFinancialState.GovernmentBalances(
         govBondOutstanding = in.s9.newGovWithYield.bondsOutstanding,
       ),
-      foreign = LedgerStateAdapter.ForeignBalances(
+      foreign = LedgerFinancialState.ForeignBalances(
         govBondHoldings = in.s9.newGovWithYield.foreignBondHoldings,
       ),
-      nbp = LedgerStateAdapter.NbpBalances(
+      nbp = LedgerFinancialState.NbpBalances(
         govBondHoldings = in.s9.finalNbp.govBondHoldings,
         foreignAssets = in.s9.finalNbp.fxReserves,
       ),
-      insurance = LedgerStateAdapter.InsuranceBalances(
+      insurance = LedgerFinancialState.InsuranceBalances(
         lifeReserve = in.s9.finalInsurance.lifeReserves,
         nonLifeReserve = in.s9.finalInsurance.nonLifeReserves,
         govBondHoldings = in.s9.finalInsurance.govBondHoldings,
         corpBondHoldings = in.s9.finalInsurance.corpBondHoldings,
         equityHoldings = in.s9.finalInsurance.equityHoldings,
       ),
-      funds = LedgerStateAdapter.FundBalances(
+      funds = LedgerFinancialState.FundBalances(
         zusCash = in.s2.newZus.fusBalance,
         nfzCash = in.s2.newNfz.balance,
         ppkGovBondHoldings = in.s9.finalPpk.bondHoldings,
@@ -547,7 +547,7 @@ object WorldAssemblyEconomics:
         fgspCash = in.s2.newEarmarked.fgspBalance,
         jstCash = in.s9.newJst.deposits,
         corpBondOtherHoldings = in.s8.corpBonds.newCorpBonds.otherHoldings,
-        nbfi = LedgerStateAdapter.NbfiFundBalances(
+        nbfi = LedgerFinancialState.NbfiFundBalances(
           tfiUnit = in.s9.finalNbfi.tfiAum,
           govBondHoldings = in.s9.finalNbfi.tfiGovBondHoldings,
           corpBondHoldings = in.s9.finalNbfi.tfiCorpBondHoldings,
@@ -555,40 +555,40 @@ object WorldAssemblyEconomics:
           cashHoldings = in.s9.finalNbfi.tfiCashHoldings,
           nbfiLoanStock = in.s9.finalNbfi.nbfiLoanStock,
         ),
-        quasiFiscal = LedgerStateAdapter.QuasiFiscalBalances(
+        quasiFiscal = LedgerFinancialState.QuasiFiscalBalances(
           bondsOutstanding = in.s9.newQuasiFiscal.bondsOutstanding,
           loanPortfolio = in.s9.newQuasiFiscal.loanPortfolio,
         ),
       ),
     )
 
-  private[economics] def withLedgerSupportedFinancialState(
+  private[economics] def withLedgerFinancialState(
       world: World,
-      supported: LedgerStateAdapter.SupportedFinancialSnapshot,
+      ledgerFinancialState: LedgerFinancialState,
   ): World =
-    val corpBonds = LedgerStateAdapter.corporateBondCircuit(supported)
+    val corpBonds = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
     world.copy(
       gov = world.gov.copy(
         financial = world.gov.financial.copy(
-          bondsOutstanding = supported.government.govBondOutstanding,
-          foreignBondHoldings = supported.foreign.govBondHoldings,
+          bondsOutstanding = ledgerFinancialState.government.govBondOutstanding,
+          foreignBondHoldings = ledgerFinancialState.foreign.govBondHoldings,
         ),
       ),
       nbp = world.nbp.copy(
         balance = world.nbp.balance.copy(
-          govBondHoldings = supported.nbp.govBondHoldings,
-          fxReserves = supported.nbp.foreignAssets,
+          govBondHoldings = ledgerFinancialState.nbp.govBondHoldings,
+          fxReserves = ledgerFinancialState.nbp.foreignAssets,
         ),
       ),
       social = world.social.copy(
-        jst = world.social.jst.copy(deposits = supported.funds.jstCash),
-        zus = world.social.zus.copy(fusBalance = supported.funds.zusCash),
-        nfz = world.social.nfz.copy(balance = supported.funds.nfzCash),
-        ppk = world.social.ppk.copy(bondHoldings = supported.funds.ppkGovBondHoldings),
+        jst = world.social.jst.copy(deposits = ledgerFinancialState.funds.jstCash),
+        zus = world.social.zus.copy(fusBalance = ledgerFinancialState.funds.zusCash),
+        nfz = world.social.nfz.copy(balance = ledgerFinancialState.funds.nfzCash),
+        ppk = world.social.ppk.copy(bondHoldings = ledgerFinancialState.funds.ppkGovBondHoldings),
         earmarked = world.social.earmarked.copy(
-          fp = world.social.earmarked.fp.copy(balance = supported.funds.fpCash),
-          pfron = world.social.earmarked.pfron.copy(balance = supported.funds.pfronCash),
-          fgsp = world.social.earmarked.fgsp.copy(balance = supported.funds.fgspCash),
+          fp = world.social.earmarked.fp.copy(balance = ledgerFinancialState.funds.fpCash),
+          pfron = world.social.earmarked.pfron.copy(balance = ledgerFinancialState.funds.pfronCash),
+          fgsp = world.social.earmarked.fgsp.copy(balance = ledgerFinancialState.funds.fgspCash),
         ),
       ),
       financial = world.financial.copy(
@@ -599,30 +599,30 @@ object WorldAssemblyEconomics:
         ),
         insurance = world.financial.insurance.copy(
           reserves = world.financial.insurance.reserves.copy(
-            lifeReserves = supported.insurance.lifeReserve,
-            nonLifeReserves = supported.insurance.nonLifeReserve,
+            lifeReserves = ledgerFinancialState.insurance.lifeReserve,
+            nonLifeReserves = ledgerFinancialState.insurance.nonLifeReserve,
           ),
           portfolio = world.financial.insurance.portfolio.copy(
-            govBondHoldings = supported.insurance.govBondHoldings,
-            corpBondHoldings = supported.insurance.corpBondHoldings,
-            equityHoldings = supported.insurance.equityHoldings,
+            govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
+            corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
+            equityHoldings = ledgerFinancialState.insurance.equityHoldings,
           ),
         ),
         nbfi = world.financial.nbfi.copy(
           tfi = world.financial.nbfi.tfi.copy(
-            tfiAum = supported.funds.nbfi.tfiUnit,
-            tfiGovBondHoldings = supported.funds.nbfi.govBondHoldings,
-            tfiCorpBondHoldings = supported.funds.nbfi.corpBondHoldings,
-            tfiEquityHoldings = supported.funds.nbfi.equityHoldings,
-            tfiCashHoldings = supported.funds.nbfi.cashHoldings,
+            tfiAum = ledgerFinancialState.funds.nbfi.tfiUnit,
+            tfiGovBondHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
+            tfiCorpBondHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
+            tfiEquityHoldings = ledgerFinancialState.funds.nbfi.equityHoldings,
+            tfiCashHoldings = ledgerFinancialState.funds.nbfi.cashHoldings,
           ),
           credit = world.financial.nbfi.credit.copy(
-            nbfiLoanStock = supported.funds.nbfi.nbfiLoanStock,
+            nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
           ),
         ),
         quasiFiscal = world.financial.quasiFiscal.copy(
-          bondsOutstanding = supported.funds.quasiFiscal.bondsOutstanding,
-          loanPortfolio = supported.funds.quasiFiscal.loanPortfolio,
+          bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
+          loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,
         ),
       ),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -449,42 +449,36 @@ object WorldAssemblyEconomics:
   ): (World, LedgerFinancialState) =
     val ledgerFinancialState = LedgerStateAdapter.roundTripLedgerFinancialState(buildLedgerFinancialState(in))
     val corporateBondCircuit = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
+    val projectedSocial      = LedgerStateAdapter.projectSocialState(
+      SocialState(
+        jst = in.s9.newJst,
+        zus = in.s2.newZus,
+        nfz = in.s2.newNfz,
+        ppk = in.s9.finalPpk,
+        demographics = in.s2.newDemographics,
+        earmarked = in.s2.newEarmarked,
+      ),
+      ledgerFinancialState,
+    )
     val world                = World(
       inflation = in.s7.newInfl,
       priceLevel = in.s7.newPrice,
       currentSigmas = in.s7.newSigmas,
-      gov = in.s9.newGovWithYield.copy(
-        financial = in.s9.newGovWithYield.financial.copy(
-          bondsOutstanding = ledgerFinancialState.government.govBondOutstanding,
-          foreignBondHoldings = ledgerFinancialState.foreign.govBondHoldings,
+      gov = LedgerStateAdapter.projectGovState(
+        in.s9.newGovWithYield.copy(
+          policy = in.s9.newGovWithYield.policy.copy(
+            minWageLevel = in.s1.baseMinWage,
+            minWagePriceLevel = in.s1.updatedMinWagePriceLevel,
+          ),
         ),
-        policy = in.s9.newGovWithYield.policy.copy(
-          minWageLevel = in.s1.baseMinWage,
-          minWagePriceLevel = in.s1.updatedMinWagePriceLevel,
-        ),
+        ledgerFinancialState,
       ),
-      nbp = in.s9.finalNbp.copy(
-        balance = in.s9.finalNbp.balance.copy(
-          govBondHoldings = ledgerFinancialState.nbp.govBondHoldings,
-          fxReserves = ledgerFinancialState.nbp.foreignAssets,
-        ),
-      ),
+      nbp = LedgerStateAdapter.projectNbpState(in.s9.finalNbp, ledgerFinancialState),
       bankingSector = in.s9.bankingMarket,
       forex = in.s8.external.newForex,
       bop = in.s8.external.newBop,
       householdMarket = HouseholdMarketState.fromAggregates(in.s9.finalHhAgg),
-      social = SocialState(
-        jst = in.s9.newJst.copy(deposits = ledgerFinancialState.funds.jstCash),
-        zus = in.s2.newZus.copy(fusBalance = ledgerFinancialState.funds.zusCash),
-        nfz = in.s2.newNfz.copy(balance = ledgerFinancialState.funds.nfzCash),
-        ppk = in.s9.finalPpk.copy(bondHoldings = ledgerFinancialState.funds.ppkGovBondHoldings),
-        demographics = in.s2.newDemographics,
-        earmarked = in.s2.newEarmarked.copy(
-          fp = in.s2.newEarmarked.fp.copy(balance = ledgerFinancialState.funds.fpCash),
-          pfron = in.s2.newEarmarked.pfron.copy(balance = ledgerFinancialState.funds.pfronCash),
-          fgsp = in.s2.newEarmarked.fgsp.copy(balance = ledgerFinancialState.funds.fgspCash),
-        ),
-      ),
+      social = projectedSocial,
       financial = FinancialMarketsState(
         equity = equityAfterStep,
         corporateBonds = in.s8.corpBonds.newCorpBonds.copy(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -6,6 +6,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.{LedgerFinancialState, LedgerStateAdapter}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -33,9 +34,28 @@ object FlowSimulation:
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
+      ledgerFinancialState: LedgerFinancialState,
   )
 
   object SimState:
+    def apply(
+        completedMonth: CompletedMonth,
+        world: World,
+        firms: Vector[Firm.State],
+        households: Vector[Household.State],
+        banks: Vector[Banking.BankState],
+        householdAggregates: Household.Aggregates,
+    ): SimState =
+      new SimState(
+        completedMonth,
+        world,
+        firms,
+        households,
+        banks,
+        householdAggregates,
+        LedgerStateAdapter.captureLedgerFinancialState(world, firms, households, banks),
+      )
+
     def fromInit(init: com.boombustgroup.amorfati.init.WorldInit.InitResult): SimState =
       SimState(CompletedMonth.Zero, init.world, init.firms, init.households, init.banks, init.householdAggregates)
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -502,7 +502,7 @@ object FlowSimulation:
     val openEcon          = OpenEconEconomics.compute(
       OpenEconEconomics.Input(
         w = w,
-        ledgerFinancialState = stateIn.ledgerFinancialState,
+        ledgerFinancialState = ledger,
         employed = s2.employed,
         newWage = s2.newWage,
         domesticConsumption = s3.domesticCons,
@@ -535,7 +535,7 @@ object FlowSimulation:
     val s8                = OpenEconEconomics.runStep(
       OpenEconEconomics.StepInput(
         w,
-        stateIn.ledgerFinancialState,
+        ledger,
         s1,
         s2,
         s3,
@@ -551,7 +551,7 @@ object FlowSimulation:
     val bankingDepositRng = randomness.bankingEconomics.newStream()
     val bankingInput      = BankingEconomics.Input(
       w = w,
-      ledgerFinancialState = stateIn.ledgerFinancialState,
+      ledgerFinancialState = ledger,
       month = fiscal.month,
       lendingBaseRate = fiscal.lendingBaseRate,
       resWage = fiscal.resWage,
@@ -579,7 +579,7 @@ object FlowSimulation:
     val s9                = BankingEconomics.runStep(
       BankingEconomics.StepInput(
         w,
-        stateIn.ledgerFinancialState,
+        ledger,
         s1,
         s2,
         s3,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -38,7 +38,7 @@ object FlowSimulation:
   )
 
   object SimState:
-    def apply(
+    def fromMirrors(
         completedMonth: CompletedMonth,
         world: World,
         firms: Vector[Firm.State],
@@ -57,7 +57,7 @@ object FlowSimulation:
       )
 
     def fromInit(init: com.boombustgroup.amorfati.init.WorldInit.InitResult): SimState =
-      SimState(CompletedMonth.Zero, init.world, init.firms, init.households, init.banks, init.householdAggregates)
+      fromMirrors(CompletedMonth.Zero, init.world, init.firms, init.households, init.banks, init.householdAggregates)
 
   /** Executed aggregate batch deltas on top of an empty runtime ledger shell.
     *
@@ -443,6 +443,7 @@ object FlowSimulation:
   private def computeStageOutputs(input: StepInput)(using p: SimParams): StageOutputs =
     val randomness        = input.randomness.stages
     val stateIn           = input.stateIn
+    val ledger            = stateIn.ledgerFinancialState
     val w                 = stateIn.world
     val firms             = stateIn.firms
     val households        = stateIn.households
@@ -501,6 +502,7 @@ object FlowSimulation:
     val openEcon          = OpenEconEconomics.compute(
       OpenEconEconomics.Input(
         w = w,
+        ledgerFinancialState = stateIn.ledgerFinancialState,
         employed = s2.employed,
         newWage = s2.newWage,
         domesticConsumption = s3.domesticCons,
@@ -531,12 +533,25 @@ object FlowSimulation:
       ),
     )
     val s8                = OpenEconEconomics.runStep(
-      OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, banks, randomness.openEconEconomics.newStream()),
+      OpenEconEconomics.StepInput(
+        w,
+        stateIn.ledgerFinancialState,
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        banks,
+        randomness.openEconEconomics.newStream(),
+      ),
     )
     val operational       = operationalSignals(s2, s4)
     val bankingDepositRng = randomness.bankingEconomics.newStream()
     val bankingInput      = BankingEconomics.Input(
       w = w,
+      ledgerFinancialState = stateIn.ledgerFinancialState,
       month = fiscal.month,
       lendingBaseRate = fiscal.lendingBaseRate,
       resWage = fiscal.resWage,
@@ -562,7 +577,20 @@ object FlowSimulation:
       depositRng = bankingDepositRng,
     )
     val s9                = BankingEconomics.runStep(
-      BankingEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, s8, banks, bankingDepositRng),
+      BankingEconomics.StepInput(
+        w,
+        stateIn.ledgerFinancialState,
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        s8,
+        banks,
+        bankingDepositRng,
+      ),
     )
     val banking           = BankingEconomics.toResult(s9, bankingInput)
     val agg               = s3.hhAgg
@@ -650,11 +678,11 @@ object FlowSimulation:
       govDebtService = w.gov.debtServiceSpend,
       govEuCofinancing = w.gov.euCofinancing,
       govCapitalSpend = w.gov.govCapitalSpend,
-      insuranceCurrentLifeReserves = w.financial.insurance.lifeReserves,
-      insuranceCurrentNonLifeReserves = w.financial.insurance.nonLifeReserves,
-      insurancePrevGovBonds = w.financial.insurance.govBondHoldings,
-      insurancePrevCorpBonds = w.financial.insurance.corpBondHoldings,
-      insurancePrevEquity = w.financial.insurance.equityHoldings,
+      insuranceCurrentLifeReserves = ledger.insurance.lifeReserve,
+      insuranceCurrentNonLifeReserves = ledger.insurance.nonLifeReserve,
+      insurancePrevGovBonds = ledger.insurance.govBondHoldings,
+      insurancePrevCorpBonds = ledger.insurance.corpBondHoldings,
+      insurancePrevEquity = ledger.insurance.equityHoldings,
       govBondYield = openEcon.newBondYield,
       corpBondYield = openEcon.corpBondYield,
     )
@@ -669,6 +697,7 @@ object FlowSimulation:
         firms = firms,
         households = households,
         banks = banks,
+        ledgerFinancialState = stateIn.ledgerFinancialState,
         s1 = s1,
         s2 = s2,
         s3 = s3,
@@ -952,13 +981,14 @@ object FlowSimulation:
     require(assembled.world.seedIn == currentSeed, "PostMonth world must remain on the pre-step seed until advanceState runs")
     require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")
 
-    SimState(
+    new SimState(
       completedMonth = input.executionMonth.completed,
       world = nextWorld,
       firms = assembled.firms,
       households = assembled.households,
       banks = assembled.banks,
       householdAggregates = assembled.householdAggregates,
+      ledgerFinancialState = assembled.ledgerFinancialState,
     )
 
   private def buildMonthTrace(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/StateAdapter.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.agents.Household
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.types.*
 
 /** Temporary bridge between old World state and new flow mechanisms.
@@ -60,15 +61,17 @@ object StateAdapter:
       ccDefault = agg.totalConsumerDefault,
     )
 
-  /** Build Insurance flow input from world state. */
-  def insuranceInput(w: World, labor: LaborEconomics.Result): InsuranceFlows.Input =
-    val ins = w.financial.insurance
+  /** Build Insurance flow input from world state + ledger-backed financial
+    * mirrors.
+    */
+  def insuranceInput(w: World, ledgerFinancialState: LedgerFinancialState, labor: LaborEconomics.Result): InsuranceFlows.Input =
+    val ins = ledgerFinancialState.insurance
     InsuranceFlows.Input(
       employed = labor.employed,
       wage = labor.wage,
       unempRate = w.unemploymentRate(labor.employed),
-      currentLifeReserves = ins.lifeReserves,
-      currentNonLifeReserves = ins.nonLifeReserves,
+      currentLifeReserves = ins.lifeReserve,
+      currentNonLifeReserves = ins.nonLifeReserve,
       prevGovBondHoldings = ins.govBondHoldings,
       prevCorpBondHoldings = ins.corpBondHoldings,
       prevEquityHoldings = ins.equityHoldings,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
@@ -2,91 +2,166 @@ package com.boombustgroup.amorfati.engine.ledger
 
 import com.boombustgroup.amorfati.types.PLN
 
+/** Ledger-owned snapshot of ledger-contracted financial stocks used by the
+  * engine.
+  *
+  * This file defines the runtime state that should become the source of truth
+  * for financial ownership with an explicit ledger contract. It is
+  * intentionally narrower than `World`: it stores ledger-backed stock balances,
+  * not monthly flow deltas, execution-only settlement shells, or public assets
+  * that the engine still keeps outside the ledger contract. Boundary code may
+  * project these balances back into `World` mirrors while the migration is in
+  * progress.
+  */
 final case class LedgerFinancialState(
+    /** Household-sector ledger-backed financial stock balances. */
     households: Vector[LedgerFinancialState.HouseholdBalances],
+    /** Firm-sector ledger-backed financial stock balances. */
     firms: Vector[LedgerFinancialState.FirmBalances],
+    /** Bank-sector ledger-backed financial stock balances. */
     banks: Vector[LedgerFinancialState.BankBalances],
+    /** Central-government ledger-backed financial stock balances. */
     government: LedgerFinancialState.GovernmentBalances,
+    /** Foreign-sector ledger-backed financial stock balances. */
     foreign: LedgerFinancialState.ForeignBalances,
+    /** Central-bank ledger-backed financial stock balances. */
     nbp: LedgerFinancialState.NbpBalances,
+    /** Insurance-sector ledger-backed financial stock balances. */
     insurance: LedgerFinancialState.InsuranceBalances,
+    /** Social, local-government, quasi-fiscal, and investment-fund balances. */
     funds: LedgerFinancialState.FundBalances,
 )
 
 object LedgerFinancialState:
 
+  /** Ledger-backed financial balances owned by a single household. */
   case class HouseholdBalances(
+      /** Bank demand deposits owned by the household. */
       demandDeposit: PLN,
+      /** Outstanding mortgage principal owed by the household. */
       mortgageLoan: PLN,
+      /** Outstanding consumer-loan principal owed by the household. */
       consumerLoan: PLN,
+      /** Listed equity owned by the household. */
       equity: PLN,
   )
 
+  /** Ledger-backed financial balances owned or issued by a single firm. */
   case class FirmBalances(
+      /** Cash or deposit-like liquidity owned by the firm. */
       cash: PLN,
+      /** Outstanding bank-loan principal owed by the firm. */
       firmLoan: PLN,
+      /** Corporate bonds issued by the firm. */
       corpBond: PLN,
+      /** Listed equity issued by the firm. */
       equity: PLN,
   )
 
+  /** Ledger-backed financial balances owned or issued by a single bank. */
   case class BankBalances(
+      /** Total customer deposits owed by the bank. */
       totalDeposits: PLN,
+      /** Demand-deposit liabilities owed by the bank. */
       demandDeposit: PLN,
+      /** Term-deposit liabilities owed by the bank. */
       termDeposit: PLN,
+      /** Firm-loan assets owned by the bank. */
       firmLoan: PLN,
+      /** Consumer-loan assets owned by the bank. */
       consumerLoan: PLN,
+      /** Available-for-sale government bonds owned by the bank. */
       govBondAfs: PLN,
+      /** Held-to-maturity government bonds owned by the bank. */
       govBondHtm: PLN,
+      /** Reserve balance held by the bank at the NBP. */
       reserve: PLN,
+      /** Interbank-loan balance owned or owed by the bank. */
       interbankLoan: PLN,
+      /** Corporate bonds owned by the bank. */
       corpBond: PLN,
   )
 
+  /** Ledger-backed financial balances issued by central government. */
   case class GovernmentBalances(
+      /** Outstanding central-government bond principal. */
       govBondOutstanding: PLN,
   )
 
+  /** Ledger-backed financial balances owned by the foreign sector. */
   case class ForeignBalances(
+      /** Central-government bonds held by foreign investors. */
       govBondHoldings: PLN,
   )
 
+  /** Ledger-backed financial balances owned by the central bank. */
   case class NbpBalances(
+      /** Central-government bonds held by the NBP. */
       govBondHoldings: PLN,
+      /** Foreign-asset stock held by the NBP. */
       foreignAssets: PLN,
   )
 
+  /** Ledger-backed financial balances owned or owed by the insurance sector. */
   case class InsuranceBalances(
+      /** Life-insurance technical reserves owed to policyholders. */
       lifeReserve: PLN,
+      /** Non-life technical reserves owed to policyholders. */
       nonLifeReserve: PLN,
+      /** Central-government bonds held by insurers. */
       govBondHoldings: PLN,
+      /** Corporate bonds held by insurers. */
       corpBondHoldings: PLN,
+      /** Listed equity held by insurers. */
       equityHoldings: PLN,
   )
 
+  /** Ledger-backed financial balances owned or owed by an NBFI fund bucket. */
   case class NbfiFundBalances(
+      /** Investment-fund units issued by the NBFI bucket. */
       tfiUnit: PLN,
+      /** Central-government bonds held by the NBFI bucket. */
       govBondHoldings: PLN,
+      /** Corporate bonds held by the NBFI bucket. */
       corpBondHoldings: PLN,
+      /** Listed equity held by the NBFI bucket. */
       equityHoldings: PLN,
+      /** Cash held by the NBFI bucket. */
       cashHoldings: PLN,
+      /** NBFI loan portfolio stock. */
       nbfiLoanStock: PLN,
   )
 
+  /** Ledger-backed financial balances for quasi-fiscal investment vehicles. */
   case class QuasiFiscalBalances(
+      /** Bonds issued by quasi-fiscal vehicles. */
       bondsOutstanding: PLN,
+      /** Loan portfolio owned by quasi-fiscal vehicles. */
       loanPortfolio: PLN,
   )
 
+  /** Ledger-backed financial balances for non-agent public and fund buckets. */
   case class FundBalances(
+      /** ZUS cash balance. */
       zusCash: PLN,
+      /** NFZ cash balance. */
       nfzCash: PLN,
+      /** PPK central-government bond holdings. */
       ppkGovBondHoldings: PLN,
+      /** PPK corporate-bond holdings. */
       ppkCorpBondHoldings: PLN,
+      /** Labour Fund cash balance. */
       fpCash: PLN,
+      /** PFRON cash balance. */
       pfronCash: PLN,
+      /** FGSP cash balance. */
       fgspCash: PLN,
+      /** Local-government cash balance. */
       jstCash: PLN,
+      /** Other fund-sector corporate-bond holdings. */
       corpBondOtherHoldings: PLN,
+      /** NBFI fund-bucket financial balances. */
       nbfi: NbfiFundBalances,
+      /** Quasi-fiscal vehicle financial balances. */
       quasiFiscal: QuasiFiscalBalances,
   )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
@@ -1,0 +1,92 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.types.PLN
+
+final case class LedgerFinancialState(
+    households: Vector[LedgerFinancialState.HouseholdBalances],
+    firms: Vector[LedgerFinancialState.FirmBalances],
+    banks: Vector[LedgerFinancialState.BankBalances],
+    government: LedgerFinancialState.GovernmentBalances,
+    foreign: LedgerFinancialState.ForeignBalances,
+    nbp: LedgerFinancialState.NbpBalances,
+    insurance: LedgerFinancialState.InsuranceBalances,
+    funds: LedgerFinancialState.FundBalances,
+)
+
+object LedgerFinancialState:
+
+  case class HouseholdBalances(
+      demandDeposit: PLN,
+      mortgageLoan: PLN,
+      consumerLoan: PLN,
+      equity: PLN,
+  )
+
+  case class FirmBalances(
+      cash: PLN,
+      firmLoan: PLN,
+      corpBond: PLN,
+      equity: PLN,
+  )
+
+  case class BankBalances(
+      totalDeposits: PLN,
+      demandDeposit: PLN,
+      termDeposit: PLN,
+      firmLoan: PLN,
+      consumerLoan: PLN,
+      govBondAfs: PLN,
+      govBondHtm: PLN,
+      reserve: PLN,
+      interbankLoan: PLN,
+      corpBond: PLN,
+  )
+
+  case class GovernmentBalances(
+      govBondOutstanding: PLN,
+  )
+
+  case class ForeignBalances(
+      govBondHoldings: PLN,
+  )
+
+  case class NbpBalances(
+      govBondHoldings: PLN,
+      foreignAssets: PLN,
+  )
+
+  case class InsuranceBalances(
+      lifeReserve: PLN,
+      nonLifeReserve: PLN,
+      govBondHoldings: PLN,
+      corpBondHoldings: PLN,
+      equityHoldings: PLN,
+  )
+
+  case class NbfiFundBalances(
+      tfiUnit: PLN,
+      govBondHoldings: PLN,
+      corpBondHoldings: PLN,
+      equityHoldings: PLN,
+      cashHoldings: PLN,
+      nbfiLoanStock: PLN,
+  )
+
+  case class QuasiFiscalBalances(
+      bondsOutstanding: PLN,
+      loanPortfolio: PLN,
+  )
+
+  case class FundBalances(
+      zusCash: PLN,
+      nfzCash: PLN,
+      ppkGovBondHoldings: PLN,
+      ppkCorpBondHoldings: PLN,
+      fpCash: PLN,
+      pfronCash: PLN,
+      fgspCash: PLN,
+      jstCash: PLN,
+      corpBondOtherHoldings: PLN,
+      nbfi: NbfiFundBalances,
+      quasiFiscal: QuasiFiscalBalances,
+  )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -2,7 +2,6 @@ package com.boombustgroup.amorfati.engine.ledger
 
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
 import com.boombustgroup.amorfati.engine.World
-import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
@@ -261,9 +260,6 @@ object LedgerStateAdapter:
       ),
     )
 
-  def captureLedgerFinancialState(sim: FlowSimulation.SimState): LedgerFinancialState =
-    sim.ledgerFinancialState
-
   /** Financial fields intentionally left outside current ledger mapping because
     * the public `EntitySector` / `AssetType` API does not yet name them
     * cleanly, or because they are fiscal/accounting metrics rather than
@@ -306,22 +302,8 @@ object LedgerStateAdapter:
     populate(state, ledgerFinancialState)
     state
 
-  def roundTripLedgerFinancialState(sim: FlowSimulation.SimState): LedgerFinancialState =
-    readLedgerFinancialState(toMutableWorldState(sim))
-
   def roundTripLedgerFinancialState(ledgerFinancialState: LedgerFinancialState): LedgerFinancialState =
     readLedgerFinancialState(toMutableWorldState(ledgerFinancialState))
-
-  def roundTripLedgerFinancialState(
-      world: World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      banks: Vector[Banking.BankState],
-      householdAggregates: Household.Aggregates,
-  ): LedgerFinancialState =
-    roundTripLedgerFinancialState(
-      FlowSimulation.SimState(CompletedMonth.Zero, world, firms, households, banks, householdAggregates),
-    )
 
   def populate(state: MutableWorldState, sim: FlowSimulation.SimState): Unit =
     populate(state, sim.ledgerFinancialState)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.ledger
 
-import com.boombustgroup.amorfati.agents.{Banking, Firm, Household}
+import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi}
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
@@ -203,6 +203,39 @@ object LedgerStateAdapter:
       insuranceHoldings = ledgerFinancialState.insurance.corpBondHoldings,
       tfiHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
       otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
+    )
+
+  def projectInsuranceState(
+      base: Insurance.State,
+      ledgerFinancialState: LedgerFinancialState,
+  ): Insurance.State =
+    base.copy(
+      reserves = base.reserves.copy(
+        lifeReserves = ledgerFinancialState.insurance.lifeReserve,
+        nonLifeReserves = ledgerFinancialState.insurance.nonLifeReserve,
+      ),
+      portfolio = base.portfolio.copy(
+        govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
+        corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
+        equityHoldings = ledgerFinancialState.insurance.equityHoldings,
+      ),
+    )
+
+  def projectNbfiState(
+      base: Nbfi.State,
+      ledgerFinancialState: LedgerFinancialState,
+  ): Nbfi.State =
+    base.copy(
+      tfi = base.tfi.copy(
+        tfiAum = ledgerFinancialState.funds.nbfi.tfiUnit,
+        tfiGovBondHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
+        tfiCorpBondHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
+        tfiEquityHoldings = ledgerFinancialState.funds.nbfi.equityHoldings,
+        tfiCashHoldings = ledgerFinancialState.funds.nbfi.cashHoldings,
+      ),
+      credit = base.credit.copy(
+        nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
+      ),
     )
 
   /** Transitional capture from mirrored world/agent state into the first-class

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.engine.ledger
 
-import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi}
-import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi, Nbp}
+import com.boombustgroup.amorfati.engine.{SocialState, World}
+import com.boombustgroup.amorfati.engine.markets.FiscalBudget
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
@@ -218,6 +219,44 @@ object LedgerStateAdapter:
         govBondHoldings = ledgerFinancialState.insurance.govBondHoldings,
         corpBondHoldings = ledgerFinancialState.insurance.corpBondHoldings,
         equityHoldings = ledgerFinancialState.insurance.equityHoldings,
+      ),
+    )
+
+  def projectGovState(
+      base: FiscalBudget.GovState,
+      ledgerFinancialState: LedgerFinancialState,
+  ): FiscalBudget.GovState =
+    base.copy(
+      financial = base.financial.copy(
+        bondsOutstanding = ledgerFinancialState.government.govBondOutstanding,
+        foreignBondHoldings = ledgerFinancialState.foreign.govBondHoldings,
+      ),
+    )
+
+  def projectNbpState(
+      base: Nbp.State,
+      ledgerFinancialState: LedgerFinancialState,
+  ): Nbp.State =
+    base.copy(
+      balance = base.balance.copy(
+        govBondHoldings = ledgerFinancialState.nbp.govBondHoldings,
+        fxReserves = ledgerFinancialState.nbp.foreignAssets,
+      ),
+    )
+
+  def projectSocialState(
+      base: SocialState,
+      ledgerFinancialState: LedgerFinancialState,
+  ): SocialState =
+    base.copy(
+      jst = base.jst.copy(deposits = ledgerFinancialState.funds.jstCash),
+      zus = base.zus.copy(fusBalance = ledgerFinancialState.funds.zusCash),
+      nfz = base.nfz.copy(balance = ledgerFinancialState.funds.nfzCash),
+      ppk = base.ppk.copy(bondHoldings = ledgerFinancialState.funds.ppkGovBondHoldings),
+      earmarked = base.earmarked.copy(
+        fp = base.earmarked.fp.copy(balance = ledgerFinancialState.funds.fpCash),
+        pfron = base.earmarked.pfron.copy(balance = ledgerFinancialState.funds.pfronCash),
+        fgsp = base.earmarked.fgsp.copy(balance = ledgerFinancialState.funds.fgspCash),
       ),
     )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -1,8 +1,8 @@
 package com.boombustgroup.amorfati.engine.ledger
 
-import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi, Nbp}
+import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi, Nbp, QuasiFiscal}
 import com.boombustgroup.amorfati.engine.{SocialState, World}
-import com.boombustgroup.amorfati.engine.markets.FiscalBudget
+import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, FiscalBudget}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
@@ -149,6 +149,67 @@ object LedgerStateAdapter:
       corpBond = b.corpBondHoldings,
     )
 
+  def governmentBalances(gov: FiscalBudget.GovState): GovernmentBalances =
+    GovernmentBalances(
+      govBondOutstanding = gov.bondsOutstanding,
+    )
+
+  def foreignBalances(gov: FiscalBudget.GovState): ForeignBalances =
+    ForeignBalances(
+      govBondHoldings = gov.foreignBondHoldings,
+    )
+
+  def nbpBalances(nbp: Nbp.State): NbpBalances =
+    NbpBalances(
+      govBondHoldings = nbp.govBondHoldings,
+      foreignAssets = nbp.fxReserves,
+    )
+
+  def insuranceBalances(insurance: Insurance.State): InsuranceBalances =
+    InsuranceBalances(
+      lifeReserve = insurance.lifeReserves,
+      nonLifeReserve = insurance.nonLifeReserves,
+      govBondHoldings = insurance.govBondHoldings,
+      corpBondHoldings = insurance.corpBondHoldings,
+      equityHoldings = insurance.equityHoldings,
+    )
+
+  def nbfiFundBalances(nbfi: Nbfi.State): NbfiFundBalances =
+    NbfiFundBalances(
+      tfiUnit = nbfi.tfiAum,
+      govBondHoldings = nbfi.tfiGovBondHoldings,
+      corpBondHoldings = nbfi.tfiCorpBondHoldings,
+      equityHoldings = nbfi.tfiEquityHoldings,
+      cashHoldings = nbfi.tfiCashHoldings,
+      nbfiLoanStock = nbfi.nbfiLoanStock,
+    )
+
+  def quasiFiscalBalances(quasiFiscal: QuasiFiscal.State): QuasiFiscalBalances =
+    QuasiFiscalBalances(
+      bondsOutstanding = quasiFiscal.bondsOutstanding,
+      loanPortfolio = quasiFiscal.loanPortfolio,
+    )
+
+  def fundBalances(
+      social: SocialState,
+      corporateBonds: CorporateBondMarket.State,
+      nbfi: Nbfi.State,
+      quasiFiscal: QuasiFiscal.State,
+  ): FundBalances =
+    FundBalances(
+      zusCash = social.zus.fusBalance,
+      nfzCash = social.nfz.balance,
+      ppkGovBondHoldings = social.ppk.bondHoldings,
+      ppkCorpBondHoldings = corporateBonds.ppkHoldings,
+      fpCash = social.earmarked.fpBalance,
+      pfronCash = social.earmarked.pfronBalance,
+      fgspCash = social.earmarked.fgspBalance,
+      jstCash = social.jst.deposits,
+      corpBondOtherHoldings = corporateBonds.otherHoldings,
+      nbfi = nbfiFundBalances(nbfi),
+      quasiFiscal = quasiFiscalBalances(quasiFiscal),
+    )
+
   def governmentBondCircuit(
       world: World,
       banks: Vector[Banking.BankState],
@@ -290,46 +351,11 @@ object LedgerStateAdapter:
       households = households.map(householdBalances),
       firms = firms.map(firmBalances),
       banks = banks.map(bankBalances),
-      government = GovernmentBalances(
-        govBondOutstanding = world.gov.bondsOutstanding,
-      ),
-      foreign = ForeignBalances(
-        govBondHoldings = world.gov.foreignBondHoldings,
-      ),
-      nbp = NbpBalances(
-        govBondHoldings = world.nbp.govBondHoldings,
-        foreignAssets = world.nbp.fxReserves,
-      ),
-      insurance = InsuranceBalances(
-        lifeReserve = world.financial.insurance.lifeReserves,
-        nonLifeReserve = world.financial.insurance.nonLifeReserves,
-        govBondHoldings = world.financial.insurance.govBondHoldings,
-        corpBondHoldings = world.financial.insurance.corpBondHoldings,
-        equityHoldings = world.financial.insurance.equityHoldings,
-      ),
-      funds = FundBalances(
-        zusCash = world.social.zus.fusBalance,
-        nfzCash = world.social.nfz.balance,
-        ppkGovBondHoldings = world.social.ppk.bondHoldings,
-        ppkCorpBondHoldings = world.financial.corporateBonds.ppkHoldings,
-        fpCash = world.social.earmarked.fpBalance,
-        pfronCash = world.social.earmarked.pfronBalance,
-        fgspCash = world.social.earmarked.fgspBalance,
-        jstCash = world.social.jst.deposits,
-        corpBondOtherHoldings = world.financial.corporateBonds.otherHoldings,
-        nbfi = NbfiFundBalances(
-          tfiUnit = world.financial.nbfi.tfiAum,
-          govBondHoldings = world.financial.nbfi.tfiGovBondHoldings,
-          corpBondHoldings = world.financial.nbfi.tfiCorpBondHoldings,
-          equityHoldings = world.financial.nbfi.tfiEquityHoldings,
-          cashHoldings = world.financial.nbfi.tfiCashHoldings,
-          nbfiLoanStock = world.financial.nbfi.nbfiLoanStock,
-        ),
-        quasiFiscal = QuasiFiscalBalances(
-          bondsOutstanding = world.financial.quasiFiscal.bondsOutstanding,
-          loanPortfolio = world.financial.quasiFiscal.loanPortfolio,
-        ),
-      ),
+      government = governmentBalances(world.gov),
+      foreign = foreignBalances(world.gov),
+      nbp = nbpBalances(world.nbp),
+      insurance = insuranceBalances(world.financial.insurance),
+      funds = fundBalances(world.social, world.financial.corporateBonds, world.financial.nbfi, world.financial.quasiFiscal),
     )
 
   /** Financial fields intentionally left outside current ledger mapping because

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -6,6 +6,7 @@ import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState.*
 
 /** Narrow bridge between runtime simulation state and ledger-owned financial
   * storage.
@@ -36,37 +37,6 @@ object LedgerStateAdapter:
   private val SingletonSectorSize = 1
   private val ForeignSectorSize   = ForeignRuntimeContract.AllNodes.iterator.map(_.index).max + 1
 
-  case class HouseholdBalances(
-      demandDeposit: PLN,
-      mortgageLoan: PLN,
-      consumerLoan: PLN,
-      equity: PLN,
-  )
-
-  case class FirmBalances(
-      cash: PLN,
-      firmLoan: PLN,
-      corpBond: PLN,
-      equity: PLN,
-  )
-
-  case class BankBalances(
-      totalDeposits: PLN,
-      demandDeposit: PLN,
-      termDeposit: PLN,
-      firmLoan: PLN,
-      consumerLoan: PLN,
-      govBondAfs: PLN,
-      govBondHtm: PLN,
-      reserve: PLN,
-      interbankLoan: PLN,
-      corpBond: PLN,
-  )
-
-  case class GovernmentBalances(
-      govBondOutstanding: PLN,
-  )
-
   case class GovernmentBondCircuit(
       outstanding: PLN,
       bankHoldings: PLN,
@@ -89,62 +59,6 @@ object LedgerStateAdapter:
   ):
     def totalHoldings: PLN =
       bankHoldings + ppkHoldings + insuranceHoldings + tfiHoldings + otherHoldings
-
-  case class ForeignBalances(
-      govBondHoldings: PLN,
-  )
-
-  case class NbpBalances(
-      govBondHoldings: PLN,
-      foreignAssets: PLN,
-  )
-
-  case class InsuranceBalances(
-      lifeReserve: PLN,
-      nonLifeReserve: PLN,
-      govBondHoldings: PLN,
-      corpBondHoldings: PLN,
-      equityHoldings: PLN,
-  )
-
-  case class NbfiFundBalances(
-      tfiUnit: PLN,
-      govBondHoldings: PLN,
-      corpBondHoldings: PLN,
-      equityHoldings: PLN,
-      cashHoldings: PLN,
-      nbfiLoanStock: PLN,
-  )
-
-  case class QuasiFiscalBalances(
-      bondsOutstanding: PLN,
-      loanPortfolio: PLN,
-  )
-
-  case class FundBalances(
-      zusCash: PLN,
-      nfzCash: PLN,
-      ppkGovBondHoldings: PLN,
-      ppkCorpBondHoldings: PLN,
-      fpCash: PLN,
-      pfronCash: PLN,
-      fgspCash: PLN,
-      jstCash: PLN,
-      corpBondOtherHoldings: PLN,
-      nbfi: NbfiFundBalances,
-      quasiFiscal: QuasiFiscalBalances,
-  )
-
-  case class SupportedFinancialSnapshot(
-      households: Vector[HouseholdBalances],
-      firms: Vector[FirmBalances],
-      banks: Vector[BankBalances],
-      government: GovernmentBalances,
-      foreign: ForeignBalances,
-      nbp: NbpBalances,
-      insurance: InsuranceBalances,
-      funds: FundBalances,
-  )
 
   case class UnsupportedBankBalances(
       capital: PLN,
@@ -183,9 +97,9 @@ object LedgerStateAdapter:
   /** Deterministic ledger sector sizes for the current runtime state. */
   def sectorSizes(sim: FlowSimulation.SimState): Map[EntitySector, Int] =
     Map(
-      EntitySector.Households -> sim.households.size,
-      EntitySector.Firms      -> sim.firms.size,
-      EntitySector.Banks      -> sim.banks.size,
+      EntitySector.Households -> sim.ledgerFinancialState.households.size,
+      EntitySector.Firms      -> sim.ledgerFinancialState.firms.size,
+      EntitySector.Banks      -> sim.ledgerFinancialState.banks.size,
       EntitySector.Government -> SingletonSectorSize,
       EntitySector.NBP        -> SingletonSectorSize,
       EntitySector.Insurance  -> SingletonSectorSize,
@@ -193,11 +107,11 @@ object LedgerStateAdapter:
       EntitySector.Foreign    -> ForeignSectorSize,
     )
 
-  def sectorSizes(supported: SupportedFinancialSnapshot): Map[EntitySector, Int] =
+  def sectorSizes(ledgerFinancialState: LedgerFinancialState): Map[EntitySector, Int] =
     Map(
-      EntitySector.Households -> supported.households.size,
-      EntitySector.Firms      -> supported.firms.size,
-      EntitySector.Banks      -> supported.banks.size,
+      EntitySector.Households -> ledgerFinancialState.households.size,
+      EntitySector.Firms      -> ledgerFinancialState.firms.size,
+      EntitySector.Banks      -> ledgerFinancialState.banks.size,
       EntitySector.Government -> SingletonSectorSize,
       EntitySector.NBP        -> SingletonSectorSize,
       EntitySector.Insurance  -> SingletonSectorSize,
@@ -251,17 +165,17 @@ object LedgerStateAdapter:
     )
 
   def governmentBondCircuit(
-      supported: SupportedFinancialSnapshot,
+      ledgerFinancialState: LedgerFinancialState,
   ): GovernmentBondCircuit =
-    val bankGovBondHoldings = supported.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.govBondAfs + bank.govBondHtm)
+    val bankGovBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.govBondAfs + bank.govBondHtm)
     GovernmentBondCircuit(
-      outstanding = supported.government.govBondOutstanding,
+      outstanding = ledgerFinancialState.government.govBondOutstanding,
       bankHoldings = bankGovBondHoldings,
-      foreignHoldings = supported.foreign.govBondHoldings,
-      nbpHoldings = supported.nbp.govBondHoldings,
-      insuranceHoldings = supported.insurance.govBondHoldings,
-      ppkHoldings = supported.funds.ppkGovBondHoldings,
-      tfiHoldings = supported.funds.nbfi.govBondHoldings,
+      foreignHoldings = ledgerFinancialState.foreign.govBondHoldings,
+      nbpHoldings = ledgerFinancialState.nbp.govBondHoldings,
+      insuranceHoldings = ledgerFinancialState.insurance.govBondHoldings,
+      ppkHoldings = ledgerFinancialState.funds.ppkGovBondHoldings,
+      tfiHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
     )
 
   def corporateBondCircuit(
@@ -280,65 +194,75 @@ object LedgerStateAdapter:
     )
 
   def corporateBondCircuit(
-      supported: SupportedFinancialSnapshot,
+      ledgerFinancialState: LedgerFinancialState,
   ): CorporateBondCircuit =
-    val bankCorpBondHoldings = supported.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
+    val bankCorpBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
     CorporateBondCircuit(
-      outstanding = PLN.fromRaw(supported.firms.map(_.corpBond.toLong).sum),
+      outstanding = PLN.fromRaw(ledgerFinancialState.firms.map(_.corpBond.toLong).sum),
       bankHoldings = bankCorpBondHoldings,
-      ppkHoldings = supported.funds.ppkCorpBondHoldings,
-      insuranceHoldings = supported.insurance.corpBondHoldings,
-      tfiHoldings = supported.funds.nbfi.corpBondHoldings,
-      otherHoldings = supported.funds.corpBondOtherHoldings,
+      ppkHoldings = ledgerFinancialState.funds.ppkCorpBondHoldings,
+      insuranceHoldings = ledgerFinancialState.insurance.corpBondHoldings,
+      tfiHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
+      otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
     )
 
-  /** Pure supported-slice read from runtime state. */
-  def supportedSnapshot(sim: FlowSimulation.SimState): SupportedFinancialSnapshot =
-    SupportedFinancialSnapshot(
-      households = sim.households.map(householdBalances),
-      firms = sim.firms.map(firmBalances),
-      banks = sim.banks.map(bankBalances),
+  /** Transitional capture from mirrored world/agent state into the first-class
+    * ledger-backed financial state.
+    */
+  def captureLedgerFinancialState(
+      world: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+  ): LedgerFinancialState =
+    LedgerFinancialState(
+      households = households.map(householdBalances),
+      firms = firms.map(firmBalances),
+      banks = banks.map(bankBalances),
       government = GovernmentBalances(
-        govBondOutstanding = sim.world.gov.bondsOutstanding,
+        govBondOutstanding = world.gov.bondsOutstanding,
       ),
       foreign = ForeignBalances(
-        govBondHoldings = sim.world.gov.foreignBondHoldings,
+        govBondHoldings = world.gov.foreignBondHoldings,
       ),
       nbp = NbpBalances(
-        govBondHoldings = sim.world.nbp.govBondHoldings,
-        foreignAssets = sim.world.nbp.fxReserves,
+        govBondHoldings = world.nbp.govBondHoldings,
+        foreignAssets = world.nbp.fxReserves,
       ),
       insurance = InsuranceBalances(
-        lifeReserve = sim.world.financial.insurance.lifeReserves,
-        nonLifeReserve = sim.world.financial.insurance.nonLifeReserves,
-        govBondHoldings = sim.world.financial.insurance.govBondHoldings,
-        corpBondHoldings = sim.world.financial.insurance.corpBondHoldings,
-        equityHoldings = sim.world.financial.insurance.equityHoldings,
+        lifeReserve = world.financial.insurance.lifeReserves,
+        nonLifeReserve = world.financial.insurance.nonLifeReserves,
+        govBondHoldings = world.financial.insurance.govBondHoldings,
+        corpBondHoldings = world.financial.insurance.corpBondHoldings,
+        equityHoldings = world.financial.insurance.equityHoldings,
       ),
       funds = FundBalances(
-        zusCash = sim.world.social.zus.fusBalance,
-        nfzCash = sim.world.social.nfz.balance,
-        ppkGovBondHoldings = sim.world.social.ppk.bondHoldings,
-        ppkCorpBondHoldings = sim.world.financial.corporateBonds.ppkHoldings,
-        fpCash = sim.world.social.earmarked.fpBalance,
-        pfronCash = sim.world.social.earmarked.pfronBalance,
-        fgspCash = sim.world.social.earmarked.fgspBalance,
-        jstCash = sim.world.social.jst.deposits,
-        corpBondOtherHoldings = sim.world.financial.corporateBonds.otherHoldings,
+        zusCash = world.social.zus.fusBalance,
+        nfzCash = world.social.nfz.balance,
+        ppkGovBondHoldings = world.social.ppk.bondHoldings,
+        ppkCorpBondHoldings = world.financial.corporateBonds.ppkHoldings,
+        fpCash = world.social.earmarked.fpBalance,
+        pfronCash = world.social.earmarked.pfronBalance,
+        fgspCash = world.social.earmarked.fgspBalance,
+        jstCash = world.social.jst.deposits,
+        corpBondOtherHoldings = world.financial.corporateBonds.otherHoldings,
         nbfi = NbfiFundBalances(
-          tfiUnit = sim.world.financial.nbfi.tfiAum,
-          govBondHoldings = sim.world.financial.nbfi.tfiGovBondHoldings,
-          corpBondHoldings = sim.world.financial.nbfi.tfiCorpBondHoldings,
-          equityHoldings = sim.world.financial.nbfi.tfiEquityHoldings,
-          cashHoldings = sim.world.financial.nbfi.tfiCashHoldings,
-          nbfiLoanStock = sim.world.financial.nbfi.nbfiLoanStock,
+          tfiUnit = world.financial.nbfi.tfiAum,
+          govBondHoldings = world.financial.nbfi.tfiGovBondHoldings,
+          corpBondHoldings = world.financial.nbfi.tfiCorpBondHoldings,
+          equityHoldings = world.financial.nbfi.tfiEquityHoldings,
+          cashHoldings = world.financial.nbfi.tfiCashHoldings,
+          nbfiLoanStock = world.financial.nbfi.nbfiLoanStock,
         ),
         quasiFiscal = QuasiFiscalBalances(
-          bondsOutstanding = sim.world.financial.quasiFiscal.bondsOutstanding,
-          loanPortfolio = sim.world.financial.quasiFiscal.loanPortfolio,
+          bondsOutstanding = world.financial.quasiFiscal.bondsOutstanding,
+          loanPortfolio = world.financial.quasiFiscal.loanPortfolio,
         ),
       ),
     )
+
+  def captureLedgerFinancialState(sim: FlowSimulation.SimState): LedgerFinancialState =
+    sim.ledgerFinancialState
 
   /** Financial fields intentionally left outside current ledger mapping because
     * the public `EntitySector` / `AssetType` API does not yet name them
@@ -377,47 +301,48 @@ object LedgerStateAdapter:
     populate(state, sim)
     state
 
-  def toMutableWorldState(supported: SupportedFinancialSnapshot): MutableWorldState =
-    val state = new MutableWorldState(sectorSizes(supported))
-    populate(state, supported)
+  def toMutableWorldState(ledgerFinancialState: LedgerFinancialState): MutableWorldState =
+    val state = new MutableWorldState(sectorSizes(ledgerFinancialState))
+    populate(state, ledgerFinancialState)
     state
 
-  def roundTripSupported(sim: FlowSimulation.SimState): SupportedFinancialSnapshot =
-    readSupported(toMutableWorldState(sim))
+  def roundTripLedgerFinancialState(sim: FlowSimulation.SimState): LedgerFinancialState =
+    readLedgerFinancialState(toMutableWorldState(sim))
 
-  def roundTripSupported(supported: SupportedFinancialSnapshot): SupportedFinancialSnapshot =
-    readSupported(toMutableWorldState(supported))
+  def roundTripLedgerFinancialState(ledgerFinancialState: LedgerFinancialState): LedgerFinancialState =
+    readLedgerFinancialState(toMutableWorldState(ledgerFinancialState))
 
-  def roundTripSupported(
+  def roundTripLedgerFinancialState(
       world: World,
       firms: Vector[Firm.State],
       households: Vector[Household.State],
       banks: Vector[Banking.BankState],
       householdAggregates: Household.Aggregates,
-  ): SupportedFinancialSnapshot =
-    roundTripSupported(FlowSimulation.SimState(CompletedMonth.Zero, world, firms, households, banks, householdAggregates))
+  ): LedgerFinancialState =
+    roundTripLedgerFinancialState(
+      FlowSimulation.SimState(CompletedMonth.Zero, world, firms, households, banks, householdAggregates),
+    )
 
   def populate(state: MutableWorldState, sim: FlowSimulation.SimState): Unit =
-    val supported = supportedSnapshot(sim)
-    populate(state, supported)
+    populate(state, sim.ledgerFinancialState)
 
-  def populate(state: MutableWorldState, supported: SupportedFinancialSnapshot): Unit =
+  def populate(state: MutableWorldState, ledgerFinancialState: LedgerFinancialState): Unit =
 
-    supported.households.zipWithIndex.foreach { (hh, idx) =>
+    ledgerFinancialState.households.zipWithIndex.foreach { (hh, idx) =>
       set(state, EntitySector.Households, AssetType.DemandDeposit, idx, hh.demandDeposit)
       set(state, EntitySector.Households, AssetType.MortgageLoan, idx, hh.mortgageLoan)
       set(state, EntitySector.Households, AssetType.ConsumerLoan, idx, hh.consumerLoan)
       set(state, EntitySector.Households, AssetType.Equity, idx, hh.equity)
     }
 
-    supported.firms.zipWithIndex.foreach { (firm, idx) =>
+    ledgerFinancialState.firms.zipWithIndex.foreach { (firm, idx) =>
       set(state, EntitySector.Firms, AssetType.Cash, idx, firm.cash)
       set(state, EntitySector.Firms, AssetType.FirmLoan, idx, firm.firmLoan)
       set(state, EntitySector.Firms, AssetType.CorpBond, idx, firm.corpBond)
       set(state, EntitySector.Firms, AssetType.Equity, idx, firm.equity)
     }
 
-    supported.banks.zipWithIndex.foreach { (bank, idx) =>
+    ledgerFinancialState.banks.zipWithIndex.foreach { (bank, idx) =>
       set(state, EntitySector.Banks, AssetType.DemandDeposit, idx, bank.demandDeposit)
       set(state, EntitySector.Banks, AssetType.TermDeposit, idx, bank.termDeposit)
       set(state, EntitySector.Banks, AssetType.FirmLoan, idx, bank.firmLoan)
@@ -429,36 +354,42 @@ object LedgerStateAdapter:
       set(state, EntitySector.Banks, AssetType.CorpBond, idx, bank.corpBond)
     }
 
-    set(state, EntitySector.Government, AssetType.GovBondHTM, 0, supported.government.govBondOutstanding)
-    set(state, EntitySector.Foreign, AssetType.GovBondHTM, 0, supported.foreign.govBondHoldings)
-    set(state, EntitySector.NBP, AssetType.GovBondHTM, 0, supported.nbp.govBondHoldings)
-    set(state, EntitySector.NBP, AssetType.ForeignAsset, 0, supported.nbp.foreignAssets)
-    set(state, EntitySector.Insurance, AssetType.LifeReserve, 0, supported.insurance.lifeReserve)
-    set(state, EntitySector.Insurance, AssetType.NonLifeReserve, 0, supported.insurance.nonLifeReserve)
-    set(state, EntitySector.Insurance, AssetType.GovBondHTM, 0, supported.insurance.govBondHoldings)
-    set(state, EntitySector.Insurance, AssetType.CorpBond, 0, supported.insurance.corpBondHoldings)
-    set(state, EntitySector.Insurance, AssetType.Equity, 0, supported.insurance.equityHoldings)
+    set(state, EntitySector.Government, AssetType.GovBondHTM, 0, ledgerFinancialState.government.govBondOutstanding)
+    set(state, EntitySector.Foreign, AssetType.GovBondHTM, 0, ledgerFinancialState.foreign.govBondHoldings)
+    set(state, EntitySector.NBP, AssetType.GovBondHTM, 0, ledgerFinancialState.nbp.govBondHoldings)
+    set(state, EntitySector.NBP, AssetType.ForeignAsset, 0, ledgerFinancialState.nbp.foreignAssets)
+    set(state, EntitySector.Insurance, AssetType.LifeReserve, 0, ledgerFinancialState.insurance.lifeReserve)
+    set(state, EntitySector.Insurance, AssetType.NonLifeReserve, 0, ledgerFinancialState.insurance.nonLifeReserve)
+    set(state, EntitySector.Insurance, AssetType.GovBondHTM, 0, ledgerFinancialState.insurance.govBondHoldings)
+    set(state, EntitySector.Insurance, AssetType.CorpBond, 0, ledgerFinancialState.insurance.corpBondHoldings)
+    set(state, EntitySector.Insurance, AssetType.Equity, 0, ledgerFinancialState.insurance.equityHoldings)
 
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Zus, supported.funds.zusCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nfz, supported.funds.nfzCash)
-    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Ppk, supported.funds.ppkGovBondHoldings)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Ppk, supported.funds.ppkCorpBondHoldings)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp, supported.funds.fpCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron, supported.funds.pfronCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp, supported.funds.fgspCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst, supported.funds.jstCash)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther, supported.funds.corpBondOtherHoldings)
-    set(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi, supported.funds.nbfi.tfiUnit)
-    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi, supported.funds.nbfi.govBondHoldings)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi, supported.funds.nbfi.corpBondHoldings)
-    set(state, EntitySector.Funds, AssetType.Equity, FundIndex.Nbfi, supported.funds.nbfi.equityHoldings)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nbfi, supported.funds.nbfi.cashHoldings)
-    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.Nbfi, supported.funds.nbfi.nbfiLoanStock)
-    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.QuasiFiscal, supported.funds.quasiFiscal.bondsOutstanding)
-    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.QuasiFiscal, supported.funds.quasiFiscal.loanPortfolio)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Zus, ledgerFinancialState.funds.zusCash)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nfz, ledgerFinancialState.funds.nfzCash)
+    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Ppk, ledgerFinancialState.funds.ppkGovBondHoldings)
+    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Ppk, ledgerFinancialState.funds.ppkCorpBondHoldings)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp, ledgerFinancialState.funds.fpCash)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron, ledgerFinancialState.funds.pfronCash)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp, ledgerFinancialState.funds.fgspCash)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst, ledgerFinancialState.funds.jstCash)
+    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther, ledgerFinancialState.funds.corpBondOtherHoldings)
+    set(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.tfiUnit)
+    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.govBondHoldings)
+    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.corpBondHoldings)
+    set(state, EntitySector.Funds, AssetType.Equity, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.equityHoldings)
+    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.cashHoldings)
+    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.nbfiLoanStock)
+    set(
+      state,
+      EntitySector.Funds,
+      AssetType.GovBondHTM,
+      FundIndex.QuasiFiscal,
+      ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
+    )
+    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.QuasiFiscal, ledgerFinancialState.funds.quasiFiscal.loanPortfolio)
 
-  def readSupported(state: MutableWorldState): SupportedFinancialSnapshot =
-    SupportedFinancialSnapshot(
+  def readLedgerFinancialState(state: MutableWorldState): LedgerFinancialState =
+    LedgerFinancialState(
       households = Vector.tabulate(state.sectorSize(EntitySector.Households))(idx =>
         HouseholdBalances(
           demandDeposit = pln(state, EntitySector.Households, AssetType.DemandDeposit, idx),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -5,6 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{MonthRandomness, OperationalSignals}
 import com.boombustgroup.amorfati.engine.flows.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -72,12 +73,25 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
       stageRandomness.priceEquityEconomics,
     )
     val s8     = OpenEconEconomics.runStep(
-      OpenEconEconomics.StepInput(w, s1, s2, s3, s4, s5, s6, s7, init.banks, stageRandomness.openEconEconomics),
+      OpenEconEconomics.StepInput(
+        w,
+        LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks),
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        init.banks,
+        stageRandomness.openEconEconomics,
+      ),
     )
 
     val res = BankingEconomics.compute(
       BankingEconomics.Input(
         w = w,
+        ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks),
         month = s1.m,
         lendingBaseRate = s1.lendingBaseRate,
         resWage = s1.resWage,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.{MonthRandomness, OperationalSignals}
+import com.boombustgroup.amorfati.engine.{MonthRandomness, OperationalSignals, World}
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -16,6 +16,14 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
   private val TestSeed       = 42L
+
+  private def ledgerState(
+      world: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+  ) =
+    LedgerStateAdapter.captureLedgerFinancialState(world, firms, households, banks)
 
   "BankingEconomics (own Input)" should "produce flows that close at SFC == 0L" in {
     val init            = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
@@ -75,7 +83,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     val s8     = OpenEconEconomics.runStep(
       OpenEconEconomics.StepInput(
         w,
-        LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks),
+        ledgerState(w, init.firms, init.households, init.banks),
         s1,
         s2,
         s3,
@@ -91,7 +99,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     val res = BankingEconomics.compute(
       BankingEconomics.Input(
         w = w,
-        ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks),
+        ledgerFinancialState = ledgerState(w, init.firms, init.households, init.banks),
         month = s1.m,
         lendingBaseRate = s1.lendingBaseRate,
         resWage = s1.resWage,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -17,9 +18,11 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
   private val TestSeed       = 42L
 
-  private val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
-  private val w    = init.world
-  private val rng  = RandomStream.seeded(TestSeed)
+  private val init                     = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
+  private val w                        = init.world
+  private val baseLedgerFinancialState =
+    LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks)
+  private val rng                      = RandomStream.seeded(TestSeed)
 
   // Run pipeline through Economics objects
   private val fiscal = FiscalConstraintEconomics.compute(w, init.banks, ExecutionMonth.First)
@@ -66,6 +69,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
   private val newResult = OpenEconEconomics.compute(
     OpenEconEconomics.Input(
       w = w,
+      ledgerFinancialState = baseLedgerFinancialState,
       banks = init.banks,
       employed = s2.employed,
       newWage = s2.newWage,
@@ -133,6 +137,110 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
 
   it should "produce a valid bond yield" in {
     ComputationBoundary.toDouble(newResult.newBondYield) should be >= 0.0
+  }
+
+  it should "read supported bond and insurance stocks from LedgerFinancialState" in {
+    val mismatchedWorld = w.copy(
+      gov = w.gov.copy(
+        financial = w.gov.financial.copy(
+          bondsOutstanding = w.gov.bondsOutstanding + PLN(101),
+          foreignBondHoldings = w.gov.foreignBondHoldings + PLN(102),
+        ),
+      ),
+      nbp = w.nbp.copy(
+        balance = w.nbp.balance.copy(
+          govBondHoldings = w.nbp.govBondHoldings + PLN(103),
+          fxReserves = w.nbp.fxReserves + PLN(104),
+        ),
+      ),
+      financial = w.financial.copy(
+        insurance = w.financial.insurance.copy(
+          reserves = w.financial.insurance.reserves.copy(
+            lifeReserves = w.financial.insurance.lifeReserves + PLN(105),
+            nonLifeReserves = w.financial.insurance.nonLifeReserves + PLN(106),
+          ),
+          portfolio = w.financial.insurance.portfolio.copy(
+            govBondHoldings = w.financial.insurance.govBondHoldings + PLN(107),
+            corpBondHoldings = w.financial.insurance.corpBondHoldings + PLN(108),
+            equityHoldings = w.financial.insurance.equityHoldings + PLN(109),
+          ),
+        ),
+      ),
+    )
+
+    val aligned    = OpenEconEconomics.compute(
+      OpenEconEconomics.Input(
+        w = w,
+        ledgerFinancialState = baseLedgerFinancialState,
+        banks = init.banks,
+        employed = s2.employed,
+        newWage = s2.newWage,
+        domesticConsumption = s3.domesticCons,
+        importConsumption = s3.importCons,
+        totalTechAndInvImports = s5.sumTechImp,
+        gdp = s7.gdp,
+        newInflation = s7.newInfl,
+        autoRatio = s7.autoR,
+        govPurchases = s4.govPurchases,
+        sectorMults = s4.sectorMults,
+        livingFirms = s5.ioFirms,
+        totalBondDefault = s5.totalBondDefault,
+        actualBondIssuance = s5.actualBondIssuance,
+        corpBondAbsorption = s5.corpBondAbsorption,
+        euMonthly = s7.euMonthly,
+        remittanceOutflow = s6.remittanceOutflow,
+        diasporaInflow = s6.diasporaInflow,
+        tourismExport = s6.tourismExport,
+        tourismImport = s6.tourismImport,
+        equityReturn = w.financial.equity.monthlyReturn,
+        investmentImports = s7.investmentImports,
+        profitShifting = s5.sumProfitShifting,
+        fdiRepatriation = s5.sumFdiRepatriation,
+        foreignDividendOutflow = s7.foreignDividendOutflow,
+        month = s1.m,
+        commodityRng = RandomStream.seeded(TestSeed),
+      ),
+    )
+    val fromLedger = OpenEconEconomics.compute(
+      OpenEconEconomics.Input(
+        w = mismatchedWorld,
+        ledgerFinancialState = baseLedgerFinancialState,
+        banks = init.banks,
+        employed = s2.employed,
+        newWage = s2.newWage,
+        domesticConsumption = s3.domesticCons,
+        importConsumption = s3.importCons,
+        totalTechAndInvImports = s5.sumTechImp,
+        gdp = s7.gdp,
+        newInflation = s7.newInfl,
+        autoRatio = s7.autoR,
+        govPurchases = s4.govPurchases,
+        sectorMults = s4.sectorMults,
+        livingFirms = s5.ioFirms,
+        totalBondDefault = s5.totalBondDefault,
+        actualBondIssuance = s5.actualBondIssuance,
+        corpBondAbsorption = s5.corpBondAbsorption,
+        euMonthly = s7.euMonthly,
+        remittanceOutflow = s6.remittanceOutflow,
+        diasporaInflow = s6.diasporaInflow,
+        tourismExport = s6.tourismExport,
+        tourismImport = s6.tourismImport,
+        equityReturn = w.financial.equity.monthlyReturn,
+        investmentImports = s7.investmentImports,
+        profitShifting = s5.sumProfitShifting,
+        fdiRepatriation = s5.sumFdiRepatriation,
+        foreignDividendOutflow = s7.foreignDividendOutflow,
+        month = s1.m,
+        commodityRng = RandomStream.seeded(TestSeed),
+      ),
+    )
+
+    fromLedger.newWeightedCoupon shouldBe aligned.newWeightedCoupon
+    fromLedger.monthlyDebtService shouldBe aligned.monthlyDebtService
+    fromLedger.nbpRemittance shouldBe aligned.nbpRemittance
+    fromLedger.newNbpGovBondHoldings shouldBe aligned.newNbpGovBondHoldings
+    fromLedger.newNbpFxReserves shouldBe aligned.newNbpFxReserves
+    fromLedger.insInvestmentIncome shouldBe aligned.insInvestmentIncome
   }
 
   it should "produce non-negative interbank flows" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -4,6 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthRandomness, MonthTraceStage, OperationalSignals, SignalExtraction, World}
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -92,11 +93,36 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     )
     val s8     =
       OpenEconEconomics.runStep(
-        OpenEconEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, init.banks, contract.stages.openEconEconomics.newStream()),
+        OpenEconEconomics.StepInput(
+          world,
+          LedgerStateAdapter.captureLedgerFinancialState(world, init.firms, init.households, init.banks),
+          s1,
+          s2,
+          s3,
+          s4,
+          s5,
+          s6,
+          s7,
+          init.banks,
+          contract.stages.openEconEconomics.newStream(),
+        ),
       )
     val s9     =
       BankingEconomics.runStep(
-        BankingEconomics.StepInput(world, s1, s2, s3, s4, s5, s6, s7, s8, init.banks, contract.stages.bankingEconomics.newStream()),
+        BankingEconomics.StepInput(
+          world,
+          LedgerStateAdapter.captureLedgerFinancialState(world, init.firms, init.households, init.banks),
+          s1,
+          s2,
+          s3,
+          s4,
+          s5,
+          s6,
+          s7,
+          s8,
+          init.banks,
+          contract.stages.bankingEconomics.newStream(),
+        ),
       )
 
     PipelineFixture(world, init.firms, init.households, init.banks, s1, s2Pre, s2, s3, s4, s5, s6, s7, s8, s9)
@@ -107,6 +133,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       baseline.firms,
       baseline.households,
       baseline.banks,
+      LedgerStateAdapter.captureLedgerFinancialState(baseline.world, baseline.firms, baseline.households, baseline.banks),
       baseline.s1,
       baseline.s2,
       baseline.s3,
@@ -167,6 +194,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
   private def baseBankingComputeInput(world: World, operationalSignals: OperationalSignals, seed: Long): BankingEconomics.Input =
     BankingEconomics.Input(
       w = world,
+      ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, baseline.firms, baseline.households, baseline.banks),
       month = baseline.s1.m,
       lendingBaseRate = baseline.s1.lendingBaseRate,
       resWage = baseline.s1.resWage,
@@ -198,6 +226,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       firms = baseline.firms,
       households = baseline.households,
       banks = baseline.banks,
+      ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, baseline.firms, baseline.households, baseline.banks),
       month = baseline.s1.m,
       lendingBaseRate = baseline.s1.lendingBaseRate,
       resWage = baseline.s1.resWage,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -15,6 +15,14 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
+  private def ledgerState(
+      world: World,
+      firms: Vector[Firm.State],
+      households: Vector[Household.State],
+      banks: Vector[Banking.BankState],
+  ) =
+    LedgerStateAdapter.captureLedgerFinancialState(world, firms, households, banks)
+
   private case class PipelineFixture(
       world: World,
       firms: Vector[Firm.State],
@@ -95,7 +103,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       OpenEconEconomics.runStep(
         OpenEconEconomics.StepInput(
           world,
-          LedgerStateAdapter.captureLedgerFinancialState(world, init.firms, init.households, init.banks),
+          ledgerState(world, init.firms, init.households, init.banks),
           s1,
           s2,
           s3,
@@ -111,7 +119,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       BankingEconomics.runStep(
         BankingEconomics.StepInput(
           world,
-          LedgerStateAdapter.captureLedgerFinancialState(world, init.firms, init.households, init.banks),
+          ledgerState(world, init.firms, init.households, init.banks),
           s1,
           s2,
           s3,
@@ -133,7 +141,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       baseline.firms,
       baseline.households,
       baseline.banks,
-      LedgerStateAdapter.captureLedgerFinancialState(baseline.world, baseline.firms, baseline.households, baseline.banks),
+      ledgerState(baseline.world, baseline.firms, baseline.households, baseline.banks),
       baseline.s1,
       baseline.s2,
       baseline.s3,
@@ -194,7 +202,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
   private def baseBankingComputeInput(world: World, operationalSignals: OperationalSignals, seed: Long): BankingEconomics.Input =
     BankingEconomics.Input(
       w = world,
-      ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, baseline.firms, baseline.households, baseline.banks),
+      ledgerFinancialState = ledgerState(world, baseline.firms, baseline.households, baseline.banks),
       month = baseline.s1.m,
       lendingBaseRate = baseline.s1.lendingBaseRate,
       resWage = baseline.s1.resWage,
@@ -226,7 +234,7 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       firms = baseline.firms,
       households = baseline.households,
       banks = baseline.banks,
-      ledgerFinancialState = LedgerStateAdapter.captureLedgerFinancialState(world, baseline.firms, baseline.households, baseline.banks),
+      ledgerFinancialState = ledgerState(world, baseline.firms, baseline.households, baseline.banks),
       month = baseline.s1.m,
       lendingBaseRate = baseline.s1.lendingBaseRate,
       resWage = baseline.s1.resWage,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.{ComputationBoundary, PLN}
@@ -56,8 +56,8 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "overwrite only supported financial slice from ledger snapshot while preserving unsupported QE metrics" in {
-    val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
-    val base      = init.world.copy(
+    val init                 = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val base                 = init.world.copy(
       gov = init.world.gov.copy(
         financial = init.world.gov.financial.copy(
           cumulativeDebt = PLN(101),
@@ -121,16 +121,16 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
     )
-    val supported = LedgerStateAdapter.SupportedFinancialSnapshot(
+    val ledgerFinancialState = LedgerFinancialState(
       households = Vector.empty,
       firms = Vector(
-        LedgerStateAdapter.FirmBalances(
+        LedgerFinancialState.FirmBalances(
           cash = PLN.Zero,
           firmLoan = PLN.Zero,
           corpBond = PLN(301),
           equity = PLN.Zero,
         ),
-        LedgerStateAdapter.FirmBalances(
+        LedgerFinancialState.FirmBalances(
           cash = PLN.Zero,
           firmLoan = PLN.Zero,
           corpBond = PLN(302),
@@ -138,7 +138,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       banks = Vector(
-        LedgerStateAdapter.BankBalances(
+        LedgerFinancialState.BankBalances(
           totalDeposits = PLN.Zero,
           demandDeposit = PLN.Zero,
           termDeposit = PLN.Zero,
@@ -150,7 +150,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
           interbankLoan = PLN.Zero,
           corpBond = PLN(7),
         ),
-        LedgerStateAdapter.BankBalances(
+        LedgerFinancialState.BankBalances(
           totalDeposits = PLN.Zero,
           demandDeposit = PLN.Zero,
           termDeposit = PLN.Zero,
@@ -163,20 +163,20 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
           corpBond = PLN(11),
         ),
       ),
-      government = LedgerStateAdapter.GovernmentBalances(PLN(201)),
-      foreign = LedgerStateAdapter.ForeignBalances(PLN(202)),
-      nbp = LedgerStateAdapter.NbpBalances(
+      government = LedgerFinancialState.GovernmentBalances(PLN(201)),
+      foreign = LedgerFinancialState.ForeignBalances(PLN(202)),
+      nbp = LedgerFinancialState.NbpBalances(
         govBondHoldings = PLN(203),
         foreignAssets = PLN(204),
       ),
-      insurance = LedgerStateAdapter.InsuranceBalances(
+      insurance = LedgerFinancialState.InsuranceBalances(
         lifeReserve = PLN(205),
         nonLifeReserve = PLN(206),
         govBondHoldings = PLN(207),
         corpBondHoldings = PLN(208),
         equityHoldings = PLN(209),
       ),
-      funds = LedgerStateAdapter.FundBalances(
+      funds = LedgerFinancialState.FundBalances(
         zusCash = PLN(210),
         nfzCash = PLN(211),
         ppkGovBondHoldings = PLN(212),
@@ -186,7 +186,7 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
         fgspCash = PLN(216),
         jstCash = PLN(217),
         corpBondOtherHoldings = PLN(218),
-        nbfi = LedgerStateAdapter.NbfiFundBalances(
+        nbfi = LedgerFinancialState.NbfiFundBalances(
           tfiUnit = PLN(219),
           govBondHoldings = PLN(220),
           corpBondHoldings = PLN(221),
@@ -194,14 +194,14 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
           cashHoldings = PLN(223),
           nbfiLoanStock = PLN(224),
         ),
-        quasiFiscal = LedgerStateAdapter.QuasiFiscalBalances(
+        quasiFiscal = LedgerFinancialState.QuasiFiscalBalances(
           bondsOutstanding = PLN(225),
           loanPortfolio = PLN(226),
         ),
       ),
     )
 
-    val updated = WorldAssemblyEconomics.withLedgerSupportedFinancialState(base, supported)
+    val updated = WorldAssemblyEconomics.withLedgerFinancialState(base, ledgerFinancialState)
 
     updated.gov.bondsOutstanding shouldBe PLN(201)
     updated.gov.foreignBondHoldings shouldBe PLN(202)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -3,10 +3,10 @@ package com.boombustgroup.amorfati.engine.economics
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
-import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
-import com.boombustgroup.amorfati.types.{ComputationBoundary, PLN}
+import com.boombustgroup.amorfati.types.ComputationBoundary
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -55,191 +55,15 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     w.gov.domesticBudgetOutlays.should(be >= w.gov.domesticBudgetDemand)
   }
 
-  it should "overwrite only supported financial slice from ledger snapshot while preserving unsupported QE metrics" in {
-    val init                 = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
-    val base                 = init.world.copy(
-      gov = init.world.gov.copy(
-        financial = init.world.gov.financial.copy(
-          cumulativeDebt = PLN(101),
-          bondsOutstanding = PLN(102),
-          foreignBondHoldings = PLN(103),
-        ),
-      ),
-      nbp = init.world.nbp.copy(
-        balance = init.world.nbp.balance.copy(
-          govBondHoldings = PLN(104),
-          qeCumulative = PLN(105),
-          fxReserves = PLN(106),
-        ),
-      ),
-      social = init.world.social.copy(
-        jst = init.world.social.jst.copy(deposits = PLN(107), debt = PLN(108)),
-        zus = init.world.social.zus.copy(fusBalance = PLN(109)),
-        nfz = init.world.social.nfz.copy(balance = PLN(110)),
-        ppk = init.world.social.ppk.copy(bondHoldings = PLN(111)),
-        earmarked = init.world.social.earmarked.copy(
-          fp = init.world.social.earmarked.fp.copy(balance = PLN(112)),
-          pfron = init.world.social.earmarked.pfron.copy(balance = PLN(113)),
-          fgsp = init.world.social.earmarked.fgsp.copy(balance = PLN(114)),
-        ),
-      ),
-      financial = init.world.financial.copy(
-        corporateBonds = init.world.financial.corporateBonds.copy(
-          outstanding = PLN(115),
-          bankHoldings = PLN(116),
-          ppkHoldings = PLN(117),
-          otherHoldings = PLN(118),
-        ),
-        insurance = init.world.financial.insurance.copy(
-          reserves = init.world.financial.insurance.reserves.copy(
-            lifeReserves = PLN(119),
-            nonLifeReserves = PLN(120),
-          ),
-          portfolio = init.world.financial.insurance.portfolio.copy(
-            govBondHoldings = PLN(121),
-            corpBondHoldings = PLN(122),
-            equityHoldings = PLN(123),
-          ),
-        ),
-        nbfi = init.world.financial.nbfi.copy(
-          tfi = init.world.financial.nbfi.tfi.copy(
-            tfiAum = PLN(124),
-            tfiGovBondHoldings = PLN(125),
-            tfiCorpBondHoldings = PLN(126),
-            tfiEquityHoldings = PLN(127),
-            tfiCashHoldings = PLN(128),
-          ),
-          credit = init.world.financial.nbfi.credit.copy(
-            nbfiLoanStock = PLN(129),
-          ),
-        ),
-        quasiFiscal = init.world.financial.quasiFiscal.copy(
-          bondsOutstanding = PLN(130),
-          bankHoldings = PLN(131),
-          nbpHoldings = PLN(132),
-          loanPortfolio = PLN(133),
-        ),
-      ),
-    )
-    val ledgerFinancialState = LedgerFinancialState(
-      households = Vector.empty,
-      firms = Vector(
-        LedgerFinancialState.FirmBalances(
-          cash = PLN.Zero,
-          firmLoan = PLN.Zero,
-          corpBond = PLN(301),
-          equity = PLN.Zero,
-        ),
-        LedgerFinancialState.FirmBalances(
-          cash = PLN.Zero,
-          firmLoan = PLN.Zero,
-          corpBond = PLN(302),
-          equity = PLN.Zero,
-        ),
-      ),
-      banks = Vector(
-        LedgerFinancialState.BankBalances(
-          totalDeposits = PLN.Zero,
-          demandDeposit = PLN.Zero,
-          termDeposit = PLN.Zero,
-          firmLoan = PLN.Zero,
-          consumerLoan = PLN.Zero,
-          govBondAfs = PLN.Zero,
-          govBondHtm = PLN.Zero,
-          reserve = PLN.Zero,
-          interbankLoan = PLN.Zero,
-          corpBond = PLN(7),
-        ),
-        LedgerFinancialState.BankBalances(
-          totalDeposits = PLN.Zero,
-          demandDeposit = PLN.Zero,
-          termDeposit = PLN.Zero,
-          firmLoan = PLN.Zero,
-          consumerLoan = PLN.Zero,
-          govBondAfs = PLN.Zero,
-          govBondHtm = PLN.Zero,
-          reserve = PLN.Zero,
-          interbankLoan = PLN.Zero,
-          corpBond = PLN(11),
-        ),
-      ),
-      government = LedgerFinancialState.GovernmentBalances(PLN(201)),
-      foreign = LedgerFinancialState.ForeignBalances(PLN(202)),
-      nbp = LedgerFinancialState.NbpBalances(
-        govBondHoldings = PLN(203),
-        foreignAssets = PLN(204),
-      ),
-      insurance = LedgerFinancialState.InsuranceBalances(
-        lifeReserve = PLN(205),
-        nonLifeReserve = PLN(206),
-        govBondHoldings = PLN(207),
-        corpBondHoldings = PLN(208),
-        equityHoldings = PLN(209),
-      ),
-      funds = LedgerFinancialState.FundBalances(
-        zusCash = PLN(210),
-        nfzCash = PLN(211),
-        ppkGovBondHoldings = PLN(212),
-        ppkCorpBondHoldings = PLN(213),
-        fpCash = PLN(214),
-        pfronCash = PLN(215),
-        fgspCash = PLN(216),
-        jstCash = PLN(217),
-        corpBondOtherHoldings = PLN(218),
-        nbfi = LedgerFinancialState.NbfiFundBalances(
-          tfiUnit = PLN(219),
-          govBondHoldings = PLN(220),
-          corpBondHoldings = PLN(221),
-          equityHoldings = PLN(222),
-          cashHoldings = PLN(223),
-          nbfiLoanStock = PLN(224),
-        ),
-        quasiFiscal = LedgerFinancialState.QuasiFiscalBalances(
-          bondsOutstanding = PLN(225),
-          loanPortfolio = PLN(226),
-        ),
-      ),
-    )
+  it should "keep world mirrors aligned with LedgerFinancialState after assembly" in {
+    val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state     = FlowSimulation.SimState.fromInit(init)
+    val nextState = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L)).nextState
 
-    val updated = WorldAssemblyEconomics.withLedgerFinancialState(base, ledgerFinancialState)
-
-    updated.gov.bondsOutstanding shouldBe PLN(201)
-    updated.gov.foreignBondHoldings shouldBe PLN(202)
-    updated.gov.cumulativeDebt shouldBe PLN(101)
-
-    updated.nbp.govBondHoldings shouldBe PLN(203)
-    updated.nbp.fxReserves shouldBe PLN(204)
-    updated.nbp.qeCumulative shouldBe PLN(105)
-
-    updated.social.jst.deposits shouldBe PLN(217)
-    updated.social.zus.fusBalance shouldBe PLN(210)
-    updated.social.nfz.balance shouldBe PLN(211)
-    updated.social.ppk.bondHoldings shouldBe PLN(212)
-    updated.social.earmarked.fpBalance shouldBe PLN(214)
-    updated.social.earmarked.pfronBalance shouldBe PLN(215)
-    updated.social.earmarked.fgspBalance shouldBe PLN(216)
-    updated.social.jst.debt shouldBe PLN(108)
-
-    updated.financial.corporateBonds.bankHoldings shouldBe PLN(18)
-    updated.financial.corporateBonds.ppkHoldings shouldBe PLN(213)
-    updated.financial.corporateBonds.outstanding shouldBe PLN(115)
-    updated.financial.corporateBonds.otherHoldings shouldBe PLN(218)
-
-    updated.financial.insurance.lifeReserves shouldBe PLN(205)
-    updated.financial.insurance.nonLifeReserves shouldBe PLN(206)
-    updated.financial.insurance.govBondHoldings shouldBe PLN(207)
-    updated.financial.insurance.corpBondHoldings shouldBe PLN(208)
-    updated.financial.insurance.equityHoldings shouldBe PLN(209)
-
-    updated.financial.nbfi.tfiAum shouldBe PLN(219)
-    updated.financial.nbfi.tfiGovBondHoldings shouldBe PLN(220)
-    updated.financial.nbfi.tfiCorpBondHoldings shouldBe PLN(221)
-    updated.financial.nbfi.tfiEquityHoldings shouldBe PLN(222)
-    updated.financial.nbfi.tfiCashHoldings shouldBe PLN(223)
-    updated.financial.nbfi.nbfiLoanStock shouldBe PLN(224)
-
-    updated.financial.quasiFiscal.bondsOutstanding shouldBe PLN(225)
-    updated.financial.quasiFiscal.loanPortfolio shouldBe PLN(226)
-    updated.financial.quasiFiscal.bankHoldings shouldBe PLN(131)
-    updated.financial.quasiFiscal.nbpHoldings shouldBe PLN(132)
+    LedgerStateAdapter.captureLedgerFinancialState(
+      nextState.world,
+      nextState.firms,
+      nextState.households,
+      nextState.banks,
+    ) shouldBe nextState.ledgerFinancialState
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -17,6 +18,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
   private val init           = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w              = init.world
+  private val ledger         = LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks)
 
   /** Run one month through the new flow pipeline (partial -- Steps 1-2
     * economics + all fund flows).
@@ -35,7 +37,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
       NfzFlows.emit(StateAdapter.nfzInput(labor)),
       PpkFlows.emit(StateAdapter.ppkInput(labor)),
       EarmarkedFlows.emit(StateAdapter.earmarkedInput(labor)),
-      InsuranceFlows.emit(StateAdapter.insuranceInput(w, labor)),
+      InsuranceFlows.emit(StateAdapter.insuranceInput(w, ledger, labor)),
     )
 
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -108,6 +108,48 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     insuranceIncomeBatches.map(_.asset).toSet shouldBe Set(AssetType.LifeReserve, AssetType.NonLifeReserve)
   }
 
+  it should "read insurance flow inputs from LedgerFinancialState instead of world mirrors" in {
+    val init            = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val baseState       = FlowSimulation.SimState.fromInit(init)
+    val worldInsurance  = baseState.world.financial.insurance.copy(
+      reserves = baseState.world.financial.insurance.reserves.copy(
+        lifeReserves = PLN(11),
+        nonLifeReserves = PLN(12),
+      ),
+      portfolio = baseState.world.financial.insurance.portfolio.copy(
+        govBondHoldings = PLN(13),
+        corpBondHoldings = PLN(14),
+        equityHoldings = PLN(15),
+      ),
+    )
+    val ledgerInsurance = baseState.ledgerFinancialState.insurance.copy(
+      lifeReserve = PLN(21),
+      nonLifeReserve = PLN(22),
+      govBondHoldings = PLN(23),
+      corpBondHoldings = PLN(24),
+      equityHoldings = PLN(25),
+    )
+    val state           = baseState.copy(
+      world = baseState.world.copy(
+        financial = baseState.world.financial.copy(
+          insurance = worldInsurance,
+        ),
+      ),
+      ledgerFinancialState = baseState.ledgerFinancialState.copy(
+        insurance = ledgerInsurance,
+      ),
+    )
+
+    val calculus = FlowSimulation.computeCalculus(state, MonthRandomness.Contract.fromSeed(42L))
+
+    worldInsurance.lifeReserves.should(not be ledgerInsurance.lifeReserve)
+    calculus.insuranceCurrentLifeReserves shouldBe ledgerInsurance.lifeReserve
+    calculus.insuranceCurrentNonLifeReserves shouldBe ledgerInsurance.nonLifeReserve
+    calculus.insurancePrevGovBonds shouldBe ledgerInsurance.govBondHoldings
+    calculus.insurancePrevCorpBonds shouldBe ledgerInsurance.corpBondHoldings
+    calculus.insurancePrevEquity shouldBe ledgerInsurance.equityHoldings
+  }
+
   it should "expose the month boundary as SimState -> StepOutput -> (nextState, trace)" in {
     val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)
@@ -221,11 +263,25 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val lowShadowW    = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.0))
     val highShadowW   = init.world.copy(mechanisms = init.world.mechanisms.copy(informalCyclicalAdj = 0.4))
     val lowShadowRun  = FlowSimulation.step(
-      FlowSimulation.SimState(SimulationMonth.CompletedMonth.Zero, lowShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      FlowSimulation.SimState.fromMirrors(
+        SimulationMonth.CompletedMonth.Zero,
+        lowShadowW,
+        init.firms,
+        init.households,
+        init.banks,
+        init.householdAggregates,
+      ),
       MonthRandomness.Contract.fromSeed(42L),
     )
     val highShadowRun = FlowSimulation.step(
-      FlowSimulation.SimState(SimulationMonth.CompletedMonth.Zero, highShadowW, init.firms, init.households, init.banks, init.householdAggregates),
+      FlowSimulation.SimState.fromMirrors(
+        SimulationMonth.CompletedMonth.Zero,
+        highShadowW,
+        init.firms,
+        init.households,
+        init.banks,
+        init.householdAggregates,
+      ),
       MonthRandomness.Contract.fromSeed(42L),
     )
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -5,6 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
@@ -24,6 +25,8 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
   private val w          = initResult.world
+  private val ledger     =
+    LedgerStateAdapter.captureLedgerFinancialState(w, initResult.firms, initResult.households, initResult.banks)
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =
@@ -136,6 +139,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
       InsuranceFlows.emit(
         StateAdapter.insuranceInput(
           w,
+          ledger,
           LaborEconomics.Result(
             s2.newWage,
             s2Post.employed,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -27,14 +27,14 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
   it should "round-trip the supported financial slice without semantic loss" in {
     val runtime  = enrichedSimState()
     val ledger   = LedgerStateAdapter.toMutableWorldState(runtime)
-    val expected = LedgerStateAdapter.supportedSnapshot(runtime)
+    val expected = runtime.ledgerFinancialState
 
-    LedgerStateAdapter.readSupported(ledger) shouldBe expected
+    LedgerStateAdapter.readLedgerFinancialState(ledger) shouldBe expected
   }
 
   it should "preserve bank total deposits and extended holder mappings in the supported slice" in {
     val runtime   = enrichedSimState()
-    val supported = LedgerStateAdapter.supportedSnapshot(runtime)
+    val supported = runtime.ledgerFinancialState
 
     supported.banks.head.totalDeposits shouldBe PLN(603e6)
     supported.banks.head.demandDeposit + supported.banks.head.termDeposit shouldBe supported.banks.head.totalDeposits
@@ -68,4 +68,15 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     ledger.snapshot.keySet should not contain ((EntitySector.Banks, AssetType.Cash, 0))
     ledger.snapshot.keySet should not contain ((EntitySector.Funds, AssetType.Reserve, LedgerStateAdapter.FundIndex.QuasiFiscal))
     ledger.snapshot.keySet should not contain ((EntitySector.Funds, AssetType.Cash, LedgerStateAdapter.FundIndex.QuasiFiscal))
+  }
+
+  it should "carry ledger financial state explicitly inside SimState" in {
+    val runtime = enrichedSimState()
+
+    runtime.ledgerFinancialState shouldBe LedgerStateAdapter.captureLedgerFinancialState(
+      runtime.world,
+      runtime.firms,
+      runtime.households,
+      runtime.banks,
+    )
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerTestFixtures.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerTestFixtures.scala
@@ -143,6 +143,13 @@ object LedgerTestFixtures:
       ),
     )
 
-    base.copy(world = world, firms = firms, households = households, banks = banks)
+    FlowSimulation.SimState(
+      completedMonth = base.completedMonth,
+      world = world,
+      firms = firms,
+      households = households,
+      banks = banks,
+      householdAggregates = base.householdAggregates,
+    )
 
 end LedgerTestFixtures

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerTestFixtures.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerTestFixtures.scala
@@ -143,7 +143,7 @@ object LedgerTestFixtures:
       ),
     )
 
-    FlowSimulation.SimState(
+    FlowSimulation.SimState.fromMirrors(
       completedMonth = base.completedMonth,
       world = world,
       firms = firms,


### PR DESCRIPTION
Summary:
- Introduce LedgerFinancialState as the ledger-owned runtime snapshot for ledger-contracted financial stocks.
- Carry ledgerFinancialState through SimState and the flow/economics boundaries that need financial stock ownership.
- Centralize ledger-backed projections/mappers and trim repeated ledger capture in specs.
- Document LedgerFinancialState responsibility and field semantics.

Validation:
- sbt scalafmtAll
- Targeted compile/spec suites were run on this branch before the final doc-only commit.

Closes #382
Refs #378
Refs #379
Refs #380
Refs #381