### PR TITLE
Remove ledger financial state round-trip adapters

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -28,7 +28,7 @@ object WorldAssemblyEconomics:
       firms: Vector[Firm.State],                  // pre-step firm population
       households: Vector[Household.State],        // pre-step household population
       banks: Vector[Banking.BankState],           // pre-step bank population
-      ledgerFinancialState: LedgerFinancialState, // ledger-backed supported financial source of truth
+      ledgerFinancialState: LedgerFinancialState, // ledger-backed financial source of truth
       s1: FiscalConstraintEconomics.Output,       // fiscal constraint (month, reservation wage, lending base rate)
       s2: LaborEconomics.Output,                  // labor/demographics (wage, employment, ZUS, PPK)
       s3: HouseholdIncomeEconomics.Output,        // household income (consumption, PIT, import propensity)
@@ -447,7 +447,7 @@ object WorldAssemblyEconomics:
       informal: InformalResult,
       obs: Observables,
   ): (World, LedgerFinancialState) =
-    val ledgerFinancialState = LedgerStateAdapter.roundTripLedgerFinancialState(buildLedgerFinancialState(in))
+    val ledgerFinancialState = buildLedgerFinancialState(in)
     val corporateBondCircuit = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
     val projectedSocial      = LedgerStateAdapter.projectSocialState(
       SocialState(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -448,7 +448,7 @@ object WorldAssemblyEconomics:
       obs: Observables,
   ): (World, LedgerFinancialState) =
     val ledgerFinancialState = buildLedgerFinancialState(in)
-    val corporateBondCircuit = LedgerStateAdapter.corporateBondCircuit(ledgerFinancialState)
+    val bankCorpBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
     val projectedSocial      = LedgerStateAdapter.projectSocialState(
       SocialState(
         jst = in.s9.newJst,
@@ -482,9 +482,9 @@ object WorldAssemblyEconomics:
       financial = FinancialMarketsState(
         equity = equityAfterStep,
         corporateBonds = in.s8.corpBonds.newCorpBonds.copy(
-          bankHoldings = corporateBondCircuit.bankHoldings,
-          ppkHoldings = corporateBondCircuit.ppkHoldings,
-          otherHoldings = corporateBondCircuit.otherHoldings,
+          bankHoldings = bankCorpBondHoldings,
+          ppkHoldings = ledgerFinancialState.funds.ppkCorpBondHoldings,
+          otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
         ),
         insurance = LedgerStateAdapter.projectInsuranceState(in.s9.finalInsurance, ledgerFinancialState),
         nbfi = LedgerStateAdapter.projectNbfiState(in.s9.finalNbfi, ledgerFinancialState),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -5,18 +5,16 @@ import com.boombustgroup.amorfati.engine.{SocialState, World}
 import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, FiscalBudget}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.{AssetType, EntitySector, MutableWorldState}
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState.*
 
 /** Narrow bridge between runtime simulation state and ledger-owned financial
   * storage.
   *
-  * This adapter intentionally supports only the current "clean" financial slice
+  * This adapter keeps only the current ledger-contracted financial slice
   * defined by [[AssetOwnershipContract]]: balances with a defensible mapping
-  * onto existing ledger [[AssetType]]s. Unsupported state such as physical
-  * capital, bank capital, or mixed monthly operational flows is left out on
-  * purpose rather than forced into the ledger abstraction under a misleading
-  * asset name.
+  * onto existing ledger asset types. State such as physical capital, bank
+  * capital, or mixed monthly operational flows is left out on purpose rather
+  * than forced into the ledger abstraction under a misleading asset name.
   */
 object LedgerStateAdapter:
 
@@ -33,9 +31,6 @@ object LedgerStateAdapter:
     val QuasiFiscal: Int   = 9
 
     val Count: Int = 10
-
-  private val SingletonSectorSize = 1
-  private val ForeignSectorSize   = ForeignRuntimeContract.AllNodes.iterator.map(_.index).max + 1
 
   case class GovernmentBondCircuit(
       outstanding: PLN,
@@ -93,31 +88,6 @@ object LedgerStateAdapter:
       jst: UnsupportedJstBalances,
       quasiFiscal: UnsupportedQuasiFiscalBalances,
   )
-
-  /** Deterministic ledger sector sizes for the current runtime state. */
-  def sectorSizes(sim: FlowSimulation.SimState): Map[EntitySector, Int] =
-    Map(
-      EntitySector.Households -> sim.ledgerFinancialState.households.size,
-      EntitySector.Firms      -> sim.ledgerFinancialState.firms.size,
-      EntitySector.Banks      -> sim.ledgerFinancialState.banks.size,
-      EntitySector.Government -> SingletonSectorSize,
-      EntitySector.NBP        -> SingletonSectorSize,
-      EntitySector.Insurance  -> SingletonSectorSize,
-      EntitySector.Funds      -> FundIndex.Count,
-      EntitySector.Foreign    -> ForeignSectorSize,
-    )
-
-  def sectorSizes(ledgerFinancialState: LedgerFinancialState): Map[EntitySector, Int] =
-    Map(
-      EntitySector.Households -> ledgerFinancialState.households.size,
-      EntitySector.Firms      -> ledgerFinancialState.firms.size,
-      EntitySector.Banks      -> ledgerFinancialState.banks.size,
-      EntitySector.Government -> SingletonSectorSize,
-      EntitySector.NBP        -> SingletonSectorSize,
-      EntitySector.Insurance  -> SingletonSectorSize,
-      EntitySector.Funds      -> FundIndex.Count,
-      EntitySector.Foreign    -> ForeignSectorSize,
-    )
 
   def householdBalances(h: Household.State): HouseholdBalances =
     HouseholdBalances(
@@ -240,21 +210,6 @@ object LedgerStateAdapter:
     )
 
   def corporateBondCircuit(
-      world: World,
-      firms: Vector[Firm.State],
-      banks: Vector[Banking.BankState],
-  ): CorporateBondCircuit =
-    val bankAgg = Banking.aggregateFromBanks(banks)
-    CorporateBondCircuit(
-      outstanding = PLN.fromRaw(firms.map(_.bondDebt.toLong).sum),
-      bankHoldings = bankAgg.corpBondHoldings,
-      ppkHoldings = world.financial.corporateBonds.ppkHoldings,
-      insuranceHoldings = world.financial.insurance.corpBondHoldings,
-      tfiHoldings = world.financial.nbfi.tfiCorpBondHoldings,
-      otherHoldings = world.financial.corporateBonds.otherHoldings,
-    )
-
-  def corporateBondCircuit(
       ledgerFinancialState: LedgerFinancialState,
   ): CorporateBondCircuit =
     val bankCorpBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
@@ -338,8 +293,12 @@ object LedgerStateAdapter:
       ),
     )
 
-  /** Transitional capture from mirrored world/agent state into the first-class
-    * ledger-backed financial state.
+  /** Legacy/bootstrap import from mirrored world/agent state into
+    * `LedgerFinancialState`.
+    *
+    * This is the only intentional reverse direction. Normal monthly assembly
+    * must carry `LedgerFinancialState` forward and project it into boundary
+    * views, not rebuild it by round-tripping through world mirrors.
     */
   def captureLedgerFinancialState(
       world: World,
@@ -389,170 +348,6 @@ object LedgerStateAdapter:
         nbpHoldings = sim.world.financial.quasiFiscal.nbpHoldings,
       ),
     )
