### PR TITLE
Complete non-standard employment mechanism

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/ContractType.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/ContractType.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.agents
 
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
 /** Employment contract types in the Polish dual labor market.
@@ -75,3 +76,11 @@ object ContractType:
     case 4 => (0.90, 0.05, 0.05) // Public — almost all permanent
     case 5 => (0.40, 0.40, 0.20) // Agriculture — high zlecenie
     case _ => (0.70, 0.20, 0.10) // default
+
+  /** Draw a sector-specific employment contract. */
+  def sampleForSector(sectorIdx: SectorIdx, rng: RandomStream): ContractType =
+    val (permanent, zlecenie, _) = sectorMix(sectorIdx.toInt)
+    val draw                     = rng.nextDouble()
+    if draw < permanent then Permanent
+    else if draw < permanent + zlecenie then Zlecenie
+    else B2B

--- a/src/main/scala/com/boombustgroup/amorfati/agents/EarmarkedFunds.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EarmarkedFunds.scala
@@ -110,9 +110,17 @@ object EarmarkedFunds:
       nBankruptFirms: Int,
       avgFirmWorkers: Int,
   )(using p: SimParams): State =
+    step(SocialSecurity.PayrollBase.aggregate(employed, wage), unempBenefitSpend, nBankruptFirms, avgFirmWorkers)
+
+  def step(
+      payroll: SocialSecurity.PayrollBase,
+      unempBenefitSpend: PLN,
+      nBankruptFirms: Int,
+      avgFirmWorkers: Int,
+  )(using p: SimParams): State =
     // Fundusz Pracy: 2.45% employer levy → finances unemployment benefits + ALMP
-    val fpContrib = employed * (wage * p.earmarked.fpRate)
-    val fpSpend   = unempBenefitSpend + employed * p.earmarked.fpAlmpSpendPerWorker
+    val fpContrib = payroll.fpContributions
+    val fpSpend   = unempBenefitSpend + payroll.employed * p.earmarked.fpAlmpSpendPerWorker
     val fpFlow    = fpContrib - fpSpend
     val fpSubv    = if fpFlow < PLN.Zero then -fpFlow else PLN.Zero
 
@@ -123,7 +131,7 @@ object EarmarkedFunds:
     val pfronSubv    = if pfronFlow < PLN.Zero then -pfronFlow else PLN.Zero
 
     // FGŚP: 0.10% payroll → pays wages on bankruptcy (counter-cyclical)
-    val fgspContrib = employed * (wage * p.earmarked.fgspRate)
+    val fgspContrib = payroll.fgspContributions
     val fgspSpend   = (nBankruptFirms * avgFirmWorkers) * p.earmarked.fgspPayoutPerWorker
     val fgspFlow    = fgspContrib - fgspSpend
     val fgspSubv    = if fgspFlow < PLN.Zero then -fgspFlow else PLN.Zero

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -288,6 +288,7 @@ object Household:
           education = edu,
           taskRoutineness = routineness,
           wageScar = Share.Zero,
+          contractType = ContractType.sampleForSector(sectorIdx, rng),
           region = firm.region,
         ),
         financialStocks = FinancialStocks(

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -91,6 +91,7 @@ object Immigration:
         education = edu,
         taskRoutineness = Household.Init.sampleTaskRoutineness(edu, sector, rng),
         wageScar = Share.Zero,
+        contractType = ContractType.sampleForSector(sector, rng),
         region = region,
       )
       val stocks    = Household.FinancialStocks(

--- a/src/main/scala/com/boombustgroup/amorfati/agents/SocialSecurity.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/SocialSecurity.scala
@@ -6,6 +6,66 @@ import com.boombustgroup.amorfati.types.*
 /** Social security and demographics: ZUS/FUS, PPK, demographics, BGK. */
 object SocialSecurity:
 
+  /** Current-month payroll basis derived from household states that are
+    * entitled to month-t income. Hiring later in the month updates the next
+    * boundary contract, not this payroll base.
+    */
+  case class PayrollBase(
+      employed: Int,
+      grossWages: PLN,
+      zusContributions: PLN,
+      nfzContributions: PLN,
+      ppkContributions: PLN,
+      fpContributions: PLN,
+      fgspContributions: PLN,
+  ):
+    def averageWage: PLN =
+      if employed <= 0 then PLN.Zero else grossWages / employed.toLong
+
+  object PayrollBase:
+    val zero: PayrollBase =
+      PayrollBase(0, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+
+    def aggregate(employed: Int, wage: PLN)(using p: SimParams): PayrollBase =
+      val grossWages = employed * wage
+      PayrollBase(
+        employed = employed,
+        grossWages = grossWages,
+        zusContributions = employed * (wage * p.social.zusContribRate * p.social.zusScale),
+        nfzContributions = employed * (wage * p.social.nfzContribRate),
+        ppkContributions = employed * (wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate)),
+        fpContributions = employed * (wage * p.earmarked.fpRate),
+        fgspContributions = employed * (wage * p.earmarked.fgspRate),
+      )
+
+    def fromHouseholds(households: Vector[Household.State])(using p: SimParams): PayrollBase =
+      households.foldLeft(zero):
+        case (acc, hh) =>
+          hh.status match
+            case HhStatus.Employed(_, _, wage) =>
+              val zus  = wage * ContractType.zusEmployerRate(hh.contractType) * p.social.zusScale
+              val nfz  = wage * p.social.nfzContribRate
+              val ppk  =
+                if hh.contractType == ContractType.B2B then PLN.Zero
+                else wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate)
+              val fp   = wage * ContractType.fpRate(hh.contractType)
+              val fgsp =
+                if hh.contractType == ContractType.B2B then PLN.Zero
+                else wage * p.earmarked.fgspRate
+              PayrollBase(
+                employed = acc.employed + 1,
+                grossWages = acc.grossWages + wage,
+                zusContributions = acc.zusContributions + zus,
+                nfzContributions = acc.nfzContributions + nfz,
+                ppkContributions = acc.ppkContributions + ppk,
+                fpContributions = acc.fpContributions + fp,
+                fgspContributions = acc.fgspContributions + fgsp,
+              )
+            case _                             => acc
+
+  def payrollBase(households: Vector[Household.State])(using p: SimParams): PayrollBase =
+    PayrollBase.fromHouseholds(households)
+
   // ---------------------------------------------------------------------------
   // ZUS / FUS
   // ---------------------------------------------------------------------------
@@ -25,7 +85,10 @@ object SocialSecurity:
     * boundary to carry the stock forward.
     */
   def zusStep(employed: Int, wage: PLN, nRetirees: Int)(using p: SimParams): ZusState =
-    val contributions = employed * (wage * p.social.zusContribRate * p.social.zusScale)
+    zusStep(PayrollBase.aggregate(employed, wage), nRetirees)
+
+  def zusStep(payroll: PayrollBase, nRetirees: Int)(using p: SimParams): ZusState =
+    val contributions = payroll.zusContributions
     val pensions      = nRetirees * p.social.zusBasePension
     val monthlyFlow   = contributions - pensions
     val govSubvention = if monthlyFlow < PLN.Zero then -monthlyFlow else PLN.Zero
