### PR TITLE
Use FirmFlows as the single equity issuance owner

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EquityFlows.scala
@@ -4,10 +4,11 @@ import com.boombustgroup.amorfati.engine.ledger.{ForeignRuntimeContract, Treasur
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
-/** GPW equity market emitting flows.
+/** GPW equity market emitting dividend flows.
   *
   * Dividends: domestic (Firm→HH net of Belka tax), foreign (Firm→Foreign).
-  * Issuance: HH→Firm (equity capital).
+  * Equity issuance belongs to FirmFlows because the current-month financing
+  * decision is produced by FirmEconomics before market memory is finalized.
   *
   * Account IDs: 0=Firm, 1=HH, 2=Foreign, 3=Gov (Belka tax)
   */
@@ -23,7 +24,6 @@ object EquityFlows:
       foreignDividends: PLN,
       dividendTax: PLN,
       govDividends: PLN,
-      issuance: PLN,
   )
 
   def emitBatches(input: Input)(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
@@ -64,15 +64,6 @@ object EquityFlows:
         AssetType.Cash,
         FlowMechanism.EquityGovDividend,
       ),
-      AggregateBatchedEmission.transfer(
-        EntitySector.Households,
-        topology.households.investors,
-        EntitySector.Firms,
-        topology.firms.aggregate,
-        input.issuance,
-        AssetType.Equity,
-        FlowMechanism.EquityIssuance,
-      ),
     )
 
   def emit(input: Input): Vector[Flow] =
@@ -82,5 +73,4 @@ object EquityFlows:
     if input.foreignDividends > PLN.Zero then flows += Flow(FIRM_ACCOUNT, FOREIGN_ACCOUNT, input.foreignDividends.toLong, FlowMechanism.EquityForDividend.toInt)
     if input.dividendTax > PLN.Zero then flows += Flow(HH_ACCOUNT, GOV_ACCOUNT, input.dividendTax.toLong, FlowMechanism.EquityDividendTax.toInt)
     if input.govDividends > PLN.Zero then flows += Flow(FIRM_ACCOUNT, GOV_ACCOUNT, input.govDividends.toLong, FlowMechanism.EquityGovDividend.toInt)
-    if input.issuance > PLN.Zero then flows += Flow(HH_ACCOUNT, FIRM_ACCOUNT, input.issuance.toLong, FlowMechanism.EquityIssuance.toInt)
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -69,7 +69,6 @@ object FlowMechanism:
   val EquityDomDividend: MechanismId            = MechanismId(54)
   val EquityForDividend: MechanismId            = MechanismId(55)
   val EquityDividendTax: MechanismId            = MechanismId(56)
-  val EquityIssuance: MechanismId               = MechanismId(57)
   // Corporate bonds
   val CorpBondCoupon: MechanismId               = MechanismId(58)
   val CorpBondDefault: MechanismId              = MechanismId(59)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -114,7 +114,6 @@ object FlowSimulation:
       equityForDividends: PLN,
       equityDivTax: PLN,
       equityGovDividends: PLN,
-      equityIssuance: PLN,
       equityReturn: Rate,
       // Stage 8: Open economy
       exports: PLN,
@@ -244,7 +243,6 @@ object FlowSimulation:
           c.equityForDividends,
           c.equityDivTax,
           c.equityGovDividends,
-          c.equityIssuance,
         ),
       ),
       CorpBondFlows.emitBatches(CorpBondFlows.Input(c.corpBondCoupon, c.corpBondDefaultAmount, c.corpBondIssuance, c.corpBondAmortization)),
@@ -561,7 +559,6 @@ object FlowSimulation:
       equityForDividends = eq.lastForeignDividends,
       equityDivTax = eq.lastDividendTax,
       equityGovDividends = w.gov.govDividendRevenue,
-      equityIssuance = eq.lastIssuance,
       equityReturn = eq.monthlyReturn,
       exports = externalFlowBop.exports,
       totalImports = externalFlowBop.totalImports,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
@@ -205,7 +205,7 @@ object AssetOwnershipContract:
         singleton(EntitySector.Insurance),
         fund(FundRuntimeIndex.Nbfi),
       ),
-      "Supported stock family despite separate timing-cleanup work for equity flows.",
+      "Supported stock family; FirmFlows owns current-month issuance while EquityFlows owns dividends.",
     ),
     PublicAssetContract(
       AssetType.LifeReserve,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -75,7 +75,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
           equityReturn = Rate(0.03),
         ),
       ),
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(
@@ -169,7 +169,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
           equityReturn = Rate(0.03),
         ),
       ),
