### PR TITLE
Align NFZ runtime emission with semantic state

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -117,6 +117,7 @@ object FirmEconomics:
       sumNewLoans: PLN,                           // total new bank loans incl. reversion
       corpBondAbsorption: Share,                  // Catalyst absorption ratio (0-1)
       actualBondIssuance: PLN,                    // bonds issued after absorption constraint
+      bondReversionByFirm: Map[FirmId, PLN],      // unsold bonds reverted to relationship-bank loans
   )
 
   /** Financing split: how a firm's CAPEX loan is divided across three channels.
@@ -414,39 +415,44 @@ object FirmEconomics:
       banks: Vector[Banking.BankState],
       ledgerFinancialState: LedgerFinancialState,
   )(using p: SimParams): BondAbsorptionResult =
-    val bankAgg            = Banking.aggregateFromBankStocks(
+    val bankAgg              = Banking.aggregateFromBankStocks(
       banks,
       ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks),
       bankId => CorporateBondOwnership.bankHolderFor(ledgerFinancialState, bankId),
     )
-    val absorption         = CorporateBondMarket
+    val absorption           = CorporateBondMarket
       .computeAbsorption(w.financialMarkets.corporateBonds, result.flows.bondIssuance, bankAgg.car, p.banking.minCar)
-    val actualBondIssuance = result.flows.bondIssuance * absorption
-    val revertShare        = Share.One - absorption
+    val actualBondIssuance   = result.flows.bondIssuance * absorption
+    val revertShare          = Share.One - absorption
+    val requestedByFirm      = result.outcomes
+      .map(o => o.firm.id -> result.firmBondAmounts.getOrElse(o.firm.id, PLN.Zero))
+      .filter((_, amount) => amount > PLN.Zero)
+    val actualIssuanceByFirm =
+      allocateAbsorbedBondIssuance(requestedByFirm, actualBondIssuance)
+    val shouldRevert         = revertShare > Share(BondRevertThreshold)
+    val bondReversionByFirm  =
+      if shouldRevert then
+        requestedByFirm
+          .map((firmId, requested) => firmId -> (requested - actualIssuanceByFirm.getOrElse(firmId, PLN.Zero)).max(PLN.Zero))
+          .filter((_, amount) => amount > PLN.Zero)
+          .toMap
+      else Map.empty[FirmId, PLN]
 
     val adjusted =
       result.outcomes.map: o =>
-        val ba = result.firmBondAmounts.getOrElse(o.firm.id, PLN.Zero)
-        if revertShare > Share(BondRevertThreshold) && ba > PLN.Zero then
-          val revert = ba * revertShare
+        val revert = bondReversionByFirm.getOrElse(o.firm.id, PLN.Zero)
+        if revert > PLN.Zero then
           (
             o.firm,
             o.financialStocks.copy(firmLoan = o.financialStocks.firmLoan + revert),
           )
         else (o.firm, o.financialStocks)
 
-    val actualIssuanceByFirm =
-      result.firmBondAmounts.view
-        .mapValues(_ * absorption)
-        .filter((_, amount) => amount > PLN.Zero)
-        .toMap
-    val issuerLedger         = ledgerFinancialState.copy(
+    val issuerLedger = ledgerFinancialState.copy(
       firms = CorporateBondOwnership.applyIssuance(ledgerFinancialState.firms, actualIssuanceByFirm),
     )
 
-    val bondRevertLoans =
-      if revertShare > Share(BondRevertThreshold) then result.flows.bondIssuance * revertShare
-      else PLN.Zero
+    val bondRevertLoans = bondReversionByFirm.valuesIterator.sum
 
     BondAbsorptionResult(
       adjusted.map(_._1),
@@ -455,7 +461,51 @@ object FirmEconomics:
       result.flows.newLoans + bondRevertLoans,
       absorption,
       actualBondIssuance,
+      bondReversionByFirm,
     )
+
+  private[amorfati] def allocateAbsorbedBondIssuance(
+      requestedByFirm: Vector[(FirmId, PLN)],
+      actualBondIssuance: PLN,
+  ): Map[FirmId, PLN] =
+    val positiveRequests = requestedByFirm.filter((_, amount) => amount > PLN.Zero)
+    val target           = actualBondIssuance.distributeRaw
+    val totalRequested   = positiveRequests.iterator.map((_, amount) => amount.distributeRaw).sum
+    if positiveRequests.isEmpty || target <= 0L || totalRequested <= 0L then Map.empty
+    else if target >= totalRequested then positiveRequests.toMap
+    else
+      case class AllocationRow(index: Int, firmId: FirmId, requested: Long, base: Long, remainder: BigInt)
+
+      val rows = positiveRequests.zipWithIndex.map { case ((firmId, requestedAmount), index) =>
+        val requested = requestedAmount.distributeRaw
+        val product   = BigInt(target) * BigInt(requested)
+        AllocationRow(
+          index = index,
+          firmId = firmId,
+          requested = requested,
+          base = (product / BigInt(totalRequested)).toLong,
+          remainder = product % BigInt(totalRequested),
+        )
+      }
+
+      val remaining         = target - rows.iterator.map(_.base).sum
+      val (_, bonusByIndex) = rows
+        .sortWith: (left, right) =>
+          if left.remainder == right.remainder then left.index < right.index
+          else left.remainder > right.remainder
+        .foldLeft((remaining, Map.empty[Int, Long])) { case ((left, bonuses), row) =>
+          if left <= 0L || row.base >= row.requested then (left, bonuses)
+          else (left - 1L, bonuses.updated(row.index, 1L))
+        }
+
+      val allocations  = rows.map: row =>
+        row.firmId -> PLN.fromRaw(row.base + bonusByIndex.getOrElse(row.index, 0L))
+      val allocatedRaw = allocations.iterator.map((_, amount) => amount.distributeRaw).sum
+      require(
+        allocatedRaw == target,
+        s"Corporate bond absorption allocation must sum to target=$target, got $allocatedRaw",
+      )
+      allocations.filter((_, amount) => amount > PLN.Zero).toMap
 
   // ---- Phase 4: Intermediate market ----
 
@@ -598,10 +648,9 @@ object FirmEconomics:
     // Add bond reversion amounts to per-bank loans
     val perBankNewLoansWithRevert =
       if bonded.corpBondAbsorption < Share.One then
-        val revertShare = Share.One - bonded.corpBondAbsorption
         fp.outcomes.foldLeft(perBankNewLoans): (acc, o) =>
-          val ba = fp.firmBondAmounts.getOrElse(o.firm.id, PLN.Zero)
-          if ba > PLN.Zero then acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + ba * revertShare)
+          val revert = bonded.bondReversionByFirm.getOrElse(o.firm.id, PLN.Zero)
+          if revert > PLN.Zero then acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + revert)
           else acc
       else perBankNewLoans
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -423,14 +423,17 @@ object FirmEconomics:
     )
     val absorption           = CorporateBondMarket
       .computeAbsorption(w.financialMarkets.corporateBonds, result.flows.bondIssuance, bankAgg.car, p.banking.minCar)
-    val actualBondIssuance   = result.flows.bondIssuance * absorption
     val revertShare          = Share.One - absorption
     val requestedByFirm      = result.outcomes
       .map(o => o.firm.id -> result.firmBondAmounts.getOrElse(o.firm.id, PLN.Zero))
       .filter((_, amount) => amount > PLN.Zero)
-    val actualIssuanceByFirm =
-      allocateAbsorbedBondIssuance(requestedByFirm, actualBondIssuance, executionMonth)
     val shouldRevert         = revertShare > Share(BondRevertThreshold)
+    val absorbedBondIssuance = result.flows.bondIssuance * absorption
+    val actualIssuanceByFirm =
+      allocateAbsorbedBondIssuance(requestedByFirm, absorbedBondIssuance, executionMonth)
+    val issuanceMapToApply   =
+      if shouldRevert then actualIssuanceByFirm
+      else requestedByFirm.toMap
     val bondReversionByFirm  =
       if shouldRevert then
         requestedByFirm
@@ -450,10 +453,13 @@ object FirmEconomics:
         else (o.firm, o.financialStocks)
 
     val issuerLedger = ledgerFinancialState.copy(
-      firms = CorporateBondOwnership.applyIssuance(ledgerFinancialState.firms, actualIssuanceByFirm),
+      firms = CorporateBondOwnership.applyIssuance(ledgerFinancialState.firms, issuanceMapToApply),
     )
 
-    val bondRevertLoans = bondReversionByFirm.valuesIterator.sum
+    val bondRevertLoans    = bondReversionByFirm.valuesIterator.sum
+    val actualBondIssuance =
+      if shouldRevert then absorbedBondIssuance
+      else result.flows.bondIssuance
 
     BondAbsorptionResult(
       adjusted.map(_._1),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -215,7 +215,7 @@ object FirmEconomics:
   private def runInternal(stepIn: StepInput, rng: RandomStream)(using p: SimParams): StepOutput =
     val lending             = prepareLending(stepIn, rng)
     val fp                  = processFirms(stepIn.firms, stepIn.ledgerFinancialState, lending, rng)
-    val bonded              = applyBondAbsorption(fp, stepIn.w, stepIn.banks, stepIn.ledgerFinancialState)
+    val bonded              = applyBondAbsorption(fp, stepIn.w, stepIn.banks, stepIn.ledgerFinancialState, lending.executionMonth)
     val intermediate        = applyIntermediateMarket(bonded.firms, bonded.financialStocks, stepIn)
     // Calvo staggered pricing: per-firm markup update
     val calvoFirms          = intermediate.firms.map: f =>
@@ -414,6 +414,7 @@ object FirmEconomics:
       w: World,
       banks: Vector[Banking.BankState],
       ledgerFinancialState: LedgerFinancialState,
+      executionMonth: ExecutionMonth,
   )(using p: SimParams): BondAbsorptionResult =
     val bankAgg              = Banking.aggregateFromBankStocks(
       banks,
@@ -428,7 +429,7 @@ object FirmEconomics:
       .map(o => o.firm.id -> result.firmBondAmounts.getOrElse(o.firm.id, PLN.Zero))
       .filter((_, amount) => amount > PLN.Zero)
     val actualIssuanceByFirm =
-      allocateAbsorbedBondIssuance(requestedByFirm, actualBondIssuance)
+      allocateAbsorbedBondIssuance(requestedByFirm, actualBondIssuance, executionMonth)
     val shouldRevert         = revertShare > Share(BondRevertThreshold)
     val bondReversionByFirm  =
       if shouldRevert then
@@ -467,6 +468,7 @@ object FirmEconomics:
   private[amorfati] def allocateAbsorbedBondIssuance(
       requestedByFirm: Vector[(FirmId, PLN)],
       actualBondIssuance: PLN,
+      executionMonth: ExecutionMonth = ExecutionMonth.First,
   ): Map[FirmId, PLN] =
     val positiveRequests = requestedByFirm.filter((_, amount) => amount > PLN.Zero)
     val target           = actualBondIssuance.distributeRaw
@@ -474,7 +476,7 @@ object FirmEconomics:
     if positiveRequests.isEmpty || target <= 0L || totalRequested <= 0L then Map.empty
     else if target >= totalRequested then positiveRequests.toMap
     else
-      case class AllocationRow(index: Int, firmId: FirmId, requested: Long, base: Long, remainder: BigInt)
+      case class AllocationRow(index: Int, firmId: FirmId, requested: Long, base: Long, remainder: BigInt, tieBreak: Long)
 
       val rows = positiveRequests.zipWithIndex.map { case ((firmId, requestedAmount), index) =>
         val requested = requestedAmount.distributeRaw
@@ -485,13 +487,16 @@ object FirmEconomics:
           requested = requested,
           base = (product / BigInt(totalRequested)).toLong,
           remainder = product % BigInt(totalRequested),
+          tieBreak = allocationTieBreak(firmId, executionMonth),
         )
       }
 
       val remaining         = target - rows.iterator.map(_.base).sum
       val (_, bonusByIndex) = rows
         .sortWith: (left, right) =>
-          if left.remainder == right.remainder then left.index < right.index
+          if left.remainder == right.remainder then
+            if left.tieBreak == right.tieBreak then left.index < right.index
+            else left.tieBreak < right.tieBreak
           else left.remainder > right.remainder
         .foldLeft((remaining, Map.empty[Int, Long])) { case ((left, bonuses), row) =>
           if left <= 0L || row.base >= row.requested then (left, bonuses)
@@ -506,6 +511,14 @@ object FirmEconomics:
         s"Corporate bond absorption allocation must sum to target=$target, got $allocatedRaw",
       )
       allocations.filter((_, amount) => amount > PLN.Zero).toMap
+
+  private def allocationTieBreak(firmId: FirmId, executionMonth: ExecutionMonth): Long =
+    val firm  = firmId.toInt.toLong
+    val month = executionMonth.toLong
+    val mixed = (firm * 0x9e3779b97f4a7c15L) ^ (month * 0xbf58476d1ce4e5b9L)
+    val step1 = (mixed ^ (mixed >>> 30)) * 0xbf58476d1ce4e5b9L
+    val step2 = (step1 ^ (step1 >>> 27)) * 0x94d049bb133111ebL
+    (step2 ^ (step2 >>> 31)) & Long.MaxValue
 
   // ---- Phase 4: Intermediate market ----
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
@@ -69,6 +69,12 @@ object LaborEconomics:
 
     // Wage growth
     val wageGrowth = wageGrowthFrom(w.householdMarket.marketWage, cleared.wage)
+    val newNfz     = SocialSecurity.nfzStep(
+      cleared.employed,
+      cleared.wage,
+      newDemographics.workingAgePop,
+      newDemographics.retirees,
+    )
 
     Output(
       newWage = cleared.wage,
@@ -80,7 +86,7 @@ object LaborEconomics:
       netMigration = netMigration,
       newDemographics = newDemographics,
       newZus = SocialSecurity.ZusState.zero,
-      newNfz = SocialSecurity.NfzState.zero,
+      newNfz = newNfz,
       newPpk = SocialSecurity.PpkState.zero,
       rawPpkBondPurchase = PLN.Zero,
       newEarmarked = EarmarkedFunds.State.zero,
@@ -105,12 +111,19 @@ object LaborEconomics:
     val realizedEmployment = Household.countEmployed(postHouseholds)
     val employedCap        = Math.min(realizedEmployment, pre.newDemographics.workingAgePop)
     val postAvailableLabor = LaborMarket.laborSupplyAtWage(cleared.wage, s1.resWage, w.derivedTotalPopulation)
+    val newNfz             = SocialSecurity.nfzStep(
+      employedCap,
+      cleared.wage,
+      pre.newDemographics.workingAgePop,
+      pre.newDemographics.retirees,
+    )
     pre.copy(
       newWage = cleared.wage,
       employed = employedCap,
       laborDemand = postLaborDemand,
       wageGrowth = Coefficient(wageGrowthFrom(w.householdMarket.marketWage, cleared.wage)),
       operationalHiringSlack = operationalHiringSlackFactor(postLaborDemand, postAvailableLabor),
+      newNfz = newNfz,
       living = postLiving,
       regionalWages = cleared.regionalWages,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -76,6 +76,7 @@ object FlowSimulation:
       livingFirms: Int,
       retirees: Int,
       workingAgePop: Int,
+      nfz: SocialSecurity.NfzState,
       nBankruptFirms: Int,
       avgFirmWorkers: Int,
       // Stage 3: HH income (aggregates)
@@ -175,7 +176,7 @@ object FlowSimulation:
     Vector.concat(
       // Tier 1: Social funds
       ZusFlows.emitBatches(ZusFlows.ZusInput(c.employed, c.wage, c.retirees)),
-      NfzFlows.emitBatches(NfzFlows.NfzInput(c.employed, c.wage, c.workingAgePop, c.retirees)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput(c.nfz)),
       PpkFlows.emitBatches(PpkFlows.PpkInput(c.employed, c.wage)),
       EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.employed, c.wage, c.totalUnempBenefits, c.nBankruptFirms, c.avgFirmWorkers)),
       JstFlows.emitBatches(JstFlows.Input(c.firmTax, c.totalIncome, c.gdp, c.livingFirms, c.pitRevenue)),
@@ -528,6 +529,7 @@ object FlowSimulation:
       livingFirms = s5.ioFirms.count(Firm.isAlive),
       retirees = s2Pre.newDemographics.retirees,
       workingAgePop = s2Pre.newDemographics.workingAgePop,
+      nfz = s2.newNfz,
       nBankruptFirms = firms.length - s2Pre.living.length,
       avgFirmWorkers = if s2Pre.living.nonEmpty then s2Pre.laborDemand / s2Pre.living.length else 0,
       totalIncome = s3.totalIncome,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NfzFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.agents.SocialSecurity
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
@@ -7,9 +8,10 @@ import com.boombustgroup.ledger.*
 
 /** NFZ (National Health Fund) mechanism emitting flows.
   *
-  * Same logic as SocialSecurity.nfzStep. 9% skladka zdrowotna from employed,
-  * spending = per-capita cost x (working-age + retirees x aging elasticity).
-  * Deficit covered by government subvention.
+  * Runtime emitter for the NFZ state computed by [[SocialSecurity.nfzStep]] in
+  * the economics pipeline. Keeping the batch input as `NfzState` makes the
+  * runtime ledger and SFC semantic projection share one current-month source of
+  * truth.
   *
   * Account IDs: 0 = HH, 1 = NFZ, 2 = GOV, 3 = Healthcare (spending sink)
   */