@@ -58,7 +121,10 @@ object SocialSecurity:
     * carry the stock forward.
     */
   def nfzStep(employed: Int, wage: PLN, workingAge: Int, nRetirees: Int)(using p: SimParams): NfzState =
-    val contributions = employed * (wage * p.social.nfzContribRate)
+    nfzStep(PayrollBase.aggregate(employed, wage), workingAge, nRetirees)
+
+  def nfzStep(payroll: PayrollBase, workingAge: Int, nRetirees: Int)(using p: SimParams): NfzState =
+    val contributions = payroll.nfzContributions
     val spending      = workingAge * p.social.nfzPerCapitaCost + nRetirees * (p.social.nfzPerCapitaCost * p.social.nfzAgingElasticity)
     val monthlyFlow   = contributions - spending
     val govSubvention = if monthlyFlow < PLN.Zero then -monthlyFlow else PLN.Zero
@@ -86,7 +152,10 @@ object SocialSecurity:
     * a pass-through bond market participant).
     */
   def ppkStep(employed: Int, wage: PLN)(using p: SimParams): PpkState =
-    val contributions = employed * (wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
+    ppkStep(PayrollBase.aggregate(employed, wage))
+
+  def ppkStep(payroll: PayrollBase): PpkState =
+    val contributions = payroll.ppkContributions
     PpkState(contributions)
 
   /** PPK bond purchase this month: contributions × bond allocation. */

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/EarmarkedFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.agents.EarmarkedFunds
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
@@ -21,25 +22,30 @@ object EarmarkedFlows:
   val GOV_ACCOUNT: Int      = 4
   val SERVICES_ACCOUNT: Int = 5
 
-  case class Input(
-      employed: Int,
-      wage: PLN,
-      unempBenefitSpend: PLN,
-      nBankruptFirms: Int,
-      avgFirmWorkers: Int,
-  )
+  case class Input(state: EarmarkedFunds.State)
 
-  def emitBatches(input: Input)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    val fpContrib = input.employed * (input.wage * p.earmarked.fpRate)
-    val fpSpend   = input.unempBenefitSpend + input.employed * p.earmarked.fpAlmpSpendPerWorker
+  object Input:
+    def apply(
+        employed: Int,
+        wage: PLN,
+        unempBenefitSpend: PLN,
+        nBankruptFirms: Int,
+        avgFirmWorkers: Int,
+    )(using p: SimParams): Input =
+      Input(EarmarkedFunds.step(employed, wage, unempBenefitSpend, nBankruptFirms, avgFirmWorkers))
+
+  def emitBatches(input: Input)(using @scala.annotation.unused p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    val state     = input.state
+    val fpContrib = state.fpContributions
+    val fpSpend   = state.fpSpending
     val fpDeficit = fpSpend - fpContrib
 
-    val pfronContrib = p.earmarked.pfronMonthlyRevenue
-    val pfronSpend   = p.earmarked.pfronMonthlySpending
+    val pfronContrib = state.pfronContributions
+    val pfronSpend   = state.pfronSpending
     val pfronDeficit = pfronSpend - pfronContrib
 
-    val fgspContrib = input.employed * (input.wage * p.earmarked.fgspRate)
-    val fgspSpend   = (input.nBankruptFirms * input.avgFirmWorkers) * p.earmarked.fgspPayoutPerWorker
+    val fgspContrib = state.fgspContributions
+    val fgspSpend   = state.fgspSpending
     val fgspDeficit = fgspSpend - fgspContrib
 
     Vector.concat(
@@ -115,12 +121,13 @@ object EarmarkedFlows:
       ),
     )
 
-  def emit(input: Input)(using p: SimParams): Vector[Flow] =
+  def emit(input: Input)(using @scala.annotation.unused p: SimParams): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
+    val state = input.state
 
     // FP: employer levy → unemployment benefits + ALMP
-    val fpContrib = input.employed * (input.wage * p.earmarked.fpRate)
-    val fpSpend   = input.unempBenefitSpend + input.employed * p.earmarked.fpAlmpSpendPerWorker
+    val fpContrib = state.fpContributions
+    val fpSpend   = state.fpSpending
     val fpDeficit = fpSpend - fpContrib
 
     if fpContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, FP_ACCOUNT, fpContrib.toLong, FlowMechanism.FpContribution.toInt)
@@ -128,8 +135,8 @@ object EarmarkedFlows:
     if fpDeficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, FP_ACCOUNT, fpDeficit.toLong, FlowMechanism.FpGovSubvention.toInt)
 
     // PFRON: flat levy → disability spending
-    val pfronContrib = p.earmarked.pfronMonthlyRevenue
-    val pfronSpend   = p.earmarked.pfronMonthlySpending
+    val pfronContrib = state.pfronContributions
+    val pfronSpend   = state.pfronSpending
     val pfronDeficit = pfronSpend - pfronContrib
 
     if pfronContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, PFRON_ACCOUNT, pfronContrib.toLong, FlowMechanism.PfronContribution.toInt)
@@ -137,8 +144,8 @@ object EarmarkedFlows:
     if pfronDeficit > PLN.Zero then flows += Flow(GOV_ACCOUNT, PFRON_ACCOUNT, pfronDeficit.toLong, FlowMechanism.PfronGovSubvention.toInt)
 
     // FGSP: payroll levy → bankruptcy payouts (counter-cyclical)