-
-  def toMutableWorldState(sim: FlowSimulation.SimState): MutableWorldState =
-    val state = new MutableWorldState(sectorSizes(sim))
-    populate(state, sim)
-    state
-
-  def toMutableWorldState(ledgerFinancialState: LedgerFinancialState): MutableWorldState =
-    val state = new MutableWorldState(sectorSizes(ledgerFinancialState))
-    populate(state, ledgerFinancialState)
-    state
-
-  def roundTripLedgerFinancialState(ledgerFinancialState: LedgerFinancialState): LedgerFinancialState =
-    readLedgerFinancialState(toMutableWorldState(ledgerFinancialState))
-
-  def populate(state: MutableWorldState, sim: FlowSimulation.SimState): Unit =
-    populate(state, sim.ledgerFinancialState)
-
-  def populate(state: MutableWorldState, ledgerFinancialState: LedgerFinancialState): Unit =
-
-    ledgerFinancialState.households.zipWithIndex.foreach { (hh, idx) =>
-      set(state, EntitySector.Households, AssetType.DemandDeposit, idx, hh.demandDeposit)
-      set(state, EntitySector.Households, AssetType.MortgageLoan, idx, hh.mortgageLoan)
-      set(state, EntitySector.Households, AssetType.ConsumerLoan, idx, hh.consumerLoan)
-      set(state, EntitySector.Households, AssetType.Equity, idx, hh.equity)
-    }
-
-    ledgerFinancialState.firms.zipWithIndex.foreach { (firm, idx) =>
-      set(state, EntitySector.Firms, AssetType.Cash, idx, firm.cash)
-      set(state, EntitySector.Firms, AssetType.FirmLoan, idx, firm.firmLoan)
-      set(state, EntitySector.Firms, AssetType.CorpBond, idx, firm.corpBond)
-      set(state, EntitySector.Firms, AssetType.Equity, idx, firm.equity)
-    }
-
-    ledgerFinancialState.banks.zipWithIndex.foreach { (bank, idx) =>
-      set(state, EntitySector.Banks, AssetType.DemandDeposit, idx, bank.demandDeposit)
-      set(state, EntitySector.Banks, AssetType.TermDeposit, idx, bank.termDeposit)
-      set(state, EntitySector.Banks, AssetType.FirmLoan, idx, bank.firmLoan)
-      set(state, EntitySector.Banks, AssetType.ConsumerLoan, idx, bank.consumerLoan)
-      set(state, EntitySector.Banks, AssetType.GovBondAFS, idx, bank.govBondAfs)
-      set(state, EntitySector.Banks, AssetType.GovBondHTM, idx, bank.govBondHtm)
-      set(state, EntitySector.Banks, AssetType.Reserve, idx, bank.reserve)
-      set(state, EntitySector.Banks, AssetType.InterbankLoan, idx, bank.interbankLoan)
-      set(state, EntitySector.Banks, AssetType.CorpBond, idx, bank.corpBond)
-    }
-
-    set(state, EntitySector.Government, AssetType.GovBondHTM, 0, ledgerFinancialState.government.govBondOutstanding)
-    set(state, EntitySector.Foreign, AssetType.GovBondHTM, 0, ledgerFinancialState.foreign.govBondHoldings)
-    set(state, EntitySector.NBP, AssetType.GovBondHTM, 0, ledgerFinancialState.nbp.govBondHoldings)
-    set(state, EntitySector.NBP, AssetType.ForeignAsset, 0, ledgerFinancialState.nbp.foreignAssets)
-    set(state, EntitySector.Insurance, AssetType.LifeReserve, 0, ledgerFinancialState.insurance.lifeReserve)
-    set(state, EntitySector.Insurance, AssetType.NonLifeReserve, 0, ledgerFinancialState.insurance.nonLifeReserve)
-    set(state, EntitySector.Insurance, AssetType.GovBondHTM, 0, ledgerFinancialState.insurance.govBondHoldings)
-    set(state, EntitySector.Insurance, AssetType.CorpBond, 0, ledgerFinancialState.insurance.corpBondHoldings)
-    set(state, EntitySector.Insurance, AssetType.Equity, 0, ledgerFinancialState.insurance.equityHoldings)
-
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Zus, ledgerFinancialState.funds.zusCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nfz, ledgerFinancialState.funds.nfzCash)
-    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Ppk, ledgerFinancialState.funds.ppkGovBondHoldings)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Ppk, ledgerFinancialState.funds.ppkCorpBondHoldings)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp, ledgerFinancialState.funds.fpCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron, ledgerFinancialState.funds.pfronCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp, ledgerFinancialState.funds.fgspCash)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst, ledgerFinancialState.funds.jstCash)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther, ledgerFinancialState.funds.corpBondOtherHoldings)
-    set(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.tfiUnit)
-    set(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.govBondHoldings)
-    set(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.corpBondHoldings)
-    set(state, EntitySector.Funds, AssetType.Equity, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.equityHoldings)
-    set(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.cashHoldings)
-    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.Nbfi, ledgerFinancialState.funds.nbfi.nbfiLoanStock)
-    set(
-      state,
-      EntitySector.Funds,
-      AssetType.GovBondHTM,
-      FundIndex.QuasiFiscal,
-      ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
-    )
-    set(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.QuasiFiscal, ledgerFinancialState.funds.quasiFiscal.loanPortfolio)
-
-  def readLedgerFinancialState(state: MutableWorldState): LedgerFinancialState =
-    LedgerFinancialState(
-      households = Vector.tabulate(state.sectorSize(EntitySector.Households))(idx =>
-        HouseholdBalances(
-          demandDeposit = pln(state, EntitySector.Households, AssetType.DemandDeposit, idx),
-          mortgageLoan = pln(state, EntitySector.Households, AssetType.MortgageLoan, idx),
-          consumerLoan = pln(state, EntitySector.Households, AssetType.ConsumerLoan, idx),
-          equity = pln(state, EntitySector.Households, AssetType.Equity, idx),
-        ),
-      ),
-      firms = Vector.tabulate(state.sectorSize(EntitySector.Firms))(idx =>
-        FirmBalances(
-          cash = pln(state, EntitySector.Firms, AssetType.Cash, idx),
-          firmLoan = pln(state, EntitySector.Firms, AssetType.FirmLoan, idx),
-          corpBond = pln(state, EntitySector.Firms, AssetType.CorpBond, idx),
-          equity = pln(state, EntitySector.Firms, AssetType.Equity, idx),
-        ),
-      ),
-      banks = Vector.tabulate(state.sectorSize(EntitySector.Banks))(idx =>
-        BankBalances(
-          totalDeposits = pln(state, EntitySector.Banks, AssetType.DemandDeposit, idx) +
-            pln(state, EntitySector.Banks, AssetType.TermDeposit, idx),
-          demandDeposit = pln(state, EntitySector.Banks, AssetType.DemandDeposit, idx),
-          termDeposit = pln(state, EntitySector.Banks, AssetType.TermDeposit, idx),
-          firmLoan = pln(state, EntitySector.Banks, AssetType.FirmLoan, idx),
-          consumerLoan = pln(state, EntitySector.Banks, AssetType.ConsumerLoan, idx),
-          govBondAfs = pln(state, EntitySector.Banks, AssetType.GovBondAFS, idx),
-          govBondHtm = pln(state, EntitySector.Banks, AssetType.GovBondHTM, idx),
-          reserve = pln(state, EntitySector.Banks, AssetType.Reserve, idx),
-          interbankLoan = pln(state, EntitySector.Banks, AssetType.InterbankLoan, idx),
-          corpBond = pln(state, EntitySector.Banks, AssetType.CorpBond, idx),
-        ),
-      ),
-      government = GovernmentBalances(
-        govBondOutstanding = pln(state, EntitySector.Government, AssetType.GovBondHTM, 0),
-      ),
-      foreign = ForeignBalances(
-        govBondHoldings = pln(state, EntitySector.Foreign, AssetType.GovBondHTM, 0),
-      ),
-      nbp = NbpBalances(
-        govBondHoldings = pln(state, EntitySector.NBP, AssetType.GovBondHTM, 0),
-        foreignAssets = pln(state, EntitySector.NBP, AssetType.ForeignAsset, 0),
-      ),
-      insurance = InsuranceBalances(
-        lifeReserve = pln(state, EntitySector.Insurance, AssetType.LifeReserve, 0),
-        nonLifeReserve = pln(state, EntitySector.Insurance, AssetType.NonLifeReserve, 0),
-        govBondHoldings = pln(state, EntitySector.Insurance, AssetType.GovBondHTM, 0),
-        corpBondHoldings = pln(state, EntitySector.Insurance, AssetType.CorpBond, 0),
-        equityHoldings = pln(state, EntitySector.Insurance, AssetType.Equity, 0),
-      ),
-      funds = FundBalances(
-        zusCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Zus),
-        nfzCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nfz),
-        ppkGovBondHoldings = pln(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Ppk),
-        ppkCorpBondHoldings = pln(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Ppk),
-        fpCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fp),
-        pfronCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Pfron),
-        fgspCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Fgsp),
-        jstCash = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Jst),
-        corpBondOtherHoldings = pln(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.CorpBondOther),
-        nbfi = NbfiFundBalances(
-          tfiUnit = pln(state, EntitySector.Funds, AssetType.TfiUnit, FundIndex.Nbfi),
-          govBondHoldings = pln(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.Nbfi),
-          corpBondHoldings = pln(state, EntitySector.Funds, AssetType.CorpBond, FundIndex.Nbfi),
-          equityHoldings = pln(state, EntitySector.Funds, AssetType.Equity, FundIndex.Nbfi),
-          cashHoldings = pln(state, EntitySector.Funds, AssetType.Cash, FundIndex.Nbfi),
-          nbfiLoanStock = pln(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.Nbfi),
-        ),
-        quasiFiscal = QuasiFiscalBalances(
-          bondsOutstanding = pln(state, EntitySector.Funds, AssetType.GovBondHTM, FundIndex.QuasiFiscal),
-          loanPortfolio = pln(state, EntitySector.Funds, AssetType.NbfiLoan, FundIndex.QuasiFiscal),
-        ),
-      ),
-    )
-
-  private def set(state: MutableWorldState, sector: EntitySector, asset: AssetType, index: Int, value: PLN): Unit =
-    AssetOwnershipContract.requireSupportedPersistedPair(sector, asset, index, "LedgerStateAdapter.set")
-    state.setBalance(sector, asset, index, value.toLong) match
-      case Right(_)  => ()
-      case Left(err) =>
-        throw new IllegalStateException(s"LedgerStateAdapter failed to populate ($sector, $asset, $index): $err")
-
-  private def pln(state: MutableWorldState, sector: EntitySector, asset: AssetType, index: Int): PLN =
-    AssetOwnershipContract.requireSupportedPersistedPair(sector, asset, index, "LedgerStateAdapter.pln")
-    PLN.fromRaw(state.balance(sector, asset, index))
 
   private def bankDemandDeposits(bank: Banking.BankState): PLN =
     if bank.demandDeposits == PLN.Zero && bank.termDeposits == PLN.Zero then bank.deposits

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapter.scala
@@ -3,7 +3,6 @@ package com.boombustgroup.amorfati.engine.ledger
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi, Nbp, QuasiFiscal}
 import com.boombustgroup.amorfati.engine.{SocialState, World}
 import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, FiscalBudget}
