### PR TITLE
Add executed NBFI and TFI flow evidence

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -110,6 +110,7 @@ against 13 accounting identities each month.
 | `CorpBondFlows.scala` | Catalyst: holder-class coupon, default, issuance, and amortization evidence |
 | `MortgageFlows.scala` | Housing: origination, principal repayment, interest, default |
 | `InsuranceFlows.scala` | Insurance: life + non-life reserve deltas for premiums, claims, and investment income |
+| `NbfiFlows.scala` | NBFI/TFI: TFI deposit drain and NBFI credit stock movement evidence |
 | `JstFlows.scala` | JST (local government): PIT/CIT shares, property tax, subventions, spending |
 | `OpenEconFlows.scala` | BoP: trade, FDI, portfolio, carry trade, primary income (NFA), secondary income (EU funds, diaspora), tourism, capital flight |
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowMechanism.scala
@@ -65,6 +65,10 @@ object FlowMechanism:
   val FirmFdiRepatriation: MechanismId          = MechanismId(52)
   val FirmGrossInvestment: MechanismId          = MechanismId(53)
   val InvestmentDepositSettlement: MechanismId  = MechanismId(102)
+  val TfiDepositDrain: MechanismId              = MechanismId(103)
+  val NbfiOrigination: MechanismId              = MechanismId(104)
+  val NbfiRepayment: MechanismId                = MechanismId(105)
+  val NbfiDefault: MechanismId                  = MechanismId(106)
   // Equity market (GPW)
   val EquityDomDividend: MechanismId            = MechanismId(54)
   val EquityForDividend: MechanismId            = MechanismId(55)
@@ -174,6 +178,10 @@ object FlowMechanism:
     FirmFdiRepatriation,
     FirmGrossInvestment,
     InvestmentDepositSettlement,
+    TfiDepositDrain,
+    NbfiOrigination,
+    NbfiRepayment,
+    NbfiDefault,
     EquityDomDividend,
     EquityForDividend,
     EquityDividendTax,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -158,6 +158,11 @@ object FlowSimulation:
       bankUnrealizedLoss: PLN,
       bankBailIn: PLN,
       bankNbpRemittance: PLN,
+      // Stage 8/9: NBFI / TFI monetary channels
+      nbfiDepositDrain: PLN,
+      nbfiOrigination: PLN,
+      nbfiRepayment: PLN,
+      nbfiDefaultAmount: PLN,
       // Stage 8: Gov budget
       govVatRevenue: PLN,
       govExciseRevenue: PLN,
@@ -308,6 +313,7 @@ object FlowSimulation:
           standingFacilityBackstop = c.bankStandingFacilityBackstop,
         ),
       ),
+      NbfiFlows.emitBatches(NbfiFlows.Input(c.nbfiDepositDrain, c.nbfiOrigination, c.nbfiRepayment, c.nbfiDefaultAmount)),
     )
 
   /** Typed month-`t` boundary input used internally by [[step]]. */
@@ -635,6 +641,10 @@ object FlowSimulation:
       bankUnrealizedLoss = s9.unrealizedBondLoss,
       bankBailIn = s9.bailInLoss,
       bankNbpRemittance = s8.banking.nbpRemittance,
+      nbfiDepositDrain = s8.nonBank.nbfiDepositDrain,
+      nbfiOrigination = s9.finalNbfi.lastNbfiOrigination,
+      nbfiRepayment = s9.finalNbfi.lastNbfiRepayment,
+      nbfiDefaultAmount = s9.finalNbfi.lastNbfiDefaultAmount,
       govVatRevenue = s9.vatAfterEvasion,
       govExciseRevenue = s9.exciseAfterEvasion,
       govCustomsDutyRevenue = s9.customsDutyRevenue,
@@ -777,6 +787,9 @@ object FlowSimulation:
     def investNetDepositFlow: PLN =
       signedAmount(FlowMechanism.InvestmentDepositSettlement)
 