-    val fgspContrib = input.employed * (input.wage * p.earmarked.fgspRate)
-    val fgspSpend   = (input.nBankruptFirms * input.avgFirmWorkers) * p.earmarked.fgspPayoutPerWorker
+    val fgspContrib = state.fgspContributions
+    val fgspSpend   = state.fgspSpending
     val fgspDeficit = fgspSpend - fgspContrib
 
     if fgspContrib > PLN.Zero then flows += Flow(HH_ACCOUNT, FGSP_ACCOUNT, fgspContrib.toLong, FlowMechanism.FgspContribution.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -524,7 +524,7 @@ object FlowSimulation:
     val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
     val nBankruptFirms    = s5.firmDeaths
     val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.laborDemand / s2Pre.living.length else 0
-    val payroll           = SocialSecurity.payrollBase(s3.updatedHouseholds)
+    val payroll           = SocialSecurity.payrollBase(households)
     val payrollZus        = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
     val payrollNfz        = SocialSecurity.nfzStep(payroll, s2Pre.newDemographics.workingAgePop, s2Pre.newDemographics.retirees)
     val payrollPpk        = SocialSecurity.ppkStep(payroll)
@@ -534,7 +534,6 @@ object FlowSimulation:
       newZus = payrollZus,
       newNfz = payrollNfz,
       newPpk = payrollPpk,
-      rawPpkBondPurchase = s2Reconciled.rawPpkBondPurchase,
       newEarmarked = payrollEarmarked,
     )
     val s6                = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -523,13 +523,15 @@ object FlowSimulation:
     val s5                = FirmEconomics.runStep(w, firms, households, banks, ledger, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
     val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
     val nBankruptFirms    = s5.firmDeaths
-    val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.laborDemand / s2Pre.living.length else 0
+    val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.employed / s2Pre.living.length else 0
     val payroll           = SocialSecurity.payrollBase(households)
     val payrollZus        = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
     val payrollNfz        = SocialSecurity.nfzStep(payroll, s2Pre.newDemographics.workingAgePop, s2Pre.newDemographics.retirees)
     val payrollPpk        = SocialSecurity.ppkStep(payroll)
     val payrollEarmarked  = EarmarkedFunds.step(payroll, s3.hhAgg.totalUnempBenefits, nBankruptFirms, avgFirmWorkers)
     val s2Reconciled      = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
+    // Labor reconciliation refreshes employment/wage state after the firm step,
+    // but social funds are pinned to the opening-boundary payroll for month t.
     val s2                = s2Reconciled.copy(
       newZus = payrollZus,
       newNfz = payrollNfz,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -73,6 +73,10 @@ object FlowSimulation:
       // Stage 2: Labor market
       wage: PLN,
       employed: Int,
+      payroll: SocialSecurity.PayrollBase,
+      zus: SocialSecurity.ZusState,
+      ppk: SocialSecurity.PpkState,
+      earmarked: EarmarkedFunds.State,
       unemploymentRate: Share,
       laborDemand: Int,
       livingFirms: Int,
@@ -196,11 +200,11 @@ object FlowSimulation:
   def emitAllBatches(c: MonthlyCalculus)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
     Vector.concat(
       // Tier 1: Social funds
-      ZusFlows.emitBatches(ZusFlows.ZusInput(c.employed, c.wage, c.retirees)),
+      ZusFlows.emitBatches(ZusFlows.ZusInput(c.zus)),
       NfzFlows.emitBatches(NfzFlows.NfzInput(c.nfz)),
-      PpkFlows.emitBatches(PpkFlows.PpkInput(c.employed, c.wage)),
+      PpkFlows.emitBatches(PpkFlows.PpkInput(c.ppk)),
       GovBondFlows.emitBatches(c.govBondRuntimeMovements),
-      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.employed, c.wage, c.totalUnempBenefits, c.nBankruptFirms, c.avgFirmWorkers)),
+      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.earmarked)),
       JstFlows.emitBatches(JstFlows.Input(c.firmTax, c.totalIncome, c.gdp, c.livingFirms, c.pitRevenue)),
       // Tier 2: Agents
       HouseholdFlows.emitBatches(
@@ -518,7 +522,21 @@ object FlowSimulation:
     val s4                = DemandEconomics.compute(w, s2Pre.employed, s2Pre.living, s3.domesticCons)
     val s5                = FirmEconomics.runStep(w, firms, households, banks, ledger, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
     val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
-    val s2                = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
+    val nBankruptFirms    = s5.firmDeaths
+    val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.laborDemand / s2Pre.living.length else 0
+    val payroll           = SocialSecurity.payrollBase(s3.updatedHouseholds)
+    val payrollZus        = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
+    val payrollNfz        = SocialSecurity.nfzStep(payroll, s2Pre.newDemographics.workingAgePop, s2Pre.newDemographics.retirees)
+    val payrollPpk        = SocialSecurity.ppkStep(payroll)
+    val payrollEarmarked  = EarmarkedFunds.step(payroll, s3.hhAgg.totalUnempBenefits, nBankruptFirms, avgFirmWorkers)
+    val s2Reconciled      = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
+    val s2                = s2Reconciled.copy(
+      newZus = payrollZus,
+      newNfz = payrollNfz,
+      newPpk = payrollPpk,
+      rawPpkBondPurchase = s2Reconciled.rawPpkBondPurchase,
+      newEarmarked = payrollEarmarked,
+    )
     val s6                = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())
     val s7                = PriceEquityEconomics.compute(
       w = w,
@@ -581,14 +599,18 @@ object FlowSimulation:
       minWagePriceLevel = s1.updatedMinWagePriceLevel,
       wage = s2.newWage,
       employed = s2.employed,
+      payroll = payroll,
+      zus = s2.newZus,
+      ppk = s2.newPpk,
+      earmarked = s2.newEarmarked,
       unemploymentRate = w.unemploymentRate(s2.employed),
       laborDemand = s2.laborDemand,
       livingFirms = s5.ioFirms.count(Firm.isAlive),
       retirees = s2Pre.newDemographics.retirees,
       workingAgePop = s2Pre.newDemographics.workingAgePop,
       nfz = s2.newNfz,
-      nBankruptFirms = firms.length - s2Pre.living.length,
-      avgFirmWorkers = if s2Pre.living.nonEmpty then s2Pre.laborDemand / s2Pre.living.length else 0,
+      nBankruptFirms = nBankruptFirms,
+      avgFirmWorkers = avgFirmWorkers,
       totalIncome = s3.totalIncome,
       consumption = agg.consumption,
       domesticConsumption = s3.domesticCons,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/PpkFlows.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.agents.SocialSecurity
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -17,25 +18,26 @@ object PpkFlows:
   val HH_ACCOUNT: Int  = 0
   val PPK_ACCOUNT: Int = 1
 
-  case class PpkInput(employed: Int, wage: PLN)
+  case class PpkInput(ppk: SocialSecurity.PpkState)
 
-  def emitBatches(input: PpkInput)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    val contributions = input.employed * (input.wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
+  object PpkInput:
+    def apply(employed: Int, wage: PLN)(using p: SimParams): PpkInput =
+      PpkInput(SocialSecurity.ppkStep(employed, wage))
+
+  def emitBatches(input: PpkInput)(using @scala.annotation.unused p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
     AggregateBatchedEmission.transfer(
       EntitySector.Households,
       topology.households.aggregate,
       EntitySector.Funds,
       topology.funds.ppk,
-      contributions,
+      input.ppk.contributions,
       AssetType.Cash,
       FlowMechanism.PpkContribution,
     )
 
-  def emit(input: PpkInput)(using p: SimParams): Vector[Flow] =
-    val contributions = input.employed * (input.wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
-
+  def emit(input: PpkInput)(using @scala.annotation.unused p: SimParams): Vector[Flow] =
     val flows = Vector.newBuilder[Flow]
 
-    if contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, PPK_ACCOUNT, contributions.toLong, FlowMechanism.PpkContribution.toInt)
+    if input.ppk.contributions > PLN.Zero then flows += Flow(HH_ACCOUNT, PPK_ACCOUNT, input.ppk.contributions.toLong, FlowMechanism.PpkContribution.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/ZusFlows.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.agents.SocialSecurity
 import com.boombustgroup.amorfati.engine.ledger.TreasuryRuntimeContract
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -24,23 +25,21 @@ object ZusFlows:
   val FUS_ACCOUNT: Int = 1
   val GOV_ACCOUNT: Int = 2
 
-  case class ZusInput(
-      employed: Int,
-      wage: PLN,
-      nRetirees: Int,
-  )
+  case class ZusInput(zus: SocialSecurity.ZusState)
 
-  def emitBatches(input: ZusInput)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    val contributions = input.employed * (input.wage * p.social.zusContribRate * p.social.zusScale)
-    val pensions      = input.nRetirees * p.social.zusBasePension
-    val deficit       = pensions - contributions
+  object ZusInput:
+    def apply(employed: Int, wage: PLN, nRetirees: Int)(using p: SimParams): ZusInput =
+      ZusInput(SocialSecurity.zusStep(employed, wage, nRetirees))
+
+  def emitBatches(input: ZusInput)(using @scala.annotation.unused p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    val zus = input.zus
     Vector.concat(
       AggregateBatchedEmission.transfer(
         EntitySector.Households,
         topology.households.aggregate,
         EntitySector.Funds,
         topology.funds.zus,
-        contributions,
+        zus.contributions,
         AssetType.Cash,
         FlowMechanism.ZusContribution,
       ),
@@ -50,7 +49,7 @@ object ZusFlows:
           topology.funds.zus,
           EntitySector.Households,
           topology.households.aggregate,
-          pensions,
+          zus.pensionPayments,
           AssetType.Cash,
           FlowMechanism.ZusPension,
         ),
@@ -59,24 +58,24 @@ object ZusFlows:
         TreasuryRuntimeContract.TreasuryBudgetSettlement.index,
         EntitySector.Funds,
         topology.funds.zus,
-        deficit,
+        zus.govSubvention,
         AssetType.Cash,
         FlowMechanism.ZusGovSubvention,
       ),
     )
 
-  def emit(input: ZusInput)(using p: SimParams): Vector[Flow] =
-    val contributions = input.employed * (input.wage * p.social.zusContribRate * p.social.zusScale)
-    val pensions      = input.nRetirees * p.social.zusBasePension
-    val deficit       = pensions - contributions
+  def emit(input: ZusInput)(using @scala.annotation.unused p: SimParams): Vector[Flow] =
+    val zus = input.zus
 
     val flows = Vector.newBuilder[Flow]
 
-    if contributions > PLN.Zero then
-      flows += Flow(from = HH_ACCOUNT, to = FUS_ACCOUNT, amount = contributions.toLong, mechanism = FlowMechanism.ZusContribution.toInt)
+    if zus.contributions > PLN.Zero then
+      flows += Flow(from = HH_ACCOUNT, to = FUS_ACCOUNT, amount = zus.contributions.toLong, mechanism = FlowMechanism.ZusContribution.toInt)
 
-    if pensions > PLN.Zero then flows += Flow(from = FUS_ACCOUNT, to = HH_ACCOUNT, amount = pensions.toLong, mechanism = FlowMechanism.ZusPension.toInt)
+    if zus.pensionPayments > PLN.Zero then
+      flows += Flow(from = FUS_ACCOUNT, to = HH_ACCOUNT, amount = zus.pensionPayments.toLong, mechanism = FlowMechanism.ZusPension.toInt)
 
-    if deficit > PLN.Zero then flows += Flow(from = GOV_ACCOUNT, to = FUS_ACCOUNT, amount = deficit.toLong, mechanism = FlowMechanism.ZusGovSubvention.toInt)
+    if zus.govSubvention > PLN.Zero then
+      flows += Flow(from = GOV_ACCOUNT, to = FUS_ACCOUNT, amount = zus.govSubvention.toLong, mechanism = FlowMechanism.ZusGovSubvention.toInt)
 
     flows.result()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/LaborMarket.scala
@@ -19,6 +19,9 @@ import com.boombustgroup.amorfati.random.RandomStream
   * skill-ranked matching with same-sector priority and cross-sector friction
   * penalty (when sectoral mobility enabled).
   *
+  * Separations use contract protection and automation vulnerability before
+  * skill tie-breaks.
+  *
   * Calibration: GUS BAEL (Labor Force Survey) 2024, NBP wage statistics.
   */
 object LaborMarket:
@@ -31,6 +34,9 @@ object LaborMarket:
 
   /** Job search matching result. */
   case class JobSearchResult(households: Vector[Household.State], crossSectorHires: Int)
+
+  private enum WorkerLossKind:
+    case Bankruptcy, Automation, HybridReduction
 
   // --- Aggregate wage clearing ---
 
@@ -77,21 +83,22 @@ object LaborMarket:
 
   // --- Separations ---
 
-  /** Separate workers from firms that automated or went bankrupt this step.
-    * Education-ranked retention: highest-educated workers kept first when firm
-    * transitions to Hybrid or Automated (skeleton crew). Returns updated
-    * households with newly unemployed workers.
+  /** Separate workers from firms that automated, downsized, or went bankrupt
+    * this step. Contract protection and automation vulnerability shape
+    * retention before skill tie-breaks. Returns updated households with newly
+    * unemployed workers.
     */
   def separations(
       households: Vector[Household.State],
       prevFirms: Vector[Firm.State],
       newFirms: Vector[Firm.State],
   )(using SimParams): Vector[Household.State] =
-    val lostFirms = firmsThatLostWorkers(prevFirms, newFirms)
-    if lostFirms.isEmpty then households
+    val lossKinds = workerLossKinds(prevFirms, newFirms)
+    if lossKinds.isEmpty then households
     else
-      val counts   = retainCounts(newFirms, lostFirms)
-      val retained = retainSets(households, lostFirms, counts)
+      val lostFirms = lossKinds.keySet
+      val counts    = retainCounts(newFirms, lostFirms)
+      val retained  = retainSets(households, lostFirms, counts, lossKinds)
       applySeparations(households, lostFirms, retained)
 
   // --- Job search ---
@@ -109,14 +116,14 @@ object LaborMarket:
       households: Vector[Household.State],
       firms: Vector[Firm.State],
       marketWage: PLN,
-      @scala.annotation.unused rng: RandomStream,
+      rng: RandomStream,
       regionalWages: Map[Region, PLN] = Map.empty,
       eligibleFirmIds: Set[FirmId] = Set.empty,
   )(using p: SimParams): JobSearchResult =
     val vacancies = computeVacancies(households, firms, eligibleFirmIds)
     if vacancies.isEmpty then JobSearchResult(households, 0)
-    else if regionalWages.nonEmpty then matchWorkersRegional(households, firms, vacancies, marketWage, regionalWages)
-    else matchWorkers(households, firms, vacancies, marketWage)
+    else if regionalWages.nonEmpty then matchWorkersRegional(households, firms, vacancies, marketWage, regionalWages, rng)
+    else matchWorkers(households, firms, vacancies, marketWage, rng)
 
   // --- Wage updating ---
 
@@ -151,15 +158,16 @@ object LaborMarket:
   /** Identify firms that lost workers: bankruptcy, automation, or hybrid
     * reduction.
     */
-  private def firmsThatLostWorkers(
+  private def workerLossKinds(
       prevFirms: Vector[Firm.State],
       newFirms: Vector[Firm.State],
-  ): Set[FirmId] =
-    newFirms.indices.collect {
-      case i if didLoseWorkers(prevFirms(i), newFirms(i)) => newFirms(i).id
-    }.toSet
+  ): Map[FirmId, WorkerLossKind] =
+    newFirms.indices
+      .flatMap: i =>
+        workerLossKind(prevFirms(i), newFirms(i)).map(newFirms(i).id -> _)
+      .toMap
 
-  private def didLoseWorkers(prev: Firm.State, curr: Firm.State): Boolean =
+  private def workerLossKind(prev: Firm.State, curr: Firm.State): Option[WorkerLossKind] =
     val wentBankrupt   = Firm.isAlive(prev) && !Firm.isAlive(curr)
     val newlyAutomated = (prev.tech, curr.tech) match
       case (_: TechState.Automated, _) => false
@@ -168,7 +176,10 @@ object LaborMarket:
     val hybridReduced  = (prev.tech, curr.tech) match
       case (TechState.Traditional(w1), TechState.Hybrid(w2, _)) => w2 < w1
       case _                                                    => false
-    wentBankrupt || newlyAutomated || hybridReduced
+    if wentBankrupt then Some(WorkerLossKind.Bankruptcy)
+    else if newlyAutomated then Some(WorkerLossKind.Automation)
+    else if hybridReduced then Some(WorkerLossKind.HybridReduction)
+    else None
 
   /** How many workers each affected firm retains (hybrid crew or skeleton
     * crew).
@@ -185,13 +196,15 @@ object LaborMarket:
           case _                      => f.id -> 0
     }.toMap
 
-  /** Build retain sets: when SBTC enabled, low-routineness (cognitive) workers
-    * retained first; otherwise education-ranked.
+  /** Build retain sets for affected firms. Automation prioritizes low
+    * AI/routine displacement risk; other reductions prioritize contract
+    * protection.
     */
   private def retainSets(
       households: Vector[Household.State],
       lostFirms: Set[FirmId],
       counts: Map[FirmId, Int],
+      lossKinds: Map[FirmId, WorkerLossKind],
   ): Map[FirmId, Set[Int]] =
     households.zipWithIndex
       .flatMap: (hh, idx) =>
@@ -200,14 +213,32 @@ object LaborMarket:
           case _                                                             => None
       .groupMap(_._1)(_._2)
       .map: (firmId, indices) =>
-        val sorted    = // Low routineness = cognitive = retained; high routineness = routine = displaced
+        val lossKind  = lossKinds(firmId)
+        val sorted    =
           indices.sortWith: (left, right) =>
             val leftHh  = households(left)
             val rightHh = households(right)
-            (leftHh.taskRoutineness < rightHh.taskRoutineness) ||
-            (leftHh.taskRoutineness == rightHh.taskRoutineness && leftHh.skill > rightHh.skill)
+            shouldRetainBefore(leftHh, rightHh, lossKind)
         val maxRetain = counts.getOrElse(firmId, 0)
         firmId -> sorted.take(maxRetain).toSet
+
+  private def shouldRetainBefore(left: Household.State, right: Household.State, lossKind: WorkerLossKind): Boolean =
+    val leftProtection  = ContractType.firingPriority(left.contractType)
+    val rightProtection = ContractType.firingPriority(right.contractType)
+    val leftRisk        = displacementRisk(left)
+    val rightRisk       = displacementRisk(right)
+    lossKind match
+      case WorkerLossKind.Automation =>
+        if leftRisk != rightRisk then leftRisk < rightRisk
+        else if leftProtection != rightProtection then leftProtection > rightProtection
+        else left.skill > right.skill
+      case _                         =>
+        if leftProtection != rightProtection then leftProtection > rightProtection
+        else if leftRisk != rightRisk then leftRisk < rightRisk
+        else left.skill > right.skill
+
+  private def displacementRisk(hh: Household.State): Double =
+    ContractType.aiVulnerability(hh.contractType) * ComputationBoundary.toDouble(hh.taskRoutineness)
 
   /** Apply separations: retained workers stay, others become unemployed. */
   private def applySeparations(
@@ -262,6 +293,7 @@ object LaborMarket:
       firms: Vector[Firm.State],
       vacancies: Map[FirmId, Int],
       marketWage: PLN,
+      rng: RandomStream,
   )(using p: SimParams): JobSearchResult =
     val ranked          = rankUnemployed(households)
     val firmsBySector   = vacancies.keys.groupBy(fid => firms(fid.toInt).sector)
@@ -270,7 +302,7 @@ object LaborMarket:
     val init   = MatchState(Map.empty, vacancies, 0)
     val result = ranked.foldLeft(init): (st, idx) =>
       if st.vacancies.isEmpty then st
-      else tryHire(st, idx, households(idx), firms, firmsBySector, firmsByPriority, marketWage)
+      else tryHire(st, idx, households(idx), firms, firmsBySector, firmsByPriority, marketWage, rng)
 
     val updated = households.zipWithIndex.map((hh, i) => result.hired.getOrElse(i, hh))
     JobSearchResult(updated, result.crossSectorHires)
@@ -284,6 +316,7 @@ object LaborMarket:
       vacancies: Map[FirmId, Int],
       marketWage: PLN,
       regionalWages: Map[Region, PLN],
+      rng: RandomStream,
   )(using p: SimParams): JobSearchResult =
     val ranked = rankUnemployed(households)
 
@@ -298,7 +331,7 @@ object LaborMarket:
     val init   = MatchState(Map.empty, vacancies, 0)
     val result = ranked.foldLeft(init): (st, idx) =>
       if st.vacancies.isEmpty then st
-      else tryHireRegional(st, idx, households(idx), firms, firmsBySectorRegion, firmsByRegion, firmsByPriority, marketWage, regionalWages)
+      else tryHireRegional(st, idx, households(idx), firms, firmsBySectorRegion, firmsByRegion, firmsByPriority, marketWage, regionalWages, rng)
 
     val updated = households.zipWithIndex.map((hh, i) => result.hired.getOrElse(i, hh))
     JobSearchResult(updated, result.crossSectorHires)
@@ -315,6 +348,7 @@ object LaborMarket:
       firmsByPriority: Vector[FirmId],
       marketWage: PLN,
       regionalWages: Map[Region, PLN],
+      rng: RandomStream,
   )(using p: SimParams): MatchState =
     val prevSector = effectivePrevSector(hh, firms)
     val hhRegion   = hh.region
@@ -344,6 +378,7 @@ object LaborMarket:
         val newHh         = hh.copy(
           status = HhStatus.Employed(fid, firm.sector, wage),
           lastSectorIdx = firm.sector,
+          contractType = ContractType.sampleForSector(firm.sector, rng),
           region = firm.region,
         )
         val remaining     = st.vacancies(fid) - 1
@@ -368,6 +403,7 @@ object LaborMarket:
       firmsBySector: Map[SectorIdx, Iterable[FirmId]],
       firmsByPriority: Vector[FirmId],
       marketWage: PLN,
+      rng: RandomStream,
   )(using p: SimParams): MatchState =
     val prevSector = effectivePrevSector(hh, firms)
     val bestFirm   = firmsBySector