-import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState.*
 
@@ -43,51 +42,6 @@ object LedgerStateAdapter:
   ):
     def totalHoldings: PLN =
       bankHoldings + foreignHoldings + nbpHoldings + insuranceHoldings + ppkHoldings + tfiHoldings
-
-  case class CorporateBondCircuit(
-      outstanding: PLN,
-      bankHoldings: PLN,
-      ppkHoldings: PLN,
-      insuranceHoldings: PLN,
-      tfiHoldings: PLN,
-      otherHoldings: PLN,
-  ):
-    def totalHoldings: PLN =
-      bankHoldings + ppkHoldings + insuranceHoldings + tfiHoldings + otherHoldings
-
-  case class UnsupportedBankBalances(
-      capital: PLN,
-      nplAmount: PLN,
-      consumerNpl: PLN,
-      loansShort: PLN,
-      loansMedium: PLN,
-      loansLong: PLN,
-  )
-
-  case class UnsupportedGovernmentBalances(
-      fiscalCumulativeDebt: PLN,
-  )
-
-  case class UnsupportedNbpBalances(
-      qeCumulativePurchases: PLN,
-  )
-
-  case class UnsupportedQuasiFiscalBalances(
-      bankHoldings: PLN,
-      nbpHoldings: PLN,
-  )
-
-  case class UnsupportedJstBalances(
-      jstDebt: PLN,
-  )
-
-  case class UnsupportedFinancialSnapshot(
-      banks: Vector[UnsupportedBankBalances],
-      government: UnsupportedGovernmentBalances,
-      nbp: UnsupportedNbpBalances,
-      jst: UnsupportedJstBalances,
-      quasiFiscal: UnsupportedQuasiFiscalBalances,
-  )
 
   def householdBalances(h: Household.State): HouseholdBalances =
     HouseholdBalances(
@@ -195,33 +149,6 @@ object LedgerStateAdapter:
       tfiHoldings = world.financial.nbfi.tfiGovBondHoldings,
     )
 
