### PR TITLE
Keep insurance reserve flows inside insurance runtime sector

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -109,7 +109,7 @@ against 13 accounting identities each month.
 | `EquityFlows.scala` | GPW: dividends (domestic net of Belka tax, foreign), equity issuance |
 | `CorpBondFlows.scala` | Catalyst: holder-class coupon, default, issuance, and amortization evidence |
 | `MortgageFlows.scala` | Housing: origination, principal repayment, interest, default |
-| `InsuranceFlows.scala` | Insurance: life + non-life premiums, claims, investment income |
+| `InsuranceFlows.scala` | Insurance: life + non-life reserve deltas for premiums, claims, and investment income |
 | `JstFlows.scala` | JST (local government): PIT/CIT shares, property tax, subventions, spending |
 | `OpenEconFlows.scala` | BoP: trade, FDI, portfolio, carry trade, primary income (NFA), secondary income (EU funds, diaspora), tourism, capital flight |
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlows.scala
@@ -55,61 +55,51 @@ object InsuranceFlows:
     val nonLifeInvIncome      = invIncome - lifeInvIncome
 
     Vector.concat(
-      AggregateBatchedEmission.transfer(
-        EntitySector.Households,
-        topology.households.aggregate,
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        lifePrem,
-        AssetType.LifeReserve,
-        FlowMechanism.InsLifePremium,
-      ),
-      AggregateBatchedEmission.transfer(
-        EntitySector.Households,
-        topology.households.aggregate,
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        nonLifePrem,
-        AssetType.NonLifeReserve,
-        FlowMechanism.InsNonLifePremium,
-      ),
-      AggregateBatchedEmission.transfer(
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        EntitySector.Households,
-        topology.households.aggregate,
-        lifeCl,
-        AssetType.LifeReserve,
-        FlowMechanism.InsLifeClaim,
-      ),
-      AggregateBatchedEmission.transfer(
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        EntitySector.Households,
-        topology.households.aggregate,
-        nonLifeCl,
-        AssetType.NonLifeReserve,
-        FlowMechanism.InsNonLifeClaim,
-      ),
-      AggregateBatchedEmission.signedTransfer(
-        EntitySector.Funds,
-        topology.funds.markets,
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        lifeInvIncome,
-        AssetType.LifeReserve,
-        FlowMechanism.InsInvestmentIncome,
-      ),
-      AggregateBatchedEmission.signedTransfer(
-        EntitySector.Funds,
-        topology.funds.markets,
-        EntitySector.Insurance,
-        topology.insurance.aggregate,
-        nonLifeInvIncome,
-        AssetType.NonLifeReserve,
-        FlowMechanism.InsInvestmentIncome,
-      ),
+      reserveIncrease(lifePrem, AssetType.LifeReserve, FlowMechanism.InsLifePremium),
+      reserveIncrease(nonLifePrem, AssetType.NonLifeReserve, FlowMechanism.InsNonLifePremium),
+      reserveDecrease(lifeCl, AssetType.LifeReserve, FlowMechanism.InsLifeClaim),
+      reserveDecrease(nonLifeCl, AssetType.NonLifeReserve, FlowMechanism.InsNonLifeClaim),
+      reserveSignedChange(lifeInvIncome, AssetType.LifeReserve, FlowMechanism.InsInvestmentIncome),
+      reserveSignedChange(nonLifeInvIncome, AssetType.NonLifeReserve, FlowMechanism.InsInvestmentIncome),
     )