@@ -376,7 +412,7 @@ object LaborMarket:
       .orElse(firmsByPriority.find(fid => st.vacancies.contains(fid)))
     bestFirm match
       case None      => st
-      case Some(fid) => hire(st, idx, hh, firms(fid.toInt), fid, prevSector, marketWage)
+      case Some(fid) => hire(st, idx, hh, firms(fid.toInt), fid, prevSector, marketWage, rng)
 
   /** Execute a hire: update household, decrement vacancy, count cross-sector.
     */
@@ -388,12 +424,14 @@ object LaborMarket:
       firmId: FirmId,
       prevSector: SectorIdx,
       marketWage: PLN,
+      rng: RandomStream,
   )(using p: SimParams): MatchState =
     val isCrossSector = firm.sector.toInt != prevSector.toInt
     val wage          = computeHireWage(hh, firm, marketWage, prevSector, isCrossSector)
     val newHh         = hh.copy(
       status = HhStatus.Employed(firmId, firm.sector, wage),
       lastSectorIdx = firm.sector,
+      contractType = ContractType.sampleForSector(firm.sector, rng),
     )
     val remaining     = st.vacancies(firmId) - 1
     val newVacancies  = if remaining <= 0 then st.vacancies - firmId else st.vacancies.updated(firmId, remaining)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ContractTypeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ContractTypeSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.agents
 
 import com.boombustgroup.amorfati.fp.ComputationBoundary
