### PR TITLE
Complete ledger boundary projections

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -448,7 +448,6 @@ object WorldAssemblyEconomics:
       obs: Observables,
   ): (World, LedgerFinancialState) =
     val ledgerFinancialState = buildLedgerFinancialState(in)
-    val bankCorpBondHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond)
     val projectedSocial      = LedgerBoundaryProjection.socialState(
       SocialState(
         jst = in.s9.newJst,
@@ -481,17 +480,10 @@ object WorldAssemblyEconomics:
       social = projectedSocial,
       financial = FinancialMarketsState(
         equity = equityAfterStep,
-        corporateBonds = in.s8.corpBonds.newCorpBonds.copy(
-          bankHoldings = bankCorpBondHoldings,
-          ppkHoldings = ledgerFinancialState.funds.ppkCorpBondHoldings,
-          otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
-        ),
+        corporateBonds = LedgerBoundaryProjection.corporateBondState(in.s8.corpBonds.newCorpBonds, ledgerFinancialState),
         insurance = LedgerBoundaryProjection.insuranceState(in.s9.finalInsurance, ledgerFinancialState),
         nbfi = LedgerBoundaryProjection.nbfiState(in.s9.finalNbfi, ledgerFinancialState),
-        quasiFiscal = in.s9.newQuasiFiscal.copy(
-          bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
-          loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,
-        ),
+        quasiFiscal = LedgerBoundaryProjection.quasiFiscalState(in.s9.newQuasiFiscal, ledgerFinancialState),
       ),
       external = ExternalState(
         gvc = in.s8.external.newGvc,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerBoundaryProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerBoundaryProjection.scala
@@ -1,8 +1,9 @@
 package com.boombustgroup.amorfati.engine.ledger
 
-import com.boombustgroup.amorfati.agents.{Insurance, Nbfi, Nbp}
+import com.boombustgroup.amorfati.agents.{Insurance, Nbfi, Nbp, QuasiFiscal}
 import com.boombustgroup.amorfati.engine.SocialState
-import com.boombustgroup.amorfati.engine.markets.FiscalBudget
+import com.boombustgroup.amorfati.engine.markets.{CorporateBondMarket, FiscalBudget}
+import com.boombustgroup.amorfati.types.PLN
 
 /** One-way projection from ledger-owned financial state into boundary views.
   *
@@ -81,4 +82,23 @@ object LedgerBoundaryProjection:
       credit = base.credit.copy(
         nbfiLoanStock = ledgerFinancialState.funds.nbfi.nbfiLoanStock,
       ),
+    )
+
+  def corporateBondState(
+      base: CorporateBondMarket.State,
+      ledgerFinancialState: LedgerFinancialState,
+  ): CorporateBondMarket.State =
+    base.copy(
+      bankHoldings = ledgerFinancialState.banks.foldLeft(PLN.Zero)((acc, bank) => acc + bank.corpBond),
+      ppkHoldings = ledgerFinancialState.funds.ppkCorpBondHoldings,
+      otherHoldings = ledgerFinancialState.funds.corpBondOtherHoldings,
+    )
+
+  def quasiFiscalState(
+      base: QuasiFiscal.State,
+      ledgerFinancialState: LedgerFinancialState,
+  ): QuasiFiscal.State =
+    base.copy(
+      bondsOutstanding = ledgerFinancialState.funds.quasiFiscal.bondsOutstanding,
+      loanPortfolio = ledgerFinancialState.funds.quasiFiscal.loanPortfolio,
     )


### PR DESCRIPTION
Summary:
- Move remaining corporate bond and quasi-fiscal mirror projection into LedgerBoundaryProjection.
- Remove inline LedgerFinancialState field rematerialization from WorldAssemblyEconomics.
- Keep WorldAssemblyEconomics using the explicit one-way boundary projection layer for all financial mirrors.

Validation:
- sbt scalafmtAll
- sbt "Test/compile" "testOnly com.boombustgroup.amorfati.engine.economics.WorldAssemblyEconomicsSpec com.boombustgroup.amorfati.engine.economics.OpenEconEconomicsSpec"

Closes #379
Refs #378