+    def nbfiDepositDrain: PLN =
+      signedAmount(FlowMechanism.TfiDepositDrain)
+
   private[flows] object ExecutedFlowEvidence:
     val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
       Vector(
@@ -823,6 +836,14 @@ object FlowSimulation:
                     case _                                        =>
                       throw new IllegalArgumentException(
                         s"InvestmentDepositSettlement batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case FlowMechanism.TfiDepositDrain                                            =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.Banks, EntitySector.Households) => amount
+                    case (EntitySector.Households, EntitySector.Banks) => -amount
+                    case _                                             =>
+                      throw new IllegalArgumentException(
+                        s"TfiDepositDrain batch has unsupported direction ${batch.from}->${batch.to}",
                       )
                 case _                                                                        => amount
 
@@ -895,10 +916,10 @@ object FlowSimulation:
       corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
       corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
       insNetDepositChange = evidence.insuranceNetDepositChange,
-      nbfiDepositDrain = openEcon.nonBank.nbfiDepositDrain,
-      nbfiOrigination = banking.finalNbfi.lastNbfiOrigination,
-      nbfiRepayment = banking.finalNbfi.lastNbfiRepayment,
-      nbfiDefaultAmount = banking.finalNbfi.lastNbfiDefaultAmount,
+      nbfiDepositDrain = evidence.nbfiDepositDrain,
+      nbfiOrigination = evidence.amount(FlowMechanism.NbfiOrigination),
+      nbfiRepayment = evidence.amount(FlowMechanism.NbfiRepayment),
+      nbfiDefaultAmount = evidence.amount(FlowMechanism.NbfiDefault),
       fdiProfitShifting = evidence.amount(FlowMechanism.FirmProfitShifting),
       fdiRepatriation = evidence.amount(FlowMechanism.FirmFdiRepatriation),
       diasporaInflow = evidence.amount(FlowMechanism.DiasporaInflow),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlows.scala
@@ -1,0 +1,77 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Runtime evidence for monetary TFI/NBFI channels.
+  *
+  * This emitter covers channels that already affect SFC monetary identities:
+  * TFI deposit drain and NBFI credit stock movements. Portfolio rebalancing,
+  * investment return, and target asset allocation remain stock projections in
+  * `Nbfi.step` until those holder books become first-class runtime contracts.
+  */
+object NbfiFlows:
+
+  val HH_ACCOUNT: Int   = 0
+  val BANK_ACCOUNT: Int = 1
+  val NBFI_ACCOUNT: Int = 2
+
+  case class Input(
+      depositDrain: PLN,
+      origination: PLN,
+      repayment: PLN,
+      defaultAmount: PLN,
+  )
+
+  def emitBatches(input: Input)(using topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    Vector.concat(
+      AggregateBatchedEmission.signedTransfer(
+        EntitySector.Banks,
+        topology.banks.aggregate,
+        EntitySector.Households,
+        topology.households.investors,
+        input.depositDrain,
+        AssetType.DemandDeposit,
+        FlowMechanism.TfiDepositDrain,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Funds,
+        topology.funds.nbfi,
+        EntitySector.Households,
+        topology.households.aggregate,
+        input.origination,
+        AssetType.NbfiLoan,
+        FlowMechanism.NbfiOrigination,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        topology.households.aggregate,
+        EntitySector.Funds,
+        topology.funds.nbfi,
+        input.repayment,
+        AssetType.NbfiLoan,
+        FlowMechanism.NbfiRepayment,
+      ),
+      AggregateBatchedEmission.transfer(
+        EntitySector.Households,
+        topology.households.aggregate,
+        EntitySector.Funds,
+        topology.funds.nbfi,
+        input.defaultAmount,
+        AssetType.NbfiLoan,
+        FlowMechanism.NbfiDefault,
+      ),
+    )
+
+  def emit(input: Input): Vector[Flow] =
+    val flows = Vector.newBuilder[Flow]
+
+    if input.depositDrain > PLN.Zero then flows += Flow(BANK_ACCOUNT, HH_ACCOUNT, input.depositDrain.toLong, FlowMechanism.TfiDepositDrain.toInt)
+    else if input.depositDrain < PLN.Zero then flows += Flow(HH_ACCOUNT, BANK_ACCOUNT, input.depositDrain.abs.toLong, FlowMechanism.TfiDepositDrain.toInt)
+    if input.origination > PLN.Zero then flows += Flow(NBFI_ACCOUNT, HH_ACCOUNT, input.origination.toLong, FlowMechanism.NbfiOrigination.toInt)
+    if input.repayment > PLN.Zero then flows += Flow(HH_ACCOUNT, NBFI_ACCOUNT, input.repayment.toLong, FlowMechanism.NbfiRepayment.toInt)
+    if input.defaultAmount > PLN.Zero then flows += Flow(HH_ACCOUNT, NBFI_ACCOUNT, input.defaultAmount.toLong, FlowMechanism.NbfiDefault.toInt)
+
+    flows.result()
+
+end NbfiFlows

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivability.scala
@@ -134,6 +134,10 @@ object RuntimeMechanismSurvivability:
       FlowMechanism.FirmFdiRepatriation,
       FlowMechanism.FirmGrossInvestment,
       FlowMechanism.InvestmentDepositSettlement,
+      FlowMechanism.TfiDepositDrain,
+      FlowMechanism.NbfiOrigination,
+      FlowMechanism.NbfiRepayment,
+      FlowMechanism.NbfiDefault,
     ),
     declared(
       ExecutionDeltaOnly,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -48,6 +48,8 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
       expectedJstRevenueMechanisms.map(mechanismTotal(result.flows, _)).foldLeft(PLN.Zero)(_ + _)
     val emittedInvestmentDepositSettlement =
       signedMechanismTotal(result.flows, FlowMechanism.InvestmentDepositSettlement, EntitySector.Banks, EntitySector.Firms)
+    val emittedNbfiDepositDrain            =
+      signedMechanismTotal(result.flows, FlowMechanism.TfiDepositDrain, EntitySector.Banks, EntitySector.Households)
 
     result.sfcResult shouldBe Right(())
     result.trace.executedFlows.govSpending shouldBe emittedGovSpending
@@ -60,6 +62,14 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
     result.trace.executedFlows.dividendTax shouldBe mechanismTotal(result.flows, FlowMechanism.EquityDividendTax)
     result.trace.executedFlows.investNetDepositFlow shouldBe emittedInvestmentDepositSettlement
     result.trace.executedFlows.investNetDepositFlow shouldBe result.calculus.investNetDepositFlow
+    result.trace.executedFlows.nbfiDepositDrain shouldBe emittedNbfiDepositDrain
+    result.trace.executedFlows.nbfiDepositDrain shouldBe result.calculus.nbfiDepositDrain
+    result.trace.executedFlows.nbfiOrigination shouldBe mechanismTotal(result.flows, FlowMechanism.NbfiOrigination)
+    result.trace.executedFlows.nbfiOrigination shouldBe result.calculus.nbfiOrigination
+    result.trace.executedFlows.nbfiRepayment shouldBe mechanismTotal(result.flows, FlowMechanism.NbfiRepayment)
+    result.trace.executedFlows.nbfiRepayment shouldBe result.calculus.nbfiRepayment
+    result.trace.executedFlows.nbfiDefaultAmount shouldBe mechanismTotal(result.flows, FlowMechanism.NbfiDefault)
+    result.trace.executedFlows.nbfiDefaultAmount shouldBe result.calculus.nbfiDefaultAmount
 
     val insurancePremiums = mechanismTotal(result.flows, FlowMechanism.InsLifePremium) +
       mechanismTotal(result.flows, FlowMechanism.InsNonLifePremium)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -78,3 +78,25 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
 
     result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
   }
+
+  it should "route deterministic NBFI and TFI calculus values into executed evidence" in {
+    val init   = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val state  = FlowSimulation.SimState.fromInit(init)
+    val result = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+
+    val calculus                = result.calculus.copy(
+      nbfiDepositDrain = PLN(-777000.0),
+      nbfiOrigination = PLN(555000.0),
+      nbfiRepayment = PLN(333000.0),
+      nbfiDefaultAmount = PLN(111000.0),
+    )
+    given RuntimeLedgerTopology = result.execution.topology
+
+    val batches  = FlowSimulation.emitAllBatches(calculus)
+    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+
+    evidence.nbfiDepositDrain shouldBe PLN(-777000.0)
+    evidence.amount(FlowMechanism.NbfiOrigination) shouldBe PLN(555000.0)
+    evidence.amount(FlowMechanism.NbfiRepayment) shouldBe PLN(333000.0)
+    evidence.amount(FlowMechanism.NbfiDefault) shouldBe PLN(111000.0)
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
@@ -1,0 +1,81 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
+  import RuntimeFlowsTestSupport.*
+
+  private given RuntimeLedgerTopology = RuntimeLedgerTopology.nonZeroPopulation
+
+  "NbfiFlows" should "preserve total wealth at exactly 0L" in {
+    val flows = NbfiFlows.emit(NbfiFlows.Input(PLN(-125000.0), PLN(300000.0), PLN(100000.0), PLN(50000.0)))
+
+    Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
+  }
+
+  it should "emit negative TFI deposit drain as household deposit drawdown" in {
+    val batches = NbfiFlows.emitBatches(NbfiFlows.Input(PLN(-125000.0), PLN.Zero, PLN.Zero, PLN.Zero))
+    val batch   = batches.head
+
+    batches should have size 1
+    batch.mechanism shouldBe FlowMechanism.TfiDepositDrain
+    batch.asset shouldBe AssetType.DemandDeposit
+    batch.from shouldBe EntitySector.Households
+    batch.to shouldBe EntitySector.Banks
+    totalTransferred(batches) shouldBe PLN(125000.0)
+
+    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    evidence.nbfiDepositDrain shouldBe PLN(-125000.0)
+  }
+
+  it should "emit positive TFI deposit drain as bank-issued household deposits" in {
+    val batches = NbfiFlows.emitBatches(NbfiFlows.Input(PLN(80000.0), PLN.Zero, PLN.Zero, PLN.Zero))
+    val batch   = batches.head
+
+    batches should have size 1
+    batch.mechanism shouldBe FlowMechanism.TfiDepositDrain
+    batch.asset shouldBe AssetType.DemandDeposit
+    batch.from shouldBe EntitySector.Banks
+    batch.to shouldBe EntitySector.Households
+    totalTransferred(batches) shouldBe PLN(80000.0)
+
+    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    evidence.nbfiDepositDrain shouldBe PLN(80000.0)
+  }
+
+  it should "emit NBFI credit stock movements with explicit mechanisms" in {
+    val batches = NbfiFlows.emitBatches(NbfiFlows.Input(PLN.Zero, PLN(300000.0), PLN(100000.0), PLN(50000.0)))
+
+    mechanismBatches(batches, FlowMechanism.NbfiOrigination) should have size 1
+    mechanismBatches(batches, FlowMechanism.NbfiRepayment) should have size 1
+    mechanismBatches(batches, FlowMechanism.NbfiDefault) should have size 1
+
+    val origination = mechanismBatches(batches, FlowMechanism.NbfiOrigination).head
+    origination.asset shouldBe AssetType.NbfiLoan
+    origination.from shouldBe EntitySector.Funds
+    origination.to shouldBe EntitySector.Households
+
+    val repayment = mechanismBatches(batches, FlowMechanism.NbfiRepayment).head
+    repayment.asset shouldBe AssetType.NbfiLoan
+    repayment.from shouldBe EntitySector.Households
+    repayment.to shouldBe EntitySector.Funds
+
+    val defaultAmount = mechanismBatches(batches, FlowMechanism.NbfiDefault).head
+    defaultAmount.asset shouldBe AssetType.NbfiLoan
+    defaultAmount.from shouldBe EntitySector.Households
+    defaultAmount.to shouldBe EntitySector.Funds
+
+    totalTransferred(mechanismBatches(batches, FlowMechanism.NbfiOrigination)) shouldBe PLN(300000.0)
+    totalTransferred(mechanismBatches(batches, FlowMechanism.NbfiRepayment)) shouldBe PLN(100000.0)
+    totalTransferred(mechanismBatches(batches, FlowMechanism.NbfiDefault)) shouldBe PLN(50000.0)
+  }
+
+  it should "emit no batch for zero monetary channels" in {
+    NbfiFlows.emitBatches(NbfiFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)) shouldBe empty
+    NbfiFlows.emit(NbfiFlows.Input(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)) shouldBe empty
+  }
+
+end NbfiFlowsSpec

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
@@ -10,21 +10,57 @@ class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
 
   private given RuntimeLedgerTopology = RuntimeLedgerTopology.nonZeroPopulation
 
+  private def onlyBroadcast(batches: Vector[BatchedFlow]): BatchedFlow.Broadcast =
+    batches should have size 1
+    batches.head match
+      case broadcast: BatchedFlow.Broadcast => broadcast
+      case other                            => fail(s"Expected Broadcast, got $other")
+
   "NbfiFlows" should "preserve total wealth at exactly 0L" in {
     val flows = NbfiFlows.emit(NbfiFlows.Input(PLN(-125000.0), PLN(300000.0), PLN(100000.0), PLN(50000.0)))
 
     Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)) shouldBe 0L
   }
 
