### PR TITLE
Source SFC flows from executed runtime evidence

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -117,11 +117,13 @@ object Sfc:
 
   /** Semantic monthly flow evidence used by the SFC oracle.
     *
-    * These values are assembled in WorldAssemblyEconomics from the intermediate
-    * results of Simulation.step. They must match the '''exact''' values used in
-    * balance sheet updates — any discrepancy will cause validate to report an
-    * SfcIdentityError. Flows for disabled mechanisms are simply zero, so the
-    * corresponding identity holds trivially.
+    * These values are assembled for SFC validation from the executed runtime
+    * flow evidence where a first-class mechanism exists, with residual
+    * non-runtime diagnostics still supplied by the month semantics. They must
+    * match the '''exact''' values used in balance sheet updates — any
+    * discrepancy will cause validate to report an SfcIdentityError. Flows for
+    * disabled mechanisms are simply zero, so the corresponding identity holds
+    * trivially.
     */
   case class SemanticFlows(
       govSpending: PLN,             // total budget expenditure (benefits + transfers + current spend + domestic capital spend + debt service + subventions + domestic EU co-financing)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -95,13 +95,13 @@ against 13 accounting identities each month.
 | File | Responsibility |
 |------|----------------|
 | `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, post-month assembly, and SFC projection, assembles `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
-| `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `FirmWages`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
+| `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `HhTotalIncome`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |
 | `NfzFlows.scala` | NFZ (National Health Fund): 9% składka zdrowotna, healthcare spending, gov subvention |
 | `PpkFlows.scala` | PPK (Pracownicze Plany Kapitałowe): employee + employer contributions, bond purchases |
 | `EarmarkedFlows.scala` | Earmarked funds (FP, PFRON, FGSP): contributions, spending, gov subvention covering deficit |
 | `HouseholdFlows.scala` | HH aggregate flows: consumption, rent, PIT, debt service, deposits, remittances |
-| `FirmFlows.scala` | Firm aggregate flows: wages, CIT, loans, investment, I-O, NPL, FDI |
+| `FirmFlows.scala` | Firm aggregate flows: household income carrier, CIT, loans, investment, I-O, NPL, FDI |
 | `GovBudgetFlows.scala` | Government budget: tax revenue, purchases, benefits, transfers, debt service, capital investment |
 | `BankingFlows.scala` | Bank P&L flows: gov bond income, reserve/standing facility/interbank interest, BFG levy, unrealized losses, bail-in, NBP remittance |
 | `EquityFlows.scala` | GPW: dividends (domestic net of Belka tax, foreign), equity issuance |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FirmFlows.scala
@@ -6,11 +6,13 @@ import com.boombustgroup.ledger.*
 
 /** Firm sector emitting flows from aggregate data.
   *
-  * Aggregate level: total wages, CIT, loans, investment, I-O, NPL, FDI flows.
-  * Per-agent BatchedFlow.Scatter will replace when new pipeline is built.
+  * Aggregate level: household income carrier, CIT, loans, investment, I-O, NPL,
+  * FDI flows. Per-agent BatchedFlow.Scatter will replace when new pipeline is
+  * built.
   *
-  * Account IDs: 0=Firm, 1=HH (wages), 2=Gov (CIT), 3=Bank (loans/interest/NPL),
-  * 4=Capital (investment), 5=Foreign (FDI/profit shifting)
+  * Account IDs: 0=Firm, 1=HH (household income), 2=Gov (CIT), 3=Bank
+  * (loans/interest/NPL), 4=Capital (investment), 5=Foreign (FDI/profit
+  * shifting)
   */
 object FirmFlows:
 
@@ -22,7 +24,7 @@ object FirmFlows:
   val FOREIGN_ACCOUNT: Int = 5
 
   case class Input(
-      wages: PLN,
+      householdIncome: PLN,
       cit: PLN,
       loanRepayment: PLN,
       newLoans: PLN,
@@ -43,9 +45,9 @@ object FirmFlows:
         topology.firms.aggregate,
         EntitySector.Households,
         topology.households.aggregate,
-        input.wages,
+        input.householdIncome,
         AssetType.Cash,
-        FlowMechanism.FirmWages,
+        FlowMechanism.HhTotalIncome,
       ),
       AggregateBatchedEmission
         .transfer(
@@ -153,7 +155,7 @@ object FirmFlows:
   def emit(input: Input): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 
-    if input.wages > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.wages.toLong, FlowMechanism.FirmWages.toInt)
+    if input.householdIncome > PLN.Zero then flows += Flow(FIRM_ACCOUNT, HH_ACCOUNT, input.householdIncome.toLong, FlowMechanism.HhTotalIncome.toInt)
     if input.cit > PLN.Zero then flows += Flow(FIRM_ACCOUNT, GOV_ACCOUNT, input.cit.toLong, FlowMechanism.FirmCit.toInt)
     if input.loanRepayment > PLN.Zero then flows += Flow(FIRM_ACCOUNT, BANK_ACCOUNT, input.loanRepayment.toLong, FlowMechanism.FirmLoanRepayment.toInt)
     if input.newLoans > PLN.Zero then flows += Flow(BANK_ACCOUNT, FIRM_ACCOUNT, input.newLoans.toLong, FlowMechanism.FirmNewLoan.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -27,6 +27,7 @@ object FlowMechanism:
   // JST
   val JstRevenue: MechanismId                   = MechanismId(18)
   val JstSpending: MechanismId                  = MechanismId(19)
+  val JstGovSubvention: MechanismId             = MechanismId(20)
   // Government budget
   val GovPurchases: MechanismId                 = MechanismId(21)
   val GovDebtService: MechanismId               = MechanismId(22)
@@ -132,6 +133,7 @@ object FlowMechanism:
     FgspGovSubvention,
     JstRevenue,
     JstSpending,
+    JstGovSubvention,
     GovPurchases,
     GovDebtService,
     GovCapitalInvestment,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -50,8 +50,8 @@ object FlowMechanism:
   val HhCcOrigination: MechanismId              = MechanismId(38)
   val HhCcDebtService: MechanismId              = MechanismId(39)
   val HhCcDefault: MechanismId                  = MechanismId(40)
-  // Firm
-  val FirmWages: MechanismId                    = MechanismId(41)
+  // Firm / household income carrier
+  val HhTotalIncome: MechanismId                = MechanismId(41)
   val FirmCit: MechanismId                      = MechanismId(42)
   val FirmLoanRepayment: MechanismId            = MechanismId(43)
   val FirmNewLoan: MechanismId                  = MechanismId(44)
@@ -152,7 +152,7 @@ object FlowMechanism:
     HhCcOrigination,
     HhCcDebtService,
     HhCcDefault,
-    FirmWages,
+    HhTotalIncome,
     FirmCit,
     FirmLoanRepayment,
     FirmNewLoan,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -72,6 +72,7 @@ object FlowSimulation:
       // Stage 2: Labor market
       wage: PLN,
       employed: Int,
+      unemploymentRate: Share,
       laborDemand: Int,
       livingFirms: Int,
       retirees: Int,
@@ -227,7 +228,7 @@ object FlowSimulation:
         InsuranceFlows.Input(
           employed = c.employed,
           wage = c.wage,
-          unempRate = Share.One - Share.fraction(c.employed, (c.employed + 1).max(1)),
+          unempRate = c.unemploymentRate,
           currentLifeReserves = c.insuranceCurrentLifeReserves,
           currentNonLifeReserves = c.insuranceCurrentNonLifeReserves,
           prevGovBondHoldings = c.insurancePrevGovBonds,
@@ -525,6 +526,7 @@ object FlowSimulation:
       minWagePriceLevel = s1.updatedMinWagePriceLevel,
       wage = s2.newWage,
       employed = s2.employed,
+      unemploymentRate = w.unemploymentRate(s2.employed),
       laborDemand = s2.laborDemand,
       livingFirms = s5.ioFirms.count(Firm.isAlive),
       retirees = s2Pre.newDemographics.retirees,
@@ -661,7 +663,7 @@ object FlowSimulation:
   ): Sfc.RuntimeState =
     Sfc.RuntimeState(w, firms, households, banks, ledgerFinancialState)
 
-  private case class ExecutedBatchEvidence(
+  private case class ExecutedFlowEvidence(
       totals: Map[MechanismId, Long],
       signedTotals: Map[MechanismId, Long],
   ):
@@ -674,9 +676,42 @@ object FlowSimulation:
     def sum(mechanisms: MechanismId*): PLN =
       PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
 
-  private object ExecutedBatchEvidence:
-    def from(batches: Vector[BatchedFlow]): ExecutedBatchEvidence =
-      val (totals, signedTotals) =
+    def sumAll(mechanisms: Iterable[MechanismId]): PLN =
+      PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
+
+    def govSpending: PLN =
+      sumAll(ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms) +
+        sumAll(ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
+
+    def jstDepositChange: PLN =
+      amount(FlowMechanism.JstRevenue) - amount(FlowMechanism.JstSpending)
+
+    def insuranceNetDepositChange: PLN =
+      sum(FlowMechanism.InsLifeClaim, FlowMechanism.InsNonLifeClaim) -
+        sum(FlowMechanism.InsLifePremium, FlowMechanism.InsNonLifePremium)
+
+  private object ExecutedFlowEvidence:
+    private val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
+      Vector(
+        FlowMechanism.GovPurchases,
+        FlowMechanism.GovDebtService,
+        FlowMechanism.GovUnempBenefit,
+        FlowMechanism.GovSocialTransfer,
+        FlowMechanism.GovEuCofin,
+        FlowMechanism.GovCapitalInvestment,
+      )
+
+    private val SocialFundGovSubventionMechanisms: Vector[MechanismId] =
+      Vector(
+        FlowMechanism.ZusGovSubvention,
+        FlowMechanism.NfzGovSubvention,
+        FlowMechanism.FpGovSubvention,
+        FlowMechanism.PfronGovSubvention,
+        FlowMechanism.FgspGovSubvention,
+      )
+
+    def from(batches: Vector[BatchedFlow]): ExecutedFlowEvidence =
+      val (totals, signedTotals): (Map[MechanismId, Long], Map[MechanismId, Long]) =
         batches.foldLeft(
           Map.empty[MechanismId, Long].withDefaultValue(0L),
           Map.empty[MechanismId, Long].withDefaultValue(0L),
@@ -696,29 +731,28 @@ object FlowSimulation:
               signedAcc.updated(batch.mechanism, signedAcc(batch.mechanism) + signedAmount),
             )
 
-      ExecutedBatchEvidence(totals, signedTotals)
+      ExecutedFlowEvidence(totals, signedTotals)
 
   private def buildSfcFlows(
       semanticProjection: MonthSemantics.SemanticProjection,
       batches: Vector[BatchedFlow],
       fofResidual: PLN,
   )(using p: SimParams): Sfc.SemanticFlows =
-    val labor       = semanticProjection.labor
-    val hhIncome    = semanticProjection.hhIncome
     val firms       = semanticProjection.firms
     val hhFinancial = semanticProjection.hhFinancial
-    val prices      = semanticProjection.prices
     val openEcon    = semanticProjection.openEcon
     val banking     = semanticProjection.banking
-    val evidence    = ExecutedBatchEvidence.from(batches)
+    val evidence    = ExecutedFlowEvidence.from(batches)
+    // Runtime-covered legs are sourced from executed flow evidence. Remaining
+    // month-semantics reads are diagnostics or stock projections without a
+    // first-class emitted mechanism yet.
     Sfc.SemanticFlows(
-      govSpending =
-        banking.newGovWithYield.domesticBudgetOutlays + labor.newZus.govSubvention + labor.newNfz.govSubvention + labor.newEarmarked.totalGovSubvention,
+      govSpending = evidence.govSpending,
       govRevenue = evidence.sum(GovBudgetFlows.CentralGovernmentRevenueMechanisms*),
       nplLoss = evidence.amount(FlowMechanism.BankNplLoss),
       interestIncome = evidence.amount(FlowMechanism.BankFirmInterest),
       hhDebtService = evidence.amount(FlowMechanism.HhDebtService),
-      totalIncome = hhIncome.totalIncome,
+      totalIncome = evidence.amount(FlowMechanism.HhTotalIncome),
       totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
       newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
       nplRecovery = firms.nplNew * p.banking.loanRecovery,
@@ -731,18 +765,18 @@ object FlowSimulation:
       reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
       standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
       interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
-      jstDepositChange = banking.jstDepositChange,
-      jstSpending = banking.newJst.spending,
-      jstRevenue = banking.newJst.revenue,
-      zusContributions = labor.newZus.contributions,
-      zusPensionPayments = labor.newZus.pensionPayments,
-      zusGovSubvention = labor.newZus.govSubvention,
-      nfzContributions = labor.newNfz.contributions,
-      nfzSpending = labor.newNfz.spending,
-      nfzGovSubvention = labor.newNfz.govSubvention,
-      dividendIncome = prices.netDomesticDividends,
-      foreignDividendOutflow = prices.foreignDividendOutflow,
-      dividendTax = prices.dividendTax,
+      jstDepositChange = evidence.jstDepositChange,
+      jstSpending = evidence.amount(FlowMechanism.JstSpending),
+      jstRevenue = evidence.amount(FlowMechanism.JstRevenue),
+      zusContributions = evidence.amount(FlowMechanism.ZusContribution),
+      zusPensionPayments = evidence.amount(FlowMechanism.ZusPension),
+      zusGovSubvention = evidence.amount(FlowMechanism.ZusGovSubvention),
+      nfzContributions = evidence.amount(FlowMechanism.NfzContribution),
+      nfzSpending = evidence.amount(FlowMechanism.NfzSpending),
+      nfzGovSubvention = evidence.amount(FlowMechanism.NfzGovSubvention),
+      dividendIncome = evidence.amount(FlowMechanism.EquityDomDividend),
+      foreignDividendOutflow = evidence.amount(FlowMechanism.EquityForDividend),
+      dividendTax = evidence.amount(FlowMechanism.EquityDividendTax),
       mortgageInterestIncome = evidence.amount(FlowMechanism.MortgageInterest),
       mortgageNplLoss = evidence.amount(FlowMechanism.BankMortgageNplLoss),
       mortgageOrigination = evidence.amount(FlowMechanism.MortgageOrigination),
@@ -760,7 +794,7 @@ object FlowSimulation:
       corpBondIssuance = evidence.amount(FlowMechanism.CorpBondIssuance),
       corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
       corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
-      insNetDepositChange = openEcon.nonBank.insNetDepositChange,
+      insNetDepositChange = evidence.insuranceNetDepositChange,
       nbfiDepositDrain = openEcon.nonBank.nbfiDepositDrain,
       nbfiOrigination = banking.finalNbfi.lastNbfiOrigination,
       nbfiRepayment = banking.finalNbfi.lastNbfiRepayment,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -663,7 +663,7 @@ object FlowSimulation:
   ): Sfc.RuntimeState =
     Sfc.RuntimeState(w, firms, households, banks, ledgerFinancialState)
 
-  private case class ExecutedFlowEvidence(
+  private[flows] case class ExecutedFlowEvidence(
       totals: Map[MechanismId, Long],
       signedTotals: Map[MechanismId, Long],
   ):
@@ -683,15 +683,18 @@ object FlowSimulation:
       sumAll(ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms) +
         sumAll(ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
 
+    def jstRevenue: PLN =
+      sumAll(ExecutedFlowEvidence.JstRevenueMechanisms)
+
     def jstDepositChange: PLN =
-      amount(FlowMechanism.JstRevenue) - amount(FlowMechanism.JstSpending)
+      jstRevenue - amount(FlowMechanism.JstSpending)
 
     def insuranceNetDepositChange: PLN =
       sum(FlowMechanism.InsLifeClaim, FlowMechanism.InsNonLifeClaim) -
         sum(FlowMechanism.InsLifePremium, FlowMechanism.InsNonLifePremium)
 
-  private object ExecutedFlowEvidence:
-    private val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
+  private[flows] object ExecutedFlowEvidence:
+    val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
       Vector(
         FlowMechanism.GovPurchases,
         FlowMechanism.GovDebtService,
@@ -699,9 +702,10 @@ object FlowSimulation:
         FlowMechanism.GovSocialTransfer,
         FlowMechanism.GovEuCofin,
         FlowMechanism.GovCapitalInvestment,
+        FlowMechanism.JstGovSubvention,
       )
 
-    private val SocialFundGovSubventionMechanisms: Vector[MechanismId] =
+    val SocialFundGovSubventionMechanisms: Vector[MechanismId] =
       Vector(
         FlowMechanism.ZusGovSubvention,
         FlowMechanism.NfzGovSubvention,
@@ -709,6 +713,9 @@ object FlowSimulation:
         FlowMechanism.PfronGovSubvention,
         FlowMechanism.FgspGovSubvention,
       )
+
+    val JstRevenueMechanisms: Vector[MechanismId] =
+      Vector(FlowMechanism.JstRevenue, FlowMechanism.JstGovSubvention)
 
     def from(batches: Vector[BatchedFlow]): ExecutedFlowEvidence =
       val (totals, signedTotals): (Map[MechanismId, Long], Map[MechanismId, Long]) =
@@ -767,7 +774,7 @@ object FlowSimulation:
       interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
       jstDepositChange = evidence.jstDepositChange,
       jstSpending = evidence.amount(FlowMechanism.JstSpending),
-      jstRevenue = evidence.amount(FlowMechanism.JstRevenue),
+      jstRevenue = evidence.jstRevenue,
       zusContributions = evidence.amount(FlowMechanism.ZusContribution),
       zusPensionPayments = evidence.amount(FlowMechanism.ZusPension),
       zusGovSubvention = evidence.amount(FlowMechanism.ZusGovSubvention),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/JstFlows.scala
@@ -7,16 +7,18 @@ import com.boombustgroup.ledger.*
 
 /** JST (local government / samorzady) emitting flows.
   *
-  * Same logic as Jst.step. Revenue from PIT/CIT shares, property tax,
-  * subventions, dotacje. Spending = revenue x multiplier (deficit bias).
+  * Same logic as Jst.step. Tax revenue from PIT/CIT shares and property tax is
+  * emitted separately from central-government subventions/dotacje so SFC
+  * diagnostics can distinguish local revenue from central budget spending.
   *
-  * Account IDs: 0=Taxpayers, 1=JST, 2=LocalServices (spending sink)
+  * Account IDs: 0=Taxpayers, 1=JST, 2=LocalServices (spending sink), 3=GOV
   */
 object JstFlows:
 
   val TAXPAYER_ACCOUNT: Int = 0
   val JST_ACCOUNT: Int      = 1
   val SERVICES_ACCOUNT: Int = 2
+  val GOV_ACCOUNT: Int      = 3
 
   case class Input(
       centralCitRevenue: PLN,
@@ -26,38 +28,14 @@ object JstFlows:
       pitRevenue: PLN,
   )
 
-  def emitBatches(input: Input)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    val jstPitIncome  =
-      if input.pitRevenue > PLN.Zero then input.pitRevenue * p.fiscal.jstPitShare
-      else input.totalWageIncome * (Share(FallbackPitRate) * p.fiscal.jstPitShare)
-    val citRevenue    = input.centralCitRevenue * p.fiscal.jstCitShare
-    val propertyTax   = input.nFirms * p.fiscal.jstPropertyTax / 12L
-    val subvention    = input.gdp * p.fiscal.jstSubventionShare / 12L
-    val dotacje       = input.gdp * p.fiscal.jstDotacjeShare / 12L
-    val totalRevenue  = jstPitIncome + citRevenue + propertyTax + subvention + dotacje
-    val totalSpending = totalRevenue * p.fiscal.jstSpendingMult
-    Vector.concat(
-      AggregateBatchedEmission.transfer(
-        EntitySector.Government,
-        TreasuryRuntimeContract.TaxpayerCollection.index,
-        EntitySector.Funds,
-        topology.funds.jst,
-        totalRevenue,
-        AssetType.Cash,
-        FlowMechanism.JstRevenue,
-      ),
-      AggregateBatchedEmission.transfer(
-        EntitySector.Funds,
-        topology.funds.jst,
-        EntitySector.Firms,
-        topology.firms.services,
-        totalSpending,
-        AssetType.Cash,
-        FlowMechanism.JstSpending,
-      ),
-    )
+  private case class Components(
+      taxRevenue: PLN,
+      govSubvention: PLN,
+      totalRevenue: PLN,
+      totalSpending: PLN,
+  )
 
-  def emit(input: Input)(using p: SimParams): Vector[Flow] =
+  private def components(input: Input)(using p: SimParams): Components =
     val jstPitIncome =
       if input.pitRevenue > PLN.Zero then input.pitRevenue * p.fiscal.jstPitShare
       else input.totalWageIncome * (Share(FallbackPitRate) * p.fiscal.jstPitShare)
@@ -66,12 +44,55 @@ object JstFlows:
     val subvention   = input.gdp * p.fiscal.jstSubventionShare / 12L
     val dotacje      = input.gdp * p.fiscal.jstDotacjeShare / 12L
 
-    val totalRevenue  = jstPitIncome + citRevenue + propertyTax + subvention + dotacje
-    val totalSpending = totalRevenue * p.fiscal.jstSpendingMult
+    val taxRevenue    = jstPitIncome + citRevenue + propertyTax
+    val govSubvention = subvention + dotacje
+    val totalRevenue  = taxRevenue + govSubvention
+    Components(
+      taxRevenue = taxRevenue,
+      govSubvention = govSubvention,
+      totalRevenue = totalRevenue,
+      totalSpending = totalRevenue * p.fiscal.jstSpendingMult,
+    )
+
+  def emitBatches(input: Input)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    val c = components(input)
+    Vector.concat(
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        TreasuryRuntimeContract.TaxpayerCollection.index,
+        EntitySector.Funds,
+        topology.funds.jst,
+        c.taxRevenue,
+        AssetType.Cash,
+        FlowMechanism.JstRevenue,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Government,
+        TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
+        EntitySector.Funds,
+        topology.funds.jst,
+        c.govSubvention,
+        AssetType.Cash,
+        FlowMechanism.JstGovSubvention,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        topology.funds.jst,
+        EntitySector.Firms,
+        topology.firms.services,
+        c.totalSpending,
+        AssetType.Cash,
+        FlowMechanism.JstSpending,
+      ),
+    )
+
+  def emit(input: Input)(using p: SimParams): Vector[Flow] =
+    val c = components(input)
 
     val flows = Vector.newBuilder[Flow]
-    if totalRevenue > PLN.Zero then flows += Flow(TAXPAYER_ACCOUNT, JST_ACCOUNT, totalRevenue.toLong, FlowMechanism.JstRevenue.toInt)
-    if totalSpending > PLN.Zero then flows += Flow(JST_ACCOUNT, SERVICES_ACCOUNT, totalSpending.toLong, FlowMechanism.JstSpending.toInt)
+    if c.taxRevenue > PLN.Zero then flows += Flow(TAXPAYER_ACCOUNT, JST_ACCOUNT, c.taxRevenue.toLong, FlowMechanism.JstRevenue.toInt)
+    if c.govSubvention > PLN.Zero then flows += Flow(GOV_ACCOUNT, JST_ACCOUNT, c.govSubvention.toLong, FlowMechanism.JstGovSubvention.toInt)
+    if c.totalSpending > PLN.Zero then flows += Flow(JST_ACCOUNT, SERVICES_ACCOUNT, c.totalSpending.toLong, FlowMechanism.JstSpending.toInt)
     flows.result()
 
   private val FallbackPitRate = 0.12

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
@@ -76,6 +76,7 @@ object RuntimeMechanismSurvivability:
       FlowMechanism.FgspGovSubvention,
       FlowMechanism.JstRevenue,
       FlowMechanism.JstSpending,
+      FlowMechanism.JstGovSubvention,
     ),
     declared(
       ExecutionDeltaOnly,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
@@ -111,7 +111,7 @@ object RuntimeMechanismSurvivability:
       FlowMechanism.HhCcOrigination,
       FlowMechanism.HhCcDebtService,
       FlowMechanism.HhCcDefault,
-      FlowMechanism.FirmWages,
+      FlowMechanism.HhTotalIncome,
       FlowMechanism.FirmCit,
       FlowMechanism.FirmLoanRepayment,
       FlowMechanism.FirmNewLoan,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -82,7 +82,7 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   "FirmEconomics.runStep" should "produce flows that close at SFC == 0L" in {
     val flows = FirmFlows.emit(
       FirmFlows.Input(
-        wages = s3.totalIncome,
+        householdIncome = s3.totalIncome,
         cit = result.sumTax,
         loanRepayment = result.sumFirmPrincipal,
         newLoans = result.sumNewLoans,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FirmFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FirmFlowsSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class FirmFlowsSpec extends AnyFlatSpec with Matchers:
 
   private val baseInput = FirmFlows.Input(
-    wages = PLN(50000000.0),
+    householdIncome = PLN(50000000.0),
     cit = PLN(5000000.0),
     loanRepayment = PLN(3000000.0),
     newLoans = PLN(4000000.0),
@@ -33,7 +33,7 @@ class FirmFlowsSpec extends AnyFlatSpec with Matchers:
     val balances = Interpreter.applyAll(Map.empty[Int, Long], flows)
 
     val inflows  = baseInput.newLoans + baseInput.equityIssuance
-    val outflows = baseInput.wages + baseInput.cit + baseInput.loanRepayment +
+    val outflows = baseInput.householdIncome + baseInput.cit + baseInput.loanRepayment +
       baseInput.interestPaid + baseInput.capex + baseInput.ioPayments +
       baseInput.nplDefault + baseInput.profitShifting + baseInput.fdiRepatriation +
       baseInput.grossInvestment
@@ -52,7 +52,7 @@ class FirmFlowsSpec extends AnyFlatSpec with Matchers:
   it should "skip zero-amount flows" in {
     val minimal =
       FirmFlows.Input(
-        wages = PLN(1000000.0),
+        householdIncome = PLN(1000000.0),
         cit = PLN.Zero,
         loanRepayment = PLN.Zero,
         newLoans = PLN.Zero,
@@ -67,7 +67,7 @@ class FirmFlowsSpec extends AnyFlatSpec with Matchers:
       )
     val flows   = FirmFlows.emit(minimal)
     flows.length shouldBe 1
-    flows.head.mechanism shouldBe FlowMechanism.FirmWages.toInt
+    flows.head.mechanism shouldBe FlowMechanism.HhTotalIncome.toInt
   }
 
   it should "preserve SFC across 120 months" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -1,0 +1,44 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
+  import RuntimeFlowsTestSupport.*
+
+  private given p: SimParams = SimParams.defaults
+
+  "FlowSimulation.step" should "source executed semantic flow evidence from emitted mechanisms in default CI" in {
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state  = FlowSimulation.SimState.fromInit(init)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+
+    val govSpendingMechanisms =
+      FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
+        FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms
+    val emittedGovSpending    =
+      govSpendingMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+    val emittedJstRevenue     =
+      FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+
+    result.sfcResult shouldBe Right(())
+    result.trace.executedFlows.govSpending shouldBe emittedGovSpending
+    result.trace.executedFlows.totalIncome shouldBe mechanismTotal(result.flows, FlowMechanism.HhTotalIncome)
+    result.trace.executedFlows.jstRevenue shouldBe emittedJstRevenue
+    result.trace.executedFlows.jstSpending shouldBe mechanismTotal(result.flows, FlowMechanism.JstSpending)
+    result.trace.executedFlows.jstDepositChange shouldBe emittedJstRevenue - mechanismTotal(result.flows, FlowMechanism.JstSpending)
+    result.trace.executedFlows.dividendIncome shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDomDividend)
+    result.trace.executedFlows.foreignDividendOutflow shouldBe mechanismTotal(result.flows, FlowMechanism.EquityForDividend)
+    result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
+
+    val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)
+    val insuranceClaims   = mechanismTotal(result.flows, FlowMechanism.InsLifeClaim) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifeClaim)
+
+    result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -17,13 +17,34 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
     val state  = FlowSimulation.SimState.fromInit(init)
     val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
 
-    val govSpendingMechanisms =
-      FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
-        FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms
+    val expectedCentralGovernmentSpendingMechanisms = Vector(
+      FlowMechanism.GovPurchases,
+      FlowMechanism.GovDebtService,
+      FlowMechanism.GovUnempBenefit,
+      FlowMechanism.GovSocialTransfer,
+      FlowMechanism.GovEuCofin,
+      FlowMechanism.GovCapitalInvestment,
+      FlowMechanism.JstGovSubvention,
+    )
+    val expectedSocialFundGovSubventionMechanisms   = Vector(
+      FlowMechanism.ZusGovSubvention,
+      FlowMechanism.NfzGovSubvention,
+      FlowMechanism.FpGovSubvention,
+      FlowMechanism.PfronGovSubvention,
+      FlowMechanism.FgspGovSubvention,
+    )
+    val expectedJstRevenueMechanisms                =
+      Vector(FlowMechanism.JstRevenue, FlowMechanism.JstGovSubvention)
+
+    FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms shouldBe expectedCentralGovernmentSpendingMechanisms
+    FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms shouldBe expectedSocialFundGovSubventionMechanisms
+    FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms shouldBe expectedJstRevenueMechanisms
+
+    val govSpendingMechanisms = expectedCentralGovernmentSpendingMechanisms ++ expectedSocialFundGovSubventionMechanisms
     val emittedGovSpending    =
       govSpendingMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
     val emittedJstRevenue     =
-      FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+      expectedJstRevenueMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
 
     result.sfcResult shouldBe Right(())
     result.trace.executedFlows.govSpending shouldBe emittedGovSpending

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -27,6 +27,14 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
         .sum,
     )
 
+  private def mechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
+    PLN.fromRaw(
+      batches.iterator
+        .filter(_.mechanism == mechanism)
+        .map(RuntimeLedgerTopology.totalTransferred)
+        .sum,
+    )
+
   private def flowTotal(flows: Vector[Flow], mechanism: MechanismId): PLN =
     PLN.fromRaw(
       flows.iterator
@@ -35,7 +43,7 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
         .sum,
     )
 
-  "FlowSimulation.step" should "align NFZ runtime emission with direct NfzFlows emission in default CI" in {
+  "FlowSimulation.step" should "align NFZ runtime emission and executed semantic flow evidence in default CI" in {
     val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)
     val result      = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
@@ -68,4 +76,37 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     emittedContributions shouldBe flowTotal(directFlows, FlowMechanism.NfzContribution)
     emittedSpending shouldBe flowTotal(directFlows, FlowMechanism.NfzSpending)
     emittedSubvention shouldBe flowTotal(directFlows, FlowMechanism.NfzGovSubvention)
+
+    result.trace.executedFlows.nfzContributions shouldBe emittedContributions
+    result.trace.executedFlows.nfzSpending shouldBe emittedSpending
+    result.trace.executedFlows.nfzGovSubvention shouldBe emittedSubvention
+
+    val emittedGovSpending = Vector(
+      FlowMechanism.GovPurchases,
+      FlowMechanism.GovDebtService,
+      FlowMechanism.GovUnempBenefit,
+      FlowMechanism.GovSocialTransfer,
+      FlowMechanism.GovEuCofin,
+      FlowMechanism.GovCapitalInvestment,
+      FlowMechanism.ZusGovSubvention,
+      FlowMechanism.NfzGovSubvention,
+      FlowMechanism.FpGovSubvention,
+      FlowMechanism.PfronGovSubvention,
+      FlowMechanism.FgspGovSubvention,
+    ).map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+
+    result.trace.executedFlows.govSpending shouldBe emittedGovSpending
+    result.trace.executedFlows.totalIncome shouldBe mechanismTotal(result.flows, FlowMechanism.HhTotalIncome)
+    result.trace.executedFlows.jstDepositChange shouldBe
+      mechanismTotal(result.flows, FlowMechanism.JstRevenue) - mechanismTotal(result.flows, FlowMechanism.JstSpending)
+    result.trace.executedFlows.dividendIncome shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDomDividend)
+    result.trace.executedFlows.foreignDividendOutflow shouldBe mechanismTotal(result.flows, FlowMechanism.EquityForDividend)
+    result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
+
+    val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)
+    val insuranceClaims   = mechanismTotal(result.flows, FlowMechanism.InsLifeClaim) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifeClaim)
+
+    result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationNfzRuntimeSpec.scala
@@ -4,46 +4,15 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthRandomness
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.{AssetType, BatchedFlow, Flow, MechanismId}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
+  import RuntimeFlowsTestSupport.*
 
   private given p: SimParams = SimParams.defaults
 
-  private def mechanismBatches(batches: Vector[BatchedFlow], mechanism: MechanismId): Vector[BatchedFlow] =
-    batches.filter(_.mechanism == mechanism)
-
-  private def assertAllCash(selected: Vector[BatchedFlow], mechanism: MechanismId): Unit =
-    withClue(s"Mechanism ${mechanism.toInt} should emit only cash batches: ") {
-      selected.map(_.asset).toSet shouldBe Set(AssetType.Cash)
-    }
-
-  private def cashMechanismTotal(selected: Vector[BatchedFlow]): PLN =
-    PLN.fromRaw(
-      selected.iterator
-        .map(RuntimeLedgerTopology.totalTransferred)
-        .sum,
-    )
-
-  private def mechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
-    PLN.fromRaw(
-      batches.iterator
-        .filter(_.mechanism == mechanism)
-        .map(RuntimeLedgerTopology.totalTransferred)
-        .sum,
-    )
-
-  private def flowTotal(flows: Vector[Flow], mechanism: MechanismId): PLN =
-    PLN.fromRaw(
-      flows.iterator
-        .filter(_.mechanism == mechanism.toInt)
-        .map(_.amount)
-        .sum,
-    )
-
-  "FlowSimulation.step" should "align NFZ runtime emission and executed semantic flow evidence in default CI" in {
+  "FlowSimulation.step" should "align NFZ runtime emission with direct NFZ emission in default CI" in {
     val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val state       = FlowSimulation.SimState.fromInit(init)
     val result      = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
@@ -80,33 +49,4 @@ class FlowSimulationNfzRuntimeSpec extends AnyFlatSpec with Matchers:
     result.trace.executedFlows.nfzContributions shouldBe emittedContributions
     result.trace.executedFlows.nfzSpending shouldBe emittedSpending
     result.trace.executedFlows.nfzGovSubvention shouldBe emittedSubvention
-
-    val emittedGovSpending = Vector(
-      FlowMechanism.GovPurchases,
-      FlowMechanism.GovDebtService,
-      FlowMechanism.GovUnempBenefit,
-      FlowMechanism.GovSocialTransfer,
-      FlowMechanism.GovEuCofin,
-      FlowMechanism.GovCapitalInvestment,
-      FlowMechanism.ZusGovSubvention,
-      FlowMechanism.NfzGovSubvention,
-      FlowMechanism.FpGovSubvention,
-      FlowMechanism.PfronGovSubvention,
-      FlowMechanism.FgspGovSubvention,
-    ).map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
-
-    result.trace.executedFlows.govSpending shouldBe emittedGovSpending
-    result.trace.executedFlows.totalIncome shouldBe mechanismTotal(result.flows, FlowMechanism.HhTotalIncome)
-    result.trace.executedFlows.jstDepositChange shouldBe
-      mechanismTotal(result.flows, FlowMechanism.JstRevenue) - mechanismTotal(result.flows, FlowMechanism.JstSpending)
-    result.trace.executedFlows.dividendIncome shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDomDividend)
-    result.trace.executedFlows.foreignDividendOutflow shouldBe mechanismTotal(result.flows, FlowMechanism.EquityForDividend)
-    result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
-
-    val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
-      mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)
-    val insuranceClaims   = mechanismTotal(result.flows, FlowMechanism.InsLifeClaim) +
-      mechanismTotal(result.flows, FlowMechanism.InsNonLifeClaim)
-
-    result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -114,6 +114,10 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     mechanismTotal(result.flows, FlowMechanism.EquityForDividend) shouldBe result.calculus.equityForDividends
     mechanismTotal(result.flows, FlowMechanism.EquityDividendTax) shouldBe result.calculus.equityDivTax
     mechanismTotal(result.flows, FlowMechanism.EquityGovDividend) shouldBe result.calculus.equityGovDividends
+
+    result.trace.executedFlows.dividendIncome shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDomDividend)
+    result.trace.executedFlows.foreignDividendOutflow shouldBe mechanismTotal(result.flows, FlowMechanism.EquityForDividend)
+    result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
   }
 
   it should "emit government and JST flows from current-month fiscal state instead of boundary fields" in {
@@ -167,6 +171,27 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     mechanismTotal(result.flows, FlowMechanism.JstSpending) shouldBe nextJst.spending
     mechanismTotal(result.flows, FlowMechanism.JstRevenue) should not equal staleJstRevenue
     mechanismTotal(result.flows, FlowMechanism.JstSpending) should not equal staleJstSpending
+
+    val emittedGovSpending = Vector(
+      FlowMechanism.GovPurchases,
+      FlowMechanism.GovDebtService,
+      FlowMechanism.GovUnempBenefit,
+      FlowMechanism.GovSocialTransfer,
+      FlowMechanism.GovEuCofin,
+      FlowMechanism.GovCapitalInvestment,
+      FlowMechanism.ZusGovSubvention,
+      FlowMechanism.NfzGovSubvention,
+      FlowMechanism.FpGovSubvention,
+      FlowMechanism.PfronGovSubvention,
+      FlowMechanism.FgspGovSubvention,
+    ).map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+
+    result.trace.executedFlows.govSpending shouldBe emittedGovSpending
+    result.trace.executedFlows.totalIncome shouldBe mechanismTotal(result.flows, FlowMechanism.HhTotalIncome)
+    result.trace.executedFlows.jstRevenue shouldBe mechanismTotal(result.flows, FlowMechanism.JstRevenue)
+    result.trace.executedFlows.jstSpending shouldBe mechanismTotal(result.flows, FlowMechanism.JstSpending)
+    result.trace.executedFlows.jstDepositChange shouldBe
+      mechanismTotal(result.flows, FlowMechanism.JstRevenue) - mechanismTotal(result.flows, FlowMechanism.JstSpending)
   }
 
   it should "align NFZ runtime subvention emission with semantic current-month state" in {
@@ -271,6 +296,14 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val insuranceIncomeBatches = result.flows.filter(_.mechanism == FlowMechanism.InsInvestmentIncome)
     insuranceIncomeBatches should not be empty
     insuranceIncomeBatches.map(_.asset).toSet shouldBe Set(AssetType.LifeReserve, AssetType.NonLifeReserve)
+
+    val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)
+    val insuranceClaims   = mechanismTotal(result.flows, FlowMechanism.InsLifeClaim) +
+      mechanismTotal(result.flows, FlowMechanism.InsNonLifeClaim)
+
+    result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
+    result.trace.executedFlows.insNetDepositChange shouldBe result.nextState.world.financialMarkets.insurance.lastNetDepositChange
   }
 
   it should "read insurance flow inputs from LedgerFinancialState instead of World market memory" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -17,22 +17,15 @@ import com.boombustgroup.amorfati.engine.ledger.CorporateBondOwnership
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.tags.Heavy
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector, ImperativeInterpreter, Interpreter, MechanismId}
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector, ImperativeInterpreter, Interpreter}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 @Heavy
 class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
