### PR TITLE
Publish ledger financial state from banking stage

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+import com.boombustgroup.amorfati.engine.ledger.{LedgerFinancialState, LedgerStateAdapter}
 import com.boombustgroup.amorfati.engine.markets.{BondAuction, FiscalBudget, HousingMarket}
 import com.boombustgroup.amorfati.engine.mechanisms.{TaxRevenue, YieldCurve}
 import com.boombustgroup.amorfati.types.*
@@ -32,7 +32,7 @@ object BankingEconomics:
 
   case class StepInput(
       w: World,                                   // current world state (pre-step)
-      ledgerFinancialState: LedgerFinancialState, // ledger-backed supported financial state
+      ledgerFinancialState: LedgerFinancialState, // ledger-backed financial state
       s1: FiscalConstraintEconomics.Output,       // fiscal constraint (month, lending base rate, res wage)
       s2: LaborEconomics.Output,                  // labor/demographics (employment, wage, immigration)
       s3: HouseholdIncomeEconomics.Output,        // household income (consumption, PIT, debt service)
@@ -82,6 +82,7 @@ object BankingEconomics:
       htmRealizedLoss: PLN,                          // realized loss from HTM forced reclassification
       eclProvisionChange: PLN,                       // aggregate IFRS 9 ECL provision change
       newQuasiFiscal: QuasiFiscal.State,             // BGK/PFR after issuance and lending
+      ledgerFinancialState: LedgerFinancialState,    // ledger-backed financial state at the banking stage boundary
   )
 
   // --- Intermediate result types for sub-methods ---
@@ -240,6 +241,30 @@ object BankingEconomics:
         in.w.nbp.qeActive,
       )
 
+    val newGovWithForeignHoldings =
+      govJst.newGovWithYield.copy(
+        financial = govJst.newGovWithYield.financial.copy(foreignBondHoldings = multi.foreignBondHoldings),
+      )
+    val socialForLedger           = SocialState(
+      jst = govJst.newJst,
+      zus = in.s2.newZus,
+      nfz = in.s2.newNfz,
+      ppk = multi.finalPpk,
+      demographics = in.s2.newDemographics,
+      earmarked = in.s2.newEarmarked,
+    )
+    val ledgerFinancialState      =
+      in.ledgerFinancialState.copy(
+        households = multi.reassignedHouseholds.map(LedgerStateAdapter.householdBalances),
+        firms = multi.reassignedFirms.map(LedgerStateAdapter.firmBalances),
+        banks = multi.finalBanks.map(LedgerStateAdapter.bankBalances),
+        government = LedgerStateAdapter.governmentBalances(newGovWithForeignHoldings),
+        foreign = LedgerStateAdapter.foreignBalances(newGovWithForeignHoldings),
+        nbp = LedgerStateAdapter.nbpBalances(multi.finalNbp),
+        insurance = LedgerStateAdapter.insuranceBalances(multi.finalInsurance),
+        funds = LedgerStateAdapter.fundBalances(socialForLedger, in.s8.corpBonds.newCorpBonds, multi.finalNbfi, newQuasiFiscal),
+      )
+
     StepOutput(
       resolvedBank = multi.resolvedBank,
       banks = multi.finalBanks,
@@ -250,9 +275,7 @@ object BankingEconomics:
       finalPpk = multi.finalPpk,
       finalInsurance = multi.finalInsurance,
       finalNbfi = multi.finalNbfi,
-      newGovWithYield = govJst.newGovWithYield.copy(
-        financial = govJst.newGovWithYield.financial.copy(foreignBondHoldings = multi.foreignBondHoldings),
-      ),
+      newGovWithYield = newGovWithForeignHoldings,
       newJst = govJst.newJst,
       housingAfterFlows = housing.housingAfterFlows,
       bfgLevy = bfgLevy,
@@ -292,6 +315,7 @@ object BankingEconomics:
           .sum
       ,
       newQuasiFiscal = newQuasiFiscal,
+      ledgerFinancialState = ledgerFinancialState,
     )
 
   def compute(in: Input)(using p: SimParams): Result =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -524,24 +524,7 @@ object WorldAssemblyEconomics:
     (world, ledgerFinancialState)
 
   private def buildLedgerFinancialState(in: StepInput): LedgerFinancialState =
-    val social = SocialState(
-      jst = in.s9.newJst,
-      zus = in.s2.newZus,
-      nfz = in.s2.newNfz,
-      ppk = in.s9.finalPpk,
-      demographics = in.s2.newDemographics,
-      earmarked = in.s2.newEarmarked,
-    )
-    in.ledgerFinancialState.copy(
-      households = in.s9.reassignedHouseholds.map(LedgerStateAdapter.householdBalances),
-      firms = in.s9.reassignedFirms.map(LedgerStateAdapter.firmBalances),
-      banks = in.s9.banks.map(LedgerStateAdapter.bankBalances),
-      government = LedgerStateAdapter.governmentBalances(in.s9.newGovWithYield),
-      foreign = LedgerStateAdapter.foreignBalances(in.s9.newGovWithYield),
-      nbp = LedgerStateAdapter.nbpBalances(in.s9.finalNbp),
-      insurance = LedgerStateAdapter.insuranceBalances(in.s9.finalInsurance),
-      funds = LedgerStateAdapter.fundBalances(social, in.s8.corpBonds.newCorpBonds, in.s9.finalNbfi, in.s9.newQuasiFiscal),
-    )
+    in.s9.ledgerFinancialState
 
   private def buildPostMonthPipelineState(in: StepInput): PipelineState =
     in.w.pipeline

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -96,40 +96,63 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
       ),
     )
 
