### PR TITLE
Align non-bank equity returns with same-month market output

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -452,7 +452,7 @@ object OpenEconEconomics:
           unempRate = unempRate,
           govBondYield = newBondYield,
           corpBondYield = newCorpBondYield,
-          equityReturn = in.w.financialMarkets.equity.monthlyReturn,
+          equityReturn = in.s7.equityAfterIssuance.monthlyReturn,
           corpBondDefaultLoss = corpBondDefaultLoss,
         ),
       )
@@ -479,7 +479,7 @@ object OpenEconEconomics:
           bankNplRatio = bankAgg.nplRatio,
           govBondYield = newBondYield,
           corpBondYield = newCorpBondYield,
-          equityReturn = in.w.financialMarkets.equity.monthlyReturn,
+          equityReturn = in.s7.equityAfterIssuance.monthlyReturn,
           depositRate = nbfiDepositRate,
           domesticCons = in.s3.domesticCons,
           corpBondDefaultLoss = corpBondDefaultLoss,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -543,7 +543,6 @@ object FlowSimulation:
       bankId => CorporateBondOwnership.bankHolderFor(ledger, bankId),
     )
     val agg               = s3.hhAgg
-    val eq                = w.financialMarkets.equity
     val h                 = s9.housingAfterFlows
     val externalFlowBop   = s8.external.flowBop
     val openingCorpBonds  = CorporateBondOwnership.stockStateFromLedger(ledger)
@@ -597,7 +596,7 @@ object FlowSimulation:
       equityForDividends = s7.foreignDividendOutflow,
       equityDivTax = s7.dividendTax,
       equityGovDividends = s7.stateOwnedGovDividends,
-      equityReturn = eq.monthlyReturn,
+      equityReturn = s7.equityAfterIssuance.monthlyReturn,
       exports = externalFlowBop.exports,
       totalImports = externalFlowBop.totalImports,
       tourismExport = s6.tourismExport,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/SignalTimingRegressionSpec.scala
@@ -170,6 +170,28 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
       ),
     )
 
+  private def baseOpenEconRunStep(
+      world: World,
+      ledgerFinancialState: LedgerFinancialState,
+      s7: PriceEquityEconomics.Output,
+      seed: Long,
+  ): OpenEconEconomics.StepOutput =
+    OpenEconEconomics.runStep(
+      OpenEconEconomics.StepInput(
+        world,
+        ledgerFinancialState,
+        baseline.s1,
+        baseline.s2,
+        baseline.s3,
+        baseline.s4,
+        baseline.s5,
+        baseline.s6,
+        s7,
+        baseline.banks,
+        RandomStream.seeded(seed),
+      ),
+    )
+
   private def assemblyRandomness(seed: Long): MonthRandomness.AssemblyStreams =
     MonthRandomness.Contract.fromSeed(seed).assembly.newStreams()
 
@@ -196,6 +218,18 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
 
   private def withSeedSignals(world: World, f: DecisionSignals => DecisionSignals): World =
     world.copy(pipeline = world.pipeline.withDecisionSignals(f(world.seedIn)))
+
+  private def withBoundaryEquityReturn(world: World, equityReturn: Rate): World =
+    world.copy(
+      financialMarkets = world.financialMarkets.copy(
+        equity = world.financialMarkets.equity.copy(monthlyReturn = equityReturn),
+      ),
+    )
+
+  private def withSameMonthEquityReturn(s7: PriceEquityEconomics.Output, equityReturn: Rate): PriceEquityEconomics.Output =
+    s7.copy(
+      equityAfterIssuance = s7.equityAfterIssuance.copy(monthlyReturn = equityReturn),
+    )
 
   private def entrySensitiveInput: WorldAssemblyEconomics.StepInput =
     val base = baseStepInput
@@ -317,6 +351,31 @@ class SignalTimingRegressionSpec extends AnyFlatSpec with Matchers:
     val freshWorldResult = baseBankingRunStep(baseline.world, seed = 777L)
 
     explicitResult shouldBe freshWorldResult