-  def governmentBondCircuit(
-      ledgerFinancialState: LedgerFinancialState,
-  ): GovernmentBondCircuit =
-    val bankGovBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.govBondAfs + bank.govBondHtm)
-    GovernmentBondCircuit(
-      outstanding = ledgerFinancialState.government.govBondOutstanding,
-      bankHoldings = bankGovBondHoldings,
-      foreignHoldings = ledgerFinancialState.foreign.govBondHoldings,
-      nbpHoldings = ledgerFinancialState.nbp.govBondHoldings,
-      insuranceHoldings = ledgerFinancialState.insurance.govBondHoldings,
-      ppkHoldings = ledgerFinancialState.funds.ppkGovBondHoldings,
-      tfiHoldings = ledgerFinancialState.funds.nbfi.govBondHoldings,
-    )
-
-  def corporateBondCircuit(
-      ledgerFinancialState: LedgerFinancialState,
-  ): CorporateBondCircuit =
-    val bankCorpBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
-    CorporateBondCircuit(
-      outstanding = PLN.fromRaw(ledgerFinancialState.firms.map(_.corpBond.toLong).sum),
-      bankHoldings = bankCorpBondHoldings,
-      ppkHoldings = ledgerFinancialState.funds.ppkCorpBondHoldings,
-      insuranceHoldings = ledgerFinancialState.insurance.corpBondHoldings,
-      tfiHoldings = ledgerFinancialState.funds.nbfi.corpBondHoldings,
-      otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
-    )
-
   def projectInsuranceState(
       base: Insurance.State,
       ledgerFinancialState: LedgerFinancialState,
@@ -315,38 +242,6 @@ object LedgerStateAdapter:
       nbp = nbpBalances(world.nbp),
       insurance = insuranceBalances(world.financial.insurance),
       funds = fundBalances(world.social, world.financial.corporateBonds, world.financial.nbfi, world.financial.quasiFiscal),
-    )
-
-  /** Financial fields intentionally left outside current ledger mapping because
-    * the public `EntitySector` / `AssetType` API does not yet name them
-    * cleanly, or because they are fiscal/accounting metrics rather than
-    * holder-tracked instruments.
-    */
-  def unsupportedSnapshot(sim: FlowSimulation.SimState): UnsupportedFinancialSnapshot =
-    UnsupportedFinancialSnapshot(
-      banks = sim.banks.map(b =>
-        UnsupportedBankBalances(
-          capital = b.capital,
-          nplAmount = b.nplAmount,
-          consumerNpl = b.consumerNpl,
-          loansShort = b.loansShort,
-          loansMedium = b.loansMedium,
-          loansLong = b.loansLong,
-        ),
-      ),
-      government = UnsupportedGovernmentBalances(
-        fiscalCumulativeDebt = sim.world.gov.cumulativeDebt,
-      ),
-      nbp = UnsupportedNbpBalances(
-        qeCumulativePurchases = sim.world.nbp.qeCumulative,
-      ),
-      jst = UnsupportedJstBalances(
-        jstDebt = sim.world.social.jst.debt,
-      ),
-      quasiFiscal = UnsupportedQuasiFiscalBalances(
-        bankHoldings = sim.world.financial.quasiFiscal.bankHoldings,
-        nbpHoldings = sim.world.financial.quasiFiscal.nbpHoldings,
-      ),
     )
 
   private def bankDemandDeposits(bank: Banking.BankState): PLN =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -4,7 +4,6 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.*
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -20,8 +19,7 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
 
   private val init                     = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
   private val w                        = init.world
