### PR TITLE
Harden interbank contagion failure semantics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -495,8 +495,9 @@ object Banking:
   // Failure detection and resolution
   // ---------------------------------------------------------------------------
 
-  /** Check for bank failures: CAR < effectiveMinCar for 3 consecutive months,
-    * or LCR breach at 50% of minimum. Already-failed banks pass through.
+  /** Check for bank failures: negative capital immediately, CAR <
+    * effectiveMinCar for 3 consecutive months, or LCR breach at 50% of minimum.
+    * Already-failed banks pass through.
     */
   def checkFailures(
       banks: Vector[BankState],
@@ -530,7 +531,8 @@ object Banking:
             val lowCar    = car(b, stocks, bankCorpBondHoldings(b.id)) < minCar
             val lcrBreach = lcr(stocks) < p.banking.lcrMin * Share(0.5)
             val newConsec = if lowCar then consec + 1 else 0
-            if newConsec >= 3 || lcrBreach then b.copy(status = BankStatus.Failed(month), capital = PLN.Zero)
+            val insolvent = b.capital < PLN.Zero
+            if insolvent || newConsec >= 3 || lcrBreach then b.copy(status = BankStatus.Failed(month), capital = PLN.Zero)
             else b.copy(status = BankStatus.Active(newConsec))
       val prevFailed = banks.filter(_.failed).map(_.id).toSet
       FailureCheckResult(updated, updated.exists(b => b.failed && !prevFailed.contains(b.id)))

--- a/src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala
@@ -4,11 +4,13 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.Distribute
 
-/** Interbank contagion: bilateral exposures, counterparty losses, liquidity
-  * hoarding.
+/** Interbank contagion: bilateral exposures, counterparty losses, and an
+  * NPL-driven liquidity-hoarding proxy.
   *
   * Models the Lehman/Bear Stearns channel: bank failure → counterparty losses
-  * proportional to bilateral exposure → secondary failures → systemic freeze.
+  * proportional to bilateral exposure → secondary failures. The hoarding proxy
+  * is calibrated from system-wide NPL stress, not directly from realized bank
+  * failures.
   *
   * Three mechanisms:
   *
@@ -20,7 +22,8 @@ import com.boombustgroup.ledger.Distribute
   *      potentially triggering secondary failure (cascade).
   *   3. '''Liquidity hoarding''' — when system-wide NPL ratio exceeds a
   *      threshold, banks cut interbank lending by a hoarding factor. This
-  *      reduces available liquidity, amplifying stress.
+  *      reduces available liquidity, amplifying stress, but it remains separate
+  *      from the realized failure/contagion-loss path.
   *
   * Pure functions — no mutable state. Called from `processInterbankAndFailures`
   * in BankingEconomics.
@@ -47,8 +50,19 @@ object InterbankContagion:
       banks.length == financialStocks.length,
       s"InterbankContagion.buildExposureMatrix requires aligned banks and financial stocks, got ${banks.length} banks and ${financialStocks.length} stock rows",
     )
+    banks
+      .zip(financialStocks)
+      .foreach: (bank, stocks) =>
+        require(
+          !bank.failed || stocks.interbankLoan == PLN.Zero,
+          s"InterbankContagion.buildExposureMatrix requires failed bank ${bank.id.toInt} to have zero interbankLoan, got ${stocks.interbankLoan}",
+        )
     val n         = banks.length
-    val nets      = financialStocks.map(_.interbankLoan)
+    val nets      = banks
+      .zip(financialStocks)
+      .map:
+        case (bank, _) if bank.failed => PLN.Zero
+        case (_, stocks)              => stocks.interbankLoan
     val borrowers = nets.indices.filter(i => nets(i) < PLN.Zero).toVector
     val weights   = borrowers.map(i => (-nets(i)).toLong)
     if borrowers.isEmpty then Vector.fill(n)(Vector.fill(n)(PLN.Zero))
@@ -67,7 +81,7 @@ object InterbankContagion:
     *
     * For each failed bank j, every lender i loses
     * `exposure(i→j) × (1 − recoveryRate)` from capital. If capital goes
-    * negative, bank i may subsequently fail in the next `checkFailures` round.
+    * negative, bank i fails in the subsequent `checkFailures` round.
     */
   def applyContagionLosses(
       banks: Vector[Banking.BankState],
@@ -90,7 +104,9 @@ object InterbankContagion:
     * `hoardingFactor = clamp(1 − sensitivity × (systemNPL − threshold), 0, 1)`
     *
     * At factor = 0, interbank market freezes completely (all banks hoard). At
-    * factor = 1, normal interbank activity.
+    * factor = 1, normal interbank activity. This proxy is intentionally
+    * NPL-only; realized failures and contagion losses are handled by
+    * `applyContagionLosses` plus `Banking.checkFailures`.
     */
   def hoardingFactor(systemNplRatio: Share)(using p: SimParams): Share =
     val excess = (systemNplRatio - p.banking.hoardingNplThreshold).max(Share.Zero)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -172,6 +172,15 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
       .consecutiveLowCar shouldBe 0
   }
 
+  it should "fail negative-capital banks immediately" in {
+    val insolvent = mkBankRow(capital = PLN(-1.0))
+    val result    = Banking.checkFailures(Vector(insolvent.bank), Vector(insolvent.stocks), ExecutionMonth(30), enabled = true, Multiplier.Zero)
+
+    result.anyFailed shouldBe true
+    result.banks.head.failed shouldBe true
+    result.banks.head.capital shouldBe PLN.Zero
+  }
+
   "Banking.resolveFailures" should "move failed-bank stocks to the healthiest survivor" in {
     val rows   = Vector(
       mkBankRow(id = 0, deposits = PLN(500000.0), loans = PLN(100000.0), capital = PLN(50000.0), govBondHoldings = PLN(10000.0)),

--- a/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/InterbankContagionSpec.scala
@@ -84,20 +84,51 @@ class InterbankContagionSpec extends AnyFlatSpec with Matchers:
     matrix.flatten.forall(_ == PLN.Zero) shouldBe true
   }
 
+  it should "exclude failed zero-position banks from exposures" in {
+    val rows   = Vector(mkBankRow(0, 100.0), mkBankRow(1, -100.0), mkBankRow(2, 0.0, failed = true))
+    val matrix = InterbankContagion.buildExposureMatrix(banks(rows), stocks(rows))
+    matrix(2).forall(_ == PLN.Zero) shouldBe true
+    matrix.map(_(2)).forall(_ == PLN.Zero) shouldBe true
+  }
+
+  it should "reject failed banks with non-zero interbank positions" in {
+    val rows = Vector(mkBankRow(0, 100.0), mkBankRow(1, -100.0, failed = true))
+    val ex   = intercept[IllegalArgumentException]:
+      InterbankContagion.buildExposureMatrix(banks(rows), stocks(rows))
+    ex.getMessage should include("failed bank 1")
+    ex.getMessage should include("interbankLoan")
+  }
+
   "applyContagionLosses" should "reduce capital of exposed lenders when counterparty fails" in {
-    val rows         = Vector(mkBankRow(0, 100.0, capital = 1e9), mkBankRow(1, -100.0, capital = -1.0, failed = true))
-    val matrix       = InterbankContagion.buildExposureMatrix(banks(rows), stocks(rows))
-    val after        = InterbankContagion.applyContagionLosses(banks(rows), matrix)
+    val exposureRows = Vector(mkBankRow(0, 100.0, capital = 1e9), mkBankRow(1, -100.0, capital = 1e9))
+    val failedRows   = Vector(mkBankRow(0, 100.0, capital = 1e9), mkBankRow(1, -100.0, capital = -1.0, failed = true))
+    val matrix       = InterbankContagion.buildExposureMatrix(banks(exposureRows), stocks(exposureRows))
+    val after        = InterbankContagion.applyContagionLosses(banks(failedRows), matrix)
     // Lender loses exposure × (1 - recovery)
     val expectedLoss = 100.0 * (1.0 - td.toDouble(p.banking.interbankRecoveryRate))
     td.toDouble(after(0).capital) shouldBe (1e9 - expectedLoss) +- 0.01
   }
 
   it should "not affect banks with no exposure to failed bank" in {
-    val rows   = Vector(mkBankRow(0, 0.0, capital = 1e9), mkBankRow(1, -100.0, capital = -1.0, failed = true), mkBankRow(2, 100.0, capital = 1e9))
-    val matrix = InterbankContagion.buildExposureMatrix(banks(rows), stocks(rows))
-    val after  = InterbankContagion.applyContagionLosses(banks(rows), matrix)
+    val exposureRows = Vector(mkBankRow(0, 0.0, capital = 1e9), mkBankRow(1, -100.0, capital = 1e9), mkBankRow(2, 100.0, capital = 1e9))
+    val failedRows   =
+      Vector(mkBankRow(0, 0.0, capital = 1e9), mkBankRow(1, -100.0, capital = -1.0, failed = true), mkBankRow(2, 100.0, capital = 1e9))
+    val matrix       = InterbankContagion.buildExposureMatrix(banks(exposureRows), stocks(exposureRows))
+    val after        = InterbankContagion.applyContagionLosses(banks(failedRows), matrix)
     td.toDouble(after(0).capital) shouldBe 1e9 +- 0.01 // safe bank untouched
+  }
+
+  it should "make contagion insolvency visible to the same-month failure check" in {
+    val exposureRows = Vector(mkBankRow(0, 100.0, capital = 1.0), mkBankRow(1, -100.0, capital = 1e9))
+    val failedRows   = Vector(mkBankRow(0, 100.0, capital = 1.0), mkBankRow(1, -100.0, capital = -1.0, failed = true))
+    val matrix       = InterbankContagion.buildExposureMatrix(banks(exposureRows), stocks(exposureRows))
+    val afterLosses  = InterbankContagion.applyContagionLosses(banks(failedRows), matrix)
+    val cleanStocks  = stocks(exposureRows).map(_.copy(demandDeposit = PLN.Zero, termDeposit = PLN.Zero))
+    val checked      = Banking.checkFailures(afterLosses, cleanStocks, ExecutionMonth(30), enabled = true, Multiplier.Zero)
+
+    afterLosses(0).capital should be < PLN.Zero
+    checked.banks(0).failed shouldBe true
+    checked.anyFailed shouldBe true
   }
 
   "hoardingFactor" should "be 1.0 when NPL below threshold" in {


### PR DESCRIPTION
Summary
- Fail active banks immediately when contagion or other losses push capital below zero.
- Guard interbank exposure construction against already-failed banks with non-zero interbank positions, while excluding zero-position failed banks from the matrix.
- Clarify that the liquidity-hoarding proxy is NPL-driven and separate from realized failure/contagion losses.
- Add regression coverage for failed-bank exposure guards, contagion-induced insolvency, and immediate negative-capital failure.

Tests
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.InterbankContagionSpec com.boombustgroup.amorfati.agents.BankingSectorSpec"
- sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorPropertySpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 1 m18 --duration 60 --run-id issue295-smoke

Smoke result
- 60m / 1 seed completed in 84.6s; Adopt=13.7%, pi=-3.5%, Unemp=5.8%.

Closes #295