-    val res = BankingEconomics.compute(
-      BankingEconomics.Input(
-        w = w,
-        ledgerFinancialState = ledgerState(w, init.firms, init.households, init.banks),
-        month = s1.m,
-        lendingBaseRate = s1.lendingBaseRate,
-        resWage = s1.resWage,
-        baseMinWage = s1.baseMinWage,
-        minWagePriceLevel = s1.updatedMinWagePriceLevel,
-        employed = s2.employed,
-        newWage = s2.newWage,
-        laborDemand = s2.laborDemand,
-        wageGrowth = s2.wageGrowth,
-        govPurchases = s4.govPurchases,
-        avgDemandMult = s4.avgDemandMult,
-        sectorCapReal = s4.sectorCapReal,
-        laggedInvestDemand = s4.laggedInvestDemand,
-        fiscalRuleStatus = s4.fiscalRuleStatus,
-        laborOutput = s2,
-        operationalSignals = OperationalSignals(
-          sectorDemandMult = s4.sectorMults,
-          sectorDemandPressure = s4.sectorDemandPressure,
-          sectorHiringSignal = s4.sectorHiringSignal,
-          operationalHiringSlack = s2.operationalHiringSlack,
-        ),
-        hhOutput = s3,
-        firmOutput = s5,
-        hhFinancialOutput = s6,
-        priceEquityOutput = s7,
-        openEconOutput = s8,
-        banks = init.banks,
-        depositRng = stageRandomness.bankingEconomics,
+    val bankingInput = BankingEconomics.Input(
+      w = w,
+      ledgerFinancialState = ledgerState(w, init.firms, init.households, init.banks),
+      month = s1.m,
+      lendingBaseRate = s1.lendingBaseRate,
+      resWage = s1.resWage,
+      baseMinWage = s1.baseMinWage,
+      minWagePriceLevel = s1.updatedMinWagePriceLevel,
+      employed = s2.employed,
+      newWage = s2.newWage,
+      laborDemand = s2.laborDemand,
+      wageGrowth = s2.wageGrowth,
+      govPurchases = s4.govPurchases,
+      avgDemandMult = s4.avgDemandMult,
+      sectorCapReal = s4.sectorCapReal,
+      laggedInvestDemand = s4.laggedInvestDemand,
+      fiscalRuleStatus = s4.fiscalRuleStatus,
+      laborOutput = s2,
+      operationalSignals = OperationalSignals(
+        sectorDemandMult = s4.sectorMults,
+        sectorDemandPressure = s4.sectorDemandPressure,
+        sectorHiringSignal = s4.sectorHiringSignal,
+        operationalHiringSlack = s2.operationalHiringSlack,
+      ),
+      hhOutput = s3,
+      firmOutput = s5,
+      hhFinancialOutput = s6,
+      priceEquityOutput = s7,
+      openEconOutput = s8,
+      banks = init.banks,
+      depositRng = stageRandomness.bankingEconomics,
+    )
+    val s9           = BankingEconomics.runStep(
+      BankingEconomics.StepInput(
+        w,
+        bankingInput.ledgerFinancialState,
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        s8,
+        init.banks,
+        stageRandomness.bankingEconomics,
       ),
     )
+    val res          = BankingEconomics.toResult(s9, bankingInput)
+
+    s9.ledgerFinancialState.government.govBondOutstanding shouldBe s9.newGovWithYield.bondsOutstanding
+    s9.ledgerFinancialState.foreign.govBondHoldings shouldBe s9.newGovWithYield.foreignBondHoldings
+    s9.ledgerFinancialState.nbp.govBondHoldings shouldBe s9.finalNbp.govBondHoldings
+    s9.ledgerFinancialState.insurance.govBondHoldings shouldBe s9.finalInsurance.govBondHoldings
+    s9.ledgerFinancialState.funds.ppkGovBondHoldings shouldBe s9.finalPpk.bondHoldings
+    s9.ledgerFinancialState.funds.nbfi.tfiUnit shouldBe s9.finalNbfi.tfiAum
+    s9.ledgerFinancialState.funds.quasiFiscal.bondsOutstanding shouldBe s9.newQuasiFiscal.bondsOutstanding
 
     val flows = BankingFlows.emit(
       BankingFlows.Input(


### PR DESCRIPTION
Summary:
- Add ledgerFinancialState to BankingEconomics.StepOutput.
- Build the banking-stage LedgerFinancialState from final banking/public/financial outputs in BankingEconomics.runStep.
- Let WorldAssemblyEconomics use s9.ledgerFinancialState instead of reconstructing the public/financial slice from mirror fields.
- Keep post-assembly dynamic household/firm/bank remapping in WorldAssemblyEconomics for now because startup staffing and regional migration still happen there.

Validation:
- sbt scalafmtAll
- sbt "Test/compile" "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.engine.economics.WorldAssemblyEconomicsSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"

Refs #380
Refs #378