+import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -47,4 +48,20 @@ class ContractTypeSpec extends AnyFlatSpec with Matchers:
   it should "have high Permanent in Public sector" in {
     val (perm, _, _) = ContractType.sectorMix(4) // Public
     perm should be > 0.8
+  }
+
+  "sampleForSector" should "draw deterministically for a seeded stream" in {
+    val firstRng  = RandomStream.seeded(293)
+    val secondRng = RandomStream.seeded(293)
+    val first     = (0 until 20).map(_ => ContractType.sampleForSector(SectorIdx(0), firstRng)).toVector
+    val second    = (0 until 20).map(_ => ContractType.sampleForSector(SectorIdx(0), secondRng)).toVector
+    first shouldBe second
+  }
+
+  it should "sample all contract types from a mixed sector" in {
+    val rng     = RandomStream.seeded(293)
+    val samples = (0 until 1000).map(_ => ContractType.sampleForSector(SectorIdx(0), rng)).toSet
+    samples should contain(ContractType.Permanent)
+    samples should contain(ContractType.Zlecenie)
+    samples should contain(ContractType.B2B)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -103,6 +103,17 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
     }
   }
 
+  it should "assign endogenous contract types from sector mixes" in {
+    val rng     = RandomStream.seeded(42)
+    val firms   = mkFirms(100)
+    val network = Array.fill(1000)(Array.empty[Int])
+    val hhs     = Household.Init.initialize(1000, firms, network, rng).households
+
+    hhs.exists(_.contractType == ContractType.Zlecenie) shouldBe true
+    hhs.exists(_.contractType == ContractType.B2B) shouldBe true
+    hhs.count(_.contractType == ContractType.Permanent) should be < hhs.length
+  }
+
   it should "assign positive savings to all households" in {
     val rng     = RandomStream.seeded(42)
     val firms   = mkFirms(50)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ImmigrationSpec.scala
@@ -77,6 +77,15 @@ class ImmigrationSpec extends AnyFlatSpec with Matchers:
     immigrants.foreach(_.status shouldBe HhStatus.Unemployed(0))
   }
 
