### PR TITLE
Materialize runtime-supported ledger state

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -103,8 +103,8 @@ object Sfc:
       interbankNetSum: PLN,          // Σ interbank net positions (must be 0)
       jstDeposits: PLN,              // local government (JST) deposits at banks
       jstDebt: PLN,                  // local government (JST) cumulative debt
-      fusBalance: PLN,               // ZUS/FUS raw surplus/deficit
-      nfzBalance: PLN,               // NFZ health fund surplus/deficit
+      fusBalance: PLN,               // ZUS/FUS cash balance after runtime-covered flows
+      nfzBalance: PLN,               // NFZ cash balance after runtime-covered flows
       foreignBondHoldings: PLN,      // non-resident SPW holdings
       ppkBondHoldings: PLN,          // PPK government bond holdings
       mortgageStock: PLN,            // Outstanding mortgage debt
@@ -452,14 +452,14 @@ object Sfc:
       ),
       IdentitySpec(
         SfcIdentity.FusBalance,
-        "FUS balance change (contributions - pensions)",
-        expected = flows.zusContributions - flows.zusPensionPayments,
+        "FUS cash change (contributions + gov subvention - pensions)",
+        expected = flows.zusContributions + flows.zusGovSubvention - flows.zusPensionPayments,
         actual = curr.fusBalance - prev.fusBalance,
       ),
       IdentitySpec(
         SfcIdentity.NfzBalance,
-        "NFZ balance change (contributions - spending)",
-        expected = flows.nfzContributions - flows.nfzSpending,
+        "NFZ cash change (contributions + gov subvention - spending)",
+        expected = flows.nfzContributions + flows.nfzGovSubvention - flows.nfzSpending,
         actual = curr.nfzBalance - prev.nfzBalance,
       ),
     ).collect:

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -26,6 +26,7 @@ engine/
 | `ledger/LedgerFinancialState.scala` | Runtime source of truth for supported financial balances; exposes projection DTOs for agent/economics execution. |
 | `ledger/AssetOwnershipContract.scala` | Audit contract for supported persisted owner/asset pairs, unsupported stock-like families, and non-persisted runtime shells. |
 | `ledger/RuntimeMechanismSurvivability.scala` | Audit contract classifying each runtime-emitted `FlowMechanism` as round-trippable stock, execution-delta-only, or unsupported/metric-only. |