+
+  private def reserveIncrease(
+      amount: PLN,
+      asset: AssetType,
+      mechanism: MechanismId,
+  )(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    AggregateBatchedEmission.transfer(
+      EntitySector.Insurance,
+      topology.insurance.aggregate,
+      EntitySector.Insurance,
+      topology.insurance.persistedOwner,
+      amount,
+      asset,
+      mechanism,
+    )
+
+  private def reserveDecrease(
+      amount: PLN,
+      asset: AssetType,
+      mechanism: MechanismId,
+  )(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    AggregateBatchedEmission.transfer(
+      EntitySector.Insurance,
+      topology.insurance.persistedOwner,
+      EntitySector.Insurance,
+      topology.insurance.aggregate,
+      amount,
+      asset,
+      mechanism,
+    )
+
+  private def reserveSignedChange(
+      amount: PLN,
+      asset: AssetType,
+      mechanism: MechanismId,
+  )(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    if amount >= PLN.Zero then reserveIncrease(amount, asset, mechanism)
+    else reserveDecrease(amount.abs, asset, mechanism)
 
   def emit(input: Input)(using p: SimParams): Vector[Flow] =
     val lifePrem    = input.employed * (input.wage * p.ins.lifePremiumRate)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
@@ -102,7 +102,7 @@ object RuntimeMechanismSurvivability:
     ),
     declared(
       ExecutionDeltaOnly,
-      "Insurance reserve flows are emitted against aggregate insurance, household, and market shells.",
+      "Insurance reserve flows use the persisted insurance reserve owner plus the aggregate insurance execution shell.",
       FlowMechanism.InsLifePremium,
       FlowMechanism.InsNonLifePremium,
       FlowMechanism.InsLifeClaim,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -282,6 +282,13 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val insuranceIncomeBatches = result.flows.filter(_.mechanism == FlowMechanism.InsInvestmentIncome)
     insuranceIncomeBatches should not be empty
     insuranceIncomeBatches.map(_.asset).toSet shouldBe Set(AssetType.LifeReserve, AssetType.NonLifeReserve)
+    all(insuranceIncomeBatches.map(_.from)) shouldBe EntitySector.Insurance
+    all(insuranceIncomeBatches.map(_.to)) shouldBe EntitySector.Insurance
+
+    val insuranceReserveBatches = result.flows.filter(batch => batch.asset == AssetType.LifeReserve || batch.asset == AssetType.NonLifeReserve)
+    insuranceReserveBatches should not be empty
+    all(insuranceReserveBatches.map(_.from)) shouldBe EntitySector.Insurance
+    all(insuranceReserveBatches.map(_.to)) shouldBe EntitySector.Insurance
 
     val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
       mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
@@ -96,9 +96,27 @@ class InsuranceFlowsSpec extends AnyFlatSpec with Matchers:
     invBatches should have size 2
     invBatches.map(_.asset).toSet shouldBe Set(AssetType.LifeReserve, AssetType.NonLifeReserve)
     invBatches.exists(batch => batch.asset == AssetType.Cash) shouldBe false
+    all(invBatches.map(_.from)) shouldBe EntitySector.Insurance
+    all(invBatches.map(_.to)) shouldBe EntitySector.Insurance
     invBatches.map(RuntimeLedgerTopology.totalTransferred).sum shouldBe expectedInvIncome.toLong
     RuntimeLedgerTopology.totalTransferred(invBatches.find(_.asset == AssetType.LifeReserve).get) shouldBe expectedLifeInv.toLong
     RuntimeLedgerTopology.totalTransferred(invBatches.find(_.asset == AssetType.NonLifeReserve).get) shouldBe expectedNonLifeInv.toLong
+  }
+
+  it should "keep reserve assets inside the insurance runtime sector" in {
+    val batches        = InsuranceFlows.emitBatches(baseInput)
+    val reserveBatches = batches.filter(batch => batch.asset == AssetType.LifeReserve || batch.asset == AssetType.NonLifeReserve)
+
+    reserveBatches should not be empty
+    all(reserveBatches.map(_.from)) shouldBe EntitySector.Insurance
+    all(reserveBatches.map(_.to)) shouldBe EntitySector.Insurance
+    reserveBatches.foreach:
+      case broadcast: BatchedFlow.Broadcast =>
+        Set(broadcast.fromIndex, broadcast.targetIndices.head) shouldBe Set(
+          summon[RuntimeLedgerTopology].insurance.aggregate,
+          summon[RuntimeLedgerTopology].insurance.persistedOwner,
+        )
+      case other                            => fail(s"Expected reserve broadcast, got $other")
   }
 
   it should "route corporate bond default losses as negative reserve investment income" in {
@@ -113,7 +131,12 @@ class InsuranceFlowsSpec extends AnyFlatSpec with Matchers:
 
     lossLegs should have size 2
     all(lossLegs.map(_.from)) shouldBe EntitySector.Insurance
-    all(lossLegs.map(_.to)) shouldBe EntitySector.Funds
+    all(lossLegs.map(_.to)) shouldBe EntitySector.Insurance
+    lossLegs.foreach:
+      case broadcast: BatchedFlow.Broadcast =>
+        broadcast.fromIndex shouldBe summon[RuntimeLedgerTopology].insurance.persistedOwner
+        broadcast.targetIndices.head shouldBe summon[RuntimeLedgerTopology].insurance.aggregate
+      case other                            => fail(s"Expected reserve loss broadcast, got $other")
     lossLegs.map(RuntimeLedgerTopology.totalTransferred).sum shouldBe expectedLoss.toLong
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/InsuranceFlowsSpec.scala
@@ -110,12 +110,16 @@ class InsuranceFlowsSpec extends AnyFlatSpec with Matchers:
     reserveBatches should not be empty
     all(reserveBatches.map(_.from)) shouldBe EntitySector.Insurance
     all(reserveBatches.map(_.to)) shouldBe EntitySector.Insurance
+    val aggregate      = summon[RuntimeLedgerTopology].insurance.aggregate
+    val persistedOwner = summon[RuntimeLedgerTopology].insurance.persistedOwner
     reserveBatches.foreach:
       case broadcast: BatchedFlow.Broadcast =>
-        Set(broadcast.fromIndex, broadcast.targetIndices.head) shouldBe Set(
-          summon[RuntimeLedgerTopology].insurance.aggregate,
-          summon[RuntimeLedgerTopology].insurance.persistedOwner,
-        )
+        if broadcast.mechanism == FlowMechanism.InsLifeClaim || broadcast.mechanism == FlowMechanism.InsNonLifeClaim then
+          broadcast.fromIndex shouldBe persistedOwner
+          broadcast.targetIndices.head shouldBe aggregate
+        else
+          broadcast.fromIndex shouldBe aggregate
+          broadcast.targetIndices.head shouldBe persistedOwner
       case other                            => fail(s"Expected reserve broadcast, got $other")
   }
 


### PR DESCRIPTION
## Summary
- stop emitting LifeReserve/NonLifeReserve through Household or Funds counterparties in InsuranceFlows
- route premium, claim, and investment-income reserve deltas between the persisted insurance owner and the aggregate insurance execution shell
- add regression coverage in InsuranceFlowsSpec and FlowSimulationStepSpec so reserve assets stay inside the Insurance sector

## Verification
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.InsuranceFlowsSpec com.boombustgroup.amorfati.engine.flows.BatchedEmissionContractSpec com.boombustgroup.amorfati.engine.ledger.RuntimeMechanismSurvivabilitySpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"
- sbt scalafmtAll
- git diff --check
- sbt Test/compile

Refs #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated insurance flow descriptions to clarify reserve-delta-based processing for premiums, claims, and investment income.

* **Refactor**
  * Improved internal structure of insurance reserve transfer handling for better maintainability.

* **Tests**
  * Expanded test assertions to verify insurance sector isolation in reserve-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->