+  it should "assign endogenous contract types from sampled sectors" in {
+    val rng        = RandomStream.seeded(42)
+    val immigrants = Immigration.spawnImmigrants(200, 0, rng)
+    val contracts  = immigrants.map(_.contractType).toSet
+
+    contracts should contain(ContractType.Zlecenie)
+    contracts should contain(ContractType.B2B)
+  }
+
   it should "clamp skill within valid range" in {
     val rng        = RandomStream.seeded(42)
     val immigrants = Immigration.spawnImmigrants(100, 0, rng)

--- a/src/test/scala/com/boombustgroup/amorfati/agents/SocialSecurityPayrollSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/SocialSecurityPayrollSpec.scala
@@ -24,14 +24,24 @@ class SocialSecurityPayrollSpec extends AnyFlatSpec with Matchers:
 
     payroll.employed shouldBe 3
     payroll.grossWages shouldBe PLN(3000.0)
-    val expectedZus =
+    val expectedZus  =
       wage * ContractType.zusEmployerRate(ContractType.Permanent) * p.social.zusScale +
         wage * ContractType.zusEmployerRate(ContractType.Zlecenie) * p.social.zusScale
     payroll.zusContributions shouldBe expectedZus
     payroll.nfzContributions shouldBe 3 * (wage * p.social.nfzContribRate)
     payroll.ppkContributions shouldBe 2 * (wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
-    payroll.fpContributions shouldBe wage * ContractType.fpRate(ContractType.Permanent)
-    payroll.fgspContributions shouldBe 2 * (wage * p.earmarked.fgspRate)
+    val expectedFp   =
+      wage * ContractType.fpRate(ContractType.Permanent) +
+        wage * ContractType.fpRate(ContractType.Zlecenie) +
+        wage * ContractType.fpRate(ContractType.B2B)
+    val expectedFgsp =
+      Vector(ContractType.Permanent, ContractType.Zlecenie, ContractType.B2B)
+        .map:
+          case ContractType.B2B => PLN.Zero
+          case _                => wage * p.earmarked.fgspRate
+        .foldLeft(PLN.Zero)(_ + _)
+    payroll.fpContributions shouldBe expectedFp
+    payroll.fgspContributions shouldBe expectedFgsp
   }
 
   it should "preserve aggregate formulas for legacy employed-and-wage drivers" in {

--- a/src/test/scala/com/boombustgroup/amorfati/agents/SocialSecurityPayrollSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/SocialSecurityPayrollSpec.scala
@@ -1,0 +1,50 @@
+package com.boombustgroup.amorfati.agents
+
+import com.boombustgroup.amorfati.TestHouseholdState
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SocialSecurityPayrollSpec extends AnyFlatSpec with Matchers:
+
+  given SimParams          = SimParams.defaults
+  private val p: SimParams = summon[SimParams]
+
+  "SocialSecurity.payrollBase" should "apply contract-specific social payroll rates" in {
+    val wage       = PLN(1000.0)
+    val households = Vector(
+      household(0, ContractType.Permanent, wage),
+      household(1, ContractType.Zlecenie, wage),
+      household(2, ContractType.B2B, wage),
+      household(3, ContractType.Permanent, wage, employed = false),
+    )
+
+    val payroll = SocialSecurity.payrollBase(households)
+
+    payroll.employed shouldBe 3
+    payroll.grossWages shouldBe PLN(3000.0)
+    val expectedZus =
+      wage * ContractType.zusEmployerRate(ContractType.Permanent) * p.social.zusScale +
+        wage * ContractType.zusEmployerRate(ContractType.Zlecenie) * p.social.zusScale
+    payroll.zusContributions shouldBe expectedZus
+    payroll.nfzContributions shouldBe 3 * (wage * p.social.nfzContribRate)
+    payroll.ppkContributions shouldBe 2 * (wage * (p.social.ppkEmployeeRate + p.social.ppkEmployerRate))
+    payroll.fpContributions shouldBe wage * ContractType.fpRate(ContractType.Permanent)
+    payroll.fgspContributions shouldBe 2 * (wage * p.earmarked.fgspRate)
+  }
+
+  it should "preserve aggregate formulas for legacy employed-and-wage drivers" in {
+    val payroll = SocialSecurity.PayrollBase.aggregate(80000, PLN(7000.0))
+
+    SocialSecurity.zusStep(payroll, 1000) shouldBe SocialSecurity.zusStep(80000, PLN(7000.0), 1000)
+    SocialSecurity.nfzStep(payroll, 100000, 1000) shouldBe SocialSecurity.nfzStep(80000, PLN(7000.0), 100000, 1000)
+    SocialSecurity.ppkStep(payroll) shouldBe SocialSecurity.ppkStep(80000, PLN(7000.0))
+  }
+
+  private def household(id: Int, contractType: ContractType, wage: PLN, employed: Boolean = true): Household.State =
+    TestHouseholdState(
+      id = HhId(id),
+      status = if employed then HhStatus.Employed(FirmId(id), SectorIdx(0), wage) else HhStatus.Unemployed(0),
+      contractType = contractType,
+    )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/LaborMarketSpec.scala
@@ -70,6 +70,62 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
     result(1).status shouldBe HhStatus.Unemployed(5)
   }
 
+  it should "retain protected contracts first during non-automation reductions" in {
+    val prevFirms = Vector(mkFirms(1)(0).copy(tech = TechState.Traditional(4), initialSize = 4))
+    val newFirms  = prevFirms.updated(0, prevFirms(0).copy(tech = TechState.Hybrid(2, Multiplier.One)))
+    val hhs       = Vector(
+      mkHousehold(0, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), contractType = ContractType.Permanent),
+      mkHousehold(1, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), contractType = ContractType.Zlecenie),
+      mkHousehold(2, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), contractType = ContractType.B2B),
+      mkHousehold(3, HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)), contractType = ContractType.B2B),
+    )
+
+    val result = LaborMarket.separations(hhs, prevFirms, newFirms)
+
+    result(0).status shouldBe a[HhStatus.Employed]
+    result(1).status shouldBe a[HhStatus.Employed]
+    result(2).status shouldBe HhStatus.Unemployed(0)
+    result(3).status shouldBe HhStatus.Unemployed(0)
+  }
+
+  it should "retain lowest AI displacement risk first when a firm automates" in {
+    val prevFirms = Vector(mkFirms(1)(0).copy(tech = TechState.Traditional(4), initialSize = 4))
+    val newFirms  = prevFirms.updated(0, prevFirms(0).copy(tech = TechState.Automated(Multiplier(1.5))))
+    val hhs       = Vector(
+      mkHousehold(
+        0,
+        HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)),
+        contractType = ContractType.Permanent,
+        taskRoutineness = Share(0.95),
+      ),
+      mkHousehold(
+        1,
+        HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)),
+        contractType = ContractType.Zlecenie,
+        taskRoutineness = Share(0.10),
+      ),
+      mkHousehold(
+        2,
+        HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)),
+        contractType = ContractType.B2B,
+        taskRoutineness = Share(0.10),
+      ),
+      mkHousehold(
+        3,
+        HhStatus.Employed(FirmId(0), SectorIdx(2), PLN(8000.0)),
+        contractType = ContractType.Permanent,
+        taskRoutineness = Share(0.90),
+      ),
+    )
+
+    val result = LaborMarket.separations(hhs, prevFirms, newFirms)
+
+    result(0).status shouldBe HhStatus.Unemployed(0)
+    result(1).status shouldBe a[HhStatus.Employed]
+    result(2).status shouldBe a[HhStatus.Employed]
+    result(3).status shouldBe HhStatus.Unemployed(0)
+  }
+
   // --- jobSearch ---
 
   "LaborMarket.jobSearch" should "employ unemployed when vacancies exist" in {
@@ -126,6 +182,19 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
     )
     val result = LaborMarket.jobSearch(hhs, firms, PLN(8000.0), rng, Map.empty, Set(FirmId(0))).households
     result.count(_.status.isInstanceOf[HhStatus.Employed]) should be >= 2