+| `ledger/RuntimeFlowProjection.scala` | Typed projection from executed runtime `deltaLedger` into the currently materialized persisted ledger slice. |
 | `MonthSemantics.scala` | Tiny typed phase markers for the internal month step: pre-seed, same-month operational state, post-assembly state, and next pre-seed extraction. |
 | `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and assembly streams for deterministic replay and auditability. |
 | `MonthDriver.scala` | Shared month-by-month unfold driver over the explicit `FlowSimulation.step` boundary. |
@@ -64,7 +65,7 @@ Read it as a month transition:
 - `operationalSignals` is the explicit same-month surface created inside the step.
 - `signalExtraction` is the dedicated `post -> pre` boundary.
 - `trace` is the emitted audit artifact for month `t`.
-- `nextState` is the typed month `t+1` boundary state.
+- `nextState` is the typed month `t+1` boundary state. Supported public-fund cash balances are materialized from executed runtime deltas before this boundary is exposed; remaining ledger-backed families still use explicit economics-stage closing state until their runtime emissions become holder-resolved closing-stock sources.
 - `MonthDriver.unfoldSteps` is the first-class month driver: callers own the explicit randomness schedule, while the engine owns the `stateIn -> step -> nextState` unfold.
 
 ## economics/
@@ -121,6 +122,7 @@ stocks and same-month execution plumbing.
 | `LedgerFinancialState.scala` | Persisted financial stock surface owned by the ledger-backed engine slice. |
 | `AssetOwnershipContract.scala` | Declares which `(EntitySector, AssetType)` owner pairs are supported persisted stock, which stock-like families remain unsupported, and which runtime nodes are non-persisted execution or settlement shells. Topology-aware checks must be used for concrete emitted batches so aggregate shell indices are not mistaken for persisted owners. |
 | `RuntimeMechanismSurvivability.scala` | Declares the survivability class for every runtime-emitted `FlowMechanism`. It separates mechanisms whose emitted legs can round-trip through persisted stock owners from mechanisms that are execution-delta-only or intentionally outside the supported persisted stock slice. |
+| `RuntimeFlowProjection.scala` | Applies executed runtime ledger deltas to the materialized persisted slice. Today this owns ZUS, NFZ, FP, PFRON, FGSP, and JST cash slots; unsupported/manual slices remain in the stage-produced `LedgerFinancialState` explicitly. |
 
 ## markets/
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, LedgerFinancialState}
+import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, LedgerFinancialState, RuntimeFlowProjection}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -386,7 +386,14 @@ object FlowSimulation:
       err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
       identity,
     )
-    val nextState               = advanceState(input, outcome)
+    val semanticNextState       = advanceState(input, outcome)
+    val runtimeProjection       = RuntimeFlowProjection.materializeSupportedState(
+      opening = stateIn.ledgerFinancialState,
+      semanticClosing = semanticNextState.ledgerFinancialState,
+      deltaLedger = execution.deltaLedger,
+      topology = execution.topology,
+    )
+    val nextState               = semanticNextState.copy(ledgerFinancialState = runtimeProjection.ledgerFinancialState)
     val sfcFlows                = buildSfcFlows(outcome.semanticProjection, flows, nextState.world.plumbing.fofResidual)
     val sfcResult               = Sfc.validate(
       prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, stateIn.ledgerFinancialState),
@@ -399,6 +406,7 @@ object FlowSimulation:
     val monthTrace              = buildMonthTrace(
       input = input,
       outcome = outcome,
+      nextState = nextState,
       executedFlows = sfcFlows,
       sfcResult = sfcResult,
     )
@@ -961,13 +969,24 @@ object FlowSimulation:
   private def buildMonthTrace(
       input: StepInput,
       outcome: MonthOutcome,
+      nextState: SimState,
       executedFlows: Sfc.SemanticFlows,
       sfcResult: Sfc.SfcResult,
   ): MonthTrace =
+    val projectedBoundary = outcome.traceCore.boundary.copy(
+      endSnapshot = MonthBoundarySnapshot.capture(
+        nextState.world,
+        nextState.firms,
+        nextState.households,
+        nextState.banks,
+        nextState.ledgerFinancialState,
+      ),
+    )
+    val projectedCore     = outcome.traceCore.copy(boundary = projectedBoundary)
     MonthTrace.fromCore(
       executionMonth = input.executionMonth,
       randomness = input.randomness,
-      core = outcome.traceCore,
+      core = projectedCore,
       executedFlows = executedFlows,
       validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeFlowProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeFlowProjection.scala
@@ -1,0 +1,98 @@
+package com.boombustgroup.amorfati.engine.ledger
+
+import com.boombustgroup.amorfati.engine.flows.RuntimeLedgerTopology
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+
+/** Materializes the ledger-supported part of the next financial state from
+  * executed runtime ledger deltas.
+  *
+  * The runtime interpreter returns month deltas over concrete
+  * `(EntitySector, AssetType, index)` accounts. This projection applies the
+  * supported deltas that already have a one-to-one persisted owner in
+  * [[LedgerFinancialState]]. Other ledger families still come from the
+  * economics stages until their emitted batches model holder-resolved closing
+  * stocks with the same precision.
+  */
+object RuntimeFlowProjection:
+
+  /** Public-fund cash buckets that are currently first-class runtime accounts.
+    *
+    * These slots are fixed fund-sector owners in `RuntimeLedgerTopology` and
+    * are also declared as supported persisted cash pairs in
+    * [[AssetOwnershipContract]]. They are the first state slice where executed
+    * runtime deltas, not stage-local formulas, own the next boundary value.
+    */
+  val MaterializedPublicFundCashSlots: Set[Int] =
+    Set(
+      FundRuntimeIndex.Zus,
+      FundRuntimeIndex.Nfz,
+      FundRuntimeIndex.Fp,
+      FundRuntimeIndex.Pfron,
+      FundRuntimeIndex.Fgsp,
+      FundRuntimeIndex.Jst,
+    )
+
+  final case class PublicFundCashProjection(
+      zusCash: PLN,
+      nfzCash: PLN,
+      fpCash: PLN,
+      pfronCash: PLN,
+      fgspCash: PLN,
+      jstCash: PLN,
+  )
+
+  final case class Projection(
+      ledgerFinancialState: LedgerFinancialState,
+      publicFundCash: PublicFundCashProjection,
+  )
+
+  def materializeSupportedState(
+      opening: LedgerFinancialState,
+      semanticClosing: LedgerFinancialState,
+      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
+      topology: RuntimeLedgerTopology,
+  ): Projection =
+    requireMaterializedSlotsAreSupported(topology)
+    val publicFundCash = projectPublicFundCash(opening, deltaLedger)
+    val projectedFunds = semanticClosing.funds.copy(
+      zusCash = publicFundCash.zusCash,
+      nfzCash = publicFundCash.nfzCash,
+      fpCash = publicFundCash.fpCash,
+      pfronCash = publicFundCash.pfronCash,
+      fgspCash = publicFundCash.fgspCash,
+      jstCash = publicFundCash.jstCash,
+    )
+    Projection(
+      ledgerFinancialState = semanticClosing.copy(funds = projectedFunds),
+      publicFundCash = publicFundCash,
+    )
+
+  def projectPublicFundCash(
+      opening: LedgerFinancialState,
+      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
+  ): PublicFundCashProjection =
+    PublicFundCashProjection(
+      zusCash = applyFundCashDelta(opening.funds.zusCash, FundRuntimeIndex.Zus, deltaLedger),
+      nfzCash = applyFundCashDelta(opening.funds.nfzCash, FundRuntimeIndex.Nfz, deltaLedger),
+      fpCash = applyFundCashDelta(opening.funds.fpCash, FundRuntimeIndex.Fp, deltaLedger),
+      pfronCash = applyFundCashDelta(opening.funds.pfronCash, FundRuntimeIndex.Pfron, deltaLedger),
+      fgspCash = applyFundCashDelta(opening.funds.fgspCash, FundRuntimeIndex.Fgsp, deltaLedger),
+      jstCash = applyFundCashDelta(opening.funds.jstCash, FundRuntimeIndex.Jst, deltaLedger),
+    )
+
+  private def applyFundCashDelta(
+      opening: PLN,
+      fundIndex: Int,
+      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
+  ): PLN =
+    opening + PLN.fromRaw(deltaLedger.getOrElse((EntitySector.Funds, AssetType.Cash, fundIndex), 0L))
+
+  private def requireMaterializedSlotsAreSupported(topology: RuntimeLedgerTopology): Unit =
+    MaterializedPublicFundCashSlots.foreach: fundIndex =>
+      require(
+        AssetOwnershipContract.isSupportedPersistedPair(topology, EntitySector.Funds, AssetType.Cash, fundIndex),
+        s"RuntimeFlowProjection cannot materialize unsupported fund cash slot $fundIndex",
+      )
+
+end RuntimeFlowProjection

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -604,7 +604,7 @@ object Generators:
       val expectedGovDebtChange  = flows.govSpending - flows.govRevenue
       val expectedNfaChange      = flows.currentAccount + flows.valuationEffect
       val expectedJstDebtChange  = flows.jstSpending - flows.jstRevenue
-      val expectedFusChange      = flows.zusContributions - flows.zusPensionPayments
+      val expectedFusChange      = flows.zusContributions + flows.zusGovSubvention - flows.zusPensionPayments
       val expectedMortgageChange =
         flows.mortgageOrigination - flows.mortgagePrincipalRepaid - flows.mortgageDefaultAmount
       val expectedCcChange       =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationRuntimeProjectionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationRuntimeProjectionSpec.scala
@@ -41,14 +41,35 @@ class FlowSimulationRuntimeProjectionSpec extends AnyFlatSpec with Matchers:
       result.trace.executedFlows.nfzGovSubvention -
       result.trace.executedFlows.nfzSpending
     funds.jstCash shouldBe state.ledgerFinancialState.funds.jstCash + result.trace.executedFlows.jstDepositChange
+  }
 
-    withClue("seed 42 should exercise runtime materialization beyond the old contribution-minus-spending NFZ stage formula: ") {
-      result.trace.executedFlows.nfzGovSubvention should be > PLN.Zero
-      val stageOnlyNfzCash = state.ledgerFinancialState.funds.nfzCash +
-        result.nextState.world.social.nfz.contributions -
-        result.nextState.world.social.nfz.spending
-      funds.nfzCash should not equal stageOnlyNfzCash
-    }
+  it should "include explicit NFZ gov subvention when materializing a deterministic deficit fixture" in {
+    val init     = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state    = FlowSimulation.SimState.fromInit(init)
+    val topology = RuntimeLedgerTopology.fromState(state)
+    val opening  = state.ledgerFinancialState
+
+    val nfzContributions = PLN(10.0)
+    val nfzSpending      = PLN(30.0)
+    val nfzGovSubvention = nfzSpending - nfzContributions
+    nfzGovSubvention should be > PLN.Zero
+
+    val stageOnlyNfzCash = opening.funds.nfzCash + nfzContributions - nfzSpending
+    val semanticClosing  = opening.copy(
+      funds = opening.funds.copy(nfzCash = stageOnlyNfzCash),
+    )
+    val executedDelta    = nfzContributions + nfzGovSubvention - nfzSpending
+
+    val projection = RuntimeFlowProjection.materializeSupportedState(
+      opening = opening,
+      semanticClosing = semanticClosing,
+      deltaLedger = Map((EntitySector.Funds, AssetType.Cash, topology.funds.nfz) -> executedDelta.toLong),
+      topology = topology,
+    )
+
+    projection.publicFundCash.nfzCash shouldBe opening.funds.nfzCash + executedDelta
+    projection.ledgerFinancialState.funds.nfzCash shouldBe opening.funds.nfzCash + executedDelta
+    projection.ledgerFinancialState.funds.nfzCash should not equal stageOnlyNfzCash
   }
 
 end FlowSimulationRuntimeProjectionSpec

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationRuntimeProjectionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationRuntimeProjectionSpec.scala
@@ -1,0 +1,54 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.ledger.{AssetOwnershipContract, RuntimeFlowProjection}
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FlowSimulationRuntimeProjectionSpec extends AnyFlatSpec with Matchers:
+
+  private given p: SimParams = SimParams.defaults
+
+  "FlowSimulation.step" should "materialize public fund cash from executed runtime deltas" in {
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state  = FlowSimulation.SimState.fromInit(init)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+
+    RuntimeFlowProjection.MaterializedPublicFundCashSlots.foreach: fundIndex =>
+      AssetOwnershipContract.isSupportedPersistedPair(result.execution.topology, EntitySector.Funds, AssetType.Cash, fundIndex) shouldBe true
+
+    val projected = RuntimeFlowProjection.projectPublicFundCash(
+      opening = state.ledgerFinancialState,
+      deltaLedger = result.execution.deltaLedger,
+    )
+    val funds     = result.nextState.ledgerFinancialState.funds
+
+    RuntimeFlowProjection.PublicFundCashProjection(
+      zusCash = funds.zusCash,
+      nfzCash = funds.nfzCash,
+      fpCash = funds.fpCash,
+      pfronCash = funds.pfronCash,
+      fgspCash = funds.fgspCash,
+      jstCash = funds.jstCash,
+    ) shouldBe projected
+
+    funds.nfzCash shouldBe state.ledgerFinancialState.funds.nfzCash +
+      result.trace.executedFlows.nfzContributions +
+      result.trace.executedFlows.nfzGovSubvention -
+      result.trace.executedFlows.nfzSpending
+    funds.jstCash shouldBe state.ledgerFinancialState.funds.jstCash + result.trace.executedFlows.jstDepositChange
+
+    withClue("seed 42 should exercise runtime materialization beyond the old contribution-minus-spending NFZ stage formula: ") {
+      result.trace.executedFlows.nfzGovSubvention should be > PLN.Zero
+      val stageOnlyNfzCash = state.ledgerFinancialState.funds.nfzCash +
+        result.nextState.world.social.nfz.contributions -
+        result.nextState.world.social.nfz.spending
+      funds.nfzCash should not equal stageOnlyNfzCash
+    }
+  }
+
+end FlowSimulationRuntimeProjectionSpec


### PR DESCRIPTION
Closes #357

## Summary
- add RuntimeFlowProjection to materialize supported public fund cash slots from executed deltaLedger
- wire FlowSimulation.nextState and MonthTrace end snapshot through the projected ledger state
- align FUS/NFZ metric diagnostics with runtime-covered cash after government subventions
- document the projected slice in engine/README.md

## Verification
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationRuntimeProjectionSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationNfzRuntimeSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec com.boombustgroup.amorfati.accounting.SfcPropertySpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"
- sbt scalafmtAll
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 1 m17 --duration 60 --run-id issue357-60m-1s

## Smoke result
- 60m / 1 seed: Adopt=13.7%, pi=-3.5%, Unemp=5.8%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented runtime cash flow projection for public fund balances, which now incorporates executed transaction deltas into ledger state calculations.

* **Bug Fixes**
  * Corrected public fund balance calculations to include government subsidies alongside contributions and spending.

* **Documentation**
  * Updated ledger state documentation to clarify how supported cash balances are materialized from runtime execution flows.

* **Tests**
  * Added comprehensive test coverage validating runtime flow simulation and cash balance projection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->