-  private val baseLedgerFinancialState =
-    LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks)
+  private val baseLedgerFinancialState = FlowSimulation.SimState.fromInit(init).ledgerFinancialState
   private val rng                      = RandomStream.seeded(TestSeed)
 
   // Run pipeline through Economics objects

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomicsSpec.scala
@@ -4,7 +4,6 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.CompletedMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.ComputationBoundary
 import org.scalatest.flatspec.AnyFlatSpec
@@ -55,15 +54,19 @@ class WorldAssemblyEconomicsSpec extends AnyFlatSpec with Matchers:
     w.gov.domesticBudgetOutlays.should(be >= w.gov.domesticBudgetDemand)
   }
 
-  it should "keep world mirrors aligned with LedgerFinancialState after assembly" in {
+  it should "project LedgerFinancialState into world boundary mirrors after assembly" in {
     val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state     = FlowSimulation.SimState.fromInit(init)
     val nextState = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L)).nextState
+    val ledger    = nextState.ledgerFinancialState
+    val world     = nextState.world
 
-    LedgerStateAdapter.captureLedgerFinancialState(
-      nextState.world,
-      nextState.firms,
-      nextState.households,
-      nextState.banks,
-    ) shouldBe nextState.ledgerFinancialState
+    world.gov.bondsOutstanding shouldBe ledger.government.govBondOutstanding
+    world.gov.foreignBondHoldings shouldBe ledger.foreign.govBondHoldings
+    world.nbp.govBondHoldings shouldBe ledger.nbp.govBondHoldings
+    world.nbp.fxReserves shouldBe ledger.nbp.foreignAssets
+    world.financial.insurance.lifeReserves shouldBe ledger.insurance.lifeReserve
+    world.financial.nbfi.tfiAum shouldBe ledger.funds.nbfi.tfiUnit
+    world.social.jst.deposits shouldBe ledger.funds.jstCash
+    world.financial.quasiFiscal.bondsOutstanding shouldBe ledger.funds.quasiFiscal.bondsOutstanding
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowPipelineSpec.scala
@@ -3,7 +3,6 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -18,7 +17,7 @@ class FlowPipelineSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
   private val init           = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
   private val w              = init.world