@@ -20,55 +22,46 @@ object NfzFlows:
   val GOV_ACCOUNT: Int        = 2
   val HEALTHCARE_ACCOUNT: Int = 3
 
-  case class NfzInput(
-      employed: Int,
-      wage: PLN,
-      workingAge: Int,
-      nRetirees: Int,
-  )
+  case class NfzInput(nfz: SocialSecurity.NfzState)
 
-  def emitBatches(input: NfzInput)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    val contributions = input.employed * (input.wage * p.social.nfzContribRate)
-    val spending      =
-      input.workingAge * p.social.nfzPerCapitaCost +
-        input.nRetirees * (p.social.nfzPerCapitaCost * p.social.nfzAgingElasticity)
-    val deficit       = spending - contributions
+  object NfzInput:
+    def fromDrivers(employed: Int, wage: PLN, workingAge: Int, nRetirees: Int)(using p: SimParams): NfzInput =
+      NfzInput(SocialSecurity.nfzStep(employed, wage, workingAge, nRetirees))
+
+  def emitBatches(input: NfzInput)(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    val nfz = input.nfz
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Households,
         topology.households.aggregate,
         EntitySector.Funds,
         topology.funds.nfz,
-        contributions,
+        nfz.contributions,
         AssetType.Cash,
         FlowMechanism.NfzContribution,
       ),
       AggregateBatchedEmission
