### PR TITLE
Read corporate bond holders from ledger state

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -270,18 +270,19 @@ object OpenEconEconomics:
     val qeRequest = Nbp.executeQe(preQeNbp, bankAgg.govBondHoldings, in.gdp, in.newInflation, newExp.expectedInflation)
 
     // 7. Corporate bonds
-    val corpBondAmort = CorporateBondMarket.amortization(in.w.financial.corporateBonds)
+    val prevCorpBonds = LedgerBoundaryProjection.corporateBondState(in.w.financial.corporateBonds, in.ledgerFinancialState)
+    val corpBondAmort = CorporateBondMarket.amortization(prevCorpBonds)
     val newCorpBonds  = CorporateBondMarket.step(
       CorporateBondMarket.StepInput(
-        in.w.financial.corporateBonds,
+        prevCorpBonds,
         marketYield,
         bankAgg.nplRatio,
         in.totalBondDefault,
         in.actualBondIssuance,
       ),
     )
-    val corpCoupon    = CorporateBondMarket.computeCoupon(in.w.financial.corporateBonds)
-    val corpDefaults  = CorporateBondMarket.processDefaults(in.w.financial.corporateBonds, in.totalBondDefault)
+    val corpCoupon    = CorporateBondMarket.computeCoupon(prevCorpBonds)
+    val corpDefaults  = CorporateBondMarket.processDefaults(prevCorpBonds, in.totalBondDefault)
 
     // 8. Insurance
     val unempRate    = in.w.unemploymentRate(in.employed)
@@ -649,11 +650,12 @@ object OpenEconEconomics:
     BondQeResult(marketYield, newWeightedCoupon, bankBondIncome, nbpRemittance, monthlyDebtService, qePurchaseAmount, postFxNbp)
 
   private def runStepCorporateBonds(in: StepInput, bankAgg: Banking.Aggregate, newBondYield: Rate)(using SimParams): CorporateBonds =
-    val corpBondAmort    = CorporateBondMarket.amortization(in.w.financial.corporateBonds)
+    val prevCorpBonds    = LedgerBoundaryProjection.corporateBondState(in.w.financial.corporateBonds, in.ledgerFinancialState)
+    val corpBondAmort    = CorporateBondMarket.amortization(prevCorpBonds)
     val newCorpBonds     = CorporateBondMarket
       .step(
         CorporateBondMarket.StepInput(
-          prev = in.w.financial.corporateBonds,
+          prev = prevCorpBonds,
           govBondYield = newBondYield,
           nplRatio = bankAgg.nplRatio,
           totalBondDefault = in.s5.totalBondDefault,
@@ -661,8 +663,8 @@ object OpenEconEconomics:
         ),
       )
       .copy(lastAbsorptionRate = in.s5.corpBondAbsorption)
-    val corpBondCoupon   = CorporateBondMarket.computeCoupon(in.w.financial.corporateBonds)
-    val corpBondDefaults = CorporateBondMarket.processDefaults(in.w.financial.corporateBonds, in.s5.totalBondDefault)
+    val corpBondCoupon   = CorporateBondMarket.computeCoupon(prevCorpBonds)
+    val corpBondDefaults = CorporateBondMarket.processDefaults(prevCorpBonds, in.s5.totalBondDefault)
     CorporateBonds(
       newCorpBonds = newCorpBonds,
       corpBondBankCoupon = corpBondCoupon.bank,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.*
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -152,6 +153,11 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       financial = w.financial.copy(
+        corporateBonds = w.financial.corporateBonds.copy(
+          bankHoldings = w.financial.corporateBonds.bankHoldings + PLN(111),
+          ppkHoldings = w.financial.corporateBonds.ppkHoldings + PLN(112),
+          otherHoldings = w.financial.corporateBonds.otherHoldings + PLN(113),
+        ),
         insurance = w.financial.insurance.copy(
           reserves = w.financial.insurance.reserves.copy(
             lifeReserves = w.financial.insurance.lifeReserves + PLN(105),
@@ -238,7 +244,47 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
     fromLedger.nbpRemittance shouldBe aligned.nbpRemittance
     fromLedger.newNbpGovBondHoldings shouldBe aligned.newNbpGovBondHoldings
     fromLedger.newNbpFxReserves shouldBe aligned.newNbpFxReserves
+    fromLedger.corpBondCoupon shouldBe aligned.corpBondCoupon
+    fromLedger.corpBondDefaultLoss shouldBe aligned.corpBondDefaultLoss
     fromLedger.insInvestmentIncome shouldBe aligned.insInvestmentIncome
+  }
+
+  it should "read corporate bond stocks from LedgerFinancialState in runStep" in {
+    val mismatchedWorld = w.copy(
+      financial = w.financial.copy(
+        corporateBonds = w.financial.corporateBonds.copy(
+          bankHoldings = w.financial.corporateBonds.bankHoldings + PLN(111),
+          ppkHoldings = w.financial.corporateBonds.ppkHoldings + PLN(112),
+          otherHoldings = w.financial.corporateBonds.otherHoldings + PLN(113),
+        ),
+      ),
+    )
+
+    def run(world: World): OpenEconEconomics.StepOutput =
+      OpenEconEconomics.runStep(
+        OpenEconEconomics.StepInput(
+          w = world,
+          ledgerFinancialState = baseLedgerFinancialState,
+          s1 = s1,
+          s2 = s2,
+          s3 = s3,
+          s4 = s4,
+          s5 = s5,
+          s6 = s6,
+          s7 = s7,
+          banks = init.banks,
+          commodityRng = RandomStream.seeded(TestSeed),
+        ),
+      )
+
+    val aligned    = run(w)
+    val fromLedger = run(mismatchedWorld)
+
+    fromLedger.corpBonds.corpBondBankCoupon shouldBe aligned.corpBonds.corpBondBankCoupon
+    fromLedger.corpBonds.corpBondBankDefaultLoss shouldBe aligned.corpBonds.corpBondBankDefaultLoss
+    fromLedger.corpBonds.newCorpBonds.bankHoldings shouldBe aligned.corpBonds.newCorpBonds.bankHoldings
+    fromLedger.corpBonds.newCorpBonds.ppkHoldings shouldBe aligned.corpBonds.newCorpBonds.ppkHoldings
+    fromLedger.corpBonds.newCorpBonds.otherHoldings shouldBe aligned.corpBonds.newCorpBonds.otherHoldings
   }
 
   it should "produce non-negative interbank flows" in {


### PR DESCRIPTION
Summary:
- Route OpenEconEconomics corporate-bond holder reads through LedgerBoundaryProjection.corporateBondState in both compute and runStep.
- Add mismatch tests proving corporate-bond holder stocks come from LedgerFinancialState rather than World mirrors.
- Keep issuer-side CorporateBondMarket.outstanding on the existing boundary state in this PR; switching it to firm ledger liabilities currently breaks the SFC CorpBondStock identity and belongs to the later firm issuer-liability ownership migration.

Validation:
- sbt scalafmtAll
- sbt "Test/compile" "testOnly com.boombustgroup.amorfati.engine.economics.OpenEconEconomicsSpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"

Refs #380
Refs #378