+  }
+
+  it should "assign new hires contract types from the hiring firm's sector" in {
+    val rng   = RandomStream.seeded(293)
+    val firms = Vector(mkFirms(1)(0).copy(tech = TechState.Traditional(12), sector = SectorIdx(0), initialSize = 12))
+    val hhs   = (0 until 12).map(i => mkHousehold(i, HhStatus.Unemployed(0), skill = 0.9 - i * 0.01)).toVector
+
+    val result         = LaborMarket.jobSearch(hhs, firms, PLN(8000.0), rng).households
+    val hiredContracts = result.collect { case hh if hh.status.isInstanceOf[HhStatus.Employed] => hh.contractType }
+
+    hiredContracts should have size 12
+    hiredContracts.toSet should contain(ContractType.B2B)
+    hiredContracts.toSet.size should be > 1
   }
 
   // --- updateWages ---
@@ -192,6 +261,8 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       status: HhStatus,
       skill: Double = 0.7,
       healthPenalty: Double = 0.0,
+      taskRoutineness: Share = Share(0.5),
+      contractType: ContractType = ContractType.Permanent,
   ): Household.State =
     TestHouseholdState(
       HhId(id),
@@ -210,6 +281,7 @@ class LaborMarketSpec extends AnyFlatSpec with Matchers:
       numDependentChildren = 0,
       consumerDebt = PLN.Zero,
       education = 2,
-      taskRoutineness = Share(0.5),
+      taskRoutineness = taskRoutineness,
       wageScar = Share.Zero,
+      contractType = contractType,
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.accounting.Sfc
-import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.agents.{ContractType, HhStatus, Household, SocialSecurity}
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{
   DecisionSignals,
@@ -243,6 +243,36 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
         .foldLeft(PLN.Zero)(_ + _)
 
     result.trace.executedFlows.govSpending shouldBe expectedGovSpending
+  }
+
+  it should "anchor same-month social payroll before month-end hiring contract changes" in {
+    val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val baseState = FlowSimulation.SimState.fromInit(init)
+    val state     = baseState.copy(
+      households = baseState.households.zipWithIndex.map:
+        case (hh, idx) if idx < 24 =>
+          hh.copy(status = HhStatus.Unemployed(0), contractType = ContractType.Permanent)
+        case (hh, _)               => hh,
+    )
+
+    val result               = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val finalPayroll         = SocialSecurity.payrollBase(result.nextState.households)
+    val hiredWithNewContract = state.households
+      .zip(result.nextState.households)
+      .exists:
+        case (before, after) =>
+          before.status == HhStatus.Unemployed(0) &&
+          after.status.isInstanceOf[HhStatus.Employed] &&
+          after.contractType != before.contractType
+
+    hiredWithNewContract shouldBe true
+    result.calculus.zus.contributions shouldBe result.calculus.payroll.zusContributions
+    result.calculus.nfz.contributions shouldBe result.calculus.payroll.nfzContributions
+    result.calculus.ppk.contributions shouldBe result.calculus.payroll.ppkContributions
+    mechanismTotal(result.flows, FlowMechanism.ZusContribution) shouldBe result.calculus.payroll.zusContributions
+    mechanismTotal(result.flows, FlowMechanism.NfzContribution) shouldBe result.calculus.payroll.nfzContributions
+    mechanismTotal(result.flows, FlowMechanism.PpkContribution) shouldBe result.calculus.payroll.ppkContributions
+    result.calculus.payroll.zusContributions should not equal finalPayroll.zusContributions
   }
 
   it should "keep corporate bond outstanding ledger-owned across month boundaries" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -256,6 +256,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     )
 
     val result               = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val openingPayroll       = SocialSecurity.payrollBase(state.households)
     val finalPayroll         = SocialSecurity.payrollBase(result.nextState.households)
     val hiredWithNewContract = state.households
       .zip(result.nextState.households)