+  it should "emit legacy flat flows with explicit directions" in {
+    val flows = NbfiFlows.emit(NbfiFlows.Input(PLN(-125000.0), PLN(300000.0), PLN(100000.0), PLN(50000.0)))
+
+    val tfiDrain = flows.filter(_.mechanism == FlowMechanism.TfiDepositDrain.toInt)
+    tfiDrain should have size 1
+    tfiDrain.head.from shouldBe NbfiFlows.HH_ACCOUNT
+    tfiDrain.head.to shouldBe NbfiFlows.BANK_ACCOUNT
+
+    val origination = flows.filter(_.mechanism == FlowMechanism.NbfiOrigination.toInt)
+    origination should have size 1
+    origination.head.from shouldBe NbfiFlows.NBFI_ACCOUNT
+    origination.head.to shouldBe NbfiFlows.HH_ACCOUNT
+
+    val repayment = flows.filter(_.mechanism == FlowMechanism.NbfiRepayment.toInt)
+    repayment should have size 1
+    repayment.head.from shouldBe NbfiFlows.HH_ACCOUNT
+    repayment.head.to shouldBe NbfiFlows.NBFI_ACCOUNT
+
+    val defaultAmount = flows.filter(_.mechanism == FlowMechanism.NbfiDefault.toInt)
+    defaultAmount should have size 1
+    defaultAmount.head.from shouldBe NbfiFlows.HH_ACCOUNT
+    defaultAmount.head.to shouldBe NbfiFlows.NBFI_ACCOUNT
+
+    val positiveDrain = NbfiFlows.emit(NbfiFlows.Input(PLN(80000.0), PLN.Zero, PLN.Zero, PLN.Zero))
+    positiveDrain should have size 1
+    positiveDrain.head.from shouldBe NbfiFlows.BANK_ACCOUNT
+    positiveDrain.head.to shouldBe NbfiFlows.HH_ACCOUNT
+  }
+
   it should "emit negative TFI deposit drain as household deposit drawdown" in {
     val batches = NbfiFlows.emitBatches(NbfiFlows.Input(PLN(-125000.0), PLN.Zero, PLN.Zero, PLN.Zero))
-    val batch   = batches.head
+    val batch   = onlyBroadcast(batches)
 
-    batches should have size 1
     batch.mechanism shouldBe FlowMechanism.TfiDepositDrain
     batch.asset shouldBe AssetType.DemandDeposit
     batch.from shouldBe EntitySector.Households
+    batch.fromIndex shouldBe summon[RuntimeLedgerTopology].households.investors
     batch.to shouldBe EntitySector.Banks
+    batch.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].banks.aggregate)
     totalTransferred(batches) shouldBe PLN(125000.0)
 
     val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