+  }
+
+  "OpenEconEconomics.runStep" should "price non-bank equity returns from same-month equity market output" in {
+    val ledger             = baseline.ledgerFinancialState.copy(
+      insurance = baseline.ledgerFinancialState.insurance.copy(equityHoldings = PLN(1000000.0)),
+      funds = baseline.ledgerFinancialState.funds.copy(
+        nbfi = baseline.ledgerFinancialState.funds.nbfi.copy(equityHoldings = PLN(2000000.0)),
+      ),
+    )
+    val sameMonthReturn    = Rate(0.04)
+    val staleBoundaryLoss  = withBoundaryEquityReturn(baseline.world, Rate(-0.20))
+    val staleBoundaryGain  = withBoundaryEquityReturn(baseline.world, Rate(0.20))
+    val sameMonthS7        = withSameMonthEquityReturn(baseline.s7, sameMonthReturn)
+    val lossBoundaryResult = baseOpenEconRunStep(staleBoundaryLoss, ledger, sameMonthS7, seed = 5150L)
+    val gainBoundaryResult = baseOpenEconRunStep(staleBoundaryGain, ledger, sameMonthS7, seed = 5150L)
+    val lowerSameMonthS7   = withSameMonthEquityReturn(baseline.s7, Rate(-0.04))
+    val lowerSameMonth     = baseOpenEconRunStep(staleBoundaryGain, ledger, lowerSameMonthS7, seed = 5150L)
+
+    lossBoundaryResult.nonBank.newInsurance.lastInvestmentIncome shouldBe gainBoundaryResult.nonBank.newInsurance.lastInvestmentIncome
+    lossBoundaryResult.nonBank.newInsuranceBalances shouldBe gainBoundaryResult.nonBank.newInsuranceBalances
+    lossBoundaryResult.nonBank.newNbfi.lastTfiNetInflow shouldBe gainBoundaryResult.nonBank.newNbfi.lastTfiNetInflow
+    lossBoundaryResult.nonBank.newNbfiBalances shouldBe gainBoundaryResult.nonBank.newNbfiBalances
+
+    gainBoundaryResult.nonBank.newInsurance.lastInvestmentIncome should not equal lowerSameMonth.nonBank.newInsurance.lastInvestmentIncome
+    gainBoundaryResult.nonBank.newNbfi.lastTfiNetInflow should not equal lowerSameMonth.nonBank.newNbfi.lastTfiNetInflow
   }
 
   "WorldAssemblyEconomics.computePostMonth" should "derive entry unemployment from lagged decision signals instead of post-firm households" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -129,6 +129,24 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
 
     result.calculus.equityReturn shouldBe result.nextState.world.financialMarkets.equity.monthlyReturn
     result.calculus.equityReturn should not equal staleEquityReturn
+
+    val insuranceInvestmentBatches = mechanismBatches(result.flows, FlowMechanism.InsInvestmentIncome)
+    insuranceInvestmentBatches should not be empty
+    result.calculus.insurancePrevEquity should be > PLN.Zero
+
+    val sameMonthInvestmentIncome     =
+      result.calculus.insurancePrevGovBonds * result.calculus.govBondYield.monthly +
+        result.calculus.insurancePrevCorpBonds * result.calculus.corpBondYield.monthly +
+        result.calculus.insurancePrevEquity * result.calculus.equityReturn -
+        result.calculus.insuranceCorpBondDefaultLoss
+    val staleBoundaryInvestmentIncome =
+      result.calculus.insurancePrevGovBonds * result.calculus.govBondYield.monthly +
+        result.calculus.insurancePrevCorpBonds * result.calculus.corpBondYield.monthly +
+        result.calculus.insurancePrevEquity * staleEquityReturn -
+        result.calculus.insuranceCorpBondDefaultLoss
+
+    totalTransferred(insuranceInvestmentBatches) shouldBe sameMonthInvestmentIncome.abs
+    totalTransferred(insuranceInvestmentBatches) should not equal staleBoundaryInvestmentIncome.abs
   }
 
   it should "emit government and JST flows from current-month fiscal state instead of boundary fields" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -113,6 +113,24 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
   }
 
+  it should "emit insurance investment income from same-month equity return instead of boundary market memory" in {
+    val init              = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val baseState         = FlowSimulation.SimState.fromInit(init)
+    val staleEquityReturn = Rate(0.42)
+    val state             = baseState.copy(
+      world = baseState.world.copy(
+        financialMarkets = baseState.world.financialMarkets.copy(
+          equity = baseState.world.financialMarkets.equity.copy(monthlyReturn = staleEquityReturn),
+        ),
+      ),
+    )
+
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+
+    result.calculus.equityReturn shouldBe result.nextState.world.financialMarkets.equity.monthlyReturn
+    result.calculus.equityReturn should not equal staleEquityReturn
+  }
+
   it should "emit government and JST flows from current-month fiscal state instead of boundary fields" in {
     val init               = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
     val baseState          = FlowSimulation.SimState.fromInit(init)


### PR DESCRIPTION
## Summary
- source insurance and NBFI equity returns from same-month stage-7 equity output
- align FlowSimulation runtime emission with the same equity return input
- add regression coverage for stale boundary return vs same-month return

Closes #347

## Verification
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.SignalTimingRegressionSpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"
- sbt scalafmtAll
- sbt Test/compile
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 10 m17 --duration 12 --run-id issue347-12m-10s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected equity return sourcing in the economic simulation engine. Insurance and non-bank financial institutions now properly calculate investment income using current-month equity market returns, eliminating reliance on stale or boundary-persisted values. This ensures pricing and financial outcomes accurately reflect live market conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->