-  private val ledger         = LedgerStateAdapter.captureLedgerFinancialState(w, init.firms, init.households, init.banks)
+  private val ledger         = FlowSimulation.SimState.fromInit(init).ledgerFinancialState
 
   /** Run one month through the new flow pipeline (partial -- Steps 1-2
     * economics + all fund flows).

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FullMonthFlowSpec.scala
@@ -5,7 +5,6 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapter
 import com.boombustgroup.amorfati.engine.markets.LaborMarket
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
@@ -25,8 +24,7 @@ class FullMonthFlowSpec extends AnyFlatSpec with Matchers:
 
   private val initResult = WorldInit.initialize(InitRandomness.Contract.fromSeed(TestSeed))
   private val w          = initResult.world
-  private val ledger     =
-    LedgerStateAdapter.captureLedgerFinancialState(w, initResult.firms, initResult.households, initResult.banks)
+  private val ledger     = FlowSimulation.SimState.fromInit(initResult).ledgerFinancialState
 
   /** Run pipeline for one month using Economics objects. */
   private def runFullMonth: Vector[Flow] =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
@@ -7,8 +7,6 @@ import org.scalatest.matchers.should.Matchers
 
 class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
 
-  import LedgerTestFixtures.enrichedSimState
-
   "AssetOwnershipContract" should "classify every public ledger asset exactly once" in {
     val grouped = publicAssets.groupBy(_.asset)
 
@@ -16,14 +14,7 @@ class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
     grouped.values.foreach(_ should have size 1)
   }
 