@@ -33,13 +69,14 @@ class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
 
   it should "emit positive TFI deposit drain as bank-issued household deposits" in {
     val batches = NbfiFlows.emitBatches(NbfiFlows.Input(PLN(80000.0), PLN.Zero, PLN.Zero, PLN.Zero))
-    val batch   = batches.head
+    val batch   = onlyBroadcast(batches)
 
-    batches should have size 1
     batch.mechanism shouldBe FlowMechanism.TfiDepositDrain
     batch.asset shouldBe AssetType.DemandDeposit
     batch.from shouldBe EntitySector.Banks
+    batch.fromIndex shouldBe summon[RuntimeLedgerTopology].banks.aggregate
     batch.to shouldBe EntitySector.Households
+    batch.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].households.investors)
     totalTransferred(batches) shouldBe PLN(80000.0)
 
     val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
@@ -53,20 +90,26 @@ class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
     mechanismBatches(batches, FlowMechanism.NbfiRepayment) should have size 1
     mechanismBatches(batches, FlowMechanism.NbfiDefault) should have size 1
 
-    val origination = mechanismBatches(batches, FlowMechanism.NbfiOrigination).head
+    val origination = onlyBroadcast(mechanismBatches(batches, FlowMechanism.NbfiOrigination))
     origination.asset shouldBe AssetType.NbfiLoan
     origination.from shouldBe EntitySector.Funds