+  import RuntimeFlowsTestSupport.*
 
   private given p: SimParams = SimParams.defaults
-
-  private def mechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
-    PLN.fromRaw(
-      batches.iterator
-        .filter(_.mechanism == mechanism)
-        .map(RuntimeLedgerTopology.totalTransferred)
-        .sum,
-    )
 
   private def canonicalHouseholds(households: Vector[Household.State]): Vector[Vector[Any]] =
     households.map: hh =>
@@ -167,31 +160,24 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     mechanismTotal(result.flows, FlowMechanism.GovUnempBenefit) shouldBe result.calculus.totalUnempBenefits
     mechanismTotal(result.flows, FlowMechanism.GovSocialTransfer) shouldBe result.calculus.totalSocialTransfers
 
-    mechanismTotal(result.flows, FlowMechanism.JstRevenue) shouldBe nextJst.revenue
+    val emittedJstRevenue =
+      FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+    emittedJstRevenue shouldBe nextJst.revenue
     mechanismTotal(result.flows, FlowMechanism.JstSpending) shouldBe nextJst.spending
-    mechanismTotal(result.flows, FlowMechanism.JstRevenue) should not equal staleJstRevenue
+    emittedJstRevenue should not equal staleJstRevenue
     mechanismTotal(result.flows, FlowMechanism.JstSpending) should not equal staleJstSpending
 