-      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
+      EquityFlows.emitBatches(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0))),
       CorpBondFlows.emitBatches(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emitBatches(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emitBatches(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -88,7 +88,7 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
         ),
       ),
       // Tier 3: Financial markets + external
-      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0), PLN(1000000.0))),
+      EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(50000.0))),
       CorpBondFlows.emit(CorpBondFlows.Input(PLN(300000.0), PLN(50000.0), PLN(1000000.0), PLN(200000.0))),
       MortgageFlows.emit(MortgageFlows.Input(PLN(5000000.0), PLN(2000000.0), PLN(1500000.0), PLN(300000.0))),
       OpenEconFlows.emit(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/EquityFlowsSpec.scala
@@ -8,20 +8,20 @@ import org.scalatest.matchers.should.Matchers
 class EquityFlowsSpec extends AnyFlatSpec with Matchers:
 
   "EquityFlows" should "preserve total wealth at exactly 0L" in {
-    val flows    = EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0)))
+    val flows    = EquityFlows.emit(EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero))
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
     Interpreter.totalWealth(balances) shouldBe 0L
   }
 
-  it should "have firm balance = -dividends + issuance" in {
-    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))
+  it should "have firm balance = -dividend payouts" in {
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN(250000.0))
     val flows    = EquityFlows.emit(input)
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
-    balances(EquityFlows.FIRM_ACCOUNT) shouldBe (input.issuance - input.netDomesticDividends - input.foreignDividends).toLong
+    balances(EquityFlows.FIRM_ACCOUNT) shouldBe (-input.netDomesticDividends - input.foreignDividends - input.govDividends).toLong
   }
 
   it should "preserve SFC across 120 months" in {
-    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero, PLN(1000000.0))
+    val input    = EquityFlows.Input(PLN(500000.0), PLN(200000.0), PLN(100000.0), PLN.Zero)
     var balances = Map.empty[Int, Long]
     (1 to 120).foreach { _ =>
       balances = Interpreter.applyAll(balances, EquityFlows.emit(input))
@@ -30,7 +30,7 @@ class EquityFlowsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "emit a dedicated firm-to-government SOE dividend flow when government extraction is positive" in {
-    val input = EquityFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN(250000.0), PLN.Zero)
+    val input = EquityFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN(250000.0))
     val flows = EquityFlows.emit(input)
 
     flows.exists(flow =>

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -51,6 +51,28 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.calculus.employed should be > 0
   }
 
+  it should "emit equity issuance once from current-month firm financing" in {
+    val init          = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val baseState     = FlowSimulation.SimState.fromInit(init)
+    val staleIssuance = PLN(987654321.0)
+    val state         = baseState.copy(
+      world = baseState.world.copy(
+        financialMarkets = baseState.world.financialMarkets.copy(
+          equity = baseState.world.financialMarkets.equity.copy(lastIssuance = staleIssuance),
+        ),
+      ),
+    )
+
+    val result                = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val firmIssuance          = mechanismTotal(result.flows, FlowMechanism.FirmEquityIssuance)
+    val equityIssuanceBatches = result.flows.filter(batch => batch.asset == AssetType.Equity && batch.to == EntitySector.Firms)
+
+    equityIssuanceBatches.map(_.mechanism).toSet shouldBe Set(FlowMechanism.FirmEquityIssuance)
+    firmIssuance shouldBe result.calculus.firmEquityIssuance
+    firmIssuance shouldBe result.nextState.world.financialMarkets.equity.lastIssuance
+    firmIssuance should not equal staleIssuance
+  }
+
   it should "keep corporate bond outstanding ledger-owned across month boundaries" in {
     val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)


### PR DESCRIPTION
## Summary

- make `FirmFlows` the single runtime owner for current-month equity issuance via `FirmEquityIssuance`
- remove the duplicate `EquityFlows` issuance leg and the stale `FlowMechanism.EquityIssuance` ID
- stop carrying `eq.lastIssuance` as a second `MonthlyCalculus` issuance source
- add a regression proving equity issuance batches to firms are emitted only through `FirmEquityIssuance` and still align with GPW market memory

## Verification

- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.engine.flows.EquityFlowsSpec com.boombustgroup.amorfati.engine.flows.FirmFlowsSpec com.boombustgroup.amorfati.engine.flows.BatchedEmissionContractSpec com.boombustgroup.amorfati.engine.flows.CompositeFlowsSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"`
- `sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"`
- `sbt assembly`
- `java -jar target/scala-3.8.2/amor-fati.jar 10 m17 --duration 60 --run-id m17-344-60m-10s`
  - `Unemp`: `5.7% .. 7.4%`
  - `pi`: `-4.5% .. 1.1%`

Closes #344