@@ -266,6 +267,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
           after.contractType != before.contractType
 
     hiredWithNewContract shouldBe true
+    result.calculus.payroll shouldBe openingPayroll
     result.calculus.zus.contributions shouldBe result.calculus.payroll.zusContributions
     result.calculus.nfz.contributions shouldBe result.calculus.payroll.nfzContributions
     result.calculus.ppk.contributions shouldBe result.calculus.payroll.ppkContributions

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -25,7 +25,11 @@ import org.scalatest.matchers.should.Matchers
 class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
   import RuntimeFlowsTestSupport.*
 
-  private given p: SimParams = SimParams.defaults
+  private given p: SimParams                                                                 = SimParams.defaults
+  private def contractHistogram(households: Vector[Household.State]): Map[ContractType, Int] =
+    ContractType.values.iterator
+      .map(ct => ct -> households.count(_.contractType == ct))
+      .toMap
 
   private def canonicalHouseholds(households: Vector[Household.State]): Vector[Vector[Any]] =
     households.map: hh =>
@@ -255,18 +259,15 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
         case (hh, _)               => hh,
     )
 
-    val result               = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
-    val openingPayroll       = SocialSecurity.payrollBase(state.households)
-    val finalPayroll         = SocialSecurity.payrollBase(result.nextState.households)
-    val hiredWithNewContract = state.households
-      .zip(result.nextState.households)
-      .exists:
-        case (before, after) =>
-          before.status == HhStatus.Unemployed(0) &&
-          after.status.isInstanceOf[HhStatus.Employed] &&
-          after.contractType != before.contractType
+    val result           = FlowSimulation.step(state, MonthRandomness.Contract.fromSeed(42L))
+    val openingPayroll   = SocialSecurity.payrollBase(state.households)
+    val finalPayroll     = SocialSecurity.payrollBase(result.nextState.households)
+    val openingContracts = contractHistogram(state.households)
+    val finalContracts   = contractHistogram(result.nextState.households)
 
-    hiredWithNewContract shouldBe true
+    withClue(s"opening=$openingContracts final=$finalContracts") {
+      finalContracts should not equal openingContracts
+    }
     result.calculus.payroll shouldBe openingPayroll
     result.calculus.zus.contributions shouldBe result.calculus.payroll.zusContributions
     result.calculus.nfz.contributions shouldBe result.calculus.payroll.nfzContributions

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeMechanismSurvivabilitySpec.scala
@@ -83,7 +83,10 @@ class RuntimeMechanismSurvivabilitySpec extends AnyFlatSpec with Matchers:
         ),
       ),
       EarmarkedFlows.emitBatches(EarmarkedFlows.Input(1000, PLN(1000.0), PLN(100000000.0), 100000, 100)),
-      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(0, PLN.Zero, PLN.Zero, 0, 0))(using SimParamsTestOverrides.pfronDeficit, summon[RuntimeLedgerTopology]),
+      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(0, PLN.Zero, PLN.Zero, 0, 0)(using SimParamsTestOverrides.pfronDeficit))(using
+        summon[SimParams],
+        summon[RuntimeLedgerTopology],
+      ),
       JstFlows.emitBatches(JstFlows.Input(PLN(5000000.0), PLN(50000000.0), PLN(100000000.0), 9000, PLN(3000000.0))),
       HouseholdFlows.emitBatches(
         HouseholdFlows.Input(


### PR DESCRIPTION
## Summary

- endogenize `contractType` at household initialization, immigration, and labor-market hires using sector mixes
- use contract protection and AI vulnerability in labor separations and automation displacement ranking
- introduce `SocialSecurity.PayrollBase` as the current-month payroll source of truth for ZUS/NFZ/PPK/FP/FGSP
- route `ZusFlows`, `PpkFlows`, and `EarmarkedFlows` through stage-owned payroll amounts instead of recomputing from `employed * wage`
- add a temporal regression that proves month-`t` hires change the closing boundary contract mix without retroactively changing month-`t` payroll
- add focused tests for assignment, separations, payroll calculus, runtime parity, and survivability fixtures

## Semantics

This keeps the monthly boundary semantics agreed in #293:

- month-`t` payroll uses the opening-boundary household payroll surface
- month-`t` separations act on the opening contract being terminated
- hires during month `t` receive a new `contractType`, but that affects the next boundary and month `t+1` payroll

NFZ now uses the same month-`t` payroll source of truth, but fully contract-specific NFZ semantics remain a separate modeling question.

## Validation

- `sbt scalafmtAll`
- `sbt test`
- `sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec -- -z payroll"`
- `sbt assembly`
- `java -jar target/scala-3.8.2/amor-fati.jar 10 m18 --duration 60 --run-id issue293-60m-10s`
  - unemployment: `5.6%` to `8.4%`
  - inflation: `-4.1%` to `1.5%`
  - total time: `207.0s`

## Follow-ups

- insurance premium timing/emission parity: #414
- contract-specific NFZ semantics: #415

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hires and immigrants now receive sector-based contract types (Permanent / Zlecenie / B2B), adding realistic contract diversity.

* **Refactor**
  * Payroll and social‑fund calculations unified into a single payroll aggregation used across social mechanisms and flow emission.
  * Flow inputs rewritten to consume precomputed payroll/earmarked/ppk/zus states.
  * Layoff retention ordering adjusted to consider automation risk and contract priority.

* **Tests**
  * New deterministic tests for contract sampling, payroll aggregation, labor separations, and month‑end payroll anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->