-    val emittedGovSpending = Vector(
-      FlowMechanism.GovPurchases,
-      FlowMechanism.GovDebtService,
-      FlowMechanism.GovUnempBenefit,
-      FlowMechanism.GovSocialTransfer,
-      FlowMechanism.GovEuCofin,
-      FlowMechanism.GovCapitalInvestment,
-      FlowMechanism.ZusGovSubvention,
-      FlowMechanism.NfzGovSubvention,
-      FlowMechanism.FpGovSubvention,
-      FlowMechanism.PfronGovSubvention,
-      FlowMechanism.FgspGovSubvention,
-    ).map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
+    val emittedGovSpending =
+      (FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
+        FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
+        .map(mechanismTotal(result.flows, _))
+        .foldLeft(PLN.Zero)(_ + _)
 
     result.trace.executedFlows.govSpending shouldBe emittedGovSpending
     result.trace.executedFlows.totalIncome shouldBe mechanismTotal(result.flows, FlowMechanism.HhTotalIncome)
-    result.trace.executedFlows.jstRevenue shouldBe mechanismTotal(result.flows, FlowMechanism.JstRevenue)
+    result.trace.executedFlows.jstRevenue shouldBe emittedJstRevenue
     result.trace.executedFlows.jstSpending shouldBe mechanismTotal(result.flows, FlowMechanism.JstSpending)
-    result.trace.executedFlows.jstDepositChange shouldBe
-      mechanismTotal(result.flows, FlowMechanism.JstRevenue) - mechanismTotal(result.flows, FlowMechanism.JstSpending)
+    result.trace.executedFlows.jstDepositChange shouldBe emittedJstRevenue - mechanismTotal(result.flows, FlowMechanism.JstSpending)
   }
 
   it should "align NFZ runtime subvention emission with semantic current-month state" in {
@@ -215,10 +201,10 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.trace.executedFlows.nfzGovSubvention shouldBe nfz.govSubvention
 
     val expectedGovSpending =
-      result.nextState.world.gov.domesticBudgetOutlays +
-        result.nextState.world.social.zus.govSubvention +
-        result.nextState.world.social.nfz.govSubvention +
-        result.nextState.world.social.earmarked.totalGovSubvention
+      (FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
+        FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
+        .map(mechanismTotal(result.flows, _))
+        .foldLeft(PLN.Zero)(_ + _)
 
     result.trace.executedFlows.govSpending shouldBe expectedGovSpending
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/JstFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/JstFlowsSpec.scala
@@ -31,10 +31,12 @@ class JstFlowsSpec extends AnyFlatSpec with Matchers:
     )
     val flows  = JstFlows.emit(JstFlows.Input(centralCitRevenue, wageIncome, gdp, nFirms, pit))
 
-    val newRevenue  = flows.filter(_.mechanism == FlowMechanism.JstRevenue.toInt).map(_.amount).sum
-    val newSpending = flows.filter(_.mechanism == FlowMechanism.JstSpending.toInt).map(_.amount).sum
+    val newTaxRevenue   = flows.filter(_.mechanism == FlowMechanism.JstRevenue.toInt).map(_.amount).sum
+    val newGovSubsidies = flows.filter(_.mechanism == FlowMechanism.JstGovSubvention.toInt).map(_.amount).sum
+    val newSpending     = flows.filter(_.mechanism == FlowMechanism.JstSpending.toInt).map(_.amount).sum
 
-    newRevenue shouldBe oldJst.state.revenue.toLong
+    newTaxRevenue + newGovSubsidies shouldBe oldJst.state.revenue.toLong
+    newGovSubsidies should be > 0L
     newSpending shouldBe oldJst.state.spending.toLong
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowsTestSupport.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowsTestSupport.scala
@@ -1,0 +1,36 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.PLN
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, Flow, MechanismId}
+import org.scalatest.matchers.should.Matchers
+
+object RuntimeFlowsTestSupport extends Matchers:
+
+  def mechanismBatches(batches: Vector[BatchedFlow], mechanism: MechanismId): Vector[BatchedFlow] =
+    batches.filter(_.mechanism == mechanism)
+
+  def assertAllCash(selected: Vector[BatchedFlow], mechanism: MechanismId): Unit =
+    withClue(s"Mechanism ${mechanism.toInt} should emit only cash batches: ") {
+      selected.map(_.asset).toSet shouldBe Set(AssetType.Cash)
+    }
+
+  def totalTransferred(selected: Vector[BatchedFlow]): PLN =
+    PLN.fromRaw(
+      selected.iterator
+        .map(RuntimeLedgerTopology.totalTransferred)
+        .sum,
+    )
+
+  def cashMechanismTotal(selected: Vector[BatchedFlow]): PLN =
+    totalTransferred(selected)
+
+  def mechanismTotal(batches: Vector[BatchedFlow], mechanism: MechanismId): PLN =
+    cashMechanismTotal(mechanismBatches(batches, mechanism))
+
+  def flowTotal(flows: Vector[Flow], mechanism: MechanismId): PLN =
+    PLN.fromRaw(
+      flows.iterator
+        .filter(_.mechanism == mechanism.toInt)
+        .map(_.amount)
+        .sum,
+    )


### PR DESCRIPTION
Closes #358

## Summary
- source runtime-covered SFC SemanticFlows from executed BatchedFlow evidence
- rename the misleading FirmWages mechanism to HhTotalIncome while preserving MechanismId(41)
- align insurance runtime emission with the actual current-month unemployment rate
- extend NFZ/default and heavy flow specs to cross-check executed semantic flow evidence against emitted mechanisms

## Verification
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.FirmFlowsSpec com.boombustgroup.amorfati.engine.flows.BatchedEmissionContractSpec com.boombustgroup.amorfati.engine.ledger.RuntimeMechanismSurvivabilitySpec com.boombustgroup.amorfati.engine.flows.FlowSimulationNfzRuntimeSpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 10 m18 --duration 60 --run-id issue358-60m-10s-r2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified flow-evidence sourcing for validation and updated flow/aggregate mapping descriptions.

* **Refactor**
  * Renamed firm payout field to emphasize household income.
  * Runtime evidence now supplies multiple semantic flow fields; JST fiscal flows split tax vs. gov subvention emissions.

* **Tests**
  * Added and extended tests to verify executed-flow evidence, mechanism totals, and related financial assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->