### PR TITLE
Harden deposit mobility semantics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -33,8 +33,11 @@ object Banking:
   def nplRatio(totalLoans: PLN, nplAmount: PLN): Share =
     if totalLoans > MinBalanceThreshold then nplAmount.ratioTo(totalLoans).toShare else Share.Zero
 
+  private def riskWeightedAssets(firmLoans: PLN, consumerLoans: PLN, corpBondHoldings: PLN): PLN =
+    firmLoans + consumerLoans + corpBondHoldings * CorpBondRiskWeight
+
   def capitalAdequacyRatio(capital: PLN, firmLoans: PLN, consumerLoans: PLN, corpBondHoldings: PLN): Multiplier =
-    val totalRwa = firmLoans + consumerLoans + corpBondHoldings * CorpBondRiskWeight
+    val totalRwa = riskWeightedAssets(firmLoans, consumerLoans, corpBondHoldings)
     if totalRwa > MinBalanceThreshold then capital.ratioTo(totalRwa).toMultiplier else SafeRatioFloor
 
   // NSFR weights (Basel III §6)
@@ -641,8 +644,14 @@ object Banking:
       }
       ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds)
 
-  /** Find the healthiest (highest CAR) surviving bank. Falls back to highest
-    * capital if all banks have failed.
+  /** Find the healthiest surviving bank.
+    *
+    * Banks with no material risk-weighted assets get the CAR safe floor, so
+    * they are excluded from CAR ranking while any risk-bearing survivor exists.
+    * This prevents empty balance-sheet shells from attracting all
+    * flight-to-safety deposits or failure-resolution assets. Falls back to
+    * highest capital if all candidates have failed or all survivors are
+    * non-risk-bearing.
     */
   def healthiestBankId(
       banks: Vector[BankState],
@@ -655,7 +664,12 @@ object Banking:
     )
     val alive = banks.zip(financialStocks).filterNot(_._1.failed)
     if alive.isEmpty then banks.maxBy(_.capital.toLong).id