-        .transfer(EntitySector.Funds, topology.funds.nfz, EntitySector.Firms, topology.firms.services, spending, AssetType.Cash, FlowMechanism.NfzSpending),
+        .transfer(EntitySector.Funds, topology.funds.nfz, EntitySector.Firms, topology.firms.services, nfz.spending, AssetType.Cash, FlowMechanism.NfzSpending),
       AggregateBatchedEmission.transfer(
         EntitySector.Government,
         TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         topology.funds.nfz,
-        deficit,
+        nfz.govSubvention,
         AssetType.Cash,
         FlowMechanism.NfzGovSubvention,
       ),
     )
 
-  def emit(input: NfzInput)(using p: SimParams): Vector[Flow] =
-    val contributions = input.employed * (input.wage * p.social.nfzContribRate)
-    val spending      =
-      input.workingAge * p.social.nfzPerCapitaCost +
-        input.nRetirees * (p.social.nfzPerCapitaCost * p.social.nfzAgingElasticity)
-    val deficit       = spending - contributions
+  def emit(input: NfzInput): Vector[Flow] =
+    val nfz = input.nfz
 
     val flows = Vector.newBuilder[Flow]
 
-    if contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, NFZ_ACCOUNT, contributions.toLong, FlowMechanism.NfzContribution.toInt)
+    if nfz.contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, NFZ_ACCOUNT, nfz.contributions.toLong, FlowMechanism.NfzContribution.toInt)
 
