### PR TITLE
Formalize DepositMobility delayed routing

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
@@ -19,8 +19,11 @@ import com.boombustgroup.amorfati.random.RandomStream
   *      `baseRunoff + panicPremium × (1 − bankCAR/systemCAR)`. Stressed banks
   *      face higher outflows.
   *
-  * Deposit switching is a zero-sum operation: total system deposits unchanged,
-  * only distribution across banks changes.
+  * Deposit switching is a delayed boundary-routing contract. This module only
+  * updates household `bankId` assignments. It does not emit same-month monetary
+  * batches and it does not move bank balance-sheet deposits in month `t`; those
+  * assignments affect future household income, consumption, debt-service, and
+  * deposit-interest routing from the next boundary onward.
   *
   * Pure function — no mutable state. Called from BankingEconomics after failure
   * resolution.
@@ -30,9 +33,10 @@ import com.boombustgroup.amorfati.random.RandomStream
   */
 object DepositMobility:
 
-  /** Result of deposit mobility: households with updated bankId assignments.
-    * Deposit flows take effect next month when income/consumption routes to the
-    * new bank (1-month lag, consistent with account transfer time).
+  /** Result of deposit mobility: households with updated `bankId` assignments.
+    * No transfer plan is carried here by design. Deposit flows take effect next
+    * month when household flows route to the new bank (1-month lag, consistent
+    * with account transfer time).
     */
   case class Result(households: Vector[Household.State])
 

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -20,7 +20,7 @@ carry behavioral state, operational diagnostics, and legacy unsupported metrics.
 | `Jst.scala` | Local government (JST) | Revenue, spending, deficit, unsupported debt metric; cash is ledger-owned | BankDeposits (JST deposits), JstDebt |
 | `Nbfi.scala` | TFI funds + NBFI credit | Origination, default, and deposit-drain diagnostics; AUM, bond/equity holdings, cash, and loan stock are ledger projections | BankDeposits (deposit drain), BondClearing (TFI bonds), NbfiCredit |
 | `Nbp.scala` | National Bank of Poland | Reference rate, QE policy metrics, monthly FX operations; gov bond holdings and FX reserves are ledger-owned | BankCapital (reserve interest), Nfa (FX intervention), BondClearing (QE bonds) |
-| `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Per-bank deposit flows, health-based flight, panic contagion | BankDeposits (redistribution) |
+| `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Boundary `bankId` reassignment, health-based flight, panic contagion; delayed routing only, no same-month balance-sheet transfer | Future BankDeposits routing via reassigned households |
 | `EarmarkedFunds.scala` | FP, PFRON, FGŚP | Payroll-funded statutory funds, bankruptcy payouts, ALMP | GovDebt (gov subvention) |
 | `EclStaging.scala` | IFRS 9 ECL provisioning | S1/S2/S3 staging, macro-driven migration, forward-looking provisions | BankCapital (provision) |
 | `InterbankContagion.scala` | Interbank contagion (Lehman channel) | 7×7 bilateral exposure matrix, counterparty losses, liquidity hoarding | InterbankNetting |

--- a/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.agents
 
+import com.boombustgroup.amorfati.Generators
 import com.boombustgroup.amorfati.TestHouseholdState
 
 import com.boombustgroup.amorfati.config.SimParams
@@ -71,6 +72,9 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
       wageScar = Share.Zero,
     )
 
+  private def mkWorld() =
+    Generators.testWorld(totalPopulation = 1, employed = 1, marketWage = PLN(8000.0), reservationWage = PLN(4666.0))
+
   "DepositMobility" should "not move deposits when all banks are healthy" in {
     val rows   = Vector(mkBankRow(0, 0.15), mkBankRow(1, 0.14))
     val hhs    = Vector(mkHh(0), mkHh(1))
@@ -119,4 +123,49 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
     val r1   = DepositMobility(hhs, banks(rows), stocks(rows), anyBankFailed = true, RandomStream.seeded(42))
     val r2   = DepositMobility(hhs, banks(rows), stocks(rows), anyBankFailed = true, RandomStream.seeded(42))
     r1.households.map(_.bankId) shouldBe r2.households.map(_.bankId)
+  }
+
+  it should "return only delayed boundary bankId updates, not a same-month transfer plan" in {
+    val rows     = Vector(mkBankRow(0, 0.04), mkBankRow(1, 0.20))
+    val original = (0 until 100).map(id => mkHh(0).copy(id = HhId(id))).toVector
+    val result   = DepositMobility(original, banks(rows), stocks(rows), anyBankFailed = false, RandomStream.seeded(42))
+
+    result.productArity shouldBe 1
+    result.productElementName(0) shouldBe "households"
+    result.households.count(_.bankId == BankId(1)) should be > 0
+    original
+      .zip(result.households)
+      .foreach: (before, after) =>
+        after shouldBe before.copy(bankId = after.bankId)
+  }
+
+  it should "route the next household step through the reassigned bankId" in {
+    val rows       = Vector(mkBankRow(0, 0.04), mkBankRow(1, 0.20))
+    val original   = (0 until 100).map(id => mkHh(0, savings = 120000.0).copy(id = HhId(id))).toVector
+    val reassigned =
+      DepositMobility(original, banks(rows), stocks(rows), anyBankFailed = false, RandomStream.seeded(42)).households
+        .find(_.bankId == BankId(1))
+        .getOrElse(fail("expected at least one household to switch to the healthiest bank"))
+
+    reassigned.bankId shouldBe BankId(1)
+
+    val bankRates = BankRates(
+      lendingRates = Vector(Rate(0.07), Rate(0.07)),
+      depositRates = Vector(Rate.Zero, Rate(0.12)),
+    )
+    val step      = Household.step(
+      households = Vector(reassigned),
+      financialStocks = Vector(TestHouseholdState.financial(savings = PLN(120000.0))),
+      world = mkWorld(),
+      marketWage = PLN(8000.0),
+      reservationWage = PLN(4666.0),
+      importAdj = Share(0.4),
+      rng = RandomStream.seeded(7),
+      nBanks = 2,
+      bankRates = Some(bankRates),
+    )
+    val flows     = step.perBankFlows.get
+
+    flows(0).depositInterest shouldBe PLN.Zero
+    flows(1).depositInterest shouldBe PLN(1200.0) +- PLN(1.0)
   }


### PR DESCRIPTION
Closes #351. Documents DepositMobility as a delayed boundary-routing contract, fixes the agents README row, and adds tests proving the result carries only household bankId updates while the next Household.step routes flows through the reassigned bank.