-    else alive.maxBy((bank, stocks) => car(bank, stocks, bankCorpBondHoldings(bank.id)))._1.id
+    else
+      val riskBearingAlive = alive.filter: (bank, stocks) =>
+        riskWeightedAssets(stocks.firmLoan, stocks.consumerLoan, bankCorpBondHoldings(bank.id)) > MinBalanceThreshold
+      if riskBearingAlive.nonEmpty then
+        riskBearingAlive.maxBy((bank, stocks) => (car(bank, stocks, bankCorpBondHoldings(bank.id)).toLong, bank.capital.toLong))._1.id
+      else alive.maxBy(_._1.capital.toLong)._1.id
 
   /** Reassign a firm/household from a failed bank to the healthiest surviving
     * bank.

--- a/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/DepositMobility.scala
@@ -5,9 +5,9 @@ import com.boombustgroup.amorfati.types.*
 
 import com.boombustgroup.amorfati.random.RandomStream
 
-/** Deposit mobility: endogenous deposit flight and bank runs.
+/** Deposit mobility: delayed deposit-account reassignment after bank stress.
   *
-  * Models three channels of deposit switching:
+  * Models two channels of household bank switching:
   *
   *   1. '''Health-based flight''' — households observe their bank's health (CAR
   *      ratio). When CAR drops below a threshold, a fraction of depositors
@@ -15,15 +15,17 @@ import com.boombustgroup.amorfati.random.RandomStream
   *   2. '''Panic contagion''' — when any bank fails this month, depositors at
   *      other banks panic-switch with probability `panicRate`. Diamond & Dybvig
   *      (1983) threshold effect. SVB/Credit Suisse/Idea Bank channel.
-  *   3. '''Endogenous LCR runoff''' — bank-level deposit runoff rate becomes
-  *      `baseRunoff + panicPremium × (1 − bankCAR/systemCAR)`. Stressed banks
-  *      face higher outflows.
   *
   * Deposit switching is a delayed boundary-routing contract. This module only
   * updates household `bankId` assignments. It does not emit same-month monetary
   * batches and it does not move bank balance-sheet deposits in month `t`; those
   * assignments affect future household income, consumption, debt-service, and
   * deposit-interest routing from the next boundary onward.
+  *
+  * Input household `bankId` values must already point to surviving banks in the
+  * current bank vector. Failure resolution is responsible for reassigning
+  * failed-bank clients before this module runs; unknown or stale bank IDs fail
+  * fast instead of receiving generic system-average switching behavior.
   *
   * Pure function — no mutable state. Called from BankingEconomics after failure
   * resolution.
@@ -56,6 +58,23 @@ object DepositMobility:
     val panicFlight  = if anyBankFailed then p.banking.depositPanicRate else Share.Zero
     (healthFlight + panicFlight).min(p.banking.maxDepositSwitchRate)
 
+  private def validateHouseholdBankIds(households: Vector[Household.State], banks: Vector[Banking.BankState]): Unit =
+    households.foreach: hh =>
+      val bankIndex = hh.bankId.toInt
+      require(
+        bankIndex >= 0 && bankIndex < banks.length,
+        s"DepositMobility requires household ${hh.id.toInt} to reference a known bankId, got $bankIndex for ${banks.length} banks",
+      )
+      val bank      = banks(bankIndex)
+      require(
+        bank.id == hh.bankId,
+        s"DepositMobility requires bankId/index alignment for household ${hh.id.toInt}, got bankId ${hh.bankId.toInt} at index $bankIndex with bank ${bank.id.toInt}",
+      )
+      require(
+        !bank.failed,
+        s"DepositMobility requires household ${hh.id.toInt} to be reassigned away from failed bank ${hh.bankId.toInt} before mobility runs",
+      )
+
   /** Run deposit mobility: households may switch from weak banks to the
     * healthiest bank.
     *
@@ -76,18 +95,14 @@ object DepositMobility:
       rng: RandomStream,
       bankCorpBondHoldings: Banking.BankCorpBondHoldings = Banking.noBankCorpBondHoldings,
   )(using p: SimParams): Result =
+    validateHouseholdBankIds(households, banks)
     val healthiest = Banking.healthiestBankId(banks, bankFinancialStocks, bankCorpBondHoldings)
-    val carByBank  = banks
+    val carByIndex = banks
       .zip(bankFinancialStocks)
-      .map((b, stocks) => b.id.toInt -> Banking.car(b, stocks, bankCorpBondHoldings(b.id)))
-      .toMap
-    val systemCar  =
-      if banks.nonEmpty then
-        Multiplier.fromRaw(banks.zip(bankFinancialStocks).map((b, stocks) => Banking.car(b, stocks, bankCorpBondHoldings(b.id)).toLong).sum / banks.length)
-      else Multiplier.Zero
+      .map((b, stocks) => Banking.car(b, stocks, bankCorpBondHoldings(b.id)))
 
     val updated = households.map: hh =>
-      val currentCar = carByBank.getOrElse(hh.bankId.toInt, systemCar)
+      val currentCar = carByIndex(hh.bankId.toInt)
       val prob       = switchProbability(currentCar, anyBankFailed)
       if prob > Share.Zero && prob.sampleBelow(rng) && hh.bankId != healthiest then hh.copy(bankId = healthiest)
       else hh

--- a/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/DepositMobilitySpec.scala
@@ -44,6 +44,24 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
       ),
     )
 
+  private def mkTinyRwaBankRow(id: Int): (Banking.BankState, Banking.BankFinancialStocks) =
+    val row = mkBankRow(id, 0.01)
+    (
+      row._1.copy(
+        capital = PLN(1e6),
+        loansShort = PLN.Zero,
+        loansMedium = PLN.Zero,
+        loansLong = PLN.Zero,
+      ),
+      row._2.copy(
+        totalDeposits = PLN(1e6),
+        firmLoan = PLN.Zero,
+        demandDeposit = PLN(6e5),
+        termDeposit = PLN(4e5),
+        consumerLoan = PLN.Zero,
+      ),
+    )
+
   private def banks(rows: Vector[(Banking.BankState, Banking.BankFinancialStocks)]): Vector[Banking.BankState] =
     rows.map(_._1)
 
@@ -115,6 +133,35 @@ class DepositMobilitySpec extends AnyFlatSpec with Matchers:
     val atBank1 = result.households.count(_.bankId == BankId(1))
     val atBank2 = result.households.count(_.bankId == BankId(2))
     atBank1 should be >= atBank2
+  }
+
+  it should "not select a tiny-RWA CAR-floor bank as the flight-to-safety target" in {
+    val rows     = Vector(mkBankRow(0, 0.04), mkTinyRwaBankRow(1), mkBankRow(2, 0.15))
+    val hhs      = (0 until 100).map(id => mkHh(0).copy(id = HhId(id))).toVector
+    val result   = DepositMobility(hhs, banks(rows), stocks(rows), anyBankFailed = false, RandomStream.seeded(42))
+    val switched = result.households.filter(_.bankId != BankId(0))
+
+    Banking.healthiestBankId(banks(rows), stocks(rows)) shouldBe BankId(2)
+    switched.map(_.bankId).distinct shouldBe Vector(BankId(2))
+    switched should not be empty
+  }
+
+  it should "fail fast for an unknown household bankId" in {
+    val rows = Vector(mkBankRow(0, 0.15), mkBankRow(1, 0.14))
+    val ex   = intercept[IllegalArgumentException]:
+      DepositMobility(Vector(mkHh(99)), banks(rows), stocks(rows), anyBankFailed = false, RandomStream.seeded(42))
+
+    ex.getMessage should include("known bankId")
+    ex.getMessage should include("99")
+  }
+
+  it should "fail fast when a household still points at a failed bank" in {
+    val rows = Vector(mkBankRow(0, 0.15), mkBankRow(1, 0.04, failed = true))
+    val ex   = intercept[IllegalArgumentException]:
+      DepositMobility(Vector(mkHh(1)), banks(rows), stocks(rows), anyBankFailed = true, RandomStream.seeded(42))
+
+    ex.getMessage should include("failed bank 1")
+    ex.getMessage should include("before mobility runs")
   }
 
   it should "be deterministic with same seed" in {


### PR DESCRIPTION
Summary
- Make healthiest-bank selection ignore CAR safe-floor winners while material risk-bearing survivors exist.
- Add explicit DepositMobility validation for unknown, index-mismatched, or failed household bankId assignments.
- Align DepositMobility docs with the implemented delayed boundary-routing semantics instead of describing same-month LCR runoff.
- Add regression coverage for tiny-RWA target selection and stale household bankId handling.

Tests
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.DepositMobilitySpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.engine.KnfBfgSpec"
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 1 m18 --duration 60 --run-id issue294-smoke

Smoke result
- 60m / 1 seed completed in 79.0s; Adopt=13.7%, pi=-3.5%, Unemp=5.8%.

Closes #294