-    if spending > PLN.Zero then flows += Flow(NFZ_ACCOUNT, HEALTHCARE_ACCOUNT, spending.toLong, FlowMechanism.NfzSpending.toInt)
+    if nfz.spending > PLN.Zero then flows += Flow(NFZ_ACCOUNT, HEALTHCARE_ACCOUNT, nfz.spending.toLong, FlowMechanism.NfzSpending.toInt)
 
-    if deficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, NFZ_ACCOUNT, deficit.toLong, FlowMechanism.NfzGovSubvention.toInt)
+    if nfz.govSubvention > PLN.Zero then flows += Flow(GOV_ACCOUNT, NFZ_ACCOUNT, nfz.govSubvention.toLong, FlowMechanism.NfzGovSubvention.toInt)
 
     flows.result()

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -99,6 +99,20 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
     Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)).shouldBe(0L)
   }
 
+  it should "allocate absorbed corporate bond issuance exactly without over-issuing a firm" in {
+    val requested   = Vector(
+      FirmId(1) -> PLN.fromRaw(1L),
+      FirmId(2) -> PLN.fromRaw(1L),
+      FirmId(3) -> PLN.fromRaw(1L),
+    )
+    val target      = PLN.fromRaw(2L)
+    val allocations = FirmEconomics.allocateAbsorbedBondIssuance(requested, target)
+
+    allocations.valuesIterator.foldLeft(PLN.Zero)(_ + _) shouldBe target
+    requested.foreach: (firmId, requestedAmount) =>
+      allocations.getOrElse(firmId, PLN.Zero) should be <= requestedAmount
+  }
+
   it should "increase manufacturing capital accumulation when strategic firms are state-owned" in {
     val privateScenario     = manufacturingScenario(stateOwned = false, cashRich = true)
     val stateOwnedScenario  = manufacturingScenario(stateOwned = true, cashRich = true)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -113,6 +113,25 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
       allocations.getOrElse(firmId, PLN.Zero) should be <= requestedAmount
   }
 