+    origination.fromIndex shouldBe summon[RuntimeLedgerTopology].funds.nbfi
     origination.to shouldBe EntitySector.Households
+    origination.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].households.aggregate)
 
-    val repayment = mechanismBatches(batches, FlowMechanism.NbfiRepayment).head
+    val repayment = onlyBroadcast(mechanismBatches(batches, FlowMechanism.NbfiRepayment))
     repayment.asset shouldBe AssetType.NbfiLoan
     repayment.from shouldBe EntitySector.Households
+    repayment.fromIndex shouldBe summon[RuntimeLedgerTopology].households.aggregate
     repayment.to shouldBe EntitySector.Funds
+    repayment.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].funds.nbfi)
 
-    val defaultAmount = mechanismBatches(batches, FlowMechanism.NbfiDefault).head
+    val defaultAmount = onlyBroadcast(mechanismBatches(batches, FlowMechanism.NbfiDefault))
     defaultAmount.asset shouldBe AssetType.NbfiLoan
     defaultAmount.from shouldBe EntitySector.Households
+    defaultAmount.fromIndex shouldBe summon[RuntimeLedgerTopology].households.aggregate
     defaultAmount.to shouldBe EntitySector.Funds
+    defaultAmount.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].funds.nbfi)
 
     totalTransferred(mechanismBatches(batches, FlowMechanism.NbfiOrigination)) shouldBe PLN(300000.0)
     totalTransferred(mechanismBatches(batches, FlowMechanism.NbfiRepayment)) shouldBe PLN(100000.0)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