-  it should "accept every materialized adapter balance and preserve fund-slot granularity" in {
-    val runtime = enrichedSimState()
-    val ledger  = LedgerStateAdapter.toMutableWorldState(runtime)
-
-    ledger.snapshot.keySet.foreach { case (sector, asset, index) =>
-      isSupportedPersistedPair(sector, asset, index) shouldBe true
-    }
-
+  it should "preserve fund-slot granularity in supported persisted pairs" in {
     supportedPairs should contain(SupportedPair(SectorId.Fixed(EntitySector.Funds, LedgerStateAdapter.FundIndex.Zus), AssetType.Cash))
     supportedPairs should not contain SupportedPair(
       SectorId.Fixed(EntitySector.Funds, LedgerStateAdapter.FundIndex.QuasiFiscal),
@@ -34,6 +25,8 @@ class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "track currently unsupported persisted families explicitly" in {
+    import LedgerTestFixtures.enrichedSimState
+
     val runtime = enrichedSimState()
 
     presentUnsupportedFamilies(runtime) shouldBe unsupportedFamilies.map(_.id).toSet

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -1,47 +1,23 @@
 package com.boombustgroup.amorfati.engine.ledger
 
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.{AssetType, EntitySector}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
 
-  import LedgerTestFixtures.{enrichedSimState, simState}
+  import LedgerTestFixtures.enrichedSimState
 
-  "LedgerStateAdapter" should "derive deterministic sector sizes from runtime populations" in {
-    val state = simState()
+  "LedgerStateAdapter" should "preserve bank total deposits and extended holder mappings in the ledger financial state" in {
+    val runtime = enrichedSimState()
+    val ledger  = runtime.ledgerFinancialState
 
-    LedgerStateAdapter.sectorSizes(state) shouldBe Map(
-      EntitySector.Households -> state.households.size,
-      EntitySector.Firms      -> state.firms.size,
-      EntitySector.Banks      -> state.banks.size,
-      EntitySector.Government -> 1,
-      EntitySector.NBP        -> 1,
-      EntitySector.Insurance  -> 1,
-      EntitySector.Funds      -> LedgerStateAdapter.FundIndex.Count,
-      EntitySector.Foreign    -> 5,
-    )
-  }
-
-  it should "round-trip the supported financial slice without semantic loss" in {
-    val runtime  = enrichedSimState()
-    val ledger   = LedgerStateAdapter.toMutableWorldState(runtime)
-    val expected = runtime.ledgerFinancialState
-
-    LedgerStateAdapter.readLedgerFinancialState(ledger) shouldBe expected
-  }
-
-  it should "preserve bank total deposits and extended holder mappings in the supported slice" in {
-    val runtime   = enrichedSimState()
-    val supported = runtime.ledgerFinancialState
-
-    supported.banks.head.totalDeposits shouldBe PLN(603e6)
-    supported.banks.head.demandDeposit + supported.banks.head.termDeposit shouldBe supported.banks.head.totalDeposits
-    supported.foreign.govBondHoldings shouldBe PLN(778e6)
-    supported.funds.ppkCorpBondHoldings shouldBe PLN(33e6)
-    supported.funds.corpBondOtherHoldings shouldBe PLN(34e6)
-    supported.funds.jstCash shouldBe PLN(10e6)
+    ledger.banks.head.totalDeposits shouldBe PLN(603e6)
+    ledger.banks.head.demandDeposit + ledger.banks.head.termDeposit shouldBe ledger.banks.head.totalDeposits
+    ledger.foreign.govBondHoldings shouldBe PLN(778e6)
+    ledger.funds.ppkCorpBondHoldings shouldBe PLN(33e6)
+    ledger.funds.corpBondOtherHoldings shouldBe PLN(34e6)
+    ledger.funds.jstCash shouldBe PLN(10e6)
   }
 
   it should "expose unsupported financial fields explicitly instead of forcing them into the ledger slice" in {
@@ -53,21 +29,6 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     unsupported.jst.jstDebt shouldBe PLN(11e6)
     unsupported.quasiFiscal.bankHoldings shouldBe PLN(29e6)
     unsupported.banks.head.capital shouldBe PLN(310e6)
-  }
-
-  it should "leave unsupported physical and mixed fields out of ledger balances" in {
-    val runtime = enrichedSimState()
-    val ledger  = LedgerStateAdapter.toMutableWorldState(runtime)
-
-    runtime.firms.head.capitalStock should be > PLN.Zero
-    runtime.banks.head.capital should be > PLN.Zero
-    runtime.world.financial.quasiFiscal.bankHoldings should be > PLN.Zero
-    runtime.world.financial.quasiFiscal.nbpHoldings should be > PLN.Zero
-
-    ledger.snapshot.keySet should not contain ((EntitySector.Firms, AssetType.Capital, 0))
-    ledger.snapshot.keySet should not contain ((EntitySector.Banks, AssetType.Cash, 0))
-    ledger.snapshot.keySet should not contain ((EntitySector.Funds, AssetType.Reserve, LedgerStateAdapter.FundIndex.QuasiFiscal))
-    ledger.snapshot.keySet should not contain ((EntitySector.Funds, AssetType.Cash, LedgerStateAdapter.FundIndex.QuasiFiscal))
   }
 
   it should "carry ledger financial state explicitly inside SimState" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerStateAdapterSpec.scala
@@ -20,17 +20,6 @@ class LedgerStateAdapterSpec extends AnyFlatSpec with Matchers:
     ledger.funds.jstCash shouldBe PLN(10e6)
   }
 
-  it should "expose unsupported financial fields explicitly instead of forcing them into the ledger slice" in {
-    val runtime     = enrichedSimState()
-    val unsupported = LedgerStateAdapter.unsupportedSnapshot(runtime)
-
-    unsupported.government.fiscalCumulativeDebt shouldBe runtime.world.gov.cumulativeDebt
-    unsupported.nbp.qeCumulativePurchases shouldBe PLN(89e6)
-    unsupported.jst.jstDebt shouldBe PLN(11e6)
-    unsupported.quasiFiscal.bankHoldings shouldBe PLN(29e6)
-    unsupported.banks.head.capital shouldBe PLN(310e6)
-  }
-
   it should "carry ledger financial state explicitly inside SimState" in {
     val runtime = enrichedSimState()
 


### PR DESCRIPTION
Summary:
- Stop normalizing LedgerFinancialState through MutableWorldState during world assembly.
- Delete the unused LedgerFinancialState <-> MutableWorldState round-trip API and related tests.
- Trim dead ledger adapter helpers and route simple init-based specs through SimState boundary construction.
- Keep captureLedgerFinancialState documented as legacy/bootstrap import only.

Validation:
- sbt scalafmtAll
- sbt "Test/compile" "testOnly com.boombustgroup.amorfati.engine.ledger.LedgerStateAdapterSpec com.boombustgroup.amorfati.engine.ledger.AssetOwnershipContractSpec com.boombustgroup.amorfati.engine.economics.WorldAssemblyEconomicsSpec"
- sbt "Test/compile" "testOnly com.boombustgroup.amorfati.engine.economics.OpenEconEconomicsSpec com.boombustgroup.amorfati.engine.flows.FlowPipelineSpec com.boombustgroup.amorfati.engine.flows.FullMonthFlowSpec"

Refs #379
Refs #378