+  it should "allocate absorbed corporate bond issuance by proportional base plus remainder" in {
+    val requested   = Vector(
+      FirmId(1) -> PLN.fromRaw(3L),
+      FirmId(2) -> PLN.fromRaw(2L),
+      FirmId(3) -> PLN.fromRaw(1L),
+    )
+    val target      = PLN.fromRaw(4L)
+    val allocations = FirmEconomics.allocateAbsorbedBondIssuance(requested, target)
+
+    allocations.valuesIterator.foldLeft(PLN.Zero)(_ + _) shouldBe target
+    requested.foreach: (firmId, requestedAmount) =>
+      allocations.getOrElse(firmId, PLN.Zero) should be <= requestedAmount
+    allocations shouldBe Map(
+      FirmId(1) -> PLN.fromRaw(2L),
+      FirmId(2) -> PLN.fromRaw(1L),
+      FirmId(3) -> PLN.fromRaw(1L),
+    )
+  }
+
   it should "increase manufacturing capital accumulation when strategic firms are state-owned" in {
     val privateScenario     = manufacturingScenario(stateOwned = false, cashRich = true)
     val stateOwnedScenario  = manufacturingScenario(stateOwned = true, cashRich = true)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/BatchedEmissionContractSpec.scala
@@ -22,7 +22,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
   "emitBatches" should "preserve mechanism totals across migrated emitters" in {
     val flatFlows = Vector.concat(
       ZusFlows.emit(ZusFlows.ZusInput(80000, PLN(7000.0), 1000)),
-      NfzFlows.emit(NfzFlows.NfzInput(80000, PLN(7000.0), 90000, 1000)),
+      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(80000, PLN(7000.0), 90000, 1000)),
       PpkFlows.emit(PpkFlows.PpkInput(80000, PLN(7000.0))),
       EarmarkedFlows.emit(EarmarkedFlows.Input(80000, PLN(7000.0), PLN(1000000.0), 10, 15)),
       JstFlows.emit(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),
@@ -117,7 +117,7 @@ class BatchedEmissionContractSpec extends AnyFlatSpec with Matchers:
 
     val batchedFlows = Vector.concat(
       ZusFlows.emitBatches(ZusFlows.ZusInput(80000, PLN(7000.0), 1000)),
-      NfzFlows.emitBatches(NfzFlows.NfzInput(80000, PLN(7000.0), 90000, 1000)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput.fromDrivers(80000, PLN(7000.0), 90000, 1000)),
       PpkFlows.emitBatches(PpkFlows.PpkInput(80000, PLN(7000.0))),
       EarmarkedFlows.emitBatches(EarmarkedFlows.Input(80000, PLN(7000.0), PLN(1000000.0), 10, 15)),
       JstFlows.emitBatches(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -17,14 +17,16 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   private def allFlows: Vector[Flow] =
-    val wage     = PLN(7000.0)
-    val employed = 80000
-    val retirees = 1000
+    val wage       = PLN(7000.0)
+    val employed   = 80000
+    val workingAge = 90000
+    val retirees   = 1000
+    val nRetirees  = retirees
 
     Vector.concat(
       // Tier 1: Social funds
       ZusFlows.emit(ZusFlows.ZusInput(employed, wage, retirees)),
-      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed, wage, 90000, retirees)),
+      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = employed, wage = wage, workingAge = workingAge, nRetirees = nRetirees)),
       PpkFlows.emit(PpkFlows.PpkInput(employed, wage)),
       EarmarkedFlows.emit(EarmarkedFlows.Input(employed, wage, PLN(1000000.0), 10, 15)),
       JstFlows.emit(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -24,7 +24,7 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
     Vector.concat(
       // Tier 1: Social funds
       ZusFlows.emit(ZusFlows.ZusInput(employed, wage, retirees)),
-      NfzFlows.emit(NfzFlows.NfzInput(employed, wage, 90000, retirees)),
+      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed, wage, 90000, retirees)),
       PpkFlows.emit(PpkFlows.PpkInput(employed, wage)),
       EarmarkedFlows.emit(EarmarkedFlows.Input(employed, wage, PLN(1000000.0), 10, 15)),
       JstFlows.emit(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/CompositeFlowsSpec.scala
@@ -21,12 +21,11 @@ class CompositeFlowsSpec extends AnyFlatSpec with Matchers:
     val employed   = 80000
     val workingAge = 90000
     val retirees   = 1000
-    val nRetirees  = retirees
 
     Vector.concat(
       // Tier 1: Social funds
       ZusFlows.emit(ZusFlows.ZusInput(employed, wage, retirees)),
-      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = employed, wage = wage, workingAge = workingAge, nRetirees = nRetirees)),
+      NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = employed, wage = wage, workingAge = workingAge, nRetirees = retirees)),
       PpkFlows.emit(PpkFlows.PpkInput(employed, wage)),
       EarmarkedFlows.emit(EarmarkedFlows.Input(employed, wage, PLN(1000000.0), 10, 15)),
       JstFlows.emit(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -12,9 +12,15 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  private def cashMechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
-    val selected = batches.filter(_.mechanism == mechanism)
-    selected.map(_.asset).toSet shouldBe Set(AssetType.Cash)
+  private def mechanismBatches(batches: Vector[BatchedFlow], mechanism: MechanismId): Vector[BatchedFlow] =
+    batches.filter(_.mechanism == mechanism)
+
+  private def assertAllCash(selected: Vector[BatchedFlow], mechanism: MechanismId): Unit =
+    withClue(s"Mechanism ${mechanism.toInt} should emit only cash batches: ") {
+      selected.map(_.asset).toSet shouldBe Set(AssetType.Cash)
+    }
+
+  private def cashMechanismTotal(selected: Vector[BatchedFlow]): PLN =
     PLN.fromRaw(
       selected.iterator
         .map(RuntimeLedgerTopology.totalTransferred)
@@ -36,9 +42,17 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     val nfz         = result.nextState.world.social.nfz
     val directFlows = NfzFlows.emit(NfzFlows.NfzInput(nfz))
 
-    val emittedContributions = cashMechanismTotal(result.flows, FlowMechanism.NfzContribution)
-    val emittedSpending      = cashMechanismTotal(result.flows, FlowMechanism.NfzSpending)
-    val emittedSubvention    = cashMechanismTotal(result.flows, FlowMechanism.NfzGovSubvention)
+    val contributionBatches = mechanismBatches(result.flows, FlowMechanism.NfzContribution)
+    val spendingBatches     = mechanismBatches(result.flows, FlowMechanism.NfzSpending)
+    val subventionBatches   = mechanismBatches(result.flows, FlowMechanism.NfzGovSubvention)
+
+    assertAllCash(contributionBatches, FlowMechanism.NfzContribution)
+    assertAllCash(spendingBatches, FlowMechanism.NfzSpending)
+    assertAllCash(subventionBatches, FlowMechanism.NfzGovSubvention)
+
+    val emittedContributions = cashMechanismTotal(contributionBatches)
+    val emittedSpending      = cashMechanismTotal(spendingBatches)
+    val emittedSubvention    = cashMechanismTotal(subventionBatches)
 
     result.sfcResult shouldBe Right(())
     withClue("SimParams.defaults with seed 42 should exercise a positive NFZ deficit path: ") {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.agents.SocialSecurity
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -34,6 +35,7 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     val state       = FlowSimulation.SimState.fromInit(init)
     val result      = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val nfz         = result.nextState.world.social.nfz
+    val expectedNfz = SocialSecurity.nfzStep(result.calculus.employed, result.calculus.wage, result.calculus.workingAgePop, result.calculus.retirees)
     val directFlows = NfzFlows.emit(NfzFlows.NfzInput(nfz))
 
     val emittedContributions = cashMechanismTotal(result.flows, FlowMechanism.NfzContribution)
@@ -41,12 +43,16 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     val emittedSubvention    = cashMechanismTotal(result.flows, FlowMechanism.NfzGovSubvention)
 
     result.sfcResult shouldBe Right(())
-    emittedSubvention should be > PLN.Zero
+    expectedNfz shouldBe nfz
+    withClue("SimParams.defaults with seed 42 should exercise the nfzStep positive govSubvention path: ") {
+      nfz.govSubvention should be > PLN.Zero
+      emittedSubvention should be > PLN.Zero
+    }
     emittedContributions shouldBe nfz.contributions
     emittedSpending shouldBe nfz.spending
     emittedSubvention shouldBe nfz.govSubvention
 
-    flowTotal(directFlows, FlowMechanism.NfzContribution) shouldBe nfz.contributions
-    flowTotal(directFlows, FlowMechanism.NfzSpending) shouldBe nfz.spending
-    flowTotal(directFlows, FlowMechanism.NfzGovSubvention) shouldBe nfz.govSubvention
+    emittedContributions shouldBe flowTotal(directFlows, FlowMechanism.NfzContribution)
+    emittedSpending shouldBe flowTotal(directFlows, FlowMechanism.NfzSpending)
+    emittedSubvention shouldBe flowTotal(directFlows, FlowMechanism.NfzGovSubvention)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -1,6 +1,5 @@
 package com.boombustgroup.amorfati.engine.flows
 
-import com.boombustgroup.amorfati.agents.SocialSecurity
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -35,7 +34,6 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     val state       = FlowSimulation.SimState.fromInit(init)
     val result      = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
     val nfz         = result.nextState.world.social.nfz
-    val expectedNfz = SocialSecurity.nfzStep(result.calculus.employed, result.calculus.wage, result.calculus.workingAgePop, result.calculus.retirees)
     val directFlows = NfzFlows.emit(NfzFlows.NfzInput(nfz))
 
     val emittedContributions = cashMechanismTotal(result.flows, FlowMechanism.NfzContribution)
@@ -43,8 +41,9 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     val emittedSubvention    = cashMechanismTotal(result.flows, FlowMechanism.NfzGovSubvention)
 
     result.sfcResult shouldBe Right(())
-    expectedNfz shouldBe nfz
-    withClue("SimParams.defaults with seed 42 should exercise the nfzStep positive govSubvention path: ") {
+    withClue("SimParams.defaults with seed 42 should exercise a positive NFZ deficit path: ") {
+      nfz.spending should be > nfz.contributions
+      nfz.govSubvention shouldBe (nfz.spending - nfz.contributions)
       nfz.govSubvention should be > PLN.Zero
       emittedSubvention should be > PLN.Zero
     }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -1,0 +1,52 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, Flow, MechanismId}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  private def cashMechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
+    val selected = batches.filter(_.mechanism == mechanism)
+    selected.map(_.asset).toSet shouldBe Set(AssetType.Cash)
+    PLN.fromRaw(
+      selected.iterator
+        .map(RuntimeLedgerTopology.totalTransferred)
+        .sum,
+    )
+
+  private def flowTotal(flows: Vector[Flow], mechanism: MechanismId): PLN =
+    PLN.fromRaw(
+      flows.iterator
+        .filter(_.mechanism == mechanism.toInt)
+        .map(_.amount)
+        .sum,
+    )
+
+  "FlowSimulation.step" should "align NFZ runtime emission with direct NfzFlows emission in default CI" in {
+    val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state       = FlowSimulation.SimState.fromInit(init)
+    val result      = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val nfz         = result.nextState.world.social.nfz
+    val directFlows = NfzFlows.emit(NfzFlows.NfzInput(nfz))
+
+    val emittedContributions = cashMechanismTotal(result.flows, FlowMechanism.NfzContribution)
+    val emittedSpending      = cashMechanismTotal(result.flows, FlowMechanism.NfzSpending)
+    val emittedSubvention    = cashMechanismTotal(result.flows, FlowMechanism.NfzGovSubvention)
+
+    result.sfcResult shouldBe Right(())
+    emittedSubvention should be > PLN.Zero
+    emittedContributions shouldBe nfz.contributions
+    emittedSpending shouldBe nfz.spending
+    emittedSubvention shouldBe nfz.govSubvention
+
+    flowTotal(directFlows, FlowMechanism.NfzContribution) shouldBe nfz.contributions
+    flowTotal(directFlows, FlowMechanism.NfzSpending) shouldBe nfz.spending
+    flowTotal(directFlows, FlowMechanism.NfzGovSubvention) shouldBe nfz.govSubvention
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -169,6 +169,35 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     mechanismTotal(result.flows, FlowMechanism.JstSpending) should not equal staleJstSpending
   }
 
+  it should "align NFZ runtime subvention emission with semantic current-month state" in {
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state  = FlowSimulation.SimState.fromInit(init)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val nfz    = result.nextState.world.social.nfz
+
+    val emittedContributions = mechanismTotal(result.flows, FlowMechanism.NfzContribution)
+    val emittedSpending      = mechanismTotal(result.flows, FlowMechanism.NfzSpending)
+    val emittedSubvention    = mechanismTotal(result.flows, FlowMechanism.NfzGovSubvention)
+
+    result.sfcResult shouldBe Right(())
+    emittedSubvention should be > PLN.Zero
+    emittedContributions shouldBe nfz.contributions
+    emittedSpending shouldBe nfz.spending
+    emittedSubvention shouldBe nfz.govSubvention
+
+    result.trace.executedFlows.nfzContributions shouldBe nfz.contributions
+    result.trace.executedFlows.nfzSpending shouldBe nfz.spending
+    result.trace.executedFlows.nfzGovSubvention shouldBe nfz.govSubvention
+
+    val expectedGovSpending =
+      result.nextState.world.gov.domesticBudgetOutlays +
+        result.nextState.world.social.zus.govSubvention +
+        result.nextState.world.social.nfz.govSubvention +
+        result.nextState.world.social.earmarked.totalGovSubvention
+
+    result.trace.executedFlows.govSpending shouldBe expectedGovSpending
+  }
+
   it should "keep corporate bond outstanding ledger-owned across month boundaries" in {
     val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NfzFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NfzFlowsSpec.scala
@@ -11,13 +11,13 @@ class NfzFlowsSpec extends AnyFlatSpec with Matchers:
   private given p: SimParams = SimParams.defaults
 
   "NfzFlows" should "preserve total wealth at exactly 0L" in {
-    val flows    = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
+    val flows    = NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
     Interpreter.totalWealth(balances) shouldBe 0L
   }
 
   it should "have NFZ balance = contributions - spending + govSubvention" in {
-    val flows    = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
+    val flows    = NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000))
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
 
     val contribs   = flows.filter(_.mechanism == FlowMechanism.NfzContribution.toInt).map(_.amount).sum
@@ -29,11 +29,11 @@ class NfzFlowsSpec extends AnyFlatSpec with Matchers:
 
   it should "emit gov subvention only when spending exceeds contributions" in {
     // High retirees = high spending (aging elasticity 2.5x)
-    val deficit = NfzFlows.emit(NfzFlows.NfzInput(employed = 1000, wage = PLN(5000.0), workingAge = 5000, nRetirees = 5000))
+    val deficit = NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = 1000, wage = PLN(5000.0), workingAge = 5000, nRetirees = 5000))
     deficit.exists(_.mechanism == FlowMechanism.NfzGovSubvention.toInt) shouldBe true
 
     // Very high wages, tiny population = surplus
-    val surplus = NfzFlows.emit(NfzFlows.NfzInput(employed = 80000, wage = PLN(50000.0), workingAge = 1000, nRetirees = 10))
+    val surplus = NfzFlows.emit(NfzFlows.NfzInput.fromDrivers(employed = 80000, wage = PLN(50000.0), workingAge = 1000, nRetirees = 10))
     surplus.exists(_.mechanism == FlowMechanism.NfzGovSubvention.toInt) shouldBe false
   }
 
@@ -41,7 +41,7 @@ class NfzFlowsSpec extends AnyFlatSpec with Matchers:
     val employed = 80000; val wage = PLN(7000.0); val workingAge = 90000; val nRetirees = 1000
 
     val oldNfz = com.boombustgroup.amorfati.agents.SocialSecurity.nfzStep(employed, wage, workingAge, nRetirees)
-    val flows  = NfzFlows.emit(NfzFlows.NfzInput(employed, wage, workingAge, nRetirees))
+    val flows  = NfzFlows.emit(NfzFlows.NfzInput(oldNfz))
 
     val newContribs   = flows.filter(_.mechanism == FlowMechanism.NfzContribution.toInt).map(_.amount).sum
     val newSpending   = flows.filter(_.mechanism == FlowMechanism.NfzSpending.toInt).map(_.amount).sum
@@ -53,7 +53,7 @@ class NfzFlowsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "preserve SFC across 120 months" in {
-    val input    = NfzFlows.NfzInput(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000)
+    val input    = NfzFlows.NfzInput.fromDrivers(employed = 80000, wage = PLN(7000.0), workingAge = 90000, nRetirees = 1000)
     var balances = Map.empty[Int, Long]
     (1 to 120).foreach { _ =>
       balances = Interpreter.applyAll(balances, NfzFlows.emit(input))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
@@ -69,7 +69,7 @@ class RuntimeMechanismSurvivabilitySpec extends AnyFlatSpec with Matchers:
 
     Vector.concat(
       ZusFlows.emitBatches(ZusFlows.ZusInput(1000, PLN(1000.0), 100000)),
-      NfzFlows.emitBatches(NfzFlows.NfzInput(1000, PLN(1000.0), 200000, 100000)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput.fromDrivers(1000, PLN(1000.0), 200000, 100000)),
       PpkFlows.emitBatches(PpkFlows.PpkInput(10000, PLN(1000.0))),
       EarmarkedFlows.emitBatches(EarmarkedFlows.Input(1000, PLN(1000.0), PLN(100000000.0), 100000, 100)),
       EarmarkedFlows.emitBatches(EarmarkedFlows.Input(0, PLN.Zero, PLN.Zero, 0, 0))(using SimParamsTestOverrides.pfronDeficit, summon[RuntimeLedgerTopology]),


### PR DESCRIPTION
Closes #398

## Summary:
- compute current-month NFZ state in LaborEconomics and carry it through FlowSimulation calculus
- make NfzFlows emit from SocialSecurity.NfzState so runtime batches and SFC semantic projection share one source of truth
- add regression coverage for NFZ gov subvention, NFZ spending/contributions, and semantic govSpending
- fix exact per-firm corporate bond absorption allocation; the 60m smoke exposed a 1 raw-unit CorpBondStock SFC mismatch before this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Bond absorption now allocates absorbed issuance proportionally to firms, computes per‑firm unsold‑bond reversions, and applies reverted amounts directly to firm loan balances.
  * Healthcare fund (NFZ) calculations now consume a precomputed NFZ state passed through the monthly simulation, ensuring consistent NFZ flows and subvention outputs.

* **Tests**
  * Added tests for proportional bond allocation and for end‑to‑end NFZ runtime emission consistency across simulation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->