@@ -116,6 +116,8 @@ class RuntimeMechanismSurvivabilitySpec extends AnyFlatSpec with Matchers:
       ),
       InvestmentDepositSettlementFlows.emitBatches(InvestmentDepositSettlementFlows.Input(PLN(2500000.0))),
       InvestmentDepositSettlementFlows.emitBatches(InvestmentDepositSettlementFlows.Input(PLN(-1500000.0))),
+      NbfiFlows.emitBatches(NbfiFlows.Input(PLN(-1200000.0), PLN(900000.0), PLN(400000.0), PLN(100000.0))),
+      NbfiFlows.emitBatches(NbfiFlows.Input(PLN(800000.0), PLN.Zero, PLN.Zero, PLN.Zero)),
       GovBudgetFlows.emitBatches(
         GovBudgetFlows.Input(
           vatRevenue = PLN(9000000.0),


### PR DESCRIPTION
## Summary
- add explicit FlowMechanism IDs and NbfiFlows runtime emission for TFI deposit drain and NBFI origination/repayment/default
- source SFC NBFI/TFI monetary fields from ExecutedFlowEvidence instead of stage state
- declare survivability coverage and add focused flow/evidence regressions plus engine README entry

## Tests
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.NbfiFlowsSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec com.boombustgroup.amorfati.engine.ledger.RuntimeMechanismSurvivabilitySpec"

Closes #348.