### PR TITLE
Generate Balance Sheet Matrix (BSM) and Transactions Flow Matrix (TFM) artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ That is the hard floor under every experiment in the model. Behavioral rules, po
 - [Core Invariants](#core-invariants)
 - [State Ontology](#state-ontology)
 - [Verified Ledger](#verified-ledger)
+- [Ledger-Derived Matrix Evidence](#ledger-derived-matrix-evidence)
 - [Tech Stack](#tech-stack)
 - [License](#license)
 
@@ -98,6 +99,16 @@ The simulation pipeline is anchored to the verified [amor-fati-ledger](https://g
 This is why Amor Fati is useful even when the long-run path is still being calibrated. If a branch generates a bad macro regime, that may be a modeling problem. If the ledger breaks, the simulation itself is wrong.
 
 That distinction matters. A nonlinear ABM can explore unstable, surprising, even pathological futures. But it should never "lose money" in the plumbing.
+
+## Ledger-Derived Matrix Evidence
+
+The project can regenerate academic SFC matrix evidence directly from an executed deterministic simulation step:
+
+```bash
+sbt "sfcMatrices --seed 1 --months 12 --out target/sfc-matrices"
+```
+
+This writes paper-facing symbolic BSM and TFM artifacts in LaTeX and Markdown, plus a symbolic-row to runtime-ledger mapping under `target/`. Numeric evidence remains the engine's CSV output; this workflow documents the accounting structure used to interpret it. The workflow, sign conventions, coverage gaps, and review checklist are documented in [docs/sfc-matrix-evidence.md](docs/sfc-matrix-evidence.md).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That is the hard floor under every experiment in the model. Behavioral rules, po
 - [Core Invariants](#core-invariants)
 - [State Ontology](#state-ontology)
 - [Verified Ledger](#verified-ledger)
-- [Ledger-Derived Matrix Evidence](#ledger-derived-matrix-evidence)
+- [Ledger-Derived Matrix Artifacts](#ledger-derived-matrix-artifacts)
 - [Tech Stack](#tech-stack)
 - [License](#license)
 
@@ -100,15 +100,15 @@ This is why Amor Fati is useful even when the long-run path is still being calib
 
 That distinction matters. A nonlinear ABM can explore unstable, surprising, even pathological futures. But it should never "lose money" in the plumbing.
 
-## Ledger-Derived Matrix Evidence
+## Ledger-Derived Matrix Artifacts
 
-The project can regenerate academic SFC matrix evidence directly from an executed deterministic simulation step:
+The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:
 
 ```bash
 sbt "sfcMatrices --seed 1 --months 12 --out target/sfc-matrices"
 ```
 
-This writes paper-facing symbolic BSM and TFM artifacts in LaTeX and Markdown, plus a symbolic-row to runtime-ledger mapping under `target/`. Numeric evidence remains the engine's CSV output; this workflow documents the accounting structure used to interpret it. The workflow, sign conventions, coverage gaps, and review checklist are documented in [docs/sfc-matrix-evidence.md](docs/sfc-matrix-evidence.md).
+This writes symbolic Balance Sheet Matrix (BSM) and Transactions Flow Matrix (TFM) artifacts in LaTeX and Markdown, plus a symbolic-row to runtime-ledger mapping under `target/`. The workflow, sign conventions, coverage gaps, and review checklist are documented in [docs/sfc-matrix-evidence.md](docs/sfc-matrix-evidence.md).
 
 ## Tech Stack
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,8 @@
+import complete.DefaultParsers.spaceDelimited
+
 lazy val ledger = ProjectRef(file("modules/ledger"), "root")
+
+lazy val sfcMatrices = inputKey[Unit]("Generate symbolic SFC BSM/TFM matrix artifacts")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -47,6 +51,13 @@ lazy val root = project
       "dev.zio"           %% "zio-streams"     % "2.1.16",
       "com.github.lalyos"  % "jfiglet"         % "0.0.9",
     ) ++ testDeps,
+    sfcMatrices := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<sfc matrix args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.SfcMatrixExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
     Test / testOptions ++= {
       val heavyTag         = "com.boombustgroup.amorfati.tags.Heavy"
       // Local `sbt test` skips @Heavy suites by default.

--- a/docs/sfc-matrix-evidence.md
+++ b/docs/sfc-matrix-evidence.md
@@ -35,11 +35,9 @@ does not dirty the repository. The output set is:
 - `matrix-mapping.tex`
 - `matrix-mapping.md`
 
-CSV and JSON are deliberately not produced by this exporter. Use the engine or
-Monte Carlo CSV output for numeric evidence.
-
-The BSM and TFM LaTeX files are plain `tabular` fragments. The mapping LaTeX
-file uses `longtable` so the runtime mapping can break across pages.
+The Balance Sheet Matrix and Transactions Flow Matrix LaTeX files are plain
+`tabular` fragments. The mapping LaTeX file uses `longtable` so the runtime
+mapping can break across pages.
 
 ## Source Contract
 
@@ -47,11 +45,12 @@ The export still executes the deterministic runtime before writing artifacts:
 
 1. Initialize deterministic state from `WorldInit.initialize`.
 2. Execute month steps through `MonthDriver.unfoldSteps`.
-3. Build ledger-derived matrix evidence from the selected step.
-4. Validate complete BSM rows, exact TFM row sums, stock-flow reconciliation,
-   and the underlying `Sfc.validate` status.
-5. Render symbolic BSM, symbolic TFM, and the mapping table only if validation
-   status is available for the selected run.
+3. Build ledger-derived validation inputs from the selected step.
+4. Validate complete Balance Sheet Matrix rows, exact Transactions Flow Matrix
+   row sums, stock-flow reconciliation, and the underlying `Sfc.validate`
+   status.
+5. Render symbolic Balance Sheet Matrix, symbolic Transactions Flow Matrix, and
+   the mapping table for the selected run.
 
 The symbolic matrix definitions live in `SfcSymbolicMatrices`. The registry in
 `SfcMatrixRegistry` fixes sector metadata, instrument metadata, mechanism
@@ -59,16 +58,16 @@ labels, LaTeX symbols, and row coverage policy.
 
 ## Sign Conventions
 
-BSM rows use asset-positive and liability-negative signs:
+Balance Sheet Matrix rows use asset-positive and liability-negative signs:
 
 - holder assets are positive;
 - issuer or borrower liabilities are negative;
 - unsupported or incomplete rows are not silently balanced;
 - the net-worth row is a paper-level column-balancing row, not a runtime asset.
 
-TFM rows use payer-negative and receiver-positive signs. Financial-account rows
-such as loan origination, repayment, bond issuance, and deposit change follow
-the same row-sum-zero convention as the paper matrix.
+Transactions Flow Matrix rows use payer-negative and receiver-positive signs.
+Financial-account rows such as loan origination, repayment, bond issuance, and
+deposit change follow the same row-sum-zero convention as the paper matrix.
 
 ## Sector Order
 
@@ -102,12 +101,13 @@ gaps in the ledger-derived validation layer. Examples include:
 - bank capital, which is persisted engine state but outside the supported
   ledger-owned stock slice.
 
-These gaps are review evidence. They are not balancing rows.
+These gaps are review diagnostics. They are not balancing rows.
 
 ## Review Checklist
 
 - The export command exits with status 0.
 - Only `.tex` and `.md` files are written by the symbolic exporter.
-- `symbolic-bsm.*` and `symbolic-tfm.*` contain paper-style symbolic matrices.
+- `symbolic-bsm.*` contains the paper-style symbolic Balance Sheet Matrix.
+- `symbolic-tfm.*` contains the paper-style symbolic Transactions Flow Matrix.
 - `matrix-mapping.*` links each symbolic row to runtime assets and mechanisms.
-- Numeric checks are reviewed against the engine or Monte Carlo CSV output.
+- `matrix-mapping.tex` is included with `\usepackage{longtable}`.

--- a/docs/sfc-matrix-evidence.md
+++ b/docs/sfc-matrix-evidence.md
@@ -1,4 +1,4 @@
-# Ledger-Derived SFC Matrix Evidence
+# Ledger-Derived SFC Matrix Artifacts
 
 This workflow generates paper-facing Stock-Flow Consistent matrix artifacts from
 an executed deterministic simulation step:
@@ -9,9 +9,7 @@ an executed deterministic simulation step:
   concepts.
 
 The matrices are intentionally symbolic. They are meant to look like the tables
-used in SFC papers and reports. Numeric evidence is not duplicated here because
-the simulation engine and Monte Carlo runner already emit CSV outputs with the
-actual time-series values.
+used in SFC papers and reports.
 
 ## Regeneration
 

--- a/docs/sfc-matrix-evidence.md
+++ b/docs/sfc-matrix-evidence.md
@@ -1,0 +1,115 @@
+# Ledger-Derived SFC Matrix Evidence
+
+This workflow generates paper-facing Stock-Flow Consistent matrix artifacts from
+an executed deterministic simulation step:
+
+- a symbolic Balance Sheet Matrix (BSM);
+- a symbolic Transactions Flow Matrix (TFM);
+- a mapping from symbolic rows to runtime `AssetType` and `FlowMechanism`
+  concepts.
+
+The matrices are intentionally symbolic. They are meant to look like the tables
+used in SFC papers and reports. Numeric evidence is not duplicated here because
+the simulation engine and Monte Carlo runner already emit CSV outputs with the
+actual time-series values.
+
+## Regeneration
+
+Generate LaTeX and Markdown artifacts for seed 1 after 12 executed months:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.SfcMatrixExport --seed 1 --months 12 --out target/sfc-matrices --format tex,md"
+```
+
+The shorter sbt input task delegates to the same entrypoint:
+
+```bash
+sbt "sfcMatrices --seed 1 --months 12 --out target/sfc-matrices"
+```
+
+By default, artifacts are written under `target/sfc-matrices`, so regeneration
+does not dirty the repository. The output set is:
+
+- `symbolic-bsm.tex`
+- `symbolic-bsm.md`
+- `symbolic-tfm.tex`
+- `symbolic-tfm.md`
+- `matrix-mapping.tex`
+- `matrix-mapping.md`
+
+CSV and JSON are deliberately not produced by this exporter. Use the engine or
+Monte Carlo CSV output for numeric evidence.
+
+The BSM and TFM LaTeX files are plain `tabular` fragments. The mapping LaTeX
+file uses `longtable` so the runtime mapping can break across pages.
+
+## Source Contract
+
+The export still executes the deterministic runtime before writing artifacts:
+
+1. Initialize deterministic state from `WorldInit.initialize`.
+2. Execute month steps through `MonthDriver.unfoldSteps`.
+3. Build ledger-derived matrix evidence from the selected step.
+4. Validate complete BSM rows, exact TFM row sums, stock-flow reconciliation,
+   and the underlying `Sfc.validate` status.
+5. Render symbolic BSM, symbolic TFM, and the mapping table only if validation
+   status is available for the selected run.
+
+The symbolic matrix definitions live in `SfcSymbolicMatrices`. The registry in
+`SfcMatrixRegistry` fixes sector metadata, instrument metadata, mechanism
+labels, LaTeX symbols, and row coverage policy.
+
+## Sign Conventions
+
+BSM rows use asset-positive and liability-negative signs:
+
+- holder assets are positive;
+- issuer or borrower liabilities are negative;
+- unsupported or incomplete rows are not silently balanced;
+- the net-worth row is a paper-level column-balancing row, not a runtime asset.
+
+TFM rows use payer-negative and receiver-positive signs. Financial-account rows
+such as loan origination, repayment, bond issuance, and deposit change follow
+the same row-sum-zero convention as the paper matrix.
+
+## Sector Order
+
+The symbolic artifacts use the registry order:
+
+1. Households
+2. Firms
+3. Banks
+4. Government
+5. NBP
+6. Insurance
+7. Funds
+8. Foreign
+
+The Funds sector covers public and fund buckets such as ZUS, NFZ, FP, PFRON,
+FGSP, JST, PPK, NBFI, and quasi-fiscal vehicles where they are represented in
+the runtime ledger topology.
+
+## Coverage Gaps
+
+The symbolic tables are complete paper-level matrices, but the mapping keeps
+runtime coverage explicit. Known incomplete rows remain visible as classified
+gaps in the ledger-derived validation layer. Examples include:
+
+- household mortgage liabilities without a supported bank-side mortgage stock;
+- firm and consumer loan rows where dynamic-population projections can leave
+  small holder/issuer gaps across month boundaries;
+- bank reserves without a persisted NBP reserve-liability row;
+- insurance reserves without holder-resolved household assets;
+- equity foreign ownership that remains metric-only;
+- bank capital, which is persisted engine state but outside the supported
+  ledger-owned stock slice.
+
+These gaps are review evidence. They are not balancing rows.
+
+## Review Checklist
+
+- The export command exits with status 0.
+- Only `.tex` and `.md` files are written by the symbolic exporter.
+- `symbolic-bsm.*` and `symbolic-tfm.*` contain paper-style symbolic matrices.
+- `matrix-mapping.*` links each symbolic row to runtime assets and mechanisms.
+- Numeric checks are reviewed against the engine or Monte Carlo CSV output.

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
@@ -91,7 +91,10 @@ object SfcMatrixEvidence:
 
   final case class TfmEvidence(
       rows: Vector[TfmRow],
+      omittedZeroBatches: Int,
       omittedZeroRows: Int,
+      droppedRows: Vector[TfmRow],
+      droppedNonRegistrySectors: Vector[EntitySector],
   ):
     def sectorTotals: Map[EntitySector, Long] =
       SfcMatrixRegistry.sectors
@@ -129,6 +132,7 @@ object SfcMatrixEvidence:
   enum MatrixValidationError:
     case BsmRowSumError(snapshot: SnapshotKind, asset: AssetType, actualRaw: Long, reason: String)
     case TfmRowSumError(rowKey: String, mechanism: MechanismId, asset: AssetType, actualRaw: Long)
+    case TfmNonRegistrySectorError(sectors: Vector[EntitySector])
     case SfcValidationFailed(errors: Vector[Sfc.SfcIdentityError])
 
   final case class MatrixValidationReport(errors: Vector[MatrixValidationError]):
@@ -243,7 +247,7 @@ object SfcMatrixEvidence:
       final case class Acc(
           cells: Map[(MechanismId, AssetType, EntitySector), Long],
           contributors: Map[(MechanismId, AssetType), Vector[BatchContribution]],
-          omittedZeroRows: Int,
+          omittedZeroBatches: Int,
       )
 
       def addCell(
@@ -261,7 +265,7 @@ object SfcMatrixEvidence:
       val acc               = batches.zipWithIndex.foldLeft(Acc(Map.empty, emptyContributors, 0)):
         case (state, (batch, index)) =>
           val nonZeroAmounts = amounts(batch).filter(_ != 0L)
-          if nonZeroAmounts.isEmpty then state.copy(omittedZeroRows = state.omittedZeroRows + 1)
+          if nonZeroAmounts.isEmpty then state.copy(omittedZeroBatches = state.omittedZeroBatches + 1)
           else
             val total = nonZeroAmounts.sum
             val cells = batch match
@@ -301,19 +305,33 @@ object SfcMatrixEvidence:
               contributors = state.contributors.updated(key, state.contributors(key) :+ contribution),
             )
 
-      val keys = acc.cells.keysIterator.map((mechanism, asset, _) => (mechanism, asset)).toSet.toVector
-      val rows = keys
+      val registrySectors           = SfcMatrixRegistry.sectors.map(_.sector)
+      val registrySectorSet         = registrySectors.toSet
+      val keys                      = acc.cells.keysIterator.map((mechanism, asset, _) => (mechanism, asset)).toSet.toVector
+      val candidateRows             = keys
         .map: (mechanism, asset) =>
-          val cells = SfcMatrixRegistry.sectors
-            .map(_.sector)
+          val cells = registrySectors
             .map(sector => sector -> acc.cells.getOrElse((mechanism, asset, sector), 0L))
             .toMap
             .filter(_._2 != 0L)
           TfmRow(mechanism, asset, cells, acc.contributors((mechanism, asset)))
-        .filter(_.cells.nonEmpty)
-        .sortBy(row => (SfcMatrixRegistry.mechanismOrder(row.mechanism), SfcMatrixRegistry.instrumentOrder(row.asset)))
+      val (keptRows, droppedRows)   = candidateRows.partition(_.cells.nonEmpty)
+      val rowOrdering               = (row: TfmRow) => (SfcMatrixRegistry.mechanismOrder(row.mechanism), SfcMatrixRegistry.instrumentOrder(row.asset))
+      val droppedNonRegistrySectors = acc.cells.keysIterator
+        .map((_, _, sector) => sector)
+        .filterNot(registrySectorSet)
+        .toSet
+        .toVector
+        .sortBy(_.ordinal)
+      val rows                      = keptRows.sortBy(rowOrdering)
 
-      TfmEvidence(rows, acc.omittedZeroRows)
+      TfmEvidence(
+        rows = rows,
+        omittedZeroBatches = acc.omittedZeroBatches,
+        omittedZeroRows = droppedRows.size,
+        droppedRows = droppedRows.sortBy(rowOrdering),
+        droppedNonRegistrySectors = droppedNonRegistrySectors,
+      )
 
     private def amounts(batch: BatchedFlow): Vector[Long] =
       batch match
@@ -389,7 +407,11 @@ object SfcMatrixEvidence:
         case row if row.rowSumRaw != 0L =>
           MatrixValidationError.TfmRowSumError(row.rowKey, row.mechanism, row.asset, row.rowSumRaw)
 
-      MatrixValidationReport(sfcErrors ++ bsmErrors ++ tfmErrors)
+      val registryErrors =
+        if tfm.droppedNonRegistrySectors.nonEmpty then Vector(MatrixValidationError.TfmNonRegistrySectorError(tfm.droppedNonRegistrySectors))
+        else Vector.empty
+
+      MatrixValidationReport(sfcErrors ++ bsmErrors ++ tfmErrors ++ registryErrors)
 
   object MatrixEvidenceBundle:
     def fromStep(seed: Long, step: FlowSimulation.StepOutput, commit: String = BuildInfo.gitCommit): MatrixEvidenceBundle =

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
@@ -1,0 +1,435 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.accounting.Sfc
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit}
+import com.boombustgroup.amorfati.util.BuildInfo
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector, MechanismId}
+
+object SfcMatrixEvidence:
+
+  enum SnapshotKind:
+    case Opening
+    case Closing
+
+  enum GapKind:
+    case IncompleteCoverage
+    case ExplicitlyExcluded
+    case UnsupportedDiagnostic
+
+  enum OtherChangeKind:
+    case TransactionReconciliation
+    case Revaluation
+    case DefaultOrWriteOff
+    case CoverageGap
+
+  final case class MatrixMetadata(
+      seed: Long,
+      executionMonth: Int,
+      commit: String,
+      schemaVersion: String,
+      sfcStatus: String,
+      matrixStatus: String,
+  )
+
+  final case class MatrixGap(
+      matrix: String,
+      rowKey: String,
+      sector: Option[EntitySector],
+      kind: GapKind,
+      reason: String,
+  )
+
+  final case class BsmRow(
+      asset: AssetType,
+      cells: Map[EntitySector, Long],
+      gaps: Vector[MatrixGap],
+  ):
+    def rowKey: String =
+      asset.toString
+
+    def amountRaw(sector: EntitySector): Long =
+      cells.getOrElse(sector, 0L)
+
+    def rowSumRaw: Long =
+      cells.valuesIterator.sum
+
+    def hasNonZeroCell: Boolean =
+      cells.valuesIterator.exists(_ != 0L)
+
+  final case class BsmEvidence(
+      snapshotKind: SnapshotKind,
+      rows: Vector[BsmRow],
+      gaps: Vector[MatrixGap],
+  ):
+    def row(asset: AssetType): BsmRow =
+      rows.find(_.asset == asset).getOrElse(BsmRow(asset, Map.empty, Vector.empty))
+
+  final case class BatchContribution(
+      batchIndex: Int,
+      batchKind: String,
+      from: EntitySector,
+      to: EntitySector,
+      amountRaw: Long,
+      legs: Int,
+  )
+
+  final case class TfmRow(
+      mechanism: MechanismId,
+      asset: AssetType,
+      cells: Map[EntitySector, Long],
+      contributors: Vector[BatchContribution],
+  ):
+    def rowKey: String =
+      s"${mechanism.toInt}:${asset.toString}"
+
+    def amountRaw(sector: EntitySector): Long =
+      cells.getOrElse(sector, 0L)
+
+    def rowSumRaw: Long =
+      cells.valuesIterator.sum
+
+  final case class TfmEvidence(
+      rows: Vector[TfmRow],
+      omittedZeroRows: Int,
+  ):
+    def sectorTotals: Map[EntitySector, Long] =
+      SfcMatrixRegistry.sectors
+        .map(_.sector)
+        .map { sector =>
+          sector -> rows.iterator.map(_.amountRaw(sector)).sum
+        }
+        .toMap
+
+    def assetSectorTotals: Map[(AssetType, EntitySector), Long] =
+      rows
+        .flatMap(row =>
+          SfcMatrixRegistry.sectors.map: sector =>
+            (row.asset, sector.sector) -> row.amountRaw(sector.sector),
+        )
+        .groupMapReduce(_._1)(_._2)(_ + _)
+
+  final case class OtherChangeCell(
+      asset: AssetType,
+      sector: EntitySector,
+      stockDeltaRaw: Long,
+      transactionDeltaRaw: Long,
+      otherChangeRaw: Long,
+      kind: OtherChangeKind,
+      reason: String,
+  )
+
+  final case class OtherChangesEvidence(
+      cells: Vector[OtherChangeCell],
+      gaps: Vector[MatrixGap],
+  ):
+    def nonZeroCells: Vector[OtherChangeCell] =
+      cells.filter(cell => cell.stockDeltaRaw != 0L || cell.transactionDeltaRaw != 0L || cell.otherChangeRaw != 0L)
+
+  enum MatrixValidationError:
+    case BsmRowSumError(snapshot: SnapshotKind, asset: AssetType, actualRaw: Long, reason: String)
+    case TfmRowSumError(rowKey: String, mechanism: MechanismId, asset: AssetType, actualRaw: Long)
+    case SectorColumnDeltaError(sector: EntitySector, stockDeltaRaw: Long, transactionDeltaRaw: Long, otherChangeRaw: Long)
+    case StockFlowReconciliationError(asset: AssetType, sector: EntitySector, stockDeltaRaw: Long, transactionDeltaRaw: Long, otherChangeRaw: Long)
+    case SfcValidationFailed(errors: Vector[Sfc.SfcIdentityError])
+
+  final case class MatrixValidationReport(errors: Vector[MatrixValidationError]):
+    def isValid: Boolean =
+      errors.isEmpty
+
+  final case class MatrixEvidenceBundle(
+      metadata: MatrixMetadata,
+      openingBsm: BsmEvidence,
+      closingBsm: BsmEvidence,
+      tfm: TfmEvidence,
+      otherChanges: OtherChangesEvidence,
+      validation: MatrixValidationReport,
+  )
+
+  object BsmEvidence:
+    def fromStepOpening(step: FlowSimulation.StepOutput): BsmEvidence =
+      fromState(SnapshotKind.Opening, step.stateIn)
+
+    def fromStepClosing(step: FlowSimulation.StepOutput): BsmEvidence =
+      fromState(SnapshotKind.Closing, step.nextState)
+
+    def fromState(snapshotKind: SnapshotKind, state: FlowSimulation.SimState): BsmEvidence =
+      val ledger = state.ledgerFinancialState
+      val bonds  = GovernmentBondCircuit.from(ledger)
+      val corp   = CorporateBondOwnership.stockStateFromLedger(ledger)
+
+      val bankCapital = state.banks.iterator.map(_.capital).sum
+      val entries     = Vector(
+        // Deposits and loans.
+        (AssetType.DemandDeposit, EntitySector.Households, ledger.households.iterator.map(_.demandDeposit).sum),
+        (AssetType.DemandDeposit, EntitySector.Banks, -ledger.banks.iterator.map(_.demandDeposit).sum),
+        (AssetType.TermDeposit, EntitySector.Banks, -ledger.banks.iterator.map(_.termDeposit).sum),
+        (AssetType.FirmLoan, EntitySector.Banks, ledger.banks.iterator.map(_.firmLoan).sum),
+        (AssetType.FirmLoan, EntitySector.Firms, -ledger.firms.iterator.map(_.firmLoan).sum),
+        (AssetType.ConsumerLoan, EntitySector.Banks, ledger.banks.iterator.map(_.consumerLoan).sum),
+        (AssetType.ConsumerLoan, EntitySector.Households, -ledger.households.iterator.map(_.consumerLoan).sum),
+        (AssetType.MortgageLoan, EntitySector.Households, -ledger.households.iterator.map(_.mortgageLoan).sum),
+        // Government and corporate bond circuits.
+        (AssetType.GovBondHTM, EntitySector.Banks, bonds.bankHoldings),
+        (AssetType.GovBondHTM, EntitySector.Government, -bonds.outstanding),
+        (AssetType.GovBondHTM, EntitySector.NBP, bonds.nbpHoldings),
+        (AssetType.GovBondHTM, EntitySector.Insurance, bonds.insuranceHoldings),
+        (AssetType.GovBondHTM, EntitySector.Funds, bonds.ppkHoldings + bonds.tfiHoldings),
+        (AssetType.GovBondHTM, EntitySector.Foreign, bonds.foreignHoldings),
+        (AssetType.QuasiFiscalBond, EntitySector.Banks, ledger.funds.quasiFiscal.bankHoldings),
+        (AssetType.QuasiFiscalBond, EntitySector.NBP, ledger.funds.quasiFiscal.nbpHoldings),
+        (AssetType.QuasiFiscalBond, EntitySector.Funds, -ledger.funds.quasiFiscal.bondsOutstanding),
+        (AssetType.CorpBond, EntitySector.Firms, -corp.outstanding),
+        (AssetType.CorpBond, EntitySector.Banks, corp.bankHoldings),
+        (AssetType.CorpBond, EntitySector.Insurance, corp.insuranceHoldings),
+        (AssetType.CorpBond, EntitySector.Funds, corp.ppkHoldings + corp.otherHoldings + corp.nbfiHoldings),
+        // Central-bank, equity, insurance, NBFI, public fund, and diagnostic stocks.
+        (AssetType.Reserve, EntitySector.Banks, ledger.banks.iterator.map(_.reserve).sum),
+        (AssetType.InterbankLoan, EntitySector.Banks, ledger.banks.iterator.map(_.interbankLoan).sum),
+        (AssetType.Equity, EntitySector.Households, ledger.households.iterator.map(_.equity).sum),
+        (AssetType.Equity, EntitySector.Firms, -ledger.firms.iterator.map(_.equity).sum),
+        (AssetType.Equity, EntitySector.Insurance, ledger.insurance.equityHoldings),
+        (AssetType.Equity, EntitySector.Funds, ledger.funds.nbfi.equityHoldings),
+        (AssetType.LifeReserve, EntitySector.Insurance, -ledger.insurance.lifeReserve),
+        (AssetType.NonLifeReserve, EntitySector.Insurance, -ledger.insurance.nonLifeReserve),
+        (AssetType.TfiUnit, EntitySector.Funds, -ledger.funds.nbfi.tfiUnit),
+        (AssetType.NbfiLoan, EntitySector.Funds, ledger.funds.nbfi.nbfiLoanStock + ledger.funds.quasiFiscal.loanPortfolio),
+        (AssetType.Cash, EntitySector.Firms, ledger.firms.iterator.map(_.cash).sum),
+        (
+          AssetType.Cash,
+          EntitySector.Funds,
+          ledger.funds.zusCash + ledger.funds.nfzCash + ledger.funds.fpCash + ledger.funds.pfronCash +
+            ledger.funds.fgspCash + ledger.funds.jstCash + ledger.funds.nbfi.cashHoldings,
+        ),
+        (AssetType.Capital, EntitySector.Banks, -bankCapital),
+        (AssetType.ForeignAsset, EntitySector.NBP, ledger.nbp.foreignAssets),
+      )
+
+      val rawCells = entries.foldLeft(Map.empty[(AssetType, EntitySector), Long].withDefaultValue(0L)):
+        case (acc, (asset, sector, amount)) =>
+          val key = (asset, sector)
+          acc.updated(key, acc(key) + amount.toLong)
+
+      val rows = SfcMatrixRegistry.instruments.map: instrument =>
+        val cells = SfcMatrixRegistry.sectors
+          .map(_.sector)
+          .map(sector => sector -> rawCells((instrument.asset, sector)))
+          .toMap
+          .filter(_._2 != 0L)
+        val gaps  = gapsForBsmRow(snapshotKind, instrument, cells)
+        BsmRow(instrument.asset, cells, gaps)
+
+      BsmEvidence(snapshotKind, rows, rows.flatMap(_.gaps))
+
+    private def gapsForBsmRow(
+        snapshotKind: SnapshotKind,
+        instrument: SfcMatrixRegistry.InstrumentMetadata,
+        cells: Map[EntitySector, Long],
+    ): Vector[MatrixGap] =
+      val matrix = s"BSM ${snapshotKind.toString.toLowerCase}"
+      instrument.completeness match
+        case SfcMatrixRegistry.RowCompleteness.Complete      => Vector.empty
+        case SfcMatrixRegistry.RowCompleteness.ClassifiedGap =>
+          Vector(MatrixGap(matrix, instrument.asset.toString, None, GapKind.IncompleteCoverage, instrument.note))
+        case SfcMatrixRegistry.RowCompleteness.Excluded      =>
+          val kind =
+            if instrument.category == SfcMatrixRegistry.InstrumentCategory.UnsupportedDiagnostic then GapKind.UnsupportedDiagnostic
+            else GapKind.ExplicitlyExcluded
+          Option.when(cells.valuesIterator.exists(_ != 0L))(MatrixGap(matrix, instrument.asset.toString, None, kind, instrument.note)).toVector
+
+  object TfmEvidence:
+    def fromStep(step: FlowSimulation.StepOutput): TfmEvidence =
+      fromBatches(step.flows)
+
+    def fromBatches(batches: Vector[BatchedFlow]): TfmEvidence =
+      final case class Acc(
+          cells: Map[(MechanismId, AssetType, EntitySector), Long],
+          contributors: Map[(MechanismId, AssetType), Vector[BatchContribution]],
+          omittedZeroRows: Int,
+      )
+
+      def addCell(
+          cells: Map[(MechanismId, AssetType, EntitySector), Long],
+          mechanism: MechanismId,
+          asset: AssetType,
+          sector: EntitySector,
+          delta: Long,
+      ): Map[(MechanismId, AssetType, EntitySector), Long] =
+        val key = (mechanism, asset, sector)
+        cells.updated(key, cells.getOrElse(key, 0L) + delta)
+
+      val emptyContributors =
+        Map.empty[(MechanismId, AssetType), Vector[BatchContribution]].withDefaultValue(Vector.empty)
+      val acc               = batches.zipWithIndex.foldLeft(Acc(Map.empty, emptyContributors, 0)):
+        case (state, (batch, index)) =>
+          val nonZeroAmounts = amounts(batch).filter(_ != 0L)
+          if nonZeroAmounts.isEmpty then state.copy(omittedZeroRows = state.omittedZeroRows + 1)
+          else
+            val total = nonZeroAmounts.sum
+            val cells = batch match
+              case scatter: BatchedFlow.Scatter     =>
+                scatter.amounts.indices.foldLeft(state.cells):
+                  case (accCells, senderIndex) =>
+                    val amount = scatter.amounts(senderIndex)
+                    if amount == 0L then accCells
+                    else
+                      addCell(
+                        addCell(accCells, scatter.mechanism, scatter.asset, scatter.from, -amount),
+                        scatter.mechanism,
+                        scatter.asset,
+                        scatter.to,
+                        amount,
+                      )
+              case broadcast: BatchedFlow.Broadcast =>
+                broadcast.amounts.indices.foldLeft(
+                  addCell(state.cells, broadcast.mechanism, broadcast.asset, broadcast.from, -total),
+                ):
+                  case (accCells, targetPosition) =>
+                    val amount = broadcast.amounts(targetPosition)
+                    if amount == 0L then accCells
+                    else addCell(accCells, broadcast.mechanism, broadcast.asset, broadcast.to, amount)
+
+            val key          = (batch.mechanism, batch.asset)
+            val contribution = BatchContribution(
+              batchIndex = index,
+              batchKind = batch.getClass.getSimpleName.stripSuffix("$"),
+              from = batch.from,
+              to = batch.to,
+              amountRaw = total,
+              legs = nonZeroAmounts.size,
+            )
+            state.copy(
+              cells = cells,
+              contributors = state.contributors.updated(key, state.contributors(key) :+ contribution),
+            )
+
+      val keys = acc.cells.keysIterator.map((mechanism, asset, _) => (mechanism, asset)).toSet.toVector
+      val rows = keys
+        .map: (mechanism, asset) =>
+          val cells = SfcMatrixRegistry.sectors
+            .map(_.sector)
+            .map(sector => sector -> acc.cells.getOrElse((mechanism, asset, sector), 0L))
+            .toMap
+            .filter(_._2 != 0L)
+          TfmRow(mechanism, asset, cells, acc.contributors((mechanism, asset)))
+        .filter(_.cells.nonEmpty)
+        .sortBy(row => (SfcMatrixRegistry.mechanismOrder(row.mechanism), SfcMatrixRegistry.instrumentOrder(row.asset)))
+
+      TfmEvidence(rows, acc.omittedZeroRows)
+
+    private def amounts(batch: BatchedFlow): Vector[Long] =
+      batch match
+        case scatter: BatchedFlow.Scatter     => scatter.amounts.toVector
+        case broadcast: BatchedFlow.Broadcast => broadcast.amounts.toVector
+
+  object OtherChangesEvidence:
+    def from(opening: BsmEvidence, closing: BsmEvidence, tfm: TfmEvidence): OtherChangesEvidence =
+      val txByAssetSector = tfm.assetSectorTotals.withDefaultValue(0L)
+      val cells           = for
+        instrument <- SfcMatrixRegistry.instruments
+        sector     <- SfcMatrixRegistry.sectors.map(_.sector)
+      yield
+        val openingRaw     = opening.row(instrument.asset).amountRaw(sector)
+        val closingRaw     = closing.row(instrument.asset).amountRaw(sector)
+        val stockDelta     = closingRaw - openingRaw
+        val txDelta        = txByAssetSector((instrument.asset, sector))
+        val other          = stockDelta - txDelta
+        val (kind, reason) = classifyOtherChange(instrument, other)
+        OtherChangeCell(instrument.asset, sector, stockDelta, txDelta, other, kind, reason)
+
+      val gaps = (opening.gaps ++ closing.gaps).distinct
+      OtherChangesEvidence(cells, gaps)
+
+    private def classifyOtherChange(
+        instrument: SfcMatrixRegistry.InstrumentMetadata,
+        otherChangeRaw: Long,
+    ): (OtherChangeKind, String) =
+      if otherChangeRaw == 0L then (OtherChangeKind.TransactionReconciliation, "Stock delta is explained by executed transaction flows.")
+      else
+        instrument.asset match
+          case AssetType.ForeignAsset | AssetType.GovBondAFS | AssetType.GovBondHTM                                           =>
+            (OtherChangeKind.Revaluation, "Residual is classified as valuation or mark-to-market evidence for this instrument family.")
+          case AssetType.FirmLoan | AssetType.ConsumerLoan | AssetType.MortgageLoan | AssetType.CorpBond | AssetType.NbfiLoan =>
+            (
+              OtherChangeKind.DefaultOrWriteOff,
+              "Residual is classified as default, write-off, amortization coverage, or unsupported borrower-side stock evidence.",
+            )
+          case _                                                                                                              =>
+            instrument.completeness match
+              case SfcMatrixRegistry.RowCompleteness.Complete =>
+                (OtherChangeKind.TransactionReconciliation, "Residual is a complete-row stock-flow reconciliation difference.")
+              case _                                          =>
+                (OtherChangeKind.CoverageGap, instrument.note)
+
+  object MatrixValidation:
+    def validate(
+        opening: BsmEvidence,
+        closing: BsmEvidence,
+        tfm: TfmEvidence,
+        otherChanges: OtherChangesEvidence,
+        sfcResult: Sfc.SfcResult,
+    ): MatrixValidationReport =
+      val sfcErrors = sfcResult.left.toOption
+        .filter(_.nonEmpty)
+        .map(MatrixValidationError.SfcValidationFailed.apply)
+        .toVector
+
+      val bsmErrors = Vector(opening, closing).flatMap: bsm =>
+        bsm.rows.flatMap: row =>
+          val instrument = SfcMatrixRegistry.instrument(row.asset)
+          if instrument.completeness == SfcMatrixRegistry.RowCompleteness.Complete && row.rowSumRaw != 0L then
+            Vector(
+              MatrixValidationError.BsmRowSumError(
+                bsm.snapshotKind,
+                row.asset,
+                row.rowSumRaw,
+                instrument.note,
+              ),
+            )
+          else Vector.empty
+
+      val tfmErrors = tfm.rows.collect:
+        case row if row.rowSumRaw != 0L =>
+          MatrixValidationError.TfmRowSumError(row.rowKey, row.mechanism, row.asset, row.rowSumRaw)
+
+      val stockFlowErrors = otherChanges.cells.collect:
+        case cell if cell.stockDeltaRaw != cell.transactionDeltaRaw + cell.otherChangeRaw =>
+          MatrixValidationError.StockFlowReconciliationError(
+            cell.asset,
+            cell.sector,
+            cell.stockDeltaRaw,
+            cell.transactionDeltaRaw,
+            cell.otherChangeRaw,
+          )
+
+      val sectorErrors = SfcMatrixRegistry.sectors.flatMap: sectorRow =>
+        val cells          = otherChanges.cells.filter(_.sector == sectorRow.sector)
+        val stockDelta     = cells.iterator.map(_.stockDeltaRaw).sum
+        val txDelta        = cells.iterator.map(_.transactionDeltaRaw).sum
+        val otherDelta     = cells.iterator.map(_.otherChangeRaw).sum
+        val reconciledSide = txDelta + otherDelta
+        if stockDelta == reconciledSide then Vector.empty
+        else Vector(MatrixValidationError.SectorColumnDeltaError(sectorRow.sector, stockDelta, txDelta, otherDelta))
+
+      MatrixValidationReport(sfcErrors ++ bsmErrors ++ tfmErrors ++ stockFlowErrors ++ sectorErrors)
+
+  object MatrixEvidenceBundle:
+    def fromStep(seed: Long, step: FlowSimulation.StepOutput, commit: String = BuildInfo.gitCommit): MatrixEvidenceBundle =
+      val opening      = BsmEvidence.fromStepOpening(step)
+      val closing      = BsmEvidence.fromStepClosing(step)
+      val tfm          = TfmEvidence.fromStep(step)
+      val other        = OtherChangesEvidence.from(opening, closing, tfm)
+      val validation   = MatrixValidation.validate(opening, closing, tfm, other, step.sfcResult)
+      val sfcStatus    = if step.sfcResult.isRight then "pass" else "fail"
+      val matrixStatus = if validation.isValid then "pass" else "fail"
+      val metadata     = MatrixMetadata(
+        seed = seed,
+        executionMonth = step.executionMonth.toInt,
+        commit = commit,
+        schemaVersion = SfcMatrixRegistry.SchemaVersion,
+        sfcStatus = sfcStatus,
+        matrixStatus = matrixStatus,
+      )
+      MatrixEvidenceBundle(metadata, opening, closing, tfm, other, validation)
+
+end SfcMatrixEvidence

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidence.scala
@@ -129,8 +129,6 @@ object SfcMatrixEvidence:
   enum MatrixValidationError:
     case BsmRowSumError(snapshot: SnapshotKind, asset: AssetType, actualRaw: Long, reason: String)
     case TfmRowSumError(rowKey: String, mechanism: MechanismId, asset: AssetType, actualRaw: Long)
-    case SectorColumnDeltaError(sector: EntitySector, stockDeltaRaw: Long, transactionDeltaRaw: Long, otherChangeRaw: Long)
-    case StockFlowReconciliationError(asset: AssetType, sector: EntitySector, stockDeltaRaw: Long, transactionDeltaRaw: Long, otherChangeRaw: Long)
     case SfcValidationFailed(errors: Vector[Sfc.SfcIdentityError])
 
   final case class MatrixValidationReport(errors: Vector[MatrixValidationError]):
@@ -366,7 +364,6 @@ object SfcMatrixEvidence:
         opening: BsmEvidence,
         closing: BsmEvidence,
         tfm: TfmEvidence,
-        otherChanges: OtherChangesEvidence,
         sfcResult: Sfc.SfcResult,
     ): MatrixValidationReport =
       val sfcErrors = sfcResult.left.toOption
@@ -392,26 +389,7 @@ object SfcMatrixEvidence:
         case row if row.rowSumRaw != 0L =>
           MatrixValidationError.TfmRowSumError(row.rowKey, row.mechanism, row.asset, row.rowSumRaw)
 
-      val stockFlowErrors = otherChanges.cells.collect:
-        case cell if cell.stockDeltaRaw != cell.transactionDeltaRaw + cell.otherChangeRaw =>
-          MatrixValidationError.StockFlowReconciliationError(
-            cell.asset,
-            cell.sector,
-            cell.stockDeltaRaw,
-            cell.transactionDeltaRaw,
-            cell.otherChangeRaw,
-          )
-
-      val sectorErrors = SfcMatrixRegistry.sectors.flatMap: sectorRow =>
-        val cells          = otherChanges.cells.filter(_.sector == sectorRow.sector)
-        val stockDelta     = cells.iterator.map(_.stockDeltaRaw).sum
-        val txDelta        = cells.iterator.map(_.transactionDeltaRaw).sum
-        val otherDelta     = cells.iterator.map(_.otherChangeRaw).sum
-        val reconciledSide = txDelta + otherDelta
-        if stockDelta == reconciledSide then Vector.empty
-        else Vector(MatrixValidationError.SectorColumnDeltaError(sectorRow.sector, stockDelta, txDelta, otherDelta))
-
-      MatrixValidationReport(sfcErrors ++ bsmErrors ++ tfmErrors ++ stockFlowErrors ++ sectorErrors)
+      MatrixValidationReport(sfcErrors ++ bsmErrors ++ tfmErrors)
 
   object MatrixEvidenceBundle:
     def fromStep(seed: Long, step: FlowSimulation.StepOutput, commit: String = BuildInfo.gitCommit): MatrixEvidenceBundle =
@@ -419,7 +397,7 @@ object SfcMatrixEvidence:
       val closing      = BsmEvidence.fromStepClosing(step)
       val tfm          = TfmEvidence.fromStep(step)
       val other        = OtherChangesEvidence.from(opening, closing, tfm)
-      val validation   = MatrixValidation.validate(opening, closing, tfm, other, step.sfcResult)
+      val validation   = MatrixValidation.validate(opening, closing, tfm, step.sfcResult)
       val sfcStatus    = if step.sfcResult.isRight then "pass" else "fail"
       val matrixStatus = if validation.isValid then "pass" else "fail"
       val metadata     = MatrixMetadata(

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRegistry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRegistry.scala
@@ -1,0 +1,438 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.engine.flows.FlowMechanism
+import com.boombustgroup.amorfati.engine.ledger.{AssetOwnershipContract, RuntimeMechanismSurvivability}
+import com.boombustgroup.ledger.{AssetType, EntitySector, MechanismId}
+
+/** Presentation and audit registry for ledger-derived SFC matrix evidence.
+  *
+  * The registry binds runtime ledger concepts to stable academic matrix rows:
+  * sector ordering, instrument rows, mechanism labels, LaTeX symbols, and
+  * row-level coverage policy. It is deliberately metadata-only; no matrix cell
+  * value is maintained here.
+  */
+object SfcMatrixRegistry:
+
+  val SchemaVersion: String = "sfc-matrix-v1"
+
+  enum InstrumentCategory:
+    case FinancialClaim
+    case SettlementShell
+    case UnsupportedDiagnostic
+
+  enum RowCompleteness:
+    /** The modeled holder/issuer slice is complete enough for exact row-sum
+      * validation.
+      */
+    case Complete
+
+    /** The row is emitted, but known holder/issuer coverage gaps are explicit
+      * diagnostics rather than silent balancing rows.
+      */
+    case ClassifiedGap
+
+    /** Public ledger concept is intentionally excluded from persisted matrix
+      * stocks.
+      */
+    case Excluded
+
+  final case class SectorMetadata(
+      sector: EntitySector,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      order: Int,
+  )
+
+  final case class InstrumentMetadata(
+      asset: AssetType,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      category: InstrumentCategory,
+      completeness: RowCompleteness,
+      note: String,
+  )
+
+  final case class MechanismMetadata(
+      mechanism: MechanismId,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      survivability: RuntimeMechanismSurvivability.Classification,
+      note: String,
+  )
+
+  val sectors: Vector[SectorMetadata] =
+    Vector(
+      SectorMetadata(EntitySector.Households, "Households", "HH", "\\mathrm{HH}", 0),
+      SectorMetadata(EntitySector.Firms, "Firms", "Firms", "\\mathrm{F}", 1),
+      SectorMetadata(EntitySector.Banks, "Banks", "Banks", "\\mathrm{B}", 2),
+      SectorMetadata(EntitySector.Government, "Government", "Gov", "\\mathrm{G}", 3),
+      SectorMetadata(EntitySector.NBP, "NBP", "NBP", "\\mathrm{NBP}", 4),
+      SectorMetadata(EntitySector.Insurance, "Insurance", "Ins", "\\mathrm{INS}", 5),
+      SectorMetadata(EntitySector.Funds, "Funds", "Funds", "\\mathrm{FND}", 6),
+      SectorMetadata(EntitySector.Foreign, "Foreign", "ROW", "\\mathrm{ROW}", 7),
+    )
+
+  private val sectorBySector: Map[EntitySector, SectorMetadata] =
+    sectors.map(row => row.sector -> row).toMap
+
+  private def financial(
+      asset: AssetType,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      completeness: RowCompleteness,
+      note: String,
+  ): InstrumentMetadata =
+    InstrumentMetadata(asset, label, shortLabel, latexSymbol, InstrumentCategory.FinancialClaim, completeness, note)
+
+  private def settlement(
+      asset: AssetType,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      note: String,
+  ): InstrumentMetadata =
+    InstrumentMetadata(asset, label, shortLabel, latexSymbol, InstrumentCategory.SettlementShell, RowCompleteness.Excluded, note)
+
+  private def unsupported(
+      asset: AssetType,
+      label: String,
+      shortLabel: String,
+      latexSymbol: String,
+      note: String,
+  ): InstrumentMetadata =
+    InstrumentMetadata(asset, label, shortLabel, latexSymbol, InstrumentCategory.UnsupportedDiagnostic, RowCompleteness.Excluded, note)
+
+  val instruments: Vector[InstrumentMetadata] =
+    Vector(
+      financial(
+        AssetType.DemandDeposit,
+        "Demand deposits",
+        "Demand dep.",
+        "D",
+        RowCompleteness.ClassifiedGap,
+        "Household and bank demand-deposit stocks are ledger-owned; firm/fund cash is reported separately as Cash.",
+      ),
+      financial(
+        AssetType.TermDeposit,
+        "Term deposits",
+        "Term dep.",
+        "TD",
+        RowCompleteness.ClassifiedGap,
+        "Bank term-deposit liabilities are currently modeled without a holder-resolved persisted counterpart.",
+      ),
+      financial(
+        AssetType.FirmLoan,
+        "Firm loans",
+        "Firm loans",
+        "L_F",
+        RowCompleteness.ClassifiedGap,
+        "Firm loan stocks are ledger-owned on both sides, but the current dynamic-population projection can leave small holder/issuer gaps across month boundaries.",
+      ),
+      financial(
+        AssetType.ConsumerLoan,
+        "Consumer loans",
+        "Consumer loans",
+        "L_C",
+        RowCompleteness.ClassifiedGap,
+        "Consumer credit stocks are ledger-owned on both sides, but the current household/bank projection can leave small holder/issuer gaps across month boundaries.",
+      ),
+      financial(
+        AssetType.MortgageLoan,
+        "Mortgage loans",
+        "Mortgages",
+        "L_M",
+        RowCompleteness.ClassifiedGap,
+        "Household mortgage principal is persisted; the bank-side mortgage stock is not yet a supported ledger-owned row.",
+      ),
+      financial(
+        AssetType.GovBondAFS,
+        "Government bonds AFS",
+        "Gov AFS",
+        "B_G^{AFS}",
+        RowCompleteness.Excluded,
+        "Bank AFS government bonds are folded into the consolidated Government bonds row for BSM evidence.",
+      ),
+      financial(
+        AssetType.GovBondHTM,
+        "Government bonds",
+        "Gov bonds",
+        "B_G",
+        RowCompleteness.Complete,
+        "Consolidated holder/issuer government-bond row, including bank AFS and HTM books.",
+      ),
+      financial(
+        AssetType.QuasiFiscalBond,
+        "Quasi-fiscal bonds",
+        "QF bonds",
+        "B_{QF}",
+        RowCompleteness.Complete,
+        "BGK/PFR issuer and bank/NBP holder stocks are supported persisted rows.",
+      ),
+      financial(
+        AssetType.CorpBond,
+        "Corporate bonds",
+        "Corp bonds",
+        "B_C",
+        RowCompleteness.Complete,
+        "Firm issuer liabilities and supported bank, insurance, PPK, other-fund, and NBFI holdings.",
+      ),
+      financial(
+        AssetType.Reserve,
+        "Bank reserves",
+        "Reserves",
+        "R",
+        RowCompleteness.ClassifiedGap,
+        "Bank reserve assets are persisted; the NBP reserve liability is currently a runtime settlement shell.",
+      ),
+      settlement(
+        AssetType.StandingFacility,
+        "Standing facility",
+        "Standing",
+        "SF",
+        "Standing-facility flows are runtime backstop evidence, not persisted stock evidence.",
+      ),
+      financial(
+        AssetType.InterbankLoan,
+        "Interbank loans",
+        "Interbank",
+        "IB",
+        RowCompleteness.Complete,
+        "Bank interbank positions are netted across persisted bank rows.",
+      ),
+      financial(
+        AssetType.Equity,
+        "Equity",
+        "Equity",
+        "EQ",
+        RowCompleteness.ClassifiedGap,
+        "Domestic supported holders and firm issuers are persisted; foreign ownership remains metric-only.",
+      ),
+      financial(
+        AssetType.LifeReserve,
+        "Life insurance reserves",
+        "Life res.",
+        "IR_L",
+        RowCompleteness.ClassifiedGap,
+        "Insurance-side reserve liabilities are persisted without holder-resolved household assets.",
+      ),
+      financial(
+        AssetType.NonLifeReserve,
+        "Non-life insurance reserves",
+        "Non-life res.",
+        "IR_N",
+        RowCompleteness.ClassifiedGap,
+        "Insurance-side reserve liabilities are persisted without holder-resolved household assets.",
+      ),
+      financial(
+        AssetType.TfiUnit,
+        "TFI units",
+        "TFI units",
+        "U_{TFI}",
+        RowCompleteness.ClassifiedGap,
+        "NBFI fund units are persisted as a fund-bucket liability/proxy without holder-resolved household units.",
+      ),
+      financial(
+        AssetType.NbfiLoan,
+        "NBFI loans",
+        "NBFI loans",
+        "L_{NBFI}",
+        RowCompleteness.ClassifiedGap,
+        "NBFI and quasi-fiscal loan portfolios are persisted; borrower-side coverage is incomplete.",
+      ),
+      financial(
+        AssetType.Cash,
+        "Cash and public fund balances",
+        "Cash",
+        "C",
+        RowCompleteness.ClassifiedGap,
+        "Firm cash, selected public fund cash, and NBFI cash are stock evidence; settlement cash shells are excluded.",
+      ),
+      unsupported(
+        AssetType.Capital,
+        "Bank capital",
+        "Capital",
+        "K_B",
+        "Bank capital is persisted engine state but outside the current supported ledger-owned stock slice.",
+      ),
+      financial(
+        AssetType.ForeignAsset,
+        "Foreign assets",
+        "Foreign assets",
+        "FA",
+        RowCompleteness.ClassifiedGap,
+        "NBP foreign assets are persisted; aggregate BoP NFA remains metric-only.",
+      ),
+    )
+
+  private val instrumentByAsset: Map[AssetType, InstrumentMetadata] =
+    instruments.map(row => row.asset -> row).toMap
+
+  private def mech(mechanism: MechanismId, label: String, shortLabel: String, latexSymbol: String): MechanismMetadata =
+    val declaration = RuntimeMechanismSurvivability
+      .declarationFor(mechanism)
+      .getOrElse:
+        throw new IllegalArgumentException(s"Missing survivability declaration for mechanism ${mechanism.toInt}")
+    MechanismMetadata(mechanism, label, shortLabel, latexSymbol, declaration.classification, declaration.note)
+
+  val mechanisms: Vector[MechanismMetadata] =
+    Vector(
+      mech(FlowMechanism.ZusContribution, "ZUS contribution", "ZUS contrib.", "ZUS_c"),
+      mech(FlowMechanism.ZusPension, "ZUS pension payment", "ZUS pension", "ZUS_p"),
+      mech(FlowMechanism.ZusGovSubvention, "ZUS government subvention", "ZUS subvention", "ZUS_g"),
+      mech(FlowMechanism.NfzContribution, "NFZ contribution", "NFZ contrib.", "NFZ_c"),
+      mech(FlowMechanism.NfzSpending, "NFZ health spending", "NFZ spend", "NFZ_s"),
+      mech(FlowMechanism.NfzGovSubvention, "NFZ government subvention", "NFZ subvention", "NFZ_g"),
+      mech(FlowMechanism.PpkContribution, "PPK contribution", "PPK contrib.", "PPK_c"),
+      mech(FlowMechanism.PpkBondPurchase, "PPK government bond purchase", "PPK gov bond", "PPK_b"),
+      mech(FlowMechanism.FpContribution, "Labour Fund contribution", "FP contrib.", "FP_c"),
+      mech(FlowMechanism.FpSpending, "Labour Fund spending", "FP spend", "FP_s"),
+      mech(FlowMechanism.FpGovSubvention, "Labour Fund government subvention", "FP subvention", "FP_g"),
+      mech(FlowMechanism.PfronContribution, "PFRON contribution", "PFRON contrib.", "PFRON_c"),
+      mech(FlowMechanism.PfronSpending, "PFRON spending", "PFRON spend", "PFRON_s"),
+      mech(FlowMechanism.PfronGovSubvention, "PFRON government subvention", "PFRON subvention", "PFRON_g"),
+      mech(FlowMechanism.FgspContribution, "FGSP contribution", "FGSP contrib.", "FGSP_c"),
+      mech(FlowMechanism.FgspSpending, "FGSP spending", "FGSP spend", "FGSP_s"),
+      mech(FlowMechanism.FgspGovSubvention, "FGSP government subvention", "FGSP subvention", "FGSP_g"),
+      mech(FlowMechanism.JstRevenue, "JST revenue", "JST revenue", "JST_r"),
+      mech(FlowMechanism.JstSpending, "JST spending", "JST spend", "JST_s"),
+      mech(FlowMechanism.JstGovSubvention, "JST government subvention", "JST subvention", "JST_g"),
+      mech(FlowMechanism.GovPurchases, "Government purchases", "Gov purchases", "G_p"),
+      mech(FlowMechanism.GovDebtService, "Government debt service", "Gov debt svc.", "G_i"),
+      mech(FlowMechanism.GovCapitalInvestment, "Government capital investment", "Gov capex", "G_k"),
+      mech(FlowMechanism.GovUnempBenefit, "Government unemployment benefits", "Unemp benefits", "G_u"),
+      mech(FlowMechanism.GovSocialTransfer, "Government social transfers", "Social transfers", "G_t"),
+      mech(FlowMechanism.GovEuCofin, "Government EU co-financing", "EU cofin", "G_{eu}"),
+      mech(FlowMechanism.InsLifePremium, "Life insurance premium", "Life premium", "INS_{lp}"),
+      mech(FlowMechanism.InsNonLifePremium, "Non-life insurance premium", "Non-life prem.", "INS_{np}"),
+      mech(FlowMechanism.InsLifeClaim, "Life insurance claim", "Life claim", "INS_{lc}"),
+      mech(FlowMechanism.InsNonLifeClaim, "Non-life insurance claim", "Non-life claim", "INS_{nc}"),
+      mech(FlowMechanism.InsInvestmentIncome, "Insurance investment income", "Ins income", "INS_i"),
+      mech(FlowMechanism.HhConsumption, "Household consumption", "HH cons.", "HH_c"),
+      mech(FlowMechanism.HhRent, "Household rent", "HH rent", "HH_r"),
+      mech(FlowMechanism.HhPit, "Household PIT", "HH PIT", "HH_{pit}"),
+      mech(FlowMechanism.HhDebtService, "Household debt service", "HH debt svc.", "HH_d"),
+      mech(FlowMechanism.HhDepositInterest, "Household deposit interest", "HH dep. int.", "HH_i"),
+      mech(FlowMechanism.HhRemittance, "Household remittance outflow", "HH remittance", "HH_{rem}"),
+      mech(FlowMechanism.HhCcOrigination, "Consumer credit origination", "CC origin.", "CC_o"),
+      mech(FlowMechanism.HhCcDebtService, "Consumer credit debt service", "CC service", "CC_s"),
+      mech(FlowMechanism.HhCcDefault, "Consumer credit default", "CC default", "CC_d"),
+      mech(FlowMechanism.HhTotalIncome, "Household total income", "HH income", "HH_y"),
+      mech(FlowMechanism.FirmCit, "Firm CIT", "CIT", "F_{cit}"),
+      mech(FlowMechanism.FirmLoanRepayment, "Firm loan repayment", "Firm repay", "F_{lr}"),
+      mech(FlowMechanism.FirmNewLoan, "Firm new loan", "Firm loan", "F_l"),
+      mech(FlowMechanism.FirmInterestPaid, "Firm interest paid", "Firm int.", "F_i"),
+      mech(FlowMechanism.FirmCapex, "Firm capex", "Firm capex", "F_k"),
+      mech(FlowMechanism.FirmEquityIssuance, "Firm equity issuance", "Equity iss.", "F_{eq}"),
+      mech(FlowMechanism.FirmIoPayment, "Firm IO payment", "IO payment", "F_{io}"),
+      mech(FlowMechanism.FirmNplDefault, "Firm NPL default", "Firm default", "F_{npl}"),
+      mech(FlowMechanism.FirmProfitShifting, "Firm profit shifting", "Profit shift", "F_{ps}"),
+      mech(FlowMechanism.FirmFdiRepatriation, "Firm FDI repatriation", "FDI repat.", "F_{fdi}"),
+      mech(FlowMechanism.FirmGrossInvestment, "Firm gross investment", "Gross inv.", "F_{inv}"),
+      mech(FlowMechanism.InvestmentDepositSettlement, "Investment deposit settlement", "Invest sett.", "INV_s"),
+      mech(FlowMechanism.TfiDepositDrain, "TFI deposit drain", "TFI drain", "TFI_d"),
+      mech(FlowMechanism.NbfiOrigination, "NBFI loan origination", "NBFI origin.", "NBFI_o"),
+      mech(FlowMechanism.NbfiRepayment, "NBFI repayment", "NBFI repay", "NBFI_r"),
+      mech(FlowMechanism.NbfiDefault, "NBFI default", "NBFI default", "NBFI_d"),
+      mech(FlowMechanism.QuasiFiscalBondIssuance, "Quasi-fiscal bond issuance", "QF bond iss.", "QF_{bi}"),
+      mech(FlowMechanism.QuasiFiscalBondAmortization, "Quasi-fiscal bond amortization", "QF bond amort.", "QF_{ba}"),
+      mech(FlowMechanism.QuasiFiscalNbpAbsorption, "Quasi-fiscal NBP absorption", "QF NBP buy", "QF_{nbp}"),
+      mech(FlowMechanism.QuasiFiscalLending, "Quasi-fiscal lending", "QF lending", "QF_l"),
+      mech(FlowMechanism.QuasiFiscalRepayment, "Quasi-fiscal repayment", "QF repay", "QF_r"),
+      mech(FlowMechanism.QuasiFiscalLendingDeposit, "Quasi-fiscal lending deposit", "QF lend dep.", "QF_{ld}"),
+      mech(FlowMechanism.QuasiFiscalRepaymentDeposit, "Quasi-fiscal repayment deposit", "QF repay dep.", "QF_{rd}"),
+      mech(FlowMechanism.QuasiFiscalNbpBondAmortization, "Quasi-fiscal NBP bond amortization", "QF NBP amort.", "QF_{nba}"),
+      mech(FlowMechanism.EquityDomDividend, "Domestic equity dividend", "Dom dividend", "EQ_d"),
+      mech(FlowMechanism.EquityForDividend, "Foreign equity dividend", "For dividend", "EQ_f"),
+      mech(FlowMechanism.EquityDividendTax, "Equity dividend tax", "Div tax", "EQ_t"),
+      mech(FlowMechanism.CorpBondCoupon, "Corporate bond coupon", "Corp coupon", "CB_c"),
+      mech(FlowMechanism.CorpBondDefault, "Corporate bond default", "Corp default", "CB_d"),
+      mech(FlowMechanism.CorpBondIssuance, "Corporate bond issuance", "Corp issue", "CB_i"),
+      mech(FlowMechanism.CorpBondAmortization, "Corporate bond amortization", "Corp amort.", "CB_a"),
+      mech(FlowMechanism.MortgageOrigination, "Mortgage origination", "Mortgage orig.", "M_o"),
+      mech(FlowMechanism.MortgageRepayment, "Mortgage repayment", "Mortgage repay", "M_r"),
+      mech(FlowMechanism.MortgageInterest, "Mortgage interest", "Mortgage int.", "M_i"),
+      mech(FlowMechanism.MortgageDefault, "Mortgage default", "Mortgage def.", "M_d"),
+      mech(FlowMechanism.TradeExports, "Trade exports", "Exports", "X"),
+      mech(FlowMechanism.TradeImports, "Trade imports", "Imports", "M"),
+      mech(FlowMechanism.TourismExport, "Tourism export", "Tourism X", "X_T"),
+      mech(FlowMechanism.TourismImport, "Tourism import", "Tourism M", "M_T"),
+      mech(FlowMechanism.Fdi, "FDI", "FDI", "FDI"),
+      mech(FlowMechanism.PortfolioFlow, "Portfolio flow", "Portfolio", "PF"),
+      mech(FlowMechanism.CarryTradeFlow, "Carry-trade flow", "Carry trade", "CT"),
+      mech(FlowMechanism.PrimaryIncome, "Primary income", "Primary inc.", "PI"),
+      mech(FlowMechanism.EuFunds, "EU funds", "EU funds", "EU"),
+      mech(FlowMechanism.DiasporaInflow, "Diaspora inflow", "Diaspora", "DI"),
+      mech(FlowMechanism.CapitalFlight, "Capital flight", "Cap flight", "CF"),
+      mech(FlowMechanism.BankFirmInterest, "Bank firm-loan interest", "Bank firm int.", "B_{fi}"),
+      mech(FlowMechanism.BankGovBondIncome, "Bank government-bond income", "Bank gov int.", "B_{gi}"),
+      mech(FlowMechanism.BankNplLoss, "Bank firm NPL loss", "Bank NPL", "B_{npl}"),
+      mech(FlowMechanism.BankMortgageNplLoss, "Bank mortgage NPL loss", "Bank mort. NPL", "B_{mnpl}"),
+      mech(FlowMechanism.BankCcNplLoss, "Bank consumer-credit NPL loss", "Bank CC NPL", "B_{cnpl}"),
+      mech(FlowMechanism.BankCorpBondLoss, "Bank corporate-bond loss", "Bank CB loss", "B_{cbl}"),
+      mech(FlowMechanism.BankBfgLevy, "Bank BFG levy", "BFG levy", "B_{bfg}"),
+      mech(FlowMechanism.BankUnrealizedLoss, "Bank unrealized bond loss", "Unrealized", "B_{ul}"),
+      mech(FlowMechanism.BankReserveInterest, "Bank reserve interest", "Reserve int.", "B_r"),
+      mech(FlowMechanism.BankStandingFacility, "Bank standing facility", "Standing fac.", "B_{sf}"),
+      mech(FlowMechanism.BankInterbankInterest, "Bank interbank interest", "Interbank int.", "B_{ib}"),
+      mech(FlowMechanism.BankBailIn, "Bank bail-in", "Bail-in", "B_{bail}"),
+      mech(FlowMechanism.BankNbpRemittance, "Bank NBP remittance", "NBP remit.", "B_{nbp}"),
+      mech(FlowMechanism.EquityGovDividend, "Government equity dividend", "Gov dividend", "EQ_g"),
+      mech(FlowMechanism.NbpFxSettlement, "NBP FX settlement", "FX settle", "NBP_{fx}"),
+      mech(FlowMechanism.BankStandingFacilityBackstop, "Bank standing-facility backstop", "SF backstop", "B_{sfb}"),
+      mech(FlowMechanism.GovVatRevenue, "Government VAT revenue", "VAT", "G_{vat}"),
+      mech(FlowMechanism.GovExciseRevenue, "Government excise revenue", "Excise", "G_{exc}"),
+      mech(FlowMechanism.GovCustomsDutyRevenue, "Government customs duty revenue", "Customs", "G_{cus}"),
+      mech(FlowMechanism.BankCorpBondCoupon, "Bank corporate-bond coupon", "Bank CB coupon", "B_{cbc}"),
+      mech(FlowMechanism.GovBondPrimaryMarket, "Government bond primary market", "Gov bond primary", "GB_p"),
+      mech(FlowMechanism.GovBondForeignPurchase, "Foreign government bond purchase", "Foreign gov bond", "GB_f"),
+      mech(FlowMechanism.NbpQeGovBondPurchase, "NBP QE government bond purchase", "NBP QE", "GB_{qe}"),
+      mech(FlowMechanism.InsuranceGovBondPurchase, "Insurance government bond purchase", "Ins gov bond", "GB_i"),
+      mech(FlowMechanism.TfiGovBondPurchase, "TFI government bond purchase", "TFI gov bond", "GB_t"),
+    )
+
+  private val mechanismById: Map[Int, MechanismMetadata] =
+    mechanisms.map(row => row.mechanism.toInt -> row).toMap
+
+  require(
+    sectorBySector.keySet == EntitySector.values.toSet,
+    "SfcMatrixRegistry must classify every public EntitySector.",
+  )
+
+  require(
+    instrumentByAsset.keySet == AssetType.values.toSet,
+    "SfcMatrixRegistry must classify every public AssetType.",
+  )
+
+  require(
+    mechanisms.map(_.mechanism.toInt).toSet == FlowMechanism.emittedRuntimeMechanisms.map(_.toInt),
+    "SfcMatrixRegistry must classify every runtime-emitted FlowMechanism.",
+  )
+
+  require(
+    instruments.forall(row => AssetOwnershipContract.publicAsset(row.asset).asset == row.asset),
+    "SfcMatrixRegistry instruments must reference the public asset ownership contract.",
+  )
+
+  def sector(sector: EntitySector): SectorMetadata =
+    sectorBySector(sector)
+
+  def instrument(asset: AssetType): InstrumentMetadata =
+    instrumentByAsset(asset)
+
+  def mechanism(mechanism: MechanismId): MechanismMetadata =
+    mechanismById(mechanism.toInt)
+
+  def sectorOrder(sector: EntitySector): Int =
+    sectorBySector(sector).order
+
+  def instrumentOrder(asset: AssetType): Int =
+    instruments.indexWhere(_.asset == asset)
+
+  def mechanismOrder(mechanism: MechanismId): Int =
+    mechanisms.indexWhere(_.mechanism == mechanism)
+
+end SfcMatrixRegistry

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
@@ -1,0 +1,223 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidence.*
+import com.boombustgroup.ledger.{AssetType, MechanismId}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+object SfcMatrixRenderers:
+
+  enum OutputFormat:
+    case Latex
+    case Markdown
+
+    def extension: String =
+      this match
+        case Latex    => "tex"
+        case Markdown => "md"
+
+  object OutputFormat:
+    val Default: Vector[OutputFormat] = Vector(OutputFormat.Latex, OutputFormat.Markdown)
+
+    def parseList(value: String): Either[String, Vector[OutputFormat]] =
+      val parsed = value
+        .split(",")
+        .toVector
+        .map(_.trim.toLowerCase)
+        .filter(_.nonEmpty)
+        .map:
+          case "latex" | "tex"   => Right(OutputFormat.Latex)
+          case "markdown" | "md" => Right(OutputFormat.Markdown)
+          case "csv" | "json"    =>
+            Left("SFC matrix export writes only tex and md; numeric evidence is already available from the engine CSV output.")
+          case other             => Left(s"Unknown matrix output format: $other")
+
+      parsed.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val formats = parsed.collect { case Right(format) => format }.distinct
+          if formats.nonEmpty then Right(formats) else Left("At least one matrix output format is required")
+
+  final case class RenderedArtifact(relativePath: String, contents: String)
+
+  def renderSymbolicBundle(
+      bundle: MatrixEvidenceBundle,
+      formats: Vector[OutputFormat],
+  ): Vector[RenderedArtifact] =
+    val matrixArtifacts = SfcSymbolicMatrices.matrices.flatMap: matrix =>
+      formats.map: format =>
+        RenderedArtifact(s"${matrix.name}.${format.extension}", renderSymbolicMatrix(bundle.metadata, matrix, format))
+
+    val mappingArtifacts = formats.map: format =>
+      RenderedArtifact(s"matrix-mapping.${format.extension}", renderMapping(bundle.metadata, format))
+
+    matrixArtifacts ++ mappingArtifacts
+
+  def writeSymbolicBundle(
+      bundle: MatrixEvidenceBundle,
+      outDir: Path,
+      formats: Vector[OutputFormat],
+  ): Vector[Path] =
+    Files.createDirectories(outDir)
+    renderSymbolicBundle(bundle, formats).map: artifact =>
+      val path = outDir.resolve(artifact.relativePath)
+      Files.createDirectories(path.getParent)
+      Files.writeString(path, artifact.contents, StandardCharsets.UTF_8)
+      path
+
+  private def renderSymbolicMatrix(
+      metadata: MatrixMetadata,
+      matrix: SfcSymbolicMatrices.SymbolicMatrix,
+      format: OutputFormat,
+  ): String =
+    format match
+      case OutputFormat.Latex    => renderSymbolicLatex(metadata, matrix)
+      case OutputFormat.Markdown => renderSymbolicMarkdown(metadata, matrix)
+
+  private def renderSymbolicLatex(metadata: MatrixMetadata, matrix: SfcSymbolicMatrices.SymbolicMatrix): String =
+    val columns = "p{0.24\\linewidth}" + ("c" * SfcSymbolicMatrices.sectors.length) + "c"
+    val header  =
+      (matrix.rowHeader +: SfcSymbolicMatrices.sectors.map(sector => SfcMatrixRegistry.sector(sector).shortLabel) :+ "Sum")
+        .map(escapeLatex)
+        .mkString(" & ")
+    val body    = matrix.rows.map: row =>
+      val cells = SfcSymbolicMatrices.sectors.map(sector => latexSymbol(row.cells.getOrElse(sector, "")))
+      (escapeLatex(row.label) +: cells :+ latexSymbol(row.zeroSymbol)).mkString(" & ") + " \\\\"
+
+    s"""% schema=${metadata.schemaVersion} seed=${metadata.seed} month=${metadata.executionMonth} commit=${escapeLatex(
+        metadata.commit,
+      )} sfc=${metadata.sfcStatus} matrix=${metadata.matrixStatus} output=symbolic
+       |\\begingroup
+       |\\scriptsize
+       |\\setlength{\\tabcolsep}{2pt}
+       |\\renewcommand{\\arraystretch}{1.15}
+       |\\begin{tabular}{$columns}
+       |$header \\\\
+       |\\hline
+       |${body.mkString("\n")}
+       |\\end{tabular}
+       |\\endgroup
+       |""".stripMargin
+
+  private def renderSymbolicMarkdown(metadata: MatrixMetadata, matrix: SfcSymbolicMatrices.SymbolicMatrix): String =
+    val header = matrix.rowHeader +: SfcSymbolicMatrices.sectors.map(sector => SfcMatrixRegistry.sector(sector).label) :+ "Sum"
+    val rows   = matrix.rows.map: row =>
+      row.label +: SfcSymbolicMatrices.sectors.map(sector => row.cells.getOrElse(sector, "")) :+ row.zeroSymbol
+
+    renderMarkdownTable(
+      s"""<!-- schema=${metadata.schemaVersion} seed=${metadata.seed} month=${metadata.executionMonth} commit=${metadata.commit} sfc=${metadata.sfcStatus} matrix=${metadata.matrixStatus} output=symbolic -->
+         |# ${matrix.title}
+         |""".stripMargin,
+      header,
+      rows,
+    )
+
+  private def renderMapping(metadata: MatrixMetadata, format: OutputFormat): String =
+    format match
+      case OutputFormat.Latex    => renderMappingLatex(metadata)
+      case OutputFormat.Markdown => renderMappingMarkdown(metadata)
+
+  private def renderMappingLatex(metadata: MatrixMetadata): String =
+    val header = Vector("Matrix", "Row", "Symbols", "Runtime assets", "Runtime mechanisms", "Note").map(escapeLatex).mkString(" & ")
+    val body   = SfcSymbolicMatrices.mappingRows.map: row =>
+      Vector(
+        escapeLatex(row.matrix),
+        escapeLatex(row.rowLabel),
+        row.symbols.map(latexSymbol).mkString(", "),
+        latexTextList(row.assets.map(assetLabel)),
+        latexTextList(row.mechanisms.map(mechanismLabel)),
+        escapeLatex(row.note),
+      ).mkString(" & ") + " \\\\"
+
+    s"""% schema=${metadata.schemaVersion} seed=${metadata.seed} month=${metadata.executionMonth} commit=${escapeLatex(
+        metadata.commit,
+      )} sfc=${metadata.sfcStatus} matrix=${metadata.matrixStatus} output=symbolic-mapping
+       |% requires \\usepackage{longtable}
+       |\\begingroup
+       |\\scriptsize
+       |\\setlength{\\tabcolsep}{2pt}
+       |\\renewcommand{\\arraystretch}{1.15}
+       |\\begin{longtable}{p{0.08\\linewidth}p{0.13\\linewidth}p{0.14\\linewidth}p{0.17\\linewidth}p{0.24\\linewidth}p{0.14\\linewidth}}
+       |$header \\\\
+       |\\hline
+       |\\endfirsthead
+       |$header \\\\
+       |\\hline
+       |\\endhead
+       |${body.mkString("\n")}
+       |\\end{longtable}
+       |\\endgroup
+       |""".stripMargin
+
+  private def renderMappingMarkdown(metadata: MatrixMetadata): String =
+    val rows = SfcSymbolicMatrices.mappingRows.map: row =>
+      Vector(
+        row.matrix,
+        row.rowLabel,
+        row.symbols.mkString(", "),
+        row.assets.map(assetLabel).mkString("<br>"),
+        row.mechanisms.map(mechanismLabel).mkString("<br>"),
+        row.note,
+      )
+
+    renderMarkdownTable(
+      s"""<!-- schema=${metadata.schemaVersion} seed=${metadata.seed} month=${metadata.executionMonth} commit=${metadata.commit} sfc=${metadata.sfcStatus} matrix=${metadata.matrixStatus} output=symbolic-mapping -->
+         |# Symbolic Matrix Mapping
+         |""".stripMargin,
+      Vector("Matrix", "Row", "Symbols", "Runtime assets", "Runtime mechanisms", "Note"),
+      rows,
+    )
+
+  private def renderMarkdownTable(prefix: String, header: Vector[String], rows: Vector[Vector[String]]): String =
+    val tableHeader = markdownRow(header)
+    val separator   = markdownRow(header.map(_ => "---"))
+    val body        = rows.map(markdownRow)
+    (Vector(prefix.trim, tableHeader, separator) ++ body).mkString("\n") + "\n"
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(escapeMarkdown).mkString("| ", " | ", " |")
+
+  private def latexSymbol(value: String): String =
+    if value.isBlank then ""
+    else "$" + value + "$"
+
+  private def latexTextList(values: Vector[String]): String =
+    values.map(escapeLatex).mkString("\\newline ")
+
+  private def assetLabel(asset: AssetType): String =
+    val metadata = SfcMatrixRegistry.instrument(asset)
+    s"${metadata.label} (${asset.toString})"
+
+  private def mechanismLabel(mechanism: MechanismId): String =
+    val metadata = SfcMatrixRegistry.mechanism(mechanism)
+    s"${metadata.label} (#${mechanism.toInt})"
+
+  private[matrix] def formatPLN(raw: Long): String =
+    s"PLN ${formatDecimal(raw)}"
+
+  private[matrix] def formatDecimal(raw: Long): String =
+    (BigDecimal(raw) / BigDecimal(10000)).setScale(4).bigDecimal.toPlainString
+
+  private[matrix] def escapeLatex(value: String): String =
+    value.flatMap:
+      case '\\' => "\\textbackslash{}"
+      case '&'  => "\\&"
+      case '%'  => "\\%"
+      case '$'  => "\\$"
+      case '#'  => "\\#"
+      case '_'  => "\\_"
+      case '{'  => "\\{"
+      case '}'  => "\\}"
+      case '~'  => "\\textasciitilde{}"
+      case '^'  => "\\textasciicircum{}"
+      case ch   => ch.toString
+
+  private[matrix] def escapeMarkdown(value: String): String =
+    value
+      .replace("\\", "\\\\")
+      .replace("|", "\\|")
+      .replace("\n", "<br>")
+      .replace("\r", "")
+
+end SfcMatrixRenderers

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
@@ -29,8 +29,6 @@ object SfcMatrixRenderers:
         .map:
           case "latex" | "tex"   => Right(OutputFormat.Latex)
           case "markdown" | "md" => Right(OutputFormat.Markdown)
-          case "csv" | "json"    =>
-            Left("SFC matrix export writes only tex and md; numeric evidence is already available from the engine CSV output.")
           case other             => Left(s"Unknown matrix output format: $other")
 
       parsed.collectFirst { case Left(err) => err } match
@@ -192,12 +190,6 @@ object SfcMatrixRenderers:
   private def mechanismLabel(mechanism: MechanismId): String =
     val metadata = SfcMatrixRegistry.mechanism(mechanism)
     s"${metadata.label} (#${mechanism.toInt})"
-
-  private[matrix] def formatPLN(raw: Long): String =
-    s"PLN ${formatDecimal(raw)}"
-
-  private[matrix] def formatDecimal(raw: Long): String =
-    (BigDecimal(raw) / BigDecimal(10000)).setScale(4).bigDecimal.toPlainString
 
   private[matrix] def escapeLatex(value: String): String =
     value.flatMap:

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderers.scala
@@ -189,7 +189,7 @@ object SfcMatrixRenderers:
 
   private def mechanismLabel(mechanism: MechanismId): String =
     val metadata = SfcMatrixRegistry.mechanism(mechanism)
-    s"${metadata.label} (#${mechanism.toInt})"
+    s"${metadata.label} [id: ${mechanism.toInt}]"
 
   private[matrix] def escapeLatex(value: String): String =
     value.flatMap:

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcSymbolicMatrices.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcSymbolicMatrices.scala
@@ -1,0 +1,311 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.engine.flows.FlowMechanism
+import com.boombustgroup.ledger.{AssetType, EntitySector, MechanismId}
+
+object SfcSymbolicMatrices:
+
+  final case class SymbolicRow(
+      rowKey: String,
+      label: String,
+      cells: Map[EntitySector, String],
+      zeroSymbol: String,
+      assets: Vector[AssetType],
+      mechanisms: Vector[MechanismId],
+      note: String,
+  )
+
+  final case class SymbolicMatrix(
+      name: String,
+      title: String,
+      rowHeader: String,
+      rows: Vector[SymbolicRow],
+  )
+
+  final case class MappingRow(
+      matrix: String,
+      rowKey: String,
+      rowLabel: String,
+      symbols: Vector[String],
+      assets: Vector[AssetType],
+      mechanisms: Vector[MechanismId],
+      note: String,
+  )
+
+  val sectors: Vector[EntitySector] =
+    SfcMatrixRegistry.sectors.map(_.sector)
+
+  private val HH    = EntitySector.Households
+  private val Firms = EntitySector.Firms
+  private val Banks = EntitySector.Banks
+  private val Gov   = EntitySector.Government
+  private val NBP   = EntitySector.NBP
+  private val Ins   = EntitySector.Insurance
+  private val Funds = EntitySector.Funds
+  private val ROW   = EntitySector.Foreign
+
+  private def row(
+      rowKey: String,
+      label: String,
+      cells: (EntitySector, String)*,
+  )(
+      zeroSymbol: String = "0",
+      assets: Vector[AssetType] = Vector.empty,
+      mechanisms: Vector[MechanismId] = Vector.empty,
+      note: String = "",
+  ): SymbolicRow =
+    SymbolicRow(rowKey, label, cells.toMap, zeroSymbol, assets, mechanisms, note)
+
+  val balanceSheet: SymbolicMatrix =
+    SymbolicMatrix(
+      name = "symbolic-bsm",
+      title = "Symbolic Balance Sheet Matrix",
+      rowHeader = "Instrument \\ Sector",
+      rows = Vector(
+        row("cash", "Cash and public balances", HH -> "+H_h", Firms -> "+H_f", Banks -> "+H_b", NBP -> "-H", Funds -> "+H_{pub}")(
+          assets = Vector(AssetType.Cash),
+          note = "Cash covers persisted firm, selected public-fund, and NBFI cash plus the paper-level currency shell.",
+        ),
+        row("demand-deposits", "Demand deposits", HH -> "+D_h", Firms -> "+D_f", Banks -> "-D", Funds -> "+D_{fnd}")(
+          assets = Vector(AssetType.DemandDeposit),
+        ),
+        row("term-deposits", "Term deposits", HH -> "+TD_h", Banks -> "-TD")(
+          assets = Vector(AssetType.TermDeposit),
+        ),
+        row("loans", "Loans", HH -> "-L_h", Firms -> "-L_f", Banks -> "+L")(
+          assets = Vector(AssetType.FirmLoan, AssetType.ConsumerLoan, AssetType.MortgageLoan, AssetType.NbfiLoan),
+          note = "Loan rows aggregate firm, consumer, mortgage, and NBFI credit instruments.",
+        ),
+        row("reserves", "Bank reserves", Banks -> "+R", NBP -> "-R")(
+          assets = Vector(AssetType.Reserve),
+          note = "The NBP reserve-liability side is a runtime settlement shell in the current engine.",
+        ),
+        row(
+          "government-bonds",
+          "Government bonds",
+          Banks -> "+B_b",
+          Gov   -> "-B_g",
+          NBP   -> "+B_{nbp}",
+          Ins   -> "+B_{ins}",
+          Funds -> "+B_{fnd}",
+          ROW   -> "+B_{row}",
+        )(
+          assets = Vector(AssetType.GovBondHTM, AssetType.GovBondAFS),
+        ),
+        row("quasi-fiscal-bonds", "Quasi-fiscal bonds", Banks -> "+Q_b", NBP -> "+Q_{nbp}", Funds -> "-Q")(
+          assets = Vector(AssetType.QuasiFiscalBond),
+        ),
+        row("corporate-bonds", "Corporate bonds", Firms -> "-B_c", Banks -> "+B_{cb}", Ins -> "+B_{ci}", Funds -> "+B_{cf}")(
+          assets = Vector(AssetType.CorpBond),
+        ),
+        row("equity", "Equity", HH -> "+E_h", Firms -> "-E", Ins -> "+E_i", Funds -> "+E_f", ROW -> "+E_{row}")(
+          assets = Vector(AssetType.Equity),
+          note = "Foreign equity ownership is currently metric-level evidence rather than a holder-resolved persisted stock.",
+        ),
+        row("insurance-reserves", "Insurance reserves", HH -> "+IR_h", Ins -> "-IR")(
+          assets = Vector(AssetType.LifeReserve, AssetType.NonLifeReserve),
+        ),
+        row("fund-units", "Fund units", HH -> "+U_h", Funds -> "-U")(
+          assets = Vector(AssetType.TfiUnit),
+        ),
+        row("foreign-assets", "Foreign assets", NBP -> "+FA", ROW -> "-FA")(
+          assets = Vector(AssetType.ForeignAsset),
+        ),
+        row(
+          "net-worth",
+          "Net worth",
+          HH    -> "-NW_h",
+          Firms -> "-NW_f",
+          Banks -> "-NW_b",
+          Gov   -> "-NW_g",
+          NBP   -> "-NW_{nbp}",
+          Ins   -> "-NW_{ins}",
+          Funds -> "-NW_{fnd}",
+          ROW   -> "-NW_{row}",
+        )(
+          note = "Column-balancing row used for the paper-level presentation; it is not emitted as a runtime asset.",
+        ),
+      ),
+    )
+
+  val transactionsFlow: SymbolicMatrix =
+    SymbolicMatrix(
+      name = "symbolic-tfm",
+      title = "Symbolic Transactions Flow Matrix",
+      rowHeader = "Flow \\ Sector",
+      rows = Vector(
+        row("consumption", "Consumption", HH -> "-C_h", Firms -> "+C_h")(
+          mechanisms = Vector(FlowMechanism.HhConsumption),
+        ),
+        row("wages-and-income", "Wages and household income", HH -> "+W", Firms -> "-W")(
+          mechanisms = Vector(FlowMechanism.HhTotalIncome),
+        ),
+        row("taxes", "Taxes", HH -> "-T_h", Firms -> "-T_f", Banks -> "-T_b", Gov -> "+T")(
+          mechanisms = Vector(
+            FlowMechanism.HhPit,
+            FlowMechanism.FirmCit,
+            FlowMechanism.GovVatRevenue,
+            FlowMechanism.GovExciseRevenue,
+            FlowMechanism.GovCustomsDutyRevenue,
+            FlowMechanism.EquityDividendTax,
+          ),
+        ),
+        row("social-contributions", "Social contributions", HH -> "-SC_h", Firms -> "-SC_f", Funds -> "+SC")(
+          mechanisms = Vector(
+            FlowMechanism.ZusContribution,
+            FlowMechanism.NfzContribution,
+            FlowMechanism.PpkContribution,
+            FlowMechanism.FpContribution,
+            FlowMechanism.PfronContribution,
+            FlowMechanism.FgspContribution,
+          ),
+        ),
+        row("transfers", "Transfers and benefits", HH -> "+TR_h", Gov -> "-TR_g", Funds -> "-TR_f")(
+          mechanisms = Vector(
+            FlowMechanism.ZusPension,
+            FlowMechanism.GovUnempBenefit,
+            FlowMechanism.GovSocialTransfer,
+          ),
+        ),
+        row("government-spending", "Government spending", Firms -> "+G", Gov -> "-G")(
+          mechanisms = Vector(
+            FlowMechanism.GovPurchases,
+            FlowMechanism.GovCapitalInvestment,
+            FlowMechanism.NfzSpending,
+            FlowMechanism.FpSpending,
+            FlowMechanism.PfronSpending,
+            FlowMechanism.FgspSpending,
+            FlowMechanism.JstSpending,
+          ),
+        ),
+        row("insurance", "Insurance premiums and claims", HH -> "-P+CL", Ins -> "+P-CL")(
+          mechanisms = Vector(
+            FlowMechanism.InsLifePremium,
+            FlowMechanism.InsNonLifePremium,
+            FlowMechanism.InsLifeClaim,
+            FlowMechanism.InsNonLifeClaim,
+            FlowMechanism.InsInvestmentIncome,
+          ),
+        ),
+        row("loan-interest", "Loan interest", HH -> "-rL_h", Firms -> "-rL_f", Banks -> "+rL")(
+          mechanisms = Vector(
+            FlowMechanism.HhDebtService,
+            FlowMechanism.FirmInterestPaid,
+            FlowMechanism.MortgageInterest,
+            FlowMechanism.BankFirmInterest,
+          ),
+        ),
+        row("deposit-and-reserve-interest", "Deposit and reserve interest", HH -> "+rD_h", Banks -> "-rD+rR", NBP -> "-rR")(
+          mechanisms = Vector(
+            FlowMechanism.HhDepositInterest,
+            FlowMechanism.BankReserveInterest,
+            FlowMechanism.BankStandingFacility,
+            FlowMechanism.BankInterbankInterest,
+          ),
+        ),
+        row("bond-coupons", "Bond coupons", Firms -> "-iB_c", Banks -> "+iB_b", Gov -> "-iB_g", Ins -> "+iB_i", Funds -> "+iB_f", ROW -> "+iB_{row}")(
+          mechanisms = Vector(
+            FlowMechanism.GovDebtService,
+            FlowMechanism.BankGovBondIncome,
+            FlowMechanism.CorpBondCoupon,
+            FlowMechanism.BankCorpBondCoupon,
+          ),
+        ),
+        row("dividends", "Dividends", HH -> "+Div_h", Firms -> "-Div", Gov -> "+Div_g", Ins -> "+Div_i", Funds -> "+Div_f", ROW -> "+Div_{row}")(
+          mechanisms = Vector(
+            FlowMechanism.EquityDomDividend,
+            FlowMechanism.EquityForDividend,
+            FlowMechanism.EquityGovDividend,
+          ),
+        ),
+        row("external", "External trade and income", HH -> "+REM", Firms -> "+X-M", Gov -> "+EU", ROW -> "-NX-REM-EU")(
+          mechanisms = Vector(
+            FlowMechanism.TradeExports,
+            FlowMechanism.TradeImports,
+            FlowMechanism.TourismExport,
+            FlowMechanism.TourismImport,
+            FlowMechanism.PrimaryIncome,
+            FlowMechanism.EuFunds,
+            FlowMechanism.DiasporaInflow,
+            FlowMechanism.HhRemittance,
+          ),
+        ),
+        row("loan-origination", "Loan origination", HH -> "+dL_h", Firms -> "+dL_f", Banks -> "-dL")(
+          assets = Vector(AssetType.FirmLoan, AssetType.ConsumerLoan, AssetType.MortgageLoan, AssetType.NbfiLoan),
+          mechanisms = Vector(
+            FlowMechanism.HhCcOrigination,
+            FlowMechanism.FirmNewLoan,
+            FlowMechanism.MortgageOrigination,
+            FlowMechanism.NbfiOrigination,
+            FlowMechanism.QuasiFiscalLending,
+          ),
+        ),
+        row("loan-repayment-default", "Loan repayment and defaults", HH -> "-repL_h", Firms -> "-repL_f", Banks -> "+repL")(
+          assets = Vector(AssetType.FirmLoan, AssetType.ConsumerLoan, AssetType.MortgageLoan, AssetType.NbfiLoan),
+          mechanisms = Vector(
+            FlowMechanism.HhCcDebtService,
+            FlowMechanism.HhCcDefault,
+            FlowMechanism.FirmLoanRepayment,
+            FlowMechanism.FirmNplDefault,
+            FlowMechanism.MortgageRepayment,
+            FlowMechanism.MortgageDefault,
+            FlowMechanism.NbfiRepayment,
+            FlowMechanism.NbfiDefault,
+            FlowMechanism.QuasiFiscalRepayment,
+          ),
+        ),
+        row(
+          "bond-issuance-purchase",
+          "Bond issuance and purchases",
+          Firms -> "+dB_c",
+          Banks -> "-dB_b",
+          Gov   -> "+dB_g",
+          NBP   -> "-dB_{nbp}",
+          Ins   -> "-dB_i",
+          Funds -> "-dB_f",
+          ROW   -> "-dB_{row}",
+        )(
+          assets = Vector(AssetType.GovBondHTM, AssetType.GovBondAFS, AssetType.QuasiFiscalBond, AssetType.CorpBond),
+          mechanisms = Vector(
+            FlowMechanism.GovBondPrimaryMarket,
+            FlowMechanism.GovBondForeignPurchase,
+            FlowMechanism.NbpQeGovBondPurchase,
+            FlowMechanism.InsuranceGovBondPurchase,
+            FlowMechanism.TfiGovBondPurchase,
+            FlowMechanism.QuasiFiscalBondIssuance,
+            FlowMechanism.QuasiFiscalBondAmortization,
+            FlowMechanism.QuasiFiscalNbpAbsorption,
+            FlowMechanism.QuasiFiscalNbpBondAmortization,
+            FlowMechanism.CorpBondIssuance,
+            FlowMechanism.CorpBondAmortization,
+          ),
+        ),
+        row("deposit-change", "Deposit change", HH -> "-dD_h", Firms -> "-dD_f", Banks -> "+dD", Funds -> "-dD_fnd")(
+          assets = Vector(AssetType.DemandDeposit, AssetType.TermDeposit),
+          mechanisms = Vector(
+            FlowMechanism.InvestmentDepositSettlement,
+            FlowMechanism.TfiDepositDrain,
+            FlowMechanism.QuasiFiscalLendingDeposit,
+            FlowMechanism.QuasiFiscalRepaymentDeposit,
+          ),
+        ),
+      ),
+    )
+
+  val matrices: Vector[SymbolicMatrix] =
+    Vector(balanceSheet, transactionsFlow)
+
+  def mappingRows: Vector[MappingRow] =
+    matrices.flatMap: matrix =>
+      matrix.rows.map: row =>
+        MappingRow(
+          matrix = matrix.name,
+          rowKey = row.rowKey,
+          rowLabel = row.label,
+          symbols = sectors.flatMap(sector => row.cells.get(sector)) :+ row.zeroSymbol,
+          assets = row.assets,
+          mechanisms = row.mechanisms,
+          note = row.note,
+        )
+
+end SfcSymbolicMatrices

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcSymbolicMatrices.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/matrix/SfcSymbolicMatrices.scala
@@ -280,7 +280,7 @@ object SfcSymbolicMatrices:
             FlowMechanism.CorpBondAmortization,
           ),
         ),
-        row("deposit-change", "Deposit change", HH -> "-dD_h", Firms -> "-dD_f", Banks -> "+dD", Funds -> "-dD_fnd")(
+        row("deposit-change", "Deposit change", HH -> "-dD_h", Firms -> "-dD_f", Banks -> "+dD", Funds -> "-dD_{fnd}")(
           assets = Vector(AssetType.DemandDeposit, AssetType.TermDeposit),
           mechanisms = Vector(
             FlowMechanism.InvestmentDepositSettlement,

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
@@ -63,24 +63,25 @@ object SfcMatrixExport:
     def missingValue(flag: String): Left[String, Config] =
       Left(s"Missing value for ${if flag == "--formats" then "--format" else flag}")
 
-    def loop(rest: Vector[String], config: Config): Either[String, Config] =
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
       rest match
-        case Vector()                                  => Right(config)
-        case Vector("--help", _*)                      => Left(usage)
-        case Vector(flag, tail*) if knownFlag(flag)    =>
-          tail.toVector match
-            case Vector()                                    => missingValue(flag)
-            case Vector(value, _*) if value.startsWith("--") => missingValue(flag)
-            case Vector(value, next*) if flag == "--seed"    =>
-              parseLong(value, flag).flatMap(seed => loop(next.toVector, config.copy(seed = seed)))
-            case Vector(value, next*) if flag == "--months"  =>
-              parseInt(value, flag).flatMap(months => loop(next.toVector, config.copy(months = months)))
-            case Vector(value, next*) if flag == "--out"     =>
-              loop(next.toVector, config.copy(out = Path.of(value)))
-            case Vector(value, next*)                        =>
-              OutputFormat.parseList(value).flatMap(formats => loop(next.toVector, config.copy(formats = formats)))
-        case Vector(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
-        case Vector(value, _*)                         => Left(s"Unexpected positional argument: $value")
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                                          => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")                       => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed"                          =>
+              parseLong(value, flag).flatMap(seed => loop(next, config.copy(seed = seed)))
+            case Seq(value, next*) if flag == "--months"                        =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--out"                           =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(value, next*) if flag == "--format" || flag == "--formats" =>
+              OutputFormat.parseList(value).flatMap(formats => loop(next, config.copy(formats = formats)))
+            case Seq(_, _*)                                                     => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
 
     loop(args, Config())
 
@@ -94,6 +95,6 @@ object SfcMatrixExport:
     Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
 
   private val usage: String =
-    "Usage: SfcMatrixExport [--seed <long>] [--months <int>] [--out <path>] [--format tex,md]"
+    "Usage: SfcMatrixExport [--seed <long>] [--months <int>] [--out <path>] [--format|--formats tex,md]"
 
 end SfcMatrixExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
@@ -63,23 +63,34 @@ object SfcMatrixExport:
           status
 
   def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] =
+      Left(s"Missing value for ${if flag == "--formats" then "--format" else flag}")
+
     def loop(rest: Vector[String], config: Config): Either[String, Config] =
       rest match
-        case Vector()                                    => Right(config)
-        case "--help" +: _                               => Left(usage)
-        case "--seed" +: value +: tail                   =>
-          parseLong(value, "--seed").flatMap(seed => loop(tail, config.copy(seed = seed)))
-        case "--months" +: value +: tail                 =>
-          parseInt(value, "--months").flatMap(months => loop(tail, config.copy(months = months)))
-        case "--out" +: value +: tail                    =>
-          loop(tail, config.copy(out = Path.of(value)))
-        case ("--format" | "--formats") +: value +: tail =>
-          OutputFormat.parseList(value).flatMap(formats => loop(tail, config.copy(formats = formats)))
-        case flag +: _ if flag.startsWith("--")          => Left(s"Unknown argument: $flag")
-        case value +: _                                  => Left(s"Unexpected positional argument: $value")
-        case other                                       => Left(s"Invalid argument list: ${other.mkString(" ")}")
+        case Vector()                           => Right(config)
+        case "--help" +: _                      => Left(usage)
+        case flag +: tail if knownFlag(flag)    =>
+          tail match
+            case Vector()                                                   => missingValue(flag)
+            case value +: _ if value.startsWith("--")                       => missingValue(flag)
+            case value +: next if flag == "--seed"                          =>
+              parseLong(value, flag).flatMap(seed => loop(next, config.copy(seed = seed)))
+            case value +: next if flag == "--months"                        =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case value +: next if flag == "--out"                           =>
+              loop(next, config.copy(out = Path.of(value)))
+            case value +: next if flag == "--format" || flag == "--formats" =>
+              OutputFormat.parseList(value).flatMap(formats => loop(next, config.copy(formats = formats)))
+            case _                                                          => Left(s"Unknown argument: $flag")
+        case flag +: _ if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case value +: _                         => Left(s"Unexpected positional argument: $value")
+        case invalid                            => Left(s"Invalid argument list: ${invalid.mkString(" ")}")
 
     loop(args, Config())
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed" || flag == "--months" || flag == "--out" || flag == "--format" || flag == "--formats"
 
   private def parseLong(value: String, name: String): Either[String, Long] =
     Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
@@ -1,0 +1,93 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidence.MatrixEvidenceBundle
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRenderers
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRenderers.OutputFormat
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.{MonthDriver, MonthRandomness}
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+
+import java.nio.file.Path
+import scala.util.Try
+
+object SfcMatrixExport:
+
+  final case class Config(
+      seed: Long = 1L,
+      months: Int = 12,
+      out: Path = Path.of("target/sfc-matrices"),
+      formats: Vector[OutputFormat] = OutputFormat.Default,
+  )
+
+  final case class ExportResult(
+      bundle: MatrixEvidenceBundle,
+      paths: Vector[Path],
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+            if !result.bundle.validation.isValid then sys.exit(1)
+
+  def run(config: Config): Either[String, ExportResult] =
+    given SimParams = SimParams.defaults
+
+    if config.months <= 0 then Left("--months must be a positive integer")
+    else
+      val initState = FlowSimulation.SimState.fromInit(WorldInit.initialize(InitRandomness.Contract.fromSeed(config.seed)))
+      val steps     = MonthDriver
+        .unfoldSteps(initState): state =>
+          Some(MonthRandomness.Contract.fromSeed(config.seed * 1000L + state.completedMonth.toLong + 1L))
+        .take(config.months)
+        .toVector
+
+      steps.lastOption match
+        case None       => Left("No simulation step was produced")
+        case Some(step) =>
+          val bundle = MatrixEvidenceBundle.fromStep(config.seed, step)
+          val paths  = SfcMatrixRenderers.writeSymbolicBundle(bundle, config.out, config.formats)
+          val status =
+            if bundle.validation.isValid then Right(ExportResult(bundle, paths))
+            else Left(s"SFC matrix validation failed; artifacts were written to ${config.out}")
+          status
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def loop(rest: Vector[String], config: Config): Either[String, Config] =
+      rest match
+        case Vector()                                    => Right(config)
+        case "--help" +: _                               => Left(usage)
+        case "--seed" +: value +: tail                   =>
+          parseLong(value, "--seed").flatMap(seed => loop(tail, config.copy(seed = seed)))
+        case "--months" +: value +: tail                 =>
+          parseInt(value, "--months").flatMap(months => loop(tail, config.copy(months = months)))
+        case "--out" +: value +: tail                    =>
+          loop(tail, config.copy(out = Path.of(value)))
+        case ("--format" | "--formats") +: value +: tail =>
+          OutputFormat.parseList(value).flatMap(formats => loop(tail, config.copy(formats = formats)))
+        case flag +: _ if flag.startsWith("--")          => Left(s"Unknown argument: $flag")
+        case value +: _                                  => Left(s"Unexpected positional argument: $value")
+        case other                                       => Left(s"Invalid argument list: ${other.mkString(" ")}")
+
+    loop(args, Config())
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private val usage: String =
+    "Usage: SfcMatrixExport [--seed <long>] [--months <int>] [--out <path>] [--format tex,md]"
+
+end SfcMatrixExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExport.scala
@@ -57,10 +57,7 @@ object SfcMatrixExport:
         case Some(step) =>
           val bundle = MatrixEvidenceBundle.fromStep(config.seed, step)
           val paths  = SfcMatrixRenderers.writeSymbolicBundle(bundle, config.out, config.formats)
-          val status =
-            if bundle.validation.isValid then Right(ExportResult(bundle, paths))
-            else Left(s"SFC matrix validation failed; artifacts were written to ${config.out}")
-          status
+          Right(ExportResult(bundle, paths))
 
   def parseArgs(args: Vector[String]): Either[String, Config] =
     def missingValue(flag: String): Left[String, Config] =
@@ -68,24 +65,22 @@ object SfcMatrixExport:
 
     def loop(rest: Vector[String], config: Config): Either[String, Config] =
       rest match
-        case Vector()                           => Right(config)
-        case "--help" +: _                      => Left(usage)
-        case flag +: tail if knownFlag(flag)    =>
-          tail match
-            case Vector()                                                   => missingValue(flag)
-            case value +: _ if value.startsWith("--")                       => missingValue(flag)
-            case value +: next if flag == "--seed"                          =>
-              parseLong(value, flag).flatMap(seed => loop(next, config.copy(seed = seed)))
-            case value +: next if flag == "--months"                        =>
-              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
-            case value +: next if flag == "--out"                           =>
-              loop(next, config.copy(out = Path.of(value)))
-            case value +: next if flag == "--format" || flag == "--formats" =>
-              OutputFormat.parseList(value).flatMap(formats => loop(next, config.copy(formats = formats)))
-            case _                                                          => Left(s"Unknown argument: $flag")
-        case flag +: _ if flag.startsWith("--") => Left(s"Unknown argument: $flag")
-        case value +: _                         => Left(s"Unexpected positional argument: $value")
-        case invalid                            => Left(s"Invalid argument list: ${invalid.mkString(" ")}")
+        case Vector()                                  => Right(config)
+        case Vector("--help", _*)                      => Left(usage)
+        case Vector(flag, tail*) if knownFlag(flag)    =>
+          tail.toVector match
+            case Vector()                                    => missingValue(flag)
+            case Vector(value, _*) if value.startsWith("--") => missingValue(flag)
+            case Vector(value, next*) if flag == "--seed"    =>
+              parseLong(value, flag).flatMap(seed => loop(next.toVector, config.copy(seed = seed)))
+            case Vector(value, next*) if flag == "--months"  =>
+              parseInt(value, flag).flatMap(months => loop(next.toVector, config.copy(months = months)))
+            case Vector(value, next*) if flag == "--out"     =>
+              loop(next.toVector, config.copy(out = Path.of(value)))
+            case Vector(value, next*)                        =>
+              OutputFormat.parseList(value).flatMap(formats => loop(next.toVector, config.copy(formats = formats)))
+        case Vector(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Vector(value, _*)                         => Left(s"Unexpected positional argument: $value")
 
     loop(args, Config())
 

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
@@ -1,0 +1,112 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidence.*
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.flows.{FlowMechanism, FlowSimulation}
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
+
+  private given SimParams = SimParams.defaults
+
+  private lazy val step =
+    val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(1L))
+    FlowSimulation.step(FlowSimulation.SimState.fromInit(init), MonthRandomness.Contract.fromSeed(1001L))
+
+  private lazy val bundle =
+    MatrixEvidenceBundle.fromStep(seed = 1L, step = step, commit = "test")
+
+  "BsmEvidence" should "derive opening and closing matrices from ledger-owned state" in {
+    val closing = bundle.closingBsm
+
+    closing.row(AssetType.DemandDeposit).amountRaw(EntitySector.Households) should not be 0L
+    closing.row(AssetType.FirmLoan).amountRaw(EntitySector.Banks) should not be 0L
+    closing.row(AssetType.GovBondHTM).amountRaw(EntitySector.Government) should be < 0L
+    closing.row(AssetType.CorpBond).amountRaw(EntitySector.Funds) should not be 0L
+    closing.row(AssetType.ForeignAsset).amountRaw(EntitySector.NBP) should not be 0L
+    closing.row(AssetType.Cash).amountRaw(EntitySector.Funds) should not be 0L
+  }
+
+  it should "validate complete financial-claim rows to zero for deterministic evidence" in {
+    val completeAssets = SfcMatrixRegistry.instruments
+      .filter(_.completeness == SfcMatrixRegistry.RowCompleteness.Complete)
+      .map(_.asset)
+
+    for
+      bsm   <- Vector(bundle.openingBsm, bundle.closingBsm)
+      asset <- completeAssets
+    do
+      withClue(s"${bsm.snapshotKind} $asset") {
+        bsm.row(asset).rowSumRaw shouldBe 0L
+      }
+  }
+
+  "TfmEvidence" should "derive transaction rows from executed batches and reconcile sector totals to the delta ledger" in {
+    val tfm = bundle.tfm
+
+    tfm.rows should not be empty
+    all(tfm.rows.map(_.rowSumRaw)) shouldBe 0L
+    tfm.rows.exists(_.contributors.nonEmpty) shouldBe true
+
+    val expectedSectorTotals = EntitySector.values.toVector.map: sector =>
+      sector -> step.execution.deltaLedger.iterator.collect { case ((`sector`, _, _), raw) =>
+        raw
+      }.sum
+
+    tfm.sectorTotals shouldBe expectedSectorTotals.toMap
+  }
+
+  it should "omit all-zero transaction rows explicitly" in {
+    val zero    = BatchedFlow.Broadcast(
+      from = EntitySector.Government,
+      fromIndex = 0,
+      to = EntitySector.Firms,
+      amounts = Array(0L),
+      targetIndices = Array(0),
+      asset = AssetType.Cash,
+      mechanism = FlowMechanism.GovPurchases,
+    )
+    val nonZero = zero.copy(amounts = Array(10L))
+
+    val evidence = TfmEvidence.fromBatches(Vector(zero, nonZero))
+
+    evidence.omittedZeroRows shouldBe 1
+    evidence.rows should have size 1
+    evidence.rows.head.rowSumRaw shouldBe 0L
+  }
+
+  "MatrixValidation" should "include SFC status and pass for deterministic evidence" in {
+    bundle.metadata.sfcStatus shouldBe "pass"
+    bundle.metadata.matrixStatus shouldBe "pass"
+    bundle.validation.isValid shouldBe true
+  }
+
+  it should "report actionable BSM, TFM, and stock-flow reconciliation perturbations" in {
+    val openingIndex = bundle.openingBsm.rows.indexWhere(_.asset == AssetType.GovBondHTM)
+    val openingRow   = bundle.openingBsm.rows(openingIndex)
+    val badOpening   = bundle.openingBsm.copy(
+      rows = bundle.openingBsm.rows.updated(
+        openingIndex,
+        openingRow.copy(cells = openingRow.cells.updated(EntitySector.Banks, openingRow.amountRaw(EntitySector.Banks) + 1L)),
+      ),
+    )
+    val bsmReport    = MatrixValidation.validate(badOpening, bundle.closingBsm, bundle.tfm, bundle.otherChanges, Right(()))
+    bsmReport.errors.exists(_.isInstanceOf[MatrixValidationError.BsmRowSumError]) shouldBe true
+
+    val tfmRow    = bundle.tfm.rows.head
+    val badTfmRow = tfmRow.copy(cells = tfmRow.cells.updated(EntitySector.Households, tfmRow.amountRaw(EntitySector.Households) + 1L))
+    val badTfm    = bundle.tfm.copy(rows = bundle.tfm.rows.updated(0, badTfmRow))
+    val tfmReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, badTfm, bundle.otherChanges, Right(()))
+    tfmReport.errors.exists(_.isInstanceOf[MatrixValidationError.TfmRowSumError]) shouldBe true
+
+    val otherCell   = bundle.otherChanges.cells.head
+    val badOther    = bundle.otherChanges.copy(cells = bundle.otherChanges.cells.updated(0, otherCell.copy(otherChangeRaw = otherCell.otherChangeRaw + 1L)))
+    val otherReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, bundle.tfm, badOther, Right(()))
+    otherReport.errors.exists(_.isInstanceOf[MatrixValidationError.StockFlowReconciliationError]) shouldBe true
+  }
+
+end SfcMatrixEvidenceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
@@ -85,7 +85,7 @@ class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
     bundle.validation.isValid shouldBe true
   }
 
-  it should "report actionable BSM, TFM, and stock-flow reconciliation perturbations" in {
+  it should "report actionable BSM and TFM perturbations" in {
     val openingIndex = bundle.openingBsm.rows.indexWhere(_.asset == AssetType.GovBondHTM)
     val openingRow   = bundle.openingBsm.rows(openingIndex)
     val badOpening   = bundle.openingBsm.copy(
@@ -94,19 +94,14 @@ class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
         openingRow.copy(cells = openingRow.cells.updated(EntitySector.Banks, openingRow.amountRaw(EntitySector.Banks) + 1L)),
       ),
     )
-    val bsmReport    = MatrixValidation.validate(badOpening, bundle.closingBsm, bundle.tfm, bundle.otherChanges, Right(()))
+    val bsmReport    = MatrixValidation.validate(badOpening, bundle.closingBsm, bundle.tfm, Right(()))
     bsmReport.errors.exists(_.isInstanceOf[MatrixValidationError.BsmRowSumError]) shouldBe true
 
     val tfmRow    = bundle.tfm.rows.head
     val badTfmRow = tfmRow.copy(cells = tfmRow.cells.updated(EntitySector.Households, tfmRow.amountRaw(EntitySector.Households) + 1L))
     val badTfm    = bundle.tfm.copy(rows = bundle.tfm.rows.updated(0, badTfmRow))
-    val tfmReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, badTfm, bundle.otherChanges, Right(()))
+    val tfmReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, badTfm, Right(()))
     tfmReport.errors.exists(_.isInstanceOf[MatrixValidationError.TfmRowSumError]) shouldBe true
-
-    val otherCell   = bundle.otherChanges.cells.head
-    val badOther    = bundle.otherChanges.copy(cells = bundle.otherChanges.cells.updated(0, otherCell.copy(otherChangeRaw = otherCell.otherChangeRaw + 1L)))
-    val otherReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, bundle.tfm, badOther, Right(()))
-    otherReport.errors.exists(_.isInstanceOf[MatrixValidationError.StockFlowReconciliationError]) shouldBe true
   }
 
 end SfcMatrixEvidenceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixEvidenceSpec.scala
@@ -60,7 +60,7 @@ class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
     tfm.sectorTotals shouldBe expectedSectorTotals.toMap
   }
 
-  it should "omit all-zero transaction rows explicitly" in {
+  it should "count all-zero batches separately from omitted transaction rows" in {
     val zero    = BatchedFlow.Broadcast(
       from = EntitySector.Government,
       fromIndex = 0,
@@ -74,9 +74,36 @@ class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
 
     val evidence = TfmEvidence.fromBatches(Vector(zero, nonZero))
 
-    evidence.omittedZeroRows shouldBe 1
+    evidence.omittedZeroBatches shouldBe 1
+    evidence.omittedZeroRows shouldBe 0
+    evidence.droppedRows shouldBe empty
     evidence.rows should have size 1
     evidence.rows.head.rowSumRaw shouldBe 0L
+  }
+
+  it should "retain provenance for rows that net to zero after aggregation" in {
+    val govToFirm = BatchedFlow.Broadcast(
+      from = EntitySector.Government,
+      fromIndex = 0,
+      to = EntitySector.Firms,
+      amounts = Array(10L),
+      targetIndices = Array(0),
+      asset = AssetType.Cash,
+      mechanism = FlowMechanism.GovPurchases,
+    )
+    val firmToGov = govToFirm.copy(
+      from = EntitySector.Firms,
+      to = EntitySector.Government,
+    )
+
+    val evidence = TfmEvidence.fromBatches(Vector(govToFirm, firmToGov))
+
+    evidence.omittedZeroBatches shouldBe 0
+    evidence.omittedZeroRows shouldBe 1
+    evidence.rows shouldBe empty
+    evidence.droppedRows should have size 1
+    evidence.droppedRows.head.contributors should have size 2
+    evidence.droppedRows.head.cells shouldBe empty
   }
 
   "MatrixValidation" should "include SFC status and pass for deterministic evidence" in {
@@ -102,6 +129,10 @@ class SfcMatrixEvidenceSpec extends AnyFlatSpec with Matchers:
     val badTfm    = bundle.tfm.copy(rows = bundle.tfm.rows.updated(0, badTfmRow))
     val tfmReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, badTfm, Right(()))
     tfmReport.errors.exists(_.isInstanceOf[MatrixValidationError.TfmRowSumError]) shouldBe true
+
+    val nonRegistryTfm    = bundle.tfm.copy(droppedNonRegistrySectors = Vector(EntitySector.Foreign))
+    val nonRegistryReport = MatrixValidation.validate(bundle.openingBsm, bundle.closingBsm, nonRegistryTfm, Right(()))
+    nonRegistryReport.errors.exists(_.isInstanceOf[MatrixValidationError.TfmNonRegistrySectorError]) shouldBe true
   }
 
 end SfcMatrixEvidenceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRegistrySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRegistrySpec.scala
@@ -1,0 +1,48 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.engine.flows.FlowMechanism
+import com.boombustgroup.amorfati.engine.ledger.RuntimeMechanismSurvivability
+import com.boombustgroup.ledger.{AssetType, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SfcMatrixRegistrySpec extends AnyFlatSpec with Matchers:
+
+  "SfcMatrixRegistry" should "classify every public sector, asset, and emitted mechanism" in {
+    SfcMatrixRegistry.sectors.map(_.sector).toSet shouldBe EntitySector.values.toSet
+    SfcMatrixRegistry.instruments.map(_.asset).toSet shouldBe AssetType.values.toSet
+    SfcMatrixRegistry.mechanisms.map(_.mechanism.toInt).toSet shouldBe FlowMechanism.emittedRuntimeMechanisms.map(_.toInt)
+  }
+
+  it should "preserve the Poland-facing sector order" in {
+    SfcMatrixRegistry.sectors.map(_.sector) shouldBe Vector(
+      EntitySector.Households,
+      EntitySector.Firms,
+      EntitySector.Banks,
+      EntitySector.Government,
+      EntitySector.NBP,
+      EntitySector.Insurance,
+      EntitySector.Funds,
+      EntitySector.Foreign,
+    )
+  }
+
+  it should "declare complete rows only for supported holder-issuer slices" in {
+    import SfcMatrixRegistry.RowCompleteness.*
+
+    SfcMatrixRegistry.instrument(AssetType.FirmLoan).completeness shouldBe ClassifiedGap
+    SfcMatrixRegistry.instrument(AssetType.ConsumerLoan).completeness shouldBe ClassifiedGap
+    SfcMatrixRegistry.instrument(AssetType.GovBondHTM).completeness shouldBe Complete
+    SfcMatrixRegistry.instrument(AssetType.CorpBond).completeness shouldBe Complete
+    SfcMatrixRegistry.instrument(AssetType.MortgageLoan).completeness shouldBe ClassifiedGap
+    SfcMatrixRegistry.instrument(AssetType.StandingFacility).completeness shouldBe Excluded
+  }
+
+  it should "carry runtime survivability metadata for mechanism rows" in {
+    SfcMatrixRegistry.mechanism(FlowMechanism.GovBondPrimaryMarket).survivability shouldBe
+      RuntimeMechanismSurvivability.Classification.RoundTrippableStock
+    SfcMatrixRegistry.mechanism(FlowMechanism.BankFirmInterest).survivability shouldBe
+      RuntimeMechanismSurvivability.Classification.UnsupportedOrMetricOnly
+  }
+
+end SfcMatrixRegistrySpec

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderersSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderersSpec.scala
@@ -18,17 +18,16 @@ class SfcMatrixRenderersSpec extends AnyFlatSpec with Matchers:
     val step = FlowSimulation.step(FlowSimulation.SimState.fromInit(init), MonthRandomness.Contract.fromSeed(1001L))
     MatrixEvidenceBundle.fromStep(seed = 1L, step = step, commit = "renderer-test")
 
-  "SfcMatrixRenderers" should "escape LaTeX labels and format raw PLN deterministically" in {
+  "SfcMatrixRenderers" should "escape LaTeX labels deterministically" in {
     SfcMatrixRenderers.escapeLatex("A&B_%$#{}~^") should include("\\&")
     SfcMatrixRenderers.escapeLatex("A&B_%$#{}~^") should include("\\_")
-    SfcMatrixRenderers.formatPLN(1234567L) shouldBe "PLN 123.4567"
   }
 
   it should "render symbolic LaTeX and Markdown artifacts with runtime mapping" in {
     val artifacts = SfcMatrixRenderers.renderSymbolicBundle(bundle, OutputFormat.Default)
     val byName    = artifacts.map(artifact => artifact.relativePath -> artifact.contents).toMap
 
-    byName.keySet should contain allOf (
+    byName.keySet shouldBe Set(
       "symbolic-bsm.tex",
       "symbolic-bsm.md",
       "symbolic-tfm.tex",
@@ -43,16 +42,12 @@ class SfcMatrixRenderersSpec extends AnyFlatSpec with Matchers:
     byName("symbolic-tfm.md") should include("Consumption")
     byName("matrix-mapping.md") should include("Demand deposits")
     byName("matrix-mapping.md") should include("Household consumption")
-    byName.keySet.exists(_.endsWith(".csv")) shouldBe false
-    byName.keySet.exists(_.endsWith(".json")) shouldBe false
   }
 
   it should "parse output format lists and reject unknown formats" in {
     OutputFormat.parseList("latex,md") shouldBe Right(OutputFormat.Default)
     OutputFormat.parseList("tex") shouldBe Right(Vector(OutputFormat.Latex))
     OutputFormat.parseList("markdown") shouldBe Right(Vector(OutputFormat.Markdown))
-    OutputFormat.parseList("csv").isLeft shouldBe true
-    OutputFormat.parseList("json").isLeft shouldBe true
     OutputFormat.parseList("yaml").isLeft shouldBe true
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderersSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/accounting/matrix/SfcMatrixRenderersSpec.scala
@@ -1,0 +1,59 @@
+package com.boombustgroup.amorfati.accounting.matrix
+
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidence.MatrixEvidenceBundle
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRenderers.OutputFormat
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthRandomness
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SfcMatrixRenderersSpec extends AnyFlatSpec with Matchers:
+
+  private given SimParams = SimParams.defaults
+
+  private lazy val bundle =
+    val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(1L))
+    val step = FlowSimulation.step(FlowSimulation.SimState.fromInit(init), MonthRandomness.Contract.fromSeed(1001L))
+    MatrixEvidenceBundle.fromStep(seed = 1L, step = step, commit = "renderer-test")
+
+  "SfcMatrixRenderers" should "escape LaTeX labels and format raw PLN deterministically" in {
+    SfcMatrixRenderers.escapeLatex("A&B_%$#{}~^") should include("\\&")
+    SfcMatrixRenderers.escapeLatex("A&B_%$#{}~^") should include("\\_")
+    SfcMatrixRenderers.formatPLN(1234567L) shouldBe "PLN 123.4567"
+  }
+
+  it should "render symbolic LaTeX and Markdown artifacts with runtime mapping" in {
+    val artifacts = SfcMatrixRenderers.renderSymbolicBundle(bundle, OutputFormat.Default)
+    val byName    = artifacts.map(artifact => artifact.relativePath -> artifact.contents).toMap
+
+    byName.keySet should contain allOf (
+      "symbolic-bsm.tex",
+      "symbolic-bsm.md",
+      "symbolic-tfm.tex",
+      "symbolic-tfm.md",
+      "matrix-mapping.tex",
+      "matrix-mapping.md",
+    )
+
+    byName("symbolic-bsm.tex") should include("\\begin{tabular}")
+    byName("symbolic-bsm.tex") should include("$+D_h$")
+    byName("symbolic-tfm.md") should include("| Flow \\\\ Sector |")
+    byName("symbolic-tfm.md") should include("Consumption")
+    byName("matrix-mapping.md") should include("Demand deposits")
+    byName("matrix-mapping.md") should include("Household consumption")
+    byName.keySet.exists(_.endsWith(".csv")) shouldBe false
+    byName.keySet.exists(_.endsWith(".json")) shouldBe false
+  }
+
+  it should "parse output format lists and reject unknown formats" in {
+    OutputFormat.parseList("latex,md") shouldBe Right(OutputFormat.Default)
+    OutputFormat.parseList("tex") shouldBe Right(Vector(OutputFormat.Latex))
+    OutputFormat.parseList("markdown") shouldBe Right(Vector(OutputFormat.Markdown))
+    OutputFormat.parseList("csv").isLeft shouldBe true
+    OutputFormat.parseList("json").isLeft shouldBe true
+    OutputFormat.parseList("yaml").isLeft shouldBe true
+  }
+
+end SfcMatrixRenderersSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
@@ -1,0 +1,41 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRenderers.OutputFormat
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+
+class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
+
+  "SfcMatrixExport" should "parse CLI arguments" in {
+    val parsed = SfcMatrixExport.parseArgs(
+      Vector("--seed", "7", "--months", "3", "--out", "target/sfc-export-parse", "--format", "md,tex"),
+    )
+
+    parsed.map(config => (config.seed, config.months, config.out, config.formats)) shouldBe
+      Right((7L, 3, Path.of("target/sfc-export-parse"), Vector(OutputFormat.Markdown, OutputFormat.Latex)))
+  }
+
+  it should "reject CSV and JSON matrix formats" in {
+    SfcMatrixExport.parseArgs(Vector("--format", "csv")).isLeft shouldBe true
+    SfcMatrixExport.parseArgs(Vector("--format", "json")).isLeft shouldBe true
+  }
+
+  it should "write generated artifacts under the requested output directory" in {
+    Files.createDirectories(Path.of("target"))
+    val out = Files.createTempDirectory(Path.of("target"), "sfc-export-spec-")
+
+    val result = SfcMatrixExport.run(
+      SfcMatrixExport.Config(seed = 1L, months = 1, out = out, formats = Vector(OutputFormat.Markdown)),
+    )
+
+    result.isRight shouldBe true
+    Files.exists(out.resolve("symbolic-bsm.md")) shouldBe true
+    Files.exists(out.resolve("symbolic-tfm.md")) shouldBe true
+    Files.exists(out.resolve("matrix-mapping.md")) shouldBe true
+    Files.exists(out.resolve("symbolic-bsm.csv")) shouldBe false
+    Files.exists(out.resolve("metadata.json")) shouldBe false
+  }
+
+end SfcMatrixExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
@@ -17,9 +17,8 @@ class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
       Right((7L, 3, Path.of("target/sfc-export-parse"), Vector(OutputFormat.Markdown, OutputFormat.Latex)))
   }
 
-  it should "reject CSV and JSON matrix formats" in {
-    SfcMatrixExport.parseArgs(Vector("--format", "csv")).isLeft shouldBe true
-    SfcMatrixExport.parseArgs(Vector("--format", "json")).isLeft shouldBe true
+  it should "reject unsupported matrix formats" in {
+    SfcMatrixExport.parseArgs(Vector("--format", "pdf")).isLeft shouldBe true
   }
 
   it should "write generated artifacts under the requested output directory" in {
@@ -31,11 +30,14 @@ class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
     )
 
     result.isRight shouldBe true
+    result.toOption.get.paths.map(_.getFileName.toString).toSet shouldBe Set(
+      "symbolic-bsm.md",
+      "symbolic-tfm.md",
+      "matrix-mapping.md",
+    )
     Files.exists(out.resolve("symbolic-bsm.md")) shouldBe true
     Files.exists(out.resolve("symbolic-tfm.md")) shouldBe true
     Files.exists(out.resolve("matrix-mapping.md")) shouldBe true
-    Files.exists(out.resolve("symbolic-bsm.csv")) shouldBe false
-    Files.exists(out.resolve("metadata.json")) shouldBe false
   }
 
 end SfcMatrixExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
 
 class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
 
@@ -21,23 +22,44 @@ class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
     SfcMatrixExport.parseArgs(Vector("--format", "pdf")).isLeft shouldBe true
   }
 
+  it should "report missing values for recognized flags" in {
+    SfcMatrixExport.parseArgs(Vector("--seed")) shouldBe Left("Missing value for --seed")
+    SfcMatrixExport.parseArgs(Vector("--months")) shouldBe Left("Missing value for --months")
+    SfcMatrixExport.parseArgs(Vector("--out")) shouldBe Left("Missing value for --out")
+    SfcMatrixExport.parseArgs(Vector("--format")) shouldBe Left("Missing value for --format")
+    SfcMatrixExport.parseArgs(Vector("--seed", "--months", "3")) shouldBe Left("Missing value for --seed")
+  }
+
   it should "write generated artifacts under the requested output directory" in {
     Files.createDirectories(Path.of("target"))
     val out = Files.createTempDirectory(Path.of("target"), "sfc-export-spec-")
 
-    val result = SfcMatrixExport.run(
-      SfcMatrixExport.Config(seed = 1L, months = 1, out = out, formats = Vector(OutputFormat.Markdown)),
-    )
+    try {
+      val result       = SfcMatrixExport.run(
+        SfcMatrixExport.Config(seed = 1L, months = 1, out = out, formats = Vector(OutputFormat.Markdown)),
+      )
+      val exportResult = result.fold(err => fail(err), identity)
 
-    result.isRight shouldBe true
-    result.toOption.get.paths.map(_.getFileName.toString).toSet shouldBe Set(
-      "symbolic-bsm.md",
-      "symbolic-tfm.md",
-      "matrix-mapping.md",
-    )
-    Files.exists(out.resolve("symbolic-bsm.md")) shouldBe true
-    Files.exists(out.resolve("symbolic-tfm.md")) shouldBe true
-    Files.exists(out.resolve("matrix-mapping.md")) shouldBe true
+      exportResult.paths.map(_.getFileName.toString).toSet shouldBe Set(
+        "symbolic-bsm.md",
+        "symbolic-tfm.md",
+        "matrix-mapping.md",
+      )
+      Files.exists(out.resolve("symbolic-bsm.md")) shouldBe true
+      Files.exists(out.resolve("symbolic-tfm.md")) shouldBe true
+      Files.exists(out.resolve("matrix-mapping.md")) shouldBe true
+      Files.exists(out.resolve("symbolic-bsm.tex")) shouldBe false
+      Files.exists(out.resolve("symbolic-tfm.tex")) shouldBe false
+      Files.exists(out.resolve("matrix-mapping.tex")) shouldBe false
+    } finally deleteRecursively(out)
   }
+
+  private def deleteRecursively(path: Path): Unit =
+    if Files.exists(path) then
+      val stream = Files.walk(path)
+      try
+        val paths = stream.iterator().asScala.toVector.sortBy(_.getNameCount).reverse
+        paths.foreach(Files.deleteIfExists)
+      finally stream.close()
 
 end SfcMatrixExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/SfcMatrixExportSpec.scala
@@ -16,6 +16,9 @@ class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
 
     parsed.map(config => (config.seed, config.months, config.out, config.formats)) shouldBe
       Right((7L, 3, Path.of("target/sfc-export-parse"), Vector(OutputFormat.Markdown, OutputFormat.Latex)))
+
+    SfcMatrixExport.parseArgs(Vector("--formats", "md")).map(_.formats) shouldBe
+      Right(Vector(OutputFormat.Markdown))
   }
 
   it should "reject unsupported matrix formats" in {
@@ -27,7 +30,14 @@ class SfcMatrixExportSpec extends AnyFlatSpec with Matchers:
     SfcMatrixExport.parseArgs(Vector("--months")) shouldBe Left("Missing value for --months")
     SfcMatrixExport.parseArgs(Vector("--out")) shouldBe Left("Missing value for --out")
     SfcMatrixExport.parseArgs(Vector("--format")) shouldBe Left("Missing value for --format")
+    SfcMatrixExport.parseArgs(Vector("--formats")) shouldBe Left("Missing value for --format")
     SfcMatrixExport.parseArgs(Vector("--seed", "--months", "3")) shouldBe Left("Missing value for --seed")
+  }
+
+  it should "document format aliases in help output" in {
+    SfcMatrixExport.parseArgs(Vector("--help")) match
+      case Left(help) => help should include("--format|--formats")
+      case Right(_)   => fail("Expected --help to return usage text")
   }
 
   it should "write generated artifacts under the requested output directory" in {


### PR DESCRIPTION
## Summary
- Add ledger-derived SFC matrix registry and validation/reconciliation checks.
- Add symbolic Balance Sheet Matrix (BSM) and Transactions Flow Matrix (TFM) renderers that write LaTeX and Markdown artifacts.
- Add symbolic-row to runtime-ledger mapping, SfcMatrixExport, the sbt sfcMatrices task, docs, and focused tests.

## Scope note
- The GitHub issue text still mentions CSV/JSON, but the final requested scope is tex/md artifacts for Balance Sheet Matrix (BSM), Transactions Flow Matrix (TFM), and mapping.
- The mapping LaTeX artifact uses longtable so it can break across pages.

## Closes
Closes #420
Closes #421
Closes #422
Closes #423
Closes #424
Closes #425
Closes #426
Closes #427

## Verification
- sbt Test/compile
- sbt testOnly com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRegistrySpec com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidenceSpec com.boombustgroup.amorfati.accounting.matrix.SfcMatrixRenderersSpec com.boombustgroup.amorfati.diagnostics.SfcMatrixExportSpec
- sbt runMain com.boombustgroup.amorfati.diagnostics.SfcMatrixExport --seed 1 --months 12 --out target/sfc-matrices-symbolic-final --format tex,md
- pdflatex smoke compile of generated BSM, TFM, and mapping fragments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI export to generate symbolic SFC artifacts (BSM, TFM, and mapping) in LaTeX and Markdown; writes outputs to a target directory and reports validation status.

* **Documentation**
  * Added user guide for regenerating matrices, expected artifact formats, sign conventions, sector ordering, known coverage notes, and an export/validation checklist.

* **Tests**
  * New deterministic tests covering evidence generation, registry completeness, rendering/format parsing, and CLI argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->