### PR TITLE
Add ODD and ODD+D model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ That is the hard floor under every experiment in the model. Behavioral rules, po
 - [Core Invariants](#core-invariants)
 - [State Ontology](#state-ontology)
 - [Verified Ledger](#verified-ledger)
+- [Model Documentation](#model-documentation)
 - [Ledger-Derived Matrix Artifacts](#ledger-derived-matrix-artifacts)
 - [Tech Stack](#tech-stack)
 - [License](#license)
@@ -99,6 +100,10 @@ The simulation pipeline is anchored to the verified [amor-fati-ledger](https://g
 This is why Amor Fati is useful even when the long-run path is still being calibrated. If a branch generates a bad macro regime, that may be a modeling problem. If the ledger breaks, the simulation itself is wrong.
 
 That distinction matters. A nonlinear ABM can explore unstable, surprising, even pathological futures. But it should never "lose money" in the plumbing.
+
+## Model Documentation
+
+The paper-facing ODD / ODD+D model description is documented in [docs/odd-model-documentation.md](docs/odd-model-documentation.md). It covers purpose, entities, state variables, scales, scheduling, design concepts, initialization, inputs, submodels, observation surfaces, decision-making notes, and open research-readiness gaps.
 
 ## Ledger-Derived Matrix Artifacts
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ That distinction matters. A nonlinear ABM can explore unstable, surprising, even
 
 The paper-facing ODD / ODD+D model description is documented in [docs/odd-model-documentation.md](docs/odd-model-documentation.md). It covers purpose, entities, state variables, scales, scheduling, design concepts, initialization, inputs, submodels, observation surfaces, decision-making notes, and open research-readiness gaps.
 
+The detailed behavioral equations and institutional decision rules are documented in [docs/behavioral-equations-and-decision-rules.md](docs/behavioral-equations-and-decision-rules.md). It links household, firm, bank, fiscal, monetary, external, insurance, NBFI, quasi-fiscal, and JST rules to implementation modules and numeric output columns.
+
+The calibration register is documented in [docs/calibration-register.md](docs/calibration-register.md). It records key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and explicit searchable gaps.
+
+The empirical validation report skeleton is documented in [docs/empirical-validation-report.md](docs/empirical-validation-report.md). It maps macro, meso, micro, financial, and external validation targets to Monte Carlo output columns and keeps missing data/output gaps visible.
+
+The sensitivity and robustness workflow is documented in [docs/sensitivity-robustness-workflow.md](docs/sensitivity-robustness-workflow.md). It generates seed envelopes and one-at-a-time parameter-sensitivity artifacts from the Monte Carlo runner.
+
+The reproducible scenario registry is documented in [docs/scenario-registry.md](docs/scenario-registry.md). It defines named policy and shock scenarios, exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path.
+
 ## Ledger-Derived Matrix Artifacts
 
 The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import complete.DefaultParsers.spaceDelimited
 lazy val ledger = ProjectRef(file("modules/ledger"), "root")
 
 lazy val sfcMatrices = inputKey[Unit]("Generate symbolic SFC BSM/TFM matrix artifacts")
+lazy val robustnessReport = inputKey[Unit]("Generate lightweight sensitivity and robustness artifacts")
+lazy val scenarioRun = inputKey[Unit]("Run named scenario-registry experiments")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -56,6 +58,20 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<sfc matrix args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.SfcMatrixExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    robustnessReport := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<robustness args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    scenarioRun := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<scenario args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.ScenarioRunExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -1,0 +1,958 @@
+# Behavioral Equations And Decision Rules
+
+This document is the paper-facing rule book for Amor Fati's current
+SFC-ABM implementation. It describes implemented equations and algorithmic
+rules, not a normative target model.
+
+The document complements:
+
+- `docs/odd-model-documentation.md`, which describes the model using the ODD
+  and ODD+D structure;
+- `docs/sfc-matrix-evidence.md`, which documents the symbolic Balance Sheet
+  Matrix (BSM) and Transactions Flow Matrix (TFM) evidence.
+
+## Scope And Notation
+
+All monetary quantities are PLN unless noted otherwise. Rates are annual unless
+the implementation explicitly applies `.monthly`. Shares are dimensionless
+values in `[0, 1]`. The runtime ledger owns supported financial stocks; agent
+modules receive projections of those stocks, compute decisions, and return
+closing projections plus flow variables.
+
+Useful shorthand:
+
+| Symbol | Meaning |
+| --- | --- |
+| `h` | household |
+| `f` | firm |
+| `b` | bank |
+| `s` | production sector |
+| `Y` | output or revenue proxy, depending on context |
+| `K` | physical capital stock |
+| `L` | labor input or loan stock, depending on context |
+| `DR` | firm digital readiness |
+| `NPL` | non-performing loan stock or ratio |
+| `CAR` | capital adequacy ratio |
+| `LCR` | liquidity coverage ratio |
+| `NSFR` | net stable funding ratio |
+
+The output-column references below refer to the Monte Carlo time-series schema
+in `src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala`.
+Those CSV outputs are the primary numeric evidence surface for these rules.
+
+## Timing Contract
+
+One model month follows the deterministic economics pipeline below, then emits
+runtime ledger flows and validates SFC identities.
+
+| Stage | Module | Rule surface |
+| --- | --- | --- |
+| s1 | `engine/economics/FiscalConstraintEconomics.scala` | minimum wage, reservation wage, lending base rate |
+| s2 | `engine/economics/LaborEconomics.scala` | wage clearing, employment, immigration, demographics |
+| s3 | `engine/economics/HouseholdIncomeEconomics.scala` and `agents/Household.scala` | household income, consumption, saving, credit, retraining, bankruptcy |
+| s4 | `engine/economics/DemandEconomics.scala` | sector demand, government purchases, fiscal-rule constraint |
+| s5 | `engine/economics/FirmEconomics.scala` and `agents/Firm.scala` | production, pricing markup contribution, technology, labor, investment, defaults, entry |
+| s6 | `engine/economics/HouseholdFinancialEconomics.scala` | mortgages, deposit interest, remittances, tourism, consumer credit aggregation |
+| s7 | `engine/economics/PriceEquityEconomics.scala` | GDP proxy, inflation, equity, macroprudential, EU funds |
+| s8 | `engine/economics/OpenEconEconomics.scala` | external sector, NBP rate, bond yield, QE, insurance, NBFI |
+| s9 | `engine/economics/BankingEconomics.scala` and `agents/Banking.scala` | bank P&L, rates, interbank, bond waterfall, failure and resolution |
+
+## Rule-To-Output Map
+
+| Rule group | Main implementation anchors | Representative output columns |
+| --- | --- | --- |
+| Household income, consumption, savings, credit | `agents/Household.scala`, `engine/economics/HouseholdIncomeEconomics.scala`, `engine/economics/HouseholdFinancialEconomics.scala` | `MarketWage`, `Unemployment`, `EffectivePitRate`, `ConsumerLoans`, `ConsumerOrigination`, `ConsumerDebtService`, `SectorMobilityRate`, `VoluntaryQuits`, `DiasporaRemittanceInflow`, `RemittanceOutflow`, `TourismExport`, `TourismImport` |
+| Labor, wages, demographics, social funds | `engine/economics/LaborEconomics.scala`, `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` | `MarketWage`, `Unemployment`, `WorkingAgePop`, `NRetirees`, `MonthlyRetirements`, `ZusContributions`, `ZusPensionPayments`, `NfzContributions`, `NfzSpending`, `PpkContributions`, `FpContributions`, `FgspSpending` |
+| Demand allocation and fiscal constraint | `engine/economics/DemandEconomics.scala`, `engine/markets/FiscalRules.scala`, `engine/markets/FiscalBudget.scala` | `GovCurrentSpend`, `GovCapitalSpendDomestic`, `FiscalRuleBinding`, `GovSpendingCutRatio`, `DebtToGdp`, `DeficitToGdp`, `PublicCapitalStock` |
+| Firm production, investment, technology, financing, default, entry | `agents/Firm.scala`, `engine/economics/FirmEconomics.scala`, `engine/mechanisms/FirmEntry.scala` | `TotalAdoption`, `AutoRatio`, `HybridRatio`, sector `*_Auto`, sector `*_Sigma`, `GrossInvestment`, `AggCapitalStock`, `AggInventoryStock`, `InventoryChange`, `AggEnergyCost`, `GreenInvestment`, `FirmBirths`, `FirmDeaths`, `NetEntry`, `LivingFirmCount`, `CorpBondIssuance`, `EquityIssuanceTotal` |
+| Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
+| Fiscal, NBP, bond market, external sector | `agents/Nbp.scala`, `engine/markets/OpenEconomy.scala`, `engine/economics/OpenEconEconomics.scala`, `engine/markets/CorporateBondMarket.scala`, `engine/markets/BondAuction.scala` | `RefRate`, `BondYield`, `WeightedCoupon`, `BondsOutstanding`, `NbpBondHoldings`, `ForeignBondHoldings`, `QeActive`, `FxReserves`, `FxInterventionAmt`, `CurrentAccount`, `CapitalAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NFA`, `FDI` |
+| Insurance, NBFI, quasi-fiscal, local government | `agents/Insurance.scala`, `agents/Nbfi.scala`, `agents/QuasiFiscal.scala`, `agents/Jst.scala` | `InsLifeReserves`, `InsNonLifeReserves`, `InsLifePremium`, `InsNonLifePremium`, `InsLifeClaims`, `InsNonLifeClaims`, `NbfiTfiAum`, `NbfiOrigination`, `NbfiDefaults`, `NbfiBankTightness`, `QfBondsOutstanding`, `QfIssuance`, `QfLoanPortfolio`, `Esa2010DebtToGdp`, `JstRevenue`, `JstSpending`, `JstDebt`, `JstDeposits` |
+
+## Household Rules
+
+Implementation anchors:
+
+- `agents/Household.scala`
+- `engine/economics/HouseholdIncomeEconomics.scala`
+- `engine/economics/HouseholdFinancialEconomics.scala`
+
+### State And Status
+
+Each household carries:
+
+- employment status: `Employed(firmId, sectorIdx, wage)`, `Unemployed(months)`,
+  `Retraining(monthsLeft, targetSector, cost)`, or `Bankrupt`;
+- behavioral traits: skill, health penalty, marginal propensity to consume
+  (MPC), social-neighbor ids, education, task routineness, wage scar,
+  dependent children, contract type, region, immigrant status;
+- bank routing id;
+- projected ledger financial stocks: demand deposit, mortgage loan, consumer
+  loan, and listed equity.
+
+### Income, Tax, Transfers
+
+For a household `h`, monthly base income is:
+
+```text
+baseIncome_h =
+  wage_h                         if employed
+  unemploymentBenefit(months_h)   if unemployed
+  0                               if retraining or bankrupt
+```
+
+Deposit interest is paid on demand deposits using the household's bank deposit
+rate when bank-specific rates are available:
+
+```text
+depositInterest_h = demandDeposit_h * depositRate_b.monthly
+```
+
+Monthly PIT is progressive and annualized in the household module:
+
+```text
+pitBase_h = grossIncome_h - employeeZus_h
+annualizedBase_h = 12 * pitBase_h
+pit_h = max(grossTax(annualizedBase_h) - annualTaxCredit, 0) / 12
+```
+
+The current social-transfer rule is a lump-sum 800+ payment:
+
+```text
+socialTransfer_h = dependentChildren_h * social800
+income_h = grossIncome_h - pit_h + socialTransfer_h
+```
+
+### Consumption, Saving, And Wealth Effects
+
+Mortgage debt service is variable-rate when bank-specific lending rates are
+available:
+
+```text
+mortgageDebtService_h =
+  mortgageLoan_h * (baseAmortRate + lendingRate_b.monthly)
+```
+
+Immigrant households send remittances:
+
+```text
+remittance_h = income_h * immigration.remitRate
+```
+
+The disposable budget is computed after rent, secured debt service, remittance,
+and consumer-credit service:
+
+```text
+obligations_h = rent_h + mortgageDebtService_h + remittance_h
+disposablePreCredit_h = max(income_h - obligations_h, 0)
+consumerCredit_h = consumerCreditRule(...)
+fullObligations_h = obligations_h + consumerCreditDebtService_h
+disposable_h = max(income_h - fullObligations_h, 0)
+savingsDrawdown_h = savingsBufferDrawdown(...)
+consumptionBudget_h = disposable_h + newConsumerLoan_h + savingsDrawdown_h
+baseConsumption_h = mpc_h * consumptionBudget_h
+```
+
+If more than the neighbor-distress threshold of social neighbors are bankrupt
+or unemployed, the household applies a precautionary consumption multiplier.
+Positive equity revaluation and housing wealth effects then add to consumption.
+
+Closing demand deposits are:
+
+```text
+demandDeposit'_h =
+  demandDeposit_h + income_h - fullObligations_h + newConsumerLoan_h
+  - consumption_h - retrainingCost_h
+```
+
+### MPC Adaptation
+
+The state-dependent MPC follows a buffer-stock rule:
+
+```text
+targetSavings_h = income_h * bufferTargetMonths
+bufferRatio_h = demandDeposit_h / targetSavings_h
+deviation_h = bufferRatio_h - 1
+bufferAdj_h = clamp(1 - bufferSensitivity * deviation_h, 0, 1)
+unemployedAdj_h = 1 + mpcUnemployedBoost if unemployed else 1
+mpc'_h = clamp(mpc_h * bufferAdj_h * unemployedAdj_h, MpcFloor, MpcCeiling)
+```
+
+Savings drawdown is more aggressive for unemployed or retraining households,
+but still keeps a protected buffer floor.
+
+### Consumer Credit
+
+Consumer credit is available only to employed households. A household is
+eligible when disposable income is stressed relative to wage, a stochastic
+eligibility draw succeeds, and the resulting debt-service-to-income ratio has
+room below `ccMaxDti`:
+
+```text
+stressed_h = disposablePreCredit_h < wage_h * DisposableWageThreshold
+headroom_h = income_h * max(ccMaxDti - existingDti_h, 0)
+newConsumerLoan_h = min(headroom_h, ccMaxLoan) if eligible else 0
+```
+
+Consumer-loan service is:
+
+```text
+consumerDebtService_h =
+  consumerLoan_h * (ccAmortRate + (lendingRate_b + ccSpread).monthly)
+```
+
+Household bankruptcy writes off the remaining unsecured consumer loan stock and
+sets household equity to zero.
+
+### Labor Mobility, Retraining, And Bankruptcy
+
+Employed households may voluntarily search across sectors. The target sector is
+selected from sector wage and vacancy signals, adjusted by a friction matrix.
+If friction is low, the household quits into unemployment; if friction is high
+and deposits cover the retraining cost, the household enters retraining.
+
+Unemployed households become retraining-eligible after the unemployment
+threshold. Retraining success depends on skill, health penalty, education, and
+sectoral friction:
+
+```text
+successProb_h =
+  retrainingBaseSuccess * skill_h * (1 - healthPenalty_h)
+  * educationMultiplier_h * (1 - friction * frictionSuccessDiscount)
+```
+
+Long unemployment reduces skill, increases health penalty, and accumulates a
+wage scar. Re-employment decays the wage scar gradually.
+
+Financial distress is tracked as consecutive months with savings below a
+bankruptcy floor:
+
+```text
+bankruptcyFloor_h =
+  max(rent_h + mortgageDebtService_h + consumerDebtService_h, rent_h)
+  * bankruptcyThreshold
+```
+
+After `bankruptcyDistressMonths`, the household enters the absorbing bankrupt
+state.
+
+## Labor, Demographics, And Social Funds
+
+Implementation anchors:
+
+- `engine/economics/FiscalConstraintEconomics.scala`
+- `engine/economics/LaborEconomics.scala`
+- `engine/markets/LaborMarket.scala`
+- `engine/markets/RegionalClearing.scala`
+- `agents/SocialSecurity.scala`
+- `agents/EarmarkedFunds.scala`
+
+### Minimum Wage And Reservation Wage
+
+On configured adjustment months, the minimum wage is indexed to cumulative
+inflation since the last adjustment and partially converges toward a target
+share of the market wage:
+
+```text
+inflIndexed = previousMinWage * (1 + max(cumulativeInflation, 0))
+targetMinWage = marketWage * minWageTargetRatio
+newMinWage = max(previousMinWage,
+                 inflIndexed + max(targetMinWage - inflIndexed, 0)
+                 * minWageConvergenceSpeed)
+reservationWage = newMinWage
+```
+
+### Wage Clearing
+
+Labor demand is the sum of workers planned by living firms. Regional labor
+clearing computes regional and national wages. The national wage is then
+adjusted for expected inflation pressure and union rigidity:
+
+```text
+wageAfterExpectations =
+  max(reservationWage,
+      rawWage * (1 + expWagePassthrough
+                 * max(expectedInflation - targetInflation, 0) / 12))
+
+newWage =
+  max(reservationWage,
+      wageAfterExpectations
+      + (previousMarketWage - wageAfterExpectations)
+        * unionRigidity * aggregateUnionDensity)
+```
+
+Employment is capped by working-age population. An operational hiring-slack
+factor reduces firm hiring when aggregate desired labor exceeds available labor.
+
+### Demographics And Payroll Funds
+
+Monthly demographics update retirements and working-age population:
+
+```text
+retirements = demRetirementRate * employed
+workingAgePop' = max(0, workingAgePop - retirements - workingAgeDecline
+                        + netMigration)
+retirees' = retirees + retirements
+```
+
+ZUS, NFZ, PPK, FP, and FGSP contributions are payroll-proportional, with
+contract-type adjustments for household workers. ZUS and NFZ deficits are
+covered by government subventions. NFZ spending is per-capita and rises with
+retirees through an aging elasticity. PPK contributions create a government-bond
+purchase request in the downstream bond waterfall.
+
+Earmarked funds follow:
+
+```text
+FP contributions = payroll * fpRate
+FP spending = unemploymentBenefits + employed * fpAlmpSpendPerWorker
+PFRON contributions = configured monthly revenue
+PFRON spending = configured monthly spending
+FGSP spending = bankruptFirms * avgFirmWorkers * fgspPayoutPerWorker
+governmentSubvention = sum(max(spending_i - contributions_i, 0))
+```
+
+## Demand, Prices, GDP, And Equity
+
+Implementation anchors:
+
+- `engine/economics/DemandEconomics.scala`
+- `engine/economics/PriceEquityEconomics.scala`
+- `engine/markets/FiscalRules.scala`
+- `engine/markets/PriceLevel.scala`
+- `engine/markets/EquityMarket.scala`
+- `engine/mechanisms/EuFunds.scala`
+- `engine/mechanisms/Macroprudential.scala`
+
+### Government Purchases And Fiscal Rules
+
+Raw government purchases are price-indexed base spending plus an automatic
+stabilizer based on unemployment above NAIRU:
+
+```text
+unempGap = max(unemploymentRate - NAIRU, 0)
+rawGovPurchases = govBaseSpending * max(priceLevel, 1)
+                  + govBaseSpending * unempGap * govAutoStabMult
+```
+
+Fiscal rules then constrain spending through:
+
+- the stabilizing expenditure rule (SRW), blending spending toward an
+  inflation-plus-real-growth ceiling;
+- the SGP deficit limit;
+- the 55 percent debt/GDP caution threshold;
+- the 60 percent debt/GDP constitutional debt ceiling.
+
+The most restrictive rule determines `FiscalRuleBinding` and the realized
+spending-cut ratio.
+
+### Sector Demand
+
+Sector demand is a flow-of-funds allocation of domestic consumption,
+government purchases, lagged investment demand, and exports:
+
+```text
+demand_s =
+  consWeight_s * domesticConsumption
+  + govWeight_s * govPurchases
+  + investWeight_s * laggedInvestmentDemand
+  + exports_s
+```
+
+Demand pressure is demand divided by nominal sector capacity. Excess demand in
+capacity-constrained sectors is redistributed to sectors with slack. The
+smoothed hiring signal persists across months to prevent one-month whipsaw in
+firm hiring.
+
+### GDP, Inflation, Equity, Macroprudential
+
+The monthly GDP proxy is:
+
+```text
+gdp =
+  domesticConsumption
+  + governmentDemandContribution
+  + euProjectContribution
+  + exports
+  + domesticGrossFixedCapitalFormation
+  + inventoryChange
+```
+
+Inflation combines price-level dynamics from expected inflation, demand,
+wage growth, and exchange-rate deviation, plus firm markup inflation.
+
+The equity market updates from reference rate, inflation, GDP growth, and firm
+profits. New listed equity issuance is added after the index update. Dividends
+are split into domestic, foreign, government, and tax components using foreign
+ownership and state-owned-firm profit signals.
+
+Macroprudential policy updates the credit-to-GDP gap and countercyclical
+capital buffer, which feeds bank approval and failure thresholds.
+
+EU funds follow a programmed monthly absorption path. Domestic co-financing and
+the capital share of the project envelope feed government demand and public
+capital.
+
+## Firm Rules
+
+Implementation anchors:
+
+- `agents/Firm.scala`
+- `engine/economics/FirmEconomics.scala`
+- `engine/markets/IntermediateMarket.scala`
+- `engine/markets/CorporateBondMarket.scala`
+- `engine/mechanisms/FirmEntry.scala`
+- `agents/StateOwned.scala`
+
+### Technology State And Capacity
+
+Firm technology is one of:
+
+- traditional, with explicit worker count;
+- hybrid, with worker count and AI efficiency;
+- automated, with AI efficiency and skeleton crew;
+- bankrupt, an inactive state.
+
+Capacity starts from sector revenue multipliers and firm-size scaling. The
+labor-effective component is:
+
+```text
+laborEff =
+  workers / initialSize                                      if traditional
+  0.4 * workers / initialSize + 0.6 * aiEfficiency           if hybrid
+  aiEfficiency                                               if automated
+  0                                                          if bankrupt
+```
+
+When physical capital is active, capacity uses a CES production function:
+
+```text
+capacity_f =
+  baseRevenue * sizeScale_f * sectorRevenueMultiplier_s
+  * CES(K_f / targetK_f, laborEff_f, sigma_s)
+```
+
+Near the Cobb-Douglas boundary, the CES helper degrades to a Cobb-Douglas
+form. Sector sigma also enters technology-adoption thresholds and evolves by
+learning-by-doing in `PriceEquityEconomics`.
+
+### Monthly P&L
+
+Revenue is capacity times sector demand and the price level:
+
+```text
+revenue_f = priceLevel * capacity_f * sectorDemandMultiplier_s
+```
+
+Costs include labor, residual domestic operating costs, depreciation, AI or
+hybrid maintenance, bank and corporate-bond interest, inventory carrying cost,
+energy and ETS cost, and foreign-owned profit shifting:
+
+```text
+profitBeforeTax_f =
+  revenue_f
+  - laborCost_f
+  - otherCosts_f
+  - depreciation_f
+  - aiMaintenance_f
+  - interest_f
+  - inventoryCost_f
+  - energyCost_f
+  - profitShiftCost_f
+```
+
+CIT uses loss carryforward. Losses accumulate when profit is negative; positive
+profit can offset accumulated losses up to the configured share, and remaining
+losses decay gradually.
+
+### Hiring, Firing, And Labor Matching
+
+Traditional firms compute desired workers by searching for the largest
+headcount where marginal revenue exceeds wage cost:
+
+```text
+MR(workers) = (capacity(workers) - capacity(workers - 1))
+              * demandMultiplier_s * priceLevel
+desiredWorkers = largest workers where MR(workers) > wageCost_s
+```
+
+The target is bounded by minimum retained workers, a multiple of initial size,
+aggregate labor slack, hiring-signal persistence, monthly hiring headroom, and
+liquidity constraints. Actual monthly adjustment closes only a fraction of the
+gap. Downsizing pays severance and can still lead to bankruptcy if solvency is
+not restored.
+
+`FirmEconomics.processLaborMarket` separates displaced workers, matches
+unemployed workers to vacancies by skill and region, updates wages, removes
+return migrants, and adds new immigrant households.
+
+### Technology Adoption
+
+Traditional firms evaluate full-AI and hybrid upgrade candidates. A candidate
+is feasible only if:
+
+- estimated post-upgrade costs clear the profitability threshold;
+- the firm can pay the down payment;
+- digital readiness exceeds the path-specific minimum;
+- the relationship bank can lend the required amount.
+
+Adoption probabilities combine risk profile, digital readiness, local
+neighbor adoption, global adoption pressure, loss-making desperation, strategic
+early adoption, and an adoption-willingness ramp. Hybrid firms may later
+upgrade to full automation.
+
+Implementation failures can be catastrophic or partial. Failed upgrades impose
+partial capex, loan, and down-payment costs; catastrophic failure bankrupts the
+firm.
+
+### Investment, Green Capital, Inventories, FDI, Informality
+
+Physical capital investment follows depreciation plus partial adjustment toward
+a sector target capital-labor ratio:
+
+```text
+desiredInvestment_f =
+  depreciation_f
+  + max(targetK_f - postDepreciationK_f, 0) * capitalAdjustSpeed
+actualInvestment_f = min(desiredInvestment_f, max(cash_f, 0))
+```
+
+Green investment mirrors this logic with green capital-labor targets, green
+depreciation, and a separate share of available cash.
+
+Inventory changes combine unsold production, spoilage, adjustment toward a
+target inventory ratio, and stress liquidation when cash is negative:
+
+```text
+unsoldValue_f = max(productionValue_f - salesValue_f, 0)
+targetInventory_f = revenue_f * inventoryTargetRatio_s
+rawInventoryChange_f =
+  unsoldValue_f
+  + (targetInventory_f - postSpoilageInventory_f) * inventoryAdjustSpeed
+```
+
+Foreign-owned firms shift a share of positive gross profit and repatriate a
+share of after-tax profit subject to available cash. Informal economy logic
+reduces paid CIT by a sector shadow share times the CIT evasion rate.
+
+### Financing, Default, Entry, Exit
+
+New technology loan demand is split through financing channels:
+
+```text
+listed equity issuance first for large firms
+corporate-bond issuance next for medium and large firms
+bank loan for the remainder
+```
+
+Corporate bond absorption depends on the corporate-bond market state and bank
+capital. Unsold bond issuance reverts to bank loans.
+
+Newly bankrupt firms generate bank NPLs and corporate-bond defaults. Bank loan
+loss is:
+
+```text
+nplLoss = newNplDebt * (1 - loanRecovery)
+```
+
+Firm entry replaces bankrupt slots and can add net entry when macro conditions
+allow. Sector entry weights depend on profit signals and entry barriers. New
+AI-native entrants become possible once aggregate adoption crosses the entry
+threshold and a probability draw succeeds.
+
+## Banking Rules
+
+Implementation anchors:
+
+- `agents/Banking.scala`
+- `engine/economics/BankingEconomics.scala`
+- `agents/EclStaging.scala`
+- `agents/DepositMobility.scala`
+- `agents/InterbankContagion.scala`
+- `engine/ledger/CorporateBondOwnership.scala`
+
+### Balance-Sheet Ratios
+
+Aggregate and per-bank diagnostics are computed from operational bank state and
+ledger-owned financial stocks.
+
+Risk-weighted assets are:
+
+```text
+RWA_b = firmLoans_b + consumerLoans_b + 0.50 * corporateBondHoldings_b
+CAR_b = capital_b / RWA_b
+```
+
+When the denominator is effectively zero, the implementation returns a safe
+ratio floor.
+
+Liquidity ratios are:
+
+```text
+HQLA_b = reserves_b + govBondAfs_b + govBondHtm_b
+netCashOutflows_b = demandDeposits_b * demandDepositRunoff
+LCR_b = HQLA_b / netCashOutflows_b
+
+ASF_b = capital_b + termDeposits_b * 0.95 + demandDeposits_b * 0.90
+RSF_b =
+  shortLoans_b * 0.50
+  + mediumLoans_b * 0.65
+  + longLoans_b * 0.85
+  + govBonds_b * 0.05
+  + corporateBonds_b * 0.50
+NSFR_b = ASF_b / RSF_b
+```
+
+### Loan Pricing And Approval
+
+Household deposit rates are the reference rate minus the household deposit
+spread, floored at zero.
+
+Firm lending rates combine:
+
+```text
+lendingRate_b =
+  referenceOrWiborRate
+  + baseSpread
+  + bankSpecificSpread_b
+  + min(NPL_b * nplSpreadFactor, NplSpreadCap)
+  + capitalShortfallPenalty_b
+  + crowdingOutSpread_b
+```
+
+Capital penalty activates when CAR falls below `minCar * 1.5`. Crowding-out
+passes part of a government-bond-yield premium into firm loan spreads. Failed
+banks receive a fixed penalty spread and cannot lend.
+
+Credit approval requires projected CAR above the macroprudential effective
+minimum, LCR and NSFR above regulatory minima, and a stochastic approval draw.
+The approval probability falls with NPL ratio and reserve deficit but has a
+configured floor.
+
+### Interbank, Facilities, And Monetary Aggregates
+
+The interbank rate is a corridor rate between the deposit facility and lombard
+facility. It rises with aggregate credit stress and scarce excess reserves:
+
+```text
+creditStress = clamp(aggregateNplRatio / stressThreshold, 0, 1)
+liquidityRatio = clamp(excessReserves / requiredReserves, 0, 1)
+interbankRate = depositFacilityRate
+                + (1 - liquidityRatio) * creditStress
+                  * (lombardRate - depositFacilityRate)
+```
+
+Interbank clearing matches lenders with excess reserves to borrowers with
+reserve deficits. A hoarding factor reduces lending when system NPL stress is
+high.
+
+Monetary aggregates are:
+
+```text
+M0 = bank reserves at NBP
+M1 = demand deposits
+M2 = demand deposits + term deposits
+M3 = M2 + TFI AUM + corporate bonds outstanding
+creditMultiplier = M2 / M0
+```
+
+### Bank P&L, Provisioning, Failure, Resolution
+
+Bank capital changes by losses plus retained income:
+
+```text
+losses_b =
+  corporateNplLoss_b
+  + mortgageNplLoss_b
+  + consumerNplLoss_b
+  + corporateBondDefaultLoss_b
+  + BFGLevy_b
+  + unrealizedAfsBondLoss_b
+
+grossIncome_b =
+  firmLoanInterest_b
+  + householdDebtService_b
+  + govBondIncome_b
+  - depositInterest_b
+  + reserveInterest_b
+  + standingFacilityIncome_b
+  + interbankInterest_b
+  + mortgageInterestIncome_b
+  + consumerDebtService_b
+  + corporateBondCoupon_b
+
+capital'_b = capital_b - losses_b + grossIncome_b * profitRetention
+```
+
+IFRS 9 ECL staging adds provision changes based on the performing book, new
+defaults, unemployment, and GDP growth.
+
+Failure is triggered by negative capital, three consecutive months below
+effective minimum CAR, or an LCR breach below half of the minimum. BFG bail-in
+haircuts uninsured deposits of failed banks. Purchase-and-assumption resolution
+transfers deposits, government bonds, performing loans, consumer loans, and
+corporate-bond holdings to the healthiest surviving bank. Firms and households
+routed to failed banks are reassigned to the absorber.
+
+## Fiscal, Monetary, Bond-Market, And External Rules
+
+Implementation anchors:
+
+- `engine/markets/FiscalBudget.scala`
+- `engine/markets/FiscalRules.scala`
+- `agents/Nbp.scala`
+- `engine/markets/OpenEconomy.scala`
+- `engine/economics/OpenEconEconomics.scala`
+- `engine/markets/BondAuction.scala`
+- `engine/markets/CorporateBondMarket.scala`
+- `engine/mechanisms/Expectations.scala`
+
+### Government Budget And Debt
+
+Government budget revenue includes CIT/PIT-related revenue, VAT, NBP
+remittance, excise, customs, and state-owned-firm dividends. Spending includes
+unemployment benefits, social transfers, current government purchases, capital
+government purchases, debt service, social-fund subventions, earmarked-fund
+subventions, and EU co-financing.
+
+```text
+totalSpend =
+  unemploymentBenefits
+  + socialTransfers
+  + govCurrentSpend
+  + govCapitalSpend
+  + debtService
+  + ZUSSubvention
+  + NFZSubvention
+  + earmarkedFundSubvention
+  + euCofinancing
+
+totalRevenue =
+  taxRevenue + governmentDividendRevenue
+
+deficit = totalSpend - totalRevenue
+cumulativeDebt' = cumulativeDebt + deficit
+govBondOutstanding' = max(govBondOutstanding + deficit, 0)
+```
+
+Public capital depreciates monthly and increases with domestic government
+capital spending plus EU project capital.
+
+The weighted coupon follows a rolling weighted-average-maturity rule. Each
+month, a fraction of the outstanding portfolio matures and new deficit issuance
+enters at the current market yield.
+
+### NBP Policy, Bond Yield, QE, FX
+
+The reference rate follows a smoothed Taylor-type rule:
+
+```text
+taylorTarget =
+  neutralRate
+  + taylorAlpha * (inflation - targetInflation)
+  - taylorDelta * outputGap
+  + taylorBeta * exchangeRateChange
+
+referenceRate' =
+  clamp(previousRate * inertia + taylorTarget * (1 - inertia),
+        rateFloor,
+        rateCeiling,
+        maxMonthlyChange)
+```
+
+Government bond yield is:
+
+```text
+bondYield =
+  referenceRate
+  + termPremium
+  + fiscalRisk(debtToGdp)
+  - qeCompression(nbpBondHoldings / GDP)
+  - foreignDemandDiscount(if NFA > 0)
+  + credibilityPremium
+```
+
+QE activates near the lower bound when realized or expected inflation is below
+target by the configured threshold. QE purchases are requested by NBP but
+settled through the bond waterfall, so actual sold bonds leave banks and enter
+NBP holdings exactly.
+
+FX intervention buys or sells EUR when the exchange rate leaves the tolerance
+band around the base rate. EUR purchases inject PLN reserves; EUR sales drain
+reserves. The intervention also contributes a shock term to the exchange-rate
+update.
+
+### External Sector
+
+Exports come from GVC sector exports when available; otherwise they follow
+foreign GDP growth, real exchange-rate competitiveness, and automation-related
+unit-labor-cost effects.
+
+Imports include household consumption imports, technology and investment
+imports, imported intermediates, and tourism imports. Imported intermediates
+depend on sector output, sector import content, and nominal exchange-rate
+effects.
+
+The current account is:
+
+```text
+currentAccount = tradeBalance + primaryIncome + secondaryIncome
+primaryIncome = NFA * nfaReturnRate.monthly
+secondaryIncome = EUFunds - remittanceOutflow + diasporaInflow
+```
+
+The capital account combines FDI, ordinary portfolio flows, carry-trade flows,
+and stress capital-flight outflows. FDI rises with automation and falls with a
+negative-NFA dampening term. Portfolio flows react to the domestic-foreign rate
+differential and NFA risk premium.
+
+Exchange-rate change responds to the balance-of-payments ratio, negative-NFA
+risk, FX intervention shock, and PPP drift:
+
+```text
+exchangeRateShock =
+  exRateAdjSpeed * (-(CA + KA) / GDP + nfaRisk)
+  + fxInterventionShock
+  + pppDrift
+```
+
+NFA updates by the current account plus a partial exchange-rate valuation effect
+on foreign assets.
+
+## Insurance, NBFI, Quasi-Fiscal, And JST Rules
+
+Implementation anchors:
+
+- `agents/Insurance.scala`
+- `agents/Nbfi.scala`
+- `agents/QuasiFiscal.scala`
+- `agents/Jst.scala`
+- `engine/economics/OpenEconEconomics.scala`
+- `engine/economics/BankingEconomics.scala`
+
+### Insurance
+
+Life and non-life premiums are proportional to the employed wage bill:
+
+```text
+lifePremium = employed * wage * lifePremiumRate
+nonLifePremium = employed * wage * nonLifePremiumRate
+```
+
+Life claims follow a loss ratio. Non-life claims widen with unemployment above
+the non-life unemployment threshold:
+
+```text
+nonLifeClaims =
+  nonLifePremium * nonLifeLossRatio
+  * (1 + max(unemploymentRate - threshold, 0) * nonLifeUnempSensitivity)
+```
+
+Investment income comes from government bonds, corporate bonds, and equity,
+minus corporate-bond default loss. Reserves update from premiums, claims, and
+investment income. Government-bond and equity holdings rebalance gradually
+toward target allocation shares.
+
+### NBFI And TFI
+
+TFI inflow is proportional to wage bill and excess fund return over deposits:
+
+```text
+baseInflow = employed * wage * tfiInflowRate
+fundReturn =
+  govBondYield * tfiGovBondShare
+  + equityReturn.annualized * tfiEquityShare
+  + govBondYield * tfiCorpBondShare
+netInflow = baseInflow * (1 + clamp(fundReturn - depositRate, cap)
+                          * ExcessReturnSensitivity)
+```
+
+TFI AUM updates by net inflow and investment income, then rebalances toward
+government-bond and equity target shares. Net TFI inflow is recorded as deposit
+drain from the banking system.
+
+NBFI credit is counter-cyclical to bank tightness:
+
+```text
+bankTightness = clamp((bankNplRatio - 0.03) / 0.03, 0, 1)
+origination = domesticConsumption * creditBaseRate
+              * (1 + countercyclical * bankTightness)
+repayment = loanStock / creditMaturity
+defaults = loanStock * defaultBase
+           * (1 + defaultUnempSensitivity * max(unemploymentRate - 0.05, 0))
+loanStock' = max(loanStock + origination - repayment - defaults, 0)
+```
+
+### Quasi-Fiscal BGK/PFR
+
+Quasi-fiscal issuance is a share of government capital programs:
+
+```text
+issuance = max((govCapitalSpend + euProjectCapital) * issuanceShare, 0)
+bondAmortization = bondsOutstanding / avgMaturityMonths
+nbpPurchase = issuance * nbpAbsorptionShare if NBP QE active else 0
+bankPurchase = issuance - nbpPurchase
+```
+
+Subsidized lending is a share of issuance, with loan amortization by maturity:
+
+```text
+lending = issuance * lendingShare
+loanRepayment = loanPortfolio / loanMaturityMonths
+loanPortfolio' = max(loanPortfolio + lending - loanRepayment, 0)
+```
+
+ESA 2010 debt includes central-government cumulative debt plus quasi-fiscal
+bonds outstanding:
+
+```text
+esa2010Debt = govCumulativeDebt + quasiFiscalBondsOutstanding
+```
+
+### JST
+
+Local-government revenue combines PIT share, CIT share, property tax,
+education subvention, and targeted grants:
+
+```text
+jstRevenue =
+  pitRevenue * jstPitShare
+  + centralCitRevenue * jstCitShare
+  + firms * jstPropertyTax / 12
+  + gdp * jstSubventionShare / 12
+  + gdp * jstDotacjeShare / 12
+
+jstSpending = jstRevenue * jstSpendingMultiplier
+jstDeficit = jstSpending - jstRevenue
+jstDeposits' = jstDeposits + jstRevenue - jstSpending
+jstDebt' = jstDebt + jstDeficit
+```
+
+## Known Simplifications And Empirical Grounding Gaps
+
+The current rule book is intentionally explicit about areas that remain
+research hypotheses or calibration targets:
+
+- Many behavioral coefficients are calibrated in `SimParams` and domain config
+  files. Their current values and provenance status are documented in
+  `docs/calibration-register.md`; empirical validation against historical
+  Polish macro and micro series is tracked separately.
+- Household decision rules are bounded procedural heuristics, not an estimated
+  structural life-cycle model.
+- Firm technology adoption and entry include network, risk, and readiness
+  effects, but their coefficients still need systematic sensitivity analysis.
+- Banks are seven named agents with rich balance-sheet rules, but deposit
+  insurance and depositor decisions are not modeled at the individual account
+  contract level.
+- Government, NBP, JST, insurance, NBFI, and rest-of-world sectors are
+  institutional aggregate agents rather than populations of micro-institutions.
+- External-sector rules combine structural trade, GVC, remittance, tourism,
+  FDI, and capital-flow channels; not every channel has an econometric estimate
+  yet.
+- Output columns expose many macro and meso diagnostics, but not every
+  household or firm micro trajectory is written to the Monte Carlo time-series
+  output by default.
+- The SFC ledger and matrix artifacts document accounting structure. They do
+  not by themselves validate behavioral realism.
+
+These gaps are part of the research-readiness roadmap, not hidden assumptions.

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -1,0 +1,305 @@
+# Calibration Register
+
+This register records the current calibration surface of Amor Fati. It is a
+paper-facing inventory of key parameters, their implementation owner, value,
+unit, provenance, empirical target, transformation, and calibration status.
+
+The register is intentionally useful before every value has a final data
+source. Missing or weak provenance is marked explicitly with searchable tokens:
+`UNKNOWN_SOURCE`, `TUNED_NEEDS_VALIDATION`, `ASSUMED`, `PLACEHOLDER`, or
+`POLICY_SCENARIO`.
+
+## Status Taxonomy
+
+| Status | Meaning |
+| --- | --- |
+| `EMPIRICAL` | Direct statutory, institutional, or data-note target is documented in code comments. |
+| `CODE_NOTE_EMPIRICAL` | Code comments name source institution/year, but no source table or URL is attached yet. |
+| `ASSUMED` | Structural modeling assumption or stylized calibration. |
+| `TUNED_NEEDS_VALIDATION` | Behavioral/dynamic coefficient chosen for model behavior; needs sensitivity and validation work. |
+| `POLICY_SCENARIO` | Scenario/shock switch or policy parameter, not a baseline empirical estimate. |
+| `PLACEHOLDER` | Explicit placeholder or simplified value awaiting data bridge. |
+| `UNKNOWN_SOURCE` | Parameter is active in the model but final provenance is not yet documented. |
+
+## Transformation Rules
+
+- Raw PLN stock values in config classes are scaled by `SimParams.gdpRatio` in
+  `SimParams.defaults` when they represent macro stocks or monthly macro flows.
+- Agent-level monetary values such as wages, rents, firm costs, and per-worker
+  values are not scaled by `gdpRatio`.
+- Rates are annual unless the consuming rule applies `.monthly`.
+- Vector parameters generally follow the six-sector order:
+  `BPO/SSC`, `Manufacturing`, `Retail/Services`, `Healthcare`, `Public`,
+  `Agriculture`.
+- Runtime numeric evidence comes from Monte Carlo output columns in
+  `McTimeseriesSchema`; this register documents parameter provenance, not run
+  results. Empirical validation targets and output mappings are documented in
+  `docs/empirical-validation-report.md`.
+
+## Core Scale And Sectors
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `pop.firmsCount` | `10000` | agents | Simulation design choice | Tractable heterogeneous firm population | Direct | `PopulationConfig` | `ASSUMED` |
+| `pop.workersPerFirm` | `10` | workers/firm normalizer | Simulation design choice | Normalizer for population and `gdpRatio` | Direct | `PopulationConfig` | `ASSUMED` |
+| `household.count` | `firmsCount * workersPerFirm = 100000` | agents | Derived from simulation scale | Household population tied to firm scale | Derived in `SimParams.defaults` | `SimParams` | `ASSUMED` |
+| `pop.firmSizeDist` | `Gus` | enum | Code note: GUS CEIDG/KRS 2024 | Polish firm-size distribution mode | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeMicroShare` | `0.962` | share | Code note: GUS CEIDG 2024 | Micro enterprise share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeSmallShare` | `0.028` | share | Code note: GUS | Small firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeMediumShare` | `0.008` | share | Code note: GUS residual | Medium firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeLargeShare` | `0.002` | share | Code note: GUS | Large firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.realGdp` | `3500e9` | PLN/year | Code note: GUS 2024 | Polish GDP scale | Feeds `gdpRatio` | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gdpRatio` | `computeGdpRatio(pop, firm.baseRevenue)` | scalar | Derived from agent flow scale and real GDP | Map agent flows to Polish macro scale | Derived | `SimParams` | `ASSUMED` |
+| `topology` | `Watts-Strogatz` | enum | Network modeling convention | Small-world interaction topology | Direct | `SimParams` | `ASSUMED` |
+| `sectorDefs` | 6 sectors | vector | Code note: GUS 2024 | Polish sector composition | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.share` | `[0.03, 0.16, 0.45, 0.06, 0.22, 0.08]` | share by sector | Code note: GUS 2024 | Firm/employment sector weights | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.sigma` | `[50, 10, 5, 2, 1, 3]` | CES elasticity | Structural automation/substitution assumption | Sectoral substitutability ranking | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
+| `sectorDefs.wageMultiplier` | `[1.35, 0.94, 0.79, 0.97, 0.91, 0.67]` | multiplier | Code note: GUS 2024 | Relative sector wages | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.revenueMultiplier` | `[1.50, 1.05, 0.91, 1.10, 1.08, 0.80]` | multiplier | UNKNOWN_SOURCE | Relative sector revenue/productivity | Direct | `SimParams` | `UNKNOWN_SOURCE` |
+
+## Household And Labor
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `household.baseWage` | `8266` | PLN/month | Code note: GUS 2024 | Mean monthly gross wage | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.baseReservationWage` | `4666` | PLN/month | Code note: 2025 minimum wage / legal act | Minimum acceptable wage | Direct | `HouseholdConfig` | `EMPIRICAL` |
+| `household.mpc` | `0.82` | share | UNKNOWN_SOURCE | Aggregate mean MPC | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.mpcAlpha`, `household.mpcBeta` | `8.2`, `1.8` | beta params | UNKNOWN_SOURCE | Heterogeneous MPC distribution | Beta draw | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.savingsMu`, `household.savingsSigma` | `9.6`, `1.2` | log PLN params | UNKNOWN_SOURCE | Initial savings distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.debtFraction` | `0.40` | share | Code note: BIK 2024 | Household positive debt share | Bernoulli init | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.debtMu`, `household.debtSigma` | `10.5`, `1.5` | log PLN params | UNKNOWN_SOURCE | Initial debt distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.rentMean`, `rentStd`, `rentFloor` | `1800`, `400`, `800` | PLN/month | Code note: Otodom/NBP 2024 | Rent distribution | Truncated normal draw | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.bufferTargetMonths` | `6.0` | months | Carroll-style buffer-stock model | Target liquid buffer | Direct | `HouseholdConfig` | `ASSUMED` |
+| `household.bufferSensitivity` | `0.4` | coefficient | UNKNOWN_SOURCE | MPC response to buffer gap | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.mpcUnemployedBoost` | `0.10` | share | UNKNOWN_SOURCE | Extra MPC while unemployed | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.skillDecayRate` | `0.02` | monthly share | UNKNOWN_SOURCE | Skill decay under unemployment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.scarringRate`, `scarringCap`, `scarringOnset` | `0.02`, `0.50`, `3` | share/months | Literature note in code | Long-run unemployment scarring | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.wageScarRate`, `wageScarCap`, `wageScarDecay` | `0.025`, `0.30`, `0.005` | share/month | Code note: Jacobson et al.; Davis and von Wachter | Wage scar accumulation and recovery | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.retrainingCost`, `retrainingDuration` | `5000`, `6` | PLN/months | UNKNOWN_SOURCE | Retraining cost and duration | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.retrainingBaseSuccess`, `retrainingProb` | `0.60`, `0.15` | share | UNKNOWN_SOURCE | Retraining success/enrollment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.bankruptcyDistressMonths` | `3` | months | ASSUMED | Distress persistence before bankruptcy | Direct | `HouseholdConfig` | `ASSUMED` |
+| `household.depositSpread` | `0.02` | annual rate | UNKNOWN_SOURCE | Deposit rate below policy rate | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.ccSpread` | `0.04` | annual rate | Code note: NBP MIR 2024 | Consumer credit spread | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.ccMaxDti` | `0.40` | share | Code note: KNF Recommendation T | Consumer credit DTI cap | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.ccMaxLoan` | `50000` | PLN | UNKNOWN_SOURCE | Maximum unsecured consumer loan | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.ccNplRecovery` | `0.15` | share | Code note: BIK 2024 | Consumer loan recovery | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.frictionMatrix` | `DefaultFrictionMatrix` | 6x6 share | Code note: GUS LFS 2024, Shimer 2005 | Cross-sector mobility friction | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.voluntarySearchProb` | `0.02` | monthly share | UNKNOWN_SOURCE | Employed voluntary sector search | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.voluntaryWageThreshold` | `0.20` | share | UNKNOWN_SOURCE | Required wage gain for voluntary search | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.unionDensity` | `[0.02, 0.15, 0.03, 0.12, 0.30, 0.04]` | share by sector | Code note: GUS 2024 | Union membership density | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.unionWagePremium` | `0.08` | share | Code note: empirical approx. | Union wage premium | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.unionRigidity` | `0.50` | share | UNKNOWN_SOURCE | Downward nominal wage rigidity | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.expLambda` | `0.70` | coefficient | Code note: Carroll 2003 | Adaptive expectations speed | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.expCredibilityInit` | `0.80` | share | UNKNOWN_SOURCE | Initial NBP credibility | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `social.zusContribRate`, `zusEmployeeRate` | `0.1952`, `0.1371` | annual rate/share | Code note: Social insurance law | ZUS payroll contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.zusBasePension` | `3500` | PLN/month | Code note: ZUS 2024 | Average pension payment | Direct | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.nfzContribRate` | `0.09` | rate | Code note: health-care law | NFZ contribution rate | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.nfzPerCapitaCost` | `1250` | PLN/month | Code note: NFZ 2024 | Health spending per capita | Direct | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.ppkEmployeeRate`, `ppkEmployerRate` | `0.02`, `0.015` | rate | Code note: PPK law | PPK contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.eduShares` | `[0.08, 0.25, 0.30, 0.37]` | share | Code note: GUS LFS 2024 | Education composition | CDF draw | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.demInitialRetirees` | `0` | agents | Explicit startup simplification | Retiree stock built from flows during simulation | Direct | `SocialConfig`, `SimParams` | `PLACEHOLDER` |
+
+## Firm Production, Entry, Capital, And Climate
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `firm.baseRevenue` | `180000` | PLN/month/worker | Code note: GUS F-01 2024 | Revenue per worker before demand shocks | Direct, unscaled | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.otherCosts` | `16667` | PLN/month/worker | UNKNOWN_SOURCE | Fixed non-wage operating cost | Direct, unscaled | `FirmConfig` | `UNKNOWN_SOURCE` |
+| `firm.aiCapex` | `1200000` | PLN/firm | UNKNOWN_SOURCE | Full automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.hybridCapex` | `350000` | PLN/firm | UNKNOWN_SOURCE | Hybrid automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.aiOpex`, `firm.hybridOpex` | `30000`, `12000` | PLN/month/firm | UNKNOWN_SOURCE | AI/hybrid operating cost | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.hybridReadinessMin`, `fullAiReadinessMin` | `0.20`, `0.35` | share | UNKNOWN_SOURCE | Digital readiness adoption thresholds | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.entryRate` | `0.02` | monthly share | Code note: GUS CEIDG 2024 | Base vacant-slot entry rate | Direct | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.entrySectorBarriers` | `[0.8, 0.6, 1.2, 0.5, 0.1, 0.7]` | coefficient by sector | Code note: GUS CEIDG/KRS 2024 | Entry barriers | Direct | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.entryAiThreshold`, `entryAiProb` | `0.15`, `0.20` | share | UNKNOWN_SOURCE | AI-native entrant trigger/probability | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.entryStartupCash` | `50000` | PLN | UNKNOWN_SOURCE | Entrant liquidity | Direct | `FirmConfig` | `UNKNOWN_SOURCE` |
+| `firm.replacementEntryRate` | `0.35` | monthly share | UNKNOWN_SOURCE | Replacement of dead firm slots | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.netEntryRate` | `0.06` | monthly share | UNKNOWN_SOURCE | Expansionary net births | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.digiDrift` | `0.001` | monthly share | UNKNOWN_SOURCE | Exogenous digital readiness drift | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.digiInvestCost`, `digiInvestBoost` | `50000`, `0.05` | PLN/share | UNKNOWN_SOURCE | Discretionary digital investment | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.networkK`, `networkRewireP` | `6`, `0.10` | degree/share | Network design assumption | Watts-Strogatz firm network | Direct | `FirmConfig` | `ASSUMED` |
+| `firm.demoEffectThresh`, `demoEffectBoost` | `0.40`, `0.15` | share | UNKNOWN_SOURCE | Peer adoption demonstration effect | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.adoptionRampMonths` | `36` | months | UNKNOWN_SOURCE | Adoption willingness ramp | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.sigmaLambda` | `0.0` | coefficient | Scenario switch | Arthur-style sigma learning off by default | Direct | `FirmConfig` | `POLICY_SCENARIO` |
+| `capital.klRatios` | `[120000, 250000, 80000, 200000, 150000, 180000]` | PLN/worker | Code note: GUS F-01 2024 | Sector capital-labor ratios | Direct | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `capital.depRates` | `[0.15, 0.08, 0.10, 0.07, 0.05, 0.08]` | annual rate | Code note: GUS F-01 2024 | Sector depreciation rates | `.monthly` in use | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `capital.importShare` | `0.35` | share | UNKNOWN_SOURCE | Import share of investment | Direct | `CapitalConfig` | `UNKNOWN_SOURCE` |
+| `capital.adjustSpeed` | `0.10` | monthly coefficient | UNKNOWN_SOURCE | Capital partial-adjustment speed | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `capital.inventoryTargetRatios` | `[0.05, 0.25, 0.15, 0.10, 0.02, 0.30]` | share by sector | Code note: GUS 2024 | Inventory/revenue targets | Direct | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.energyCostShares` | `[0.02, 0.10, 0.04, 0.05, 0.03, 0.06]` | share of revenue | Code note: Eurostat/GUS 2023 | Energy burden by sector | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.etsBasePrice` | `80` | EUR/tCO2 | Code note: KOBiZE 2024 | EU ETS starting price | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.etsPriceDrift` | `0.03` | annual rate | Code note: EC Fit for 55 trajectory | ETS trend | `.monthly` in use | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.greenBudgetShare` | `0.20` | share | UNKNOWN_SOURCE | Green investment budget share | Direct | `ClimateConfig` | `TUNED_NEEDS_VALIDATION` |
+| `climate.greenImportShare` | `0.35` | share | UNKNOWN_SOURCE | Import share of green capex | Direct | `ClimateConfig` | `UNKNOWN_SOURCE` |
+
+## Fiscal, Monetary, And Banking
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `fiscal.citRate` | `0.19` | rate | Code note: MF 2024 / CIT law | Corporate income tax rate | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.vatRates` | `[0.23, 0.19, 0.12, 0.06, 0.10, 0.07]` | rate by sector | Code note: MF 2024 effective rates | Sector VAT rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.exciseRates` | `[0.01, 0.04, 0.03, 0.005, 0.002, 0.02]` | rate by sector | Code note: MF 2024 aggregate | Effective excise rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.customsDutyRate` | `0.04` | rate | Code note: EU CET/Eurostat TARIC | Average non-EU customs duty | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govBaseSpending` | `58.3e9` | raw PLN/month | Code note: MF 2024 | Government base spending | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govInvestShare` | `0.20` | share | Code note: MF 2024 | Capital share of government spending | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govCapitalMultiplier`, `govCurrentMultiplier` | `1.5`, `0.8` | multiplier | Code note: Ilzetzki, Mendoza and Vegh 2013 | Fiscal multipliers | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govInitCapital` | `0` | PLN | Explicit startup simplification | Initial public capital stock | Built from investment flows | `FiscalConfig` | `PLACEHOLDER` |
+| `fiscal.euFundsTotalEur` | `76e9` | EUR | Code note: EC 2021 | 2021-2027 EU allocation | Beta absorption path | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.euCofinanceRate`, `euCapitalShare` | `0.15`, `0.60` | share | Code note: MFiPR / EU funds | National cofinance and capex split | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.minWageTargetRatio` | `0.50` | share | Code note: minimum wage act | Target minimum/average wage ratio | Annual adjustment | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.govBenefitM1to3`, `govBenefitM4to6` | `1500`, `1200` | PLN/month | Code note: GUS 2024 | Unemployment benefit amounts | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govAvgMaturityMonths` | `54` | months | Code note: MF 2024 | Government debt average maturity | WAM coupon update | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.baseForeignShare`, `maxForeignShare` | `0.35`, `0.55` | share | Code note: NBP SPW holder structure 2024 | Foreign government-bond holdings | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.fiscalRuleDebtCeiling` | `0.60` | debt/GDP share | Code note: Polish constitution Art. 216 | Constitutional debt ceiling | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.fiscalRuleCautionThreshold` | `0.55` | debt/GDP share | Code note: public finance act Art. 86 | Caution threshold | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.sgpDeficitLimit` | `0.03` | deficit/GDP share | Maastricht / SGP | Deficit limit | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.initGovDebt` | `1600e9` | raw PLN | Code note: MF 2024 | Initial government debt | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.jstPitShare`, `jstCitShare` | `0.3846`, `0.0671` | share | Code note: JST revenue act | Local-government tax shares | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.pitRate1`, `pitRate2`, `pitBracket1Annual` | `0.12`, `0.32`, `120000` | rate/PLN/year | Code note: PIT law 2024 | PIT brackets | Annualized monthly PIT | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.social800` | `800` | PLN/month/child | Code note: legal act 2023 | 800+ benefit | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `monetary.initialRate` | `0.0575` | annual rate | Code note: NBP 2024 | NBP reference rate | Direct | `MonetaryConfig` | `CODE_NOTE_EMPIRICAL` |
+| `monetary.targetInfl` | `0.025` | annual rate | NBP inflation target | Inflation target | Direct | `MonetaryConfig` | `EMPIRICAL` |
+| `monetary.neutralRate` | `0.04` | annual rate | Estimated in code note | Long-run neutral rate | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorAlpha`, `taylorBeta`, `taylorDelta` | `1.5`, `0.8`, `0.5` | coefficients | Taylor-rule convention | Policy reaction coefficients | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorInertia` | `0.70` | share | UNKNOWN_SOURCE | Policy-rate smoothing | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.rateFloor`, `rateCeiling` | `0.001`, `0.15` | annual rate | Structural lower/upper bounds | Policy-rate corridor bounds | Direct | `MonetaryConfig` | `ASSUMED` |
+| `monetary.nairu` | `0.05` | share | Code note: estimated | NAIRU | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.reserveRateMult` | `0.5` | share | Code note: NBP 2024 | Reserve remuneration fraction | Direct | `MonetaryConfig` | `CODE_NOTE_EMPIRICAL` |
+| `monetary.depositFacilitySpread`, `lombardSpread` | `0.01`, `0.01` | annual rate | Code note: NBP corridor | Corridor +/- 100 bp | Direct | `MonetaryConfig` | `EMPIRICAL` |
+| `monetary.qePace` | `5e9` | raw PLN/month | UNKNOWN_SOURCE | QE monthly purchase pace | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `POLICY_SCENARIO` |
+| `monetary.qeMaxGdpShare` | `0.30` | GDP share | UNKNOWN_SOURCE | QE stock ceiling | Direct | `MonetaryConfig` | `POLICY_SCENARIO` |
+| `monetary.fxReserves` | `185e9` | raw PLN | Code note: NBP 2024 | Initial FX reserves | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initCapital` | `270e9` | raw PLN | Code note: KNF 2024 | Aggregate bank equity | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initDeposits` | `1900e9` | raw PLN | Code note: NBP M3 2024 | Aggregate deposits | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initLoans` | `700e9` | raw PLN | Code note: NBP 2024 | Corporate loans | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initGovBonds`, `initNbpGovBonds` | `400e9`, `300e9` | raw PLN | Code note: NBP 2024 | Bank/NBP government-bond holdings | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initConsumerLoans` | `200e9` | raw PLN | Code note: BIK 2024 | Consumer loan stock | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.baseSpread` | `0.015` | annual rate | UNKNOWN_SOURCE | Base firm-loan spread | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
+| `banking.minCar` | `0.08` | multiplier/share | Code note: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.loanRecovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate loan recovery | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
+| `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note: NBP 2024 maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.reserveReq` | `0.035` | share | Code note: NBP 2024 | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.lcrMin`, `nsfrMin` | `1.0`, `1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020]` | multiplier by bank | Code note: KNF 2024 | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.bfgLevyRate` | `0.0024` | annual rate | Code note: BFG 2024 | Resolution levy | `.monthly` in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.bfgDepositGuarantee` | `400000` | PLN/depositor | Code note: BFG guarantee | Deposit guarantee threshold | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.ccybMax` | `0.025` | multiplier | Code note: KNF 2024 | Max CCyB | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.htmShare` | `0.60` | share | Code note: NBP 2024 | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.depositPanicRate` | `0.03` | monthly share | Code note: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+
+## External Sector And Financial Markets
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `forex.baseExRate` | `4.33` | PLN/EUR | Code note: NBP 2024 | Starting exchange rate | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.foreignRate` | `0.04` | annual rate | UNKNOWN_SOURCE | Foreign reference rate | Direct | `ForexConfig` | `UNKNOWN_SOURCE` |
+| `forex.importPropensity` | `0.22` | GDP share | Code note: GUS/NBP 2024 | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.techImportShare` | `0.40` | share | UNKNOWN_SOURCE | Technology/capital goods share of imports | Direct | `ForexConfig` | `UNKNOWN_SOURCE` |
+| `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15`, `0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
+| `forex.riskOffShockMonth` | `0` | month | Scenario switch | No baseline risk-off shock | Direct | `ForexConfig` | `POLICY_SCENARIO` |
+| `openEcon.importContent` | `[0.15, 0.50, 0.20, 0.15, 0.05, 0.12]` | share by sector | Code note: GUS supply-use 2024 | Import content of production | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.exportBase` | `138.5e9` | raw PLN/month | Code note: NBP BoP 2024 | Monthly export base | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.foreignGdpGrowth` | `0.015` | annual rate | Code note: ECB/IMF projections | Foreign GDP growth | `.monthly` in export rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.exportPriceElasticity`, `importPriceElasticity` | `0.8`, `0.6` | coefficient | Code note: Marshall-Lerner / Campa-Goldberg | Trade price elasticities | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.erElasticity` | `0.5` | coefficient | UNKNOWN_SOURCE | Exchange-rate elasticity of trade | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.euTransfers` | `1.458e9` | raw PLN/month | Code note: MFiPR 2024 | EU transfer monthly flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.fdiBase` | `583.1e6` | raw PLN/month | Code note: NBP IIP 2024 | Monthly FDI base flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.portfolioSensitivity`, `riskPremiumSensitivity` | `0.20`, `0.10` | coefficient | UNKNOWN_SOURCE | Portfolio/risk premium response | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.pppSpeed` | `0.10` | annual coefficient | Code note: Rogoff 1996 | PPP convergence speed | `.monthly` in FX rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fdi.foreignShares` | `[0.15, 0.30, 0.10, 0.03, 0.00, 0.05]` | share by sector | Code note: NBP IIP 2024 and GUS 2024 | Foreign-owned firm share by sector | Direct | `FdiConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fdi.profitShiftRate`, `repatriationRate` | `0.15`, `0.70` | share | Code note: FDI outflow calibration | Profit shifting and dividend repatriation | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `fdi.maProb`, `maSizeMin` | `0.001`, `50` | monthly share / employees | UNKNOWN_SOURCE | Domestic firm acquisition probability and eligibility | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `gvc.euTradeShare` | `0.70` | share | Code note: GUS/NBP 2024 | EU share of total trade | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.exportShares` | `[0.05, 0.55, 0.15, 0.03, 0.02, 0.20]` | share by sector | Code note: GUS 2024 | Sector export shares | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.depth` | `[0.35, 0.75, 0.30, 0.40, 0.10, 0.45]` | share by sector | Code note: WIOD/OECD ICIO | GVC backward linkage | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02`, `0.015` | annual rate | Code note: ECB/IMF | Foreign inflation/growth | `.monthly` where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.demandShockMonth`, `commodityShockMonth` | `0`, `0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
+| `immigration.monthlyRate` | `0.001` | monthly share | UNKNOWN_SOURCE | Base immigration rate | Direct | `ImmigrationConfig` | `UNKNOWN_SOURCE` |
+| `immigration.wageElasticity` | `2.0` | coefficient | Code note: NBP 2023 survey | Wage differential migration response | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.remitRate` | `0.15` | income share | Code note: NBP 2023 | Immigrant remittance outflow | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.sectorShares` | `[0.05, 0.35, 0.25, 0.05, 0.05, 0.25]` | share by sector | Code note: GUS LFS 2024 | Immigrant sector allocation | CDF draw | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Immigration accumulates from monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
+| `remittance.perCapita` | `40` | PLN/person/month | Code note: NBP BoP 2024 | Diaspora remittance inflow | Direct | `RemittanceConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.inboundShare`, `outboundShare` | `0.05`, `0.03` | GDP share | Code note: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.seasonality`, `peakMonth` | `0.40`, `7` | share/month | Code note: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.initIndex`, `initMcap` | `2400`, `1.4e12` | index/raw PLN | Code note: GPW 2024 | WIG index and market cap | `initMcap` scaled by `gdpRatio` | `EquityConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `equity.peMean`, `divYield` | `10.0`, `0.057` | scalar/annual rate | Code note: GPW 2024 | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.foreignShare` | `0.67` | share | Code note: KNF/KDPW 2024 | Foreign ownership share | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.spread` | `0.025` | annual rate | Code note: RRRF 2024 BBB | Corporate bond spread | Direct | `CorpBondConfig` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.initStock` | `90e9` | raw PLN | Code note: KNF 2024 | Corporate bonds outstanding | Scaled by `gdpRatio` | `CorpBondConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.recovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate bond recovery | Direct | `CorpBondConfig` | `UNKNOWN_SOURCE` |
+
+## Housing, Prices, Regions, IO, Informal, And SOE
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `housing.initHpi` | `100` | index | Base-index convention | National HPI starting point | Direct | `HousingConfig` | `ASSUMED` |
+| `housing.initValue` | `3.0e12` | raw PLN | Code note: NBP residential price survey 2024 | Aggregate housing stock value | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `housing.initMortgage` | `485e9` | raw PLN | Code note: NBP 2024 | Aggregate mortgage stock | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2`, `-0.8`, `0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.mortgageSpread` | `0.025` | annual rate | Code note: NBP 2024 | Mortgage spread over policy rate | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.mortgageMaturity`, `ltvMax` | `300`, `0.80` | months/share | Code note: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
+| `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003`, `0.001`, `0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.mortgageRecovery` | `0.70` | share | UNKNOWN_SOURCE | Defaulted mortgage recovery | Direct | `HousingConfig` | `UNKNOWN_SOURCE` |
+| `housing.wealthMpc`, `rentalYield` | `0.05`, `0.045` | share/annual rate | Code note: Case, Quigley and Shiller 2005; Otodom/NBP | Housing wealth consumption effect and rental yield | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.regionalMarkets` | 7 regional rows | vector | Code note: NBP/GUS 2024 | Regional HPI, value share, mortgage share, income multipliers | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `regional.baseMigrationRate` | `0.005` | monthly share | Code note: GUS 2024 | Internal migration probability for unemployed workers | Direct | `RegionalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `regional.housingBarrierThreshold` | `0.7` | share | UNKNOWN_SOURCE | Housing-cost migration barrier | Direct | `RegionalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.calvoTheta` | `0.15` | monthly share | Code note: Alvarez et al. 2006 | Average EU price duration around 6.7 months | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pricing.baseMarkup` | `1.15` | multiplier | Code note: Polish microdata approximation | Steady-state markup over marginal cost | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pricing.demandSensitivity`, `costPassthrough` | `0.5`, `0.4` | coefficients | UNKNOWN_SOURCE | Markup response to demand and cost shocks | Direct | `PricingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.minMarkup`, `maxMarkup` | `0.95`, `1.50` | multiplier | Structural bounds | Markup floor and ceiling | Direct | `PricingConfig` | `ASSUMED` |
+| `io.matrix` | 6x6 matrix | technical coefficients | Code note: GUS supply-use tables 2024 | Inter-sector intermediate demand | Direct | `IoConfig` | `CODE_NOTE_EMPIRICAL` |
+| `io.scale` | `1.0` | multiplier | Sensitivity switch | Full-strength I-O flows by default | Direct | `IoConfig` | `POLICY_SCENARIO` |
+| `informal.sectorShares` | `[0.05, 0.15, 0.30, 0.20, 0.02, 0.35]` | share by sector | Code note: Schneider 2023 | Shadow-economy sector shares | Direct | `InformalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `informal.citEvasion`, `vatEvasion`, `pitEvasion`, `exciseEvasion` | `0.80`, `0.90`, `0.85`, `0.70` | share | UNKNOWN_SOURCE | Tax evasion rates by tax channel | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `informal.unempThreshold`, `cyclicalSens`, `smoothing` | `0.05`, `0.50`, `0.92` | rate/coefficient | UNKNOWN_SOURCE | Counter-cyclical informal-sector response | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `soe.baseDividendMultiplier` | `1.3` | multiplier | Code note: MF | Baseline SOE dividend payout versus private firms | Direct | `SoeConfig` | `CODE_NOTE_EMPIRICAL` |
+| `soe.dividendFiscalThreshold`, `dividendFiscalSensitivity` | `0.03`, `5.0` | share/coefficient | UNKNOWN_SOURCE | Fiscal-pressure dividend response | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
+| `soe.firingReduction`, `investmentMultiplier`, `energyPassthrough` | `0.70`, `1.2`, `0.60` | share/multiplier | UNKNOWN_SOURCE | SOE labor buffer, directed investment, energy pass-through | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
+
+## Non-Bank Financials And Public Funds
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ins.lifeReserves`, `nonLifeReserves` | `110e9`, `90e9` | raw PLN | Code note: KNF 2024 | Insurance reserve pools | Scaled by `gdpRatio` | `InsuranceConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `ins.govBondShare`, `corpBondShare`, `equityShare` | `0.35`, `0.08`, `0.12` | share | UNKNOWN_SOURCE | Insurance asset allocation | Portfolio rebalance target | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifePremiumRate`, `nonLifePremiumRate` | `0.003`, `0.0025` | wage-bill share | UNKNOWN_SOURCE | Insurance premium flow | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifeLossRatio`, `nonLifeLossRatio` | `0.85`, `0.70` | share | UNKNOWN_SOURCE | Insurance claims/premiums | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.tfiInitAum` | `380e9` | raw PLN | Code note: KNF/IZFiA 2024 | TFI AUM | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `nbfi.creditInitStock` | `231e9` | raw PLN | Code note: KNF 2024 | NBFI credit stock | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40`, `0.10`, `0.10` | share | UNKNOWN_SOURCE | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.creditBaseRate` | `0.005` | monthly share | UNKNOWN_SOURCE | NBFI credit origination rate | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `nbfi.creditRate` | `0.10` | annual rate | UNKNOWN_SOURCE | NBFI loan rate | `.monthly` in income | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.defaultBase`, `defaultUnempSens` | `0.002`, `3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `quasiFiscal.issuanceShare` | `0.40` | share | Code note: NIK 2024 | BGK/PFR share of capital programs | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.avgMaturityMonths` | `72` | months | Code note: NIK/BGK/PFR | BGK/PFR bond maturity | Amortization `1/maturity` | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.nbpAbsorptionShare` | `0.70` | share | Code note: COVID quasi-QE | NBP absorption under QE | Active when NBP QE active | `QuasiFiscalConfig` | `POLICY_SCENARIO` |
+| `quasiFiscal.lendingShare` | `0.50` | share | Code note: BGK subsidized lending | Lending share of issuance | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `earmarked.fpRate` | `0.0245` | payroll rate | Code note: employment promotion law | Fundusz Pracy levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
+| `earmarked.pfronMonthlyRevenue`, `pfronMonthlySpending` | `460e6`, `420e6` | PLN/month | Code note: PFRON 2024 | PFRON revenue/spending | Direct, currently unscaled | `EarmarkedConfig` | `CODE_NOTE_EMPIRICAL` |
+| `earmarked.fgspRate` | `0.001` | payroll rate | Code note: employee claims law | FGSP levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
+| `earmarked.fgspPayoutPerWorker` | `10000` | PLN/worker | UNKNOWN_SOURCE | Bankruptcy wage payout | Direct | `EarmarkedConfig` | `UNKNOWN_SOURCE` |
+
+## Searchable Gaps
+
+Use the following commands to audit open provenance gaps:
+
+```bash
+rg "UNKNOWN_SOURCE|TUNED_NEEDS_VALIDATION|PLACEHOLDER|POLICY_SCENARIO" docs/calibration-register.md
+```
+
+Priority gaps before publication:
+
+- Replace `UNKNOWN_SOURCE` rows with source table, year, and transformation
+  notes.
+- Split `CODE_NOTE_EMPIRICAL` rows into source-specific evidence links once
+  the data bridge exists.
+- Validate `TUNED_NEEDS_VALIDATION` coefficients with historical fit,
+  stylized-fact matching, or sensitivity ranges.
+- Decide whether currently unscaled institutional monthly flows, such as PFRON
+  monthly revenue/spending, should remain agent-scale values or be moved into
+  the `gdpRatio`-scaled macro-stock convention.
+- Keep scenario deltas in `docs/scenario-registry.md`; this register remains
+  the baseline parameter-provenance surface.

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -1,0 +1,152 @@
+# Empirical Validation Report Skeleton
+
+This report defines how Amor Fati outputs should be compared with empirical
+macro, meso, and micro stylized facts. It is deliberately a skeleton: the
+model already writes numeric simulation evidence, but the external data bridge
+and publication-grade source tables are still tracked separately in #437.
+
+The goal is to keep failed, missing, or weak validation targets visible. A row
+with `MISSING_OUTPUT`, `MISSING_DATA_BRIDGE`, or `NOT_RUN` is part of the report
+surface, not an omission.
+
+## Validation Boundary
+
+Accounting validation and empirical validation answer different questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Runtime ledger checks | Did emitted monetary flows conserve value through the ledger? | Engine runtime checks and SFC identity validation |
+| Paper-facing accounting structure | Are Balance Sheet Matrix and Transactions Flow Matrix rows documented and traceable to runtime mechanisms? | `docs/sfc-matrix-evidence.md` |
+| Empirical validation | Do simulated paths reproduce empirical Polish/EU macro, meso, and micro stylized facts? | This report |
+| Revaluation and other-change accounting | Do stocks reconcile with transactions plus independent revaluations or other changes? | Follow-up #436 |
+
+Empirical validation must not be used to relax accounting constraints. A model
+run can fit an empirical target and still be invalid if the ledger or SFC
+checks fail.
+
+## Status Taxonomy
+
+| Status | Meaning |
+| --- | --- |
+| `READY_FOR_BASELINE` | Output columns exist and the empirical target family is identified. |
+| `PARTIAL_OUTPUT` | Output exists but requires a derived metric, normalization, or additional aggregation. |
+| `MISSING_DATA_BRIDGE` | Model output exists, but external source extraction/transformation is not documented yet. |
+| `MISSING_OUTPUT` | Target is known, but the Monte Carlo output schema does not yet expose enough model state. |
+| `ACCOUNTING_ONLY` | This belongs to accounting validation, not empirical fit. |
+| `NOT_RUN` | The baseline validation run has not yet been summarized in this report. |
+
+## Reproducible Workflow
+
+Run a small deterministic baseline Monte Carlo batch:
+
+```bash
+sbt "run 3 validation-baseline --duration 120 --run-id validation-baseline"
+```
+
+Expected output files:
+
+```text
+mc/validation-baseline_validation-baseline_120m_seed001.csv
+mc/validation-baseline_validation-baseline_120m_seed002.csv
+mc/validation-baseline_validation-baseline_120m_seed003.csv
+mc/validation-baseline_validation-baseline_120m_hh.csv
+mc/validation-baseline_validation-baseline_120m_banks.csv
+```
+
+Use the per-seed CSV files for monthly macro, meso, financial, and mechanism
+paths. Use the `_hh.csv` and `_banks.csv` files for terminal household and bank
+cross-section summaries.
+
+Manual update procedure until #437 adds a formal data bridge:
+
+1. Run the command above from the repository root.
+2. Record commit hash, run id, duration, seed count, and parameter branch.
+3. For each target row below, compute the model statistic from the mapped CSV
+   column or terminal summary field.
+4. Fill empirical source, vintage, target value, model value, tolerance, and
+   status in the report snapshot.
+5. Keep rows with missing model output or missing empirical data in the table.
+
+## Output Mapping
+
+The primary numeric surface is
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala`.
+Terminal cross-sections come from
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala`.
+
+| Validation target | Empirical comparator | Model output mapping | Suggested statistic | Current status |
+| --- | --- | --- | --- | --- |
+| GDP growth | GUS national accounts real GDP growth | Engine state `world.cachedMonthlyGdpProxy`; no direct CSV column yet. `GovDebt` and `DebtToGdp` can imply annualized GDP only when both are valid. | Annual or quarterly growth of real/price-adjusted GDP proxy | `MISSING_OUTPUT` |
+| Inflation | GUS CPI / HICP, NBP inflation target | `Inflation`, `PriceLevel`, `ExpectedInflation`, `InflationForecastError` | Mean, volatility, target deviation, persistence | `READY_FOR_BASELINE` |
+| Unemployment | GUS BAEL / registered unemployment | `Unemployment`, `Unemp_Central`, `Unemp_South`, `Unemp_East`, `Unemp_Northwest`, `Unemp_Southwest`, `Unemp_North` | Mean level, volatility, regional dispersion | `READY_FOR_BASELINE` |
+| Wages | GUS average wage, sector wage indices | `MarketWage`, `MinWageLevel`; terminal household income distribution not directly emitted | Mean wage level and growth; minimum/market wage ratio | `PARTIAL_OUTPUT` |
+| Credit/GDP | NBP credit aggregates to GDP | `CreditToGdpGap`, `ConsumerLoans`, `MortgageToGdp`, `MortgageStock`, `NbfiLoanStock`; terminal `_banks.csv` field `Loans` | Credit/GDP level, gap, household/firm split | `PARTIAL_OUTPUT` |
+| Public debt/GDP | MF public debt, ESA2010 general-government debt | `DebtToGdp`, `Esa2010DebtToGdp`, `GovDebt`, `QfBondsOutstanding`, `BondsOutstanding` | Terminal debt/GDP and path against thresholds | `READY_FOR_BASELINE` |
+| Current account | NBP balance of payments | `CurrentAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NetRemittances`, `NetTourismBalance`, `FDI` | Annualized current-account/GDP and component signs | `PARTIAL_OUTPUT` |
+| Firm-size distribution | GUS/REGON firm-size distribution | Initialization config `PopulationConfig`; no monthly or terminal firm-size histogram CSV yet | Init distribution and survival-weighted terminal distribution | `MISSING_OUTPUT` |
+| Bankruptcies | GUS / Ministry of Justice corporate insolvencies, consumer bankruptcy statistics | `FirmDeaths`, `FirmBirths`, `NetEntry`, `BankFailures`; terminal `_hh.csv` fields `HH_Bankrupt`, `BankruptcyRate`, `MeanMonthsToRuin` | Firm exit rate, household bankruptcy rate, bank failures | `PARTIAL_OUTPUT` |
+| Bank capital and liquidity | KNF banking-sector CAR, LCR, NSFR, NPL | `MinBankCAR`, `MinBankLCR`, `MinBankNSFR`, `NPL`, `MaxBankNPL`; terminal `_banks.csv` fields `CAR`, `NPL`, `Capital`, `Deposits`, `Loans` | Minimum and distributional stress indicators | `READY_FOR_BASELINE` |
+| Inequality | GUS household surveys, EU-SILC, OECD income/wealth indicators | Terminal `_hh.csv` fields `Gini_Individual`, `Gini_Wealth`, `ConsumptionP10`, `ConsumptionP50`, `ConsumptionP90`, `PovertyRate_50pct`, `PovertyRate_30pct` | Terminal Gini, poverty rates, consumption percentile ratios | `MISSING_DATA_BRIDGE` |
+| Sectoral output | GUS national accounts by sector, supply-use tables | Sector columns currently expose `BPO_Auto`, `Manuf_Auto`, `Retail_Auto`, `Health_Auto`, `Public_Auto`, `Agri_Auto`, sector sigmas, and `IoFlows`; direct sector output is not emitted | Sector output shares and growth | `MISSING_OUTPUT` |
+| External prices and FX | NBP exchange rate, ECB/Eurostat external prices | `ExRate`, `ForeignPriceIndex`, `GvcImportCostIndex`, `CommodityPriceIndex`, `FxReserves`, `FxInterventionAmt` | FX level/volatility, reserve path, import-cost shocks | `READY_FOR_BASELINE` |
+| Housing and mortgages | NBP housing prices, mortgage stock, KNF mortgage risk | `HousingPriceIndex`, `WawHpi`, `KrkHpi`, `WroHpi`, `GdnHpi`, `LdzHpi`, `PozHpi`, `RestHpi`, `MortgageToGdp`, `MortgageDefault` | HPI path, regional dispersion, mortgage/GDP, defaults | `READY_FOR_BASELINE` |
+| Fiscal stance | MF budget execution, Eurostat deficit/GDP | `DeficitToGdp`, `GovCurrentSpend`, `GovCapitalSpendDomestic`, `DebtService`, `FiscalRuleBinding`, `GovSpendingCutRatio` | Deficit/GDP, expenditure mix, fiscal-rule episodes | `READY_FOR_BASELINE` |
+| Monetary and financial market conditions | NBP reference rate, WIBOR, bond yields, GPW | `RefRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BondYield`, `GpwIndex`, `GpwMarketCap`, `CorpBondYield`, `CorpBondSpread` | Policy-rate path, spread behavior, market stress | `READY_FOR_BASELINE` |
+
+## Baseline Report Snapshot
+
+This table is the publication-facing slot that should be filled after a
+baseline run. Placeholder values remain explicit until the empirical data
+bridge and baseline analysis have been completed.
+
+| Target | Empirical source and vintage | Empirical value | Model run | Model value | Tolerance / criterion | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| GDP growth | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct GDP output column still needed. |
+| Inflation | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use `Inflation` and `PriceLevel`. |
+| Unemployment | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Include regional dispersion. |
+| Wages | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Current output is aggregate market wage. |
+| Credit/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Firm-loan split depends partly on terminal bank summary. |
+| Public debt/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Compare `DebtToGdp` and `Esa2010DebtToGdp`. |
+| Current account | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Needs GDP denominator and annualization convention. |
+| Firm-size distribution | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal firm-size histogram not emitted yet. |
+| Bankruptcies | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use firm deaths and household bankruptcy separately. |
+| Bank capital/liquidity | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use minima and terminal bank distribution. |
+| Inequality | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal household summary has first-pass measures. |
+| Sectoral output | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct sector output columns still needed. |
+
+## Target-Specific Notes
+
+GDP growth should be reported only after the model exposes a direct GDP or
+monthly GDP proxy column. The engine already computes `world.cachedMonthlyGdpProxy`,
+but relying on `GovDebt / DebtToGdp` as a CSV reconstruction is too fragile for
+publication use.
+
+Inflation validation should use both the period inflation column and the price
+level path. The report should state whether the statistic is monthly,
+annualized, or year-over-year.
+
+Credit/GDP should distinguish bank firm loans, consumer loans, mortgage credit,
+and NBFI credit. Current outputs cover several pieces but do not yet provide a
+single total-credit-to-GDP series.
+
+Firm-size distribution and sectoral output are currently the most visible
+meso-level output gaps. The model has sector metadata, firm state, and
+population initialization, but the Monte Carlo CSV does not yet emit a terminal
+firm-size histogram or sector output shares.
+
+Inequality validation is terminal-only for now. The household summary already
+emits Gini, poverty, and consumption percentile fields, but external source
+mapping and frequency conventions belong in #437.
+
+## Follow-Up Links
+
+- #437: external data bridge, source vintages, licenses, transformations, and
+  empirical target values.
+- `docs/sensitivity-robustness-workflow.md`: stochastic uncertainty, parameter
+  sensitivity, confidence envelopes, and robustness metrics around this
+  baseline report.
+- `docs/scenario-registry.md`: named scenarios whose outputs should reuse the
+  same validation target table.
+- #436: stock-flow reconciliation and revaluation artifact; keep this separate
+  from empirical fit.
+- #438: milestone tracker for the full research-readiness spine.

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -1,0 +1,438 @@
+# ODD and ODD+D Model Documentation
+
+This document is the paper-facing model description for Amor Fati as a
+stock-flow consistent agent-based macroeconomic model of the Polish economy.
+It follows the ODD protocol structure and adds ODD+D notes for human and
+institutional decision making.
+
+The document describes the current implementation, not an idealized target
+model. Open gaps are listed explicitly at the end.
+
+## Protocol References
+
+The structure follows:
+
+- Grimm et al. (2020), "The ODD protocol for describing agent-based and other
+  simulation models: A second update to improve clarity, replication, and
+  structural realism", JASSS 23(2), https://www.jasss.org/23/2/7.html
+- Grimm et al. (2006), "A standard protocol for describing individual-based
+  and agent-based models", https://www.usgs.gov/publications/a-standard-protocol-describing-individual-based-and-agent-based-models
+- Mueller et al. (2013), "Describing human decisions in agent-based models -
+  ODD+D, an extension of the ODD protocol",
+  https://doi.org/10.1016/j.envsoft.2013.06.003
+
+ODD is used here as a stable model-description format. ODD+D is used as an
+overlay for decision rules, information, constraints, heterogeneity, and
+adaptation in households, firms, banks, and policy institutions.
+
+## 1. Purpose And Patterns
+
+### Purpose
+
+Amor Fati is designed to support executable counterfactual analysis of a
+monetary production economy under strict stock-flow consistency. The immediate
+domain is the Polish economy with heterogeneous households, heterogeneous firms,
+seven banks, public-sector institutions, financial markets, non-bank financial
+institutions, insurance, and a rest-of-world sector.
+
+The model is intended to answer questions of the following kind:
+
+- How do fiscal, monetary, banking, external-sector, and technology shocks
+  propagate through heterogeneous agents and balance sheets?
+- Which channels produce macro outcomes such as unemployment, inflation,
+  bank stress, credit contraction, public debt pressure, current-account
+  movement, and firm entry or exit?
+- Which outputs are behavioral model results and which are accounting
+  invariants enforced by the runtime ledger?
+
+The central design constraint is stronger than calibration plausibility:
+financial flows must conserve value exactly and the semantic SFC identities
+must close each month. Behavioral rules may be revised; accounting drift is a
+model error.
+
+### Target Patterns
+
+The current model is expected to generate and expose:
+
+- macro time series: GDP proxy, inflation, unemployment, wages, public debt,
+  fiscal balance, credit, deposits, bank capital, and monetary aggregates;
+- meso patterns: sectoral output, hiring pressure, production capacity,
+  firm-size and technology composition, regional labor variation, and external
+  trade/GVC stress;
+- micro patterns: household employment status, consumption, savings, debt
+  distress, retraining, bankruptcy, education, region, and social-neighbor
+  effects;
+- financial-stability patterns: CAR, NPLs, LCR/NSFR inputs, interbank stress,
+  bank failure and resolution, BFG levy and bail-in, government-bond portfolio
+  effects, and credit rationing;
+- accounting artifacts: symbolic Balance Sheet Matrix (BSM), Transactions
+  Flow Matrix (TFM), and runtime mapping generated from an executed simulation
+  step.
+
+Empirical validation of these patterns is tracked separately in #433.
+
+## 2. Entities, State Variables, And Scales
+
+### Entity Classes
+
+| Entity | Representation | Main state | Code anchor |
+| --- | --- | --- | --- |
+| Households | Individual agents | employment/activity status, wage, skill, health penalty, MPC, rent, social neighbors, bank assignment, region, education, contract type, household financial stocks projected from the ledger | `agents/Household.scala` |
+| Firms | Individual agents | sector, technology regime, workers, productivity/capacity, capital stock, inventory, cash/debt/equity projections, digital readiness, network position, bankruptcy state | `agents/Firm.scala` |
+| Banks | Seven named bank agents | operational status, capital diagnostics, NPLs, risk buckets, regulatory ratios, per-bank rates, resolution state; financial stocks projected from ledger rows | `agents/Banking.scala` |
+| Government | Aggregate institution | spending, tax revenue, debt, fiscal rules, bond issuance, benefits, transfers, capital investment | `engine/markets/FiscalBudget.scala`, `engine/flows/GovBudgetFlows.scala` |
+| NBP | Central bank institution | reference rate, QE policy, FX operations, reserve/standing-facility plumbing, government-bond and foreign-asset stocks | `agents/Nbp.scala`, `engine/flows/BankingFlows.scala` |
+| Social funds | Aggregate public-fund agents | ZUS/FUS, NFZ, PPK, FP, PFRON, FGSP balances and monthly contribution/spending flows | `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` |
+| Local government | Aggregate JST sector | local tax revenue, central-government subvention, spending, unsupported local debt metric, cash | `agents/Jst.scala`, `engine/flows/JstFlows.scala` |
+| Insurance | Aggregate life and non-life sector | premiums, claims, investment income, reserves, bond/equity holdings | `agents/Insurance.scala`, `engine/flows/InsuranceFlows.scala` |
+| NBFI and funds | Aggregate TFI/NBFI/BGK/PFR layer | fund units, AUM, deposit drain, NBFI credit, quasi-fiscal bonds and lending | `agents/Nbfi.scala`, `agents/QuasiFiscal.scala` |
+| Rest of world | Aggregate external sector | trade, tourism, FDI, portfolio flows, carry trade, remittances, primary income, EU funds, foreign holdings | `engine/markets/OpenEconomy.scala`, `engine/flows/OpenEconFlows.scala` |
+
+The ledger-facing sector ontology is `EntitySector`: Households, Firms, Banks,
+Government, NBP, Insurance, Funds, and Foreign. In paper matrices, Foreign is
+shown as ROW, meaning Rest of World.
+
+### State Variables
+
+Amor Fati separates state into three broad surfaces:
+
+- behavioral agent state: household, firm, and bank decision-relevant state;
+- macro and market state: prices, policy, external conditions, expectations,
+  market memory, demand signals, regional wages, and mechanism state;
+- ledger-owned financial state: supported financial balances in
+  `LedgerFinancialState`, projected into runtime execution and validation.
+
+The top-level monthly boundary is `FlowSimulation.SimState`, containing:
+
+- completed month index;
+- `World` macro/runtime state;
+- firm, household, and bank vectors;
+- household aggregate diagnostics;
+- ledger financial state.
+
+`World` contains nested state for social systems, household market state,
+financial markets, external sector, real economy, mechanisms, monetary plumbing,
+pipeline signals, flows, and regional wages.
+
+### Scale
+
+The default scale is:
+
+- economy: Poland, with explicit rest-of-world sector;
+- time: monthly discrete time steps;
+- firms: 10,000 default firm agents;
+- households: default total population equals `firmsCount * workersPerFirm`,
+  currently 100,000 household agents under default parameters;
+- banks: seven bank agents;
+- production sectors: BPO/SSC, Manufacturing, Retail/Services, Healthcare,
+  Public, Agriculture;
+- regions: six NUTS-1 macroregions used for regional labor and housing
+  mechanics;
+- money: PLN-denominated fixed-point domain values, with agent-level flows
+  scaled to Polish macro magnitudes through `gdpRatio`.
+
+The model is not a geospatial ABM in the GIS sense. Region is an agent
+attribute and market segmentation device, not a continuous spatial coordinate.
+
+## 3. Process Overview And Scheduling
+
+### Initialization
+
+Initialization is deterministic given an `InitRandomness.Contract`. `WorldInit`
+constructs:
+
+- initial `World` macro state;
+- firms, households, and banks;
+- household aggregates;
+- initial `LedgerFinancialState`.
+
+Sub-factories create specific slices: firm network and sector structure, bank
+rows, household demographic/financial heterogeneity, immigrants, demographics,
+GVC state, insurance, NBFI, expectations, and housing.
+
+### Monthly Step
+
+Each model month is executed by:
+
+```scala
+FlowSimulation.step(state: SimState, randomness: MonthRandomness.Contract)
+```
+
+The high-level order is fixed:
+
+1. Read the start-of-month state and explicit randomness contract.
+2. Compute same-month economics in a nine-stage deterministic pipeline.
+3. Translate calculated quantities into typed monetary-flow mechanisms.
+4. Emit batched flows into the runtime ledger topology.
+5. Execute flows through the ledger interpreter.
+6. Project supported runtime deltas back into ledger-owned financial state.
+7. Run exact SFC validation.
+8. Extract end-of-month outputs and next-month decision signals.
+9. Return `StepOutput` with `nextState`, trace, flows, validation, and deltas.
+
+### Economics Pipeline
+
+The monthly calculus stages are:
+
+| Stage | Module | Domain |
+| --- | --- | --- |
+| s1 | `FiscalConstraintEconomics` | minimum wage indexation, reservation wage, lending base rate |
+| s2 | `LaborEconomics` | labor market, wages, employment, demographics, immigration, payroll base |
+| s3 | `HouseholdIncomeEconomics` | household income, consumption, saving, portfolios, separations, mobility |
+| s4 | `DemandEconomics` | demand allocation across consumption, government purchases, investment, exports |
+| s5 | `FirmEconomics` | production, I-O intermediate market, capex, financing, labor, NPL detection |
+| s6 | `HouseholdFinancialEconomics` | mortgages, deposit interest, remittances, tourism, consumer credit |
+| s7 | `PriceEquityEconomics` | inflation, equity market, GDP proxy, macroprudential, EU funds |
+| s8 | `OpenEconEconomics` | BoP, forex, GVC, Taylor rule, bond yields, insurance, NBFI |
+| s9 | `BankingEconomics` | bank P&L, provisioning, CAR, resolution, interbank, BFG levy, M1/M2/M3 |
+| final | `WorldAssemblyEconomics` | aggregation, informal economy, observables, SFC status, next state |
+
+### Flow Emission And Accounting Boundary
+
+Economics stages compute quantities. Monetary execution is done through
+runtime flows. Each emitted flow has a `FlowMechanism` and an `AssetType`.
+Flows are grouped into `BatchedFlow` values and executed through the ledger.
+
+The SFC matrix evidence workflow generates symbolic BSM and TFM artifacts from
+an executed deterministic step. See `docs/sfc-matrix-evidence.md`.
+
+### Timing Contract
+
+The model distinguishes:
+
+- `pre` decision inputs persisted at the beginning of a month;
+- same-month operational signals computed inside a month;
+- post-month realized outcomes;
+- extracted next-month `DecisionSignals`.
+
+This contract is implemented through `MonthSemantics`, `OperationalSignals`,
+`SignalExtraction`, and `MonthTrace`. It prevents same-month results from being
+silently read as if they were beginning-of-month information.
+
+### Randomness And Reproducibility
+
+Initialization and monthly execution use explicit root seeds split into named
+random streams. Fixing the initialization seed and month-level randomness
+schedule fixes replay. Monte Carlo runs use the same engine path, varying seeds
+and writing per-seed time series.
+
+## 4. Design Concepts
+
+### Basic Principles
+
+The model combines:
+
+- stock-flow consistent macro accounting;
+- heterogeneous-agent ABM microstructure;
+- institutional detail for Poland;
+- ledger-first monetary execution;
+- bounded, rule-based decisions rather than representative-agent optimization.
+
+The strongest invariant is accounting conservation. Behavioral rules are
+research hypotheses encoded as executable mechanisms.
+
+### Emergence
+
+The model treats macro variables as emergent from agent and institutional
+interactions: GDP proxy, inflation, unemployment, credit, defaults, public debt,
+bank stress, trade balance, monetary aggregates, firm entry/exit, sectoral
+composition, automation ratios, and financial-market indicators.
+
+### Adaptation
+
+Households adapt consumption, saving pressure, sectoral mobility, retraining,
+credit usage, and distress state to income, employment, networks, prices, and
+bank rates. Firms adapt hiring, firing, pricing, investment, technology choice,
+financing, production, and survival to demand, costs, credit, expectations, and
+sector conditions. Banks adapt lending rates, approval conditions, liquidity,
+interbank behavior, provisioning, and resolution behavior to capital, NPLs,
+rates, liquidity and regulation. Fiscal, monetary, and macroprudential rules
+respond to debt, inflation, output, unemployment, and credit conditions.
+
+### Objectives
+
+The model uses local procedural objectives:
+
+- households attempt to maintain consumption, housing payments, employment,
+  financial buffers, and solvency under bounded resources;
+- firms attempt to produce profitably, meet demand, manage labor and capital,
+  finance investment, adopt technology when favorable, and avoid insolvency;
+- banks attempt to lend profitably while satisfying capital and liquidity
+  constraints and absorbing losses;
+- government follows fiscal-rule and spending/tax logic;
+- NBP follows monetary and liquidity-plumbing rules;
+- funds, insurance, and external-sector modules follow institutional flow and
+  balance-sheet rules.
+
+No global social planner optimizes the economy.
+
+### Learning And Prediction
+
+The model contains adaptive expectations and lagged signal propagation rather
+than full rational expectations. The `DecisionSignals` surface carries lagged
+inflation, expected inflation, unemployment, hiring slack, startup absorption,
+and sector demand signals. Expectations, pricing, investment, mobility, and
+entry decisions use these signals through local rules.
+
+### Sensing
+
+Agents and institutions sense local or aggregate state depending on their role:
+
+- households sense wage, employment status, bank rates, financial buffers,
+  social-neighbor distress, region, and sector mobility opportunities;
+- firms sense sector demand, capacity, labor cost, capital cost, technology
+  readiness, cash/debt constraints, neighbors, and market prices;
+- banks sense loan books, deposits, reserves, NPLs, CAR, regulatory buffers,
+  bond yields, failed-bank state, and interbank conditions;
+- public institutions sense tax bases, unemployment, debt, spending pressure,
+  social-insurance balances, inflation, and external-sector conditions.
+
+### Interaction
+
+Interactions are mediated by:
+
+- labor markets and firm-worker matching;
+- goods demand and sectoral production;
+- household social networks and distress contagion;
+- firm networks and technology demonstration effects;
+- bank assignment, rates, lending, defaults, interbank, and resolution;
+- fiscal transfers, taxes, benefits, and government purchases;
+- bond, equity, mortgage, insurance, NBFI, and quasi-fiscal markets;
+- external trade, capital flows, remittances, tourism, and GVC shocks;
+- the runtime ledger, which records monetary consequences.
+
+### Stochasticity
+
+Stochasticity enters through explicit random streams. Examples include
+initial heterogeneity, firm network topology, household traits, sectoral
+assignment, mobility, retraining, technology adoption/failure, market draws,
+and Monte Carlo seeds. Randomness is not hidden in global mutable state.
+
+### Collectives
+
+Some entities are true individual agents: households, firms, banks. Others are
+collective or institutional sectors represented at aggregate resolution:
+government, NBP, social funds, insurance, NBFI/funds, quasi-fiscal bodies, and
+rest of world. This is intentional: the model allocates agent detail where it
+is expected to affect macro dynamics or distributional outcomes.
+
+### Observation
+
+Observation surfaces include:
+
+- `MonthTrace` for boundary, randomness, validation, and timing diagnostics;
+- Monte Carlo per-seed CSV time series;
+- household and bank terminal summary CSVs;
+- SFC validation results;
+- ledger-derived symbolic BSM and TFM artifacts;
+- symbolic-row to runtime-ledger mapping.
+
+## ODD+D Decision Notes
+
+The following table summarizes the current human and institutional decision
+surfaces. Detailed mathematical rule documentation is tracked in #431.
+
+| Decision unit | Decisions | Information used | Constraints | Heterogeneity and adaptation |
+| --- | --- | --- | --- | --- |
+| Households | consume, save/draw buffers, pay rent/debt, use consumer credit, retrain, change sector, become bankrupt | wage, employment status, bank rates, debt service, deposits, social-neighbor distress, region, education, sector signals | income, deposits, debt, credit terms, unemployment duration, retraining cost and success probability | skill, health, MPC, education, region, contract type, immigrant status, social network |
+| Firms | produce, hire/fire, price/markup, invest, adopt hybrid/AI technology, borrow, issue equity/bonds, enter or exit | demand pressure, capacity, wages, costs, credit rates, cash, debt, sector, network effects, digital readiness | cash, working capital, labor availability, bank lending, profitability thresholds, technology failure risk | sector, size, technology regime, readiness, productivity, bank relation, network position |
+| Banks | price loans/deposits, approve credit, manage liquidity, absorb losses, provision, resolve failures, participate in interbank and bond markets | deposits, loans, reserves, capital, NPLs, bond yields, regulatory buffers, failed-bank state | CAR, LCR/NSFR inputs, reserve requirement, BFG/bail-in rules, failed-bank exclusion | seven bank rows with bank-specific buffers, spreads, capital, balance sheets |
+| Government | tax, spend, transfer, invest, issue debt, service debt, respond to fiscal rules | fiscal balance, debt, unemployment, tax bases, bond demand, social fund balances | fiscal-rule severity, debt brake, spending cuts, financing needs | aggregate institution with policy parameters |
+| NBP | set rate channel inputs, provide reserve interest and standing facilities, QE/FX operations | inflation, output, forex, reserves, bond market, interbank state | policy corridor, reserves, QE pace, FX reserve stock | aggregate institution |
+| Funds and insurance | collect contributions/premiums, pay claims/benefits, allocate holdings, issue/absorb quasi-fiscal instruments | payroll, unemployment, bankruptcies, AUM, reserves, bond/equity returns | statutory contribution/spending rules, portfolio shares, reserve/liability constraints | aggregate institution by fund family |
+| Rest of world | trade, tourism, FDI, portfolio, carry trade, primary income, remittances, foreign bond/equity participation | exchange rate, yields, demand, GVC state, risk-off conditions | external demand, capital-flow rules, foreign-asset positions | aggregate foreign sector |
+
+Decision rules are currently procedural and bounded. The project does not claim
+that every behavioral rule is empirically final. Parameter provenance and
+calibration status are tracked in #432.
+
+## 5. Initialization
+
+The initialized state is produced by `WorldInit.initialize`, using
+`InitRandomness.Contract.fromSeed(seed)`. The initializer:
+
+- builds firm and household populations from `PopulationConfig`, `FirmConfig`,
+  `HouseholdConfig`, sector definitions, firm-size distribution, networks, and
+  region/education/skill draws;
+- builds seven banks and their initial financial-stock DTOs;
+- initializes government, NBP, social funds, insurance, NBFI, quasi-fiscal,
+  housing, GVC, expectations, immigration, and demographics state;
+- assembles initial `LedgerFinancialState` as the source of truth for
+  supported financial stocks;
+- derives initial household aggregates.
+
+Default parameters are hardcoded in `SimParams.defaults`; stock values are
+scaled by `gdpRatio` to map agent-level monthly flows to real Polish macro
+magnitudes. The current initialization does not yet read a formal external data
+bundle. That data bridge is tracked in #437.
+
+## 6. Input Data
+
+Current inputs are:
+
+- source-code defaults in `SimParams.defaults` and sub-config classes;
+- explicit initialization seed;
+- explicit monthly randomness schedule;
+- Monte Carlo configuration (`nSeeds`, duration, run id, output prefix);
+- scenario changes expressed by modifying/copying config values in code.
+
+The model contains many Poland-specific calibration comments and values, but a
+single structured calibration register is not yet available. That work is
+tracked in #432. A reproducible scenario registry is tracked in #435.
+
+## 7. Submodels
+
+The model is organized into submodels by package:
+
+- `agents`: autonomous household, firm, bank, public-sector, insurance, NBFI,
+  quasi-fiscal, migration, and social-security state/rules;
+- `init`: factories for deterministic initial state construction;
+- `engine/economics`: fixed monthly computation pipeline;
+- `engine/flows`: monetary-flow emission and ledger execution;
+- `engine/ledger`: financial-stock ownership contracts and runtime projection;
+- `engine/markets`: market clearing, prices, yields, equity, housing,
+  corporate bonds, open economy, capital flows, GVC, I-O, and regional markets;
+- `engine/mechanisms`: policy, expectations, macroprudential, mobility, tax,
+  yield-curve, informal-economy, and entry mechanisms;
+- `accounting`: exact SFC identities and ledger-derived matrix evidence;
+- `montecarlo`: multi-seed execution and output schemas.
+
+The current paper-facing behavioral equation catalog is not yet complete. This
+ODD document therefore identifies submodels and decision surfaces, while #431
+will document equations and algorithmic rules in greater depth.
+
+## Accounting And Validation Boundary
+
+Amor Fati has two related but distinct accounting surfaces:
+
+- runtime ledger execution: every emitted monetary flow is applied through the
+  ledger topology and must conserve value exactly;
+- semantic SFC validation: 15 accounting identities are checked over the
+  economic stocks and flows exposed by the model.
+
+The matrix evidence workflow adds paper-facing symbolic artifacts:
+
+- Balance Sheet Matrix (BSM);
+- Transactions Flow Matrix (TFM);
+- symbolic-row to runtime-ledger mapping.
+
+Numeric evidence remains in the simulation and Monte Carlo outputs. Symbolic
+matrix artifacts document the accounting structure used to interpret those
+outputs.
+
+## Open Gaps
+
+This document deliberately marks unfinished research-readiness work:
+
+- #431: detailed behavioral equations and decision-rule book;
+- #432: calibration register with parameter provenance, units, targets, and
+  status;
+- #433: empirical validation report and stylized-fact mapping;
+- #434: sensitivity and robustness workflow;
+- #435: reproducible scenario registry;
+- #436: stock-flow reconciliation and revaluation matrix artifact;
+- #437: data bridge to national and financial accounts.
+
+These gaps do not mean the engine is undocumented or untestable. They mean the
+model is not yet fully packaged as a publication-ready empirical research
+system.

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -69,7 +69,8 @@ The current model is expected to generate and expose:
   Flow Matrix (TFM), and runtime mapping generated from an executed simulation
   step.
 
-Empirical validation of these patterns is tracked separately in #433.
+Empirical validation of these patterns is structured in
+`docs/empirical-validation-report.md`.
 
 ## 2. Entities, State Variables, And Scales
 
@@ -330,7 +331,8 @@ Observation surfaces include:
 ## ODD+D Decision Notes
 
 The following table summarizes the current human and institutional decision
-surfaces. Detailed mathematical rule documentation is tracked in #431.
+surfaces. Detailed mathematical rules are documented in
+`docs/behavioral-equations-and-decision-rules.md`.
 
 | Decision unit | Decisions | Information used | Constraints | Heterogeneity and adaptation |
 | --- | --- | --- | --- | --- |
@@ -344,7 +346,7 @@ surfaces. Detailed mathematical rule documentation is tracked in #431.
 
 Decision rules are currently procedural and bounded. The project does not claim
 that every behavioral rule is empirically final. Parameter provenance and
-calibration status are tracked in #432.
+calibration status are documented in `docs/calibration-register.md`.
 
 ## 5. Initialization
 
@@ -374,11 +376,13 @@ Current inputs are:
 - explicit initialization seed;
 - explicit monthly randomness schedule;
 - Monte Carlo configuration (`nSeeds`, duration, run id, output prefix);
-- scenario changes expressed by modifying/copying config values in code.
+- named scenario changes from `docs/scenario-registry.md`, or direct config
+  changes in code for exploratory work.
 
 The model contains many Poland-specific calibration comments and values, but a
-single structured calibration register is not yet available. That work is
-tracked in #432. A reproducible scenario registry is tracked in #435.
+structured calibration register is documented in
+`docs/calibration-register.md`. The reproducible scenario registry is
+documented in `docs/scenario-registry.md`.
 
 ## 7. Submodels
 
@@ -397,9 +401,26 @@ The model is organized into submodels by package:
 - `accounting`: exact SFC identities and ledger-derived matrix evidence;
 - `montecarlo`: multi-seed execution and output schemas.
 
-The current paper-facing behavioral equation catalog is not yet complete. This
-ODD document therefore identifies submodels and decision surfaces, while #431
-will document equations and algorithmic rules in greater depth.
+The paper-facing behavioral equation catalog is documented in
+`docs/behavioral-equations-and-decision-rules.md`. This ODD document keeps the
+protocol-level model description, while that rule book carries equations,
+algorithmic rules, implementation references, output columns, and explicit
+simplifications.
+
+The empirical validation report skeleton is documented in
+`docs/empirical-validation-report.md`. It maps the current Monte Carlo output
+surface to macro, meso, micro, financial, and external validation targets and
+keeps missing data or output coverage visible.
+
+The sensitivity and robustness workflow is documented in
+`docs/sensitivity-robustness-workflow.md`. It runs small Monte Carlo seed bands
+and one-at-a-time parameter sweeps, producing seed envelopes and sensitivity
+summaries under `target/`.
+
+The reproducible scenario registry is documented in
+`docs/scenario-registry.md`. It defines named baseline, policy, banking,
+external, energy, tourism, and quasi-fiscal experiments with exact parameter
+deltas and an executable `scenarioRun` command path.
 
 ## Accounting And Validation Boundary
 
@@ -424,12 +445,6 @@ outputs.
 
 This document deliberately marks unfinished research-readiness work:
 
-- #431: detailed behavioral equations and decision-rule book;
-- #432: calibration register with parameter provenance, units, targets, and
-  status;
-- #433: empirical validation report and stylized-fact mapping;
-- #434: sensitivity and robustness workflow;
-- #435: reproducible scenario registry;
 - #436: stock-flow reconciliation and revaluation matrix artifact;
 - #437: data bridge to national and financial accounts.
 

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -1,0 +1,116 @@
+# Scenario Registry
+
+This registry defines named policy and shock experiments that can be inspected,
+run, and compared reproducibly. It is separate from the sensitivity workflow:
+scenario runs are named economic stories, while sensitivity runs are local
+one-at-a-time parameter checks.
+
+The source of truth is
+`src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala`.
+The executable runner is
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala`.
+
+## Command
+
+Run the baseline plus two nontrivial scenarios:
+
+```bash
+sbt "scenarioRun --scenarios baseline,monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+```
+
+Run every registered scenario:
+
+```bash
+sbt "scenarioRun --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+## Output Layout
+
+For `--out target/scenarios --run-id local-review`, the runner writes:
+
+```text
+target/scenarios/local-review/
+  scenario-registry.md
+  scenario-deltas.csv
+  run-summary.csv
+  baseline/
+    metadata.md
+    local-review_baseline_24m_seed001.csv
+  monetary-tightening/
+    metadata.md
+    local-review_monetary-tightening_24m_seed001.csv
+```
+
+Each per-seed CSV uses `McTimeseriesSchema.colNames` as the header, so scenario
+outputs can be compared directly with validation and robustness artifacts.
+
+## Registered Scenarios
+
+| Scenario | Label | Category | Recommended months | Purpose |
+| --- | --- | --- | --- | --- |
+| `baseline` | Baseline | baseline | 120 | Reference scenario using `SimParams.defaults`. |
+| `monetary-tightening` | Monetary tightening | policy rates | 60 | Higher NBP policy stance for inflation and credit stress analysis. |
+| `fiscal-expansion` | Fiscal expansion | fiscal policy | 60 | Higher government demand and capital share for fiscal multiplier and debt-path comparisons. |
+| `credit-crunch` | Credit crunch | banking stress | 60 | Tighter credit supply and weaker recovery assumptions for credit and default stress testing. |
+| `energy-shock` | Energy shock | climate and commodity shock | 60 | ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure. |
+| `tourism-shock` | Tourism shock | external demand shock | 36 | Tourism-demand loss for services demand, current account, employment, and FX flows. |
+| `bank-failure` | Bank failure stress | financial stability | 36 | Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels. |
+| `fx-capital-flight` | FX and capital-flight stress | external financial shock | 60 | Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand. |
+| `quasi-fiscal-program` | Quasi-fiscal program | quasi-fiscal policy | 60 | BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending. |
+
+## Parameter Deltas
+
+| Scenario | Parameter | Baseline | Scenario value | Note |
+| --- | --- | --- | --- | --- |
+| `baseline` | `SimParams` | `SimParams.defaults` | `SimParams.defaults` | No parameter change. |
+| `monetary-tightening` | `monetary.initialRate` | `0.0575` | `0.075` | Higher starting reference rate. |
+| `monetary-tightening` | `monetary.neutralRate` | `0.04` | `0.05` | Higher neutral-rate anchor. |
+| `monetary-tightening` | `monetary.taylorAlpha` | `1.5` | `1.8` | Stronger inflation response. |
+| `fiscal-expansion` | `fiscal.govBaseSpending` | scaled default | scaled default `* 1.15` | 15% higher base government spending. |
+| `fiscal-expansion` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share. |
+| `fiscal-expansion` | `fiscal.govAutoStabMult` | `3.0` | `3.5` | Stronger automatic stabilization. |
+| `credit-crunch` | `banking.baseSpread` | `0.015` | `0.035` | Higher firm-loan spread. |
+| `credit-crunch` | `banking.minCar` | `0.08` | `0.10` | Higher capital constraint. |
+| `credit-crunch` | `banking.loanRecovery` | `0.30` | `0.20` | Lower corporate-loan recovery. |
+| `credit-crunch` | `banking.eclMigrationSensitivity` | `3.0` | `4.5` | Faster IFRS 9 migration under stress. |
+| `credit-crunch` | `household.ccMaxDti` | `0.40` | `0.30` | Tighter household credit affordability cap. |
+| `energy-shock` | `climate.etsBasePrice` | `80` | `120` | Higher EU ETS starting price. |
+| `energy-shock` | `climate.energyCostShares` | `[0.02,0.10,0.04,0.05,0.03,0.06]` | `[0.03,0.15,0.06,0.075,0.045,0.09]` | 50% higher sector energy-cost burden. |
+| `energy-shock` | `climate.greenBudgetShare` | `0.20` | `0.12` | Lower discretionary green investment capacity under stress. |
+| `energy-shock` | `gvc.commodityShockMonth` | `0` | `6` | Commodity-price shock starts in month 6. |
+| `energy-shock` | `gvc.commodityShockMag` | `0.0` | `1.5` | One-time commodity-price shock magnitude. |
+| `tourism-shock` | `tourism.shockMonth` | `0` | `6` | Tourism shock starts in month 6. |
+| `tourism-shock` | `tourism.shockSize` | `0.80` | `0.60` | 60% tourism-demand loss in the named scenario. |
+| `tourism-shock` | `tourism.shockRecovery` | `0.03` | `0.05` | Faster monthly recovery than default COVID-style setting. |
+| `tourism-shock` | `tourism.inboundShare` | `0.05` | `0.04` | Lower inbound tourism baseline share. |
+| `bank-failure` | `banking.initCapital` | scaled default | scaled default `* 0.55` | Lower opening banking-sector capital. |
+| `bank-failure` | `banking.minCar` | `0.08` | `0.12` | Higher regulatory capital requirement. |
+| `bank-failure` | `banking.depositPanicRate` | `0.03` | `0.08` | Higher deposit panic migration after failures. |
+| `bank-failure` | `banking.maxDepositSwitchRate` | `0.10` | `0.18` | Higher maximum monthly deposit switching. |
+| `fx-capital-flight` | `forex.riskOffShockMonth` | `0` | `6` | Risk-off shock starts in month 6. |
+| `fx-capital-flight` | `forex.riskOffMagnitude` | `0.10` | `0.20` | Larger capital outflow shock. |
+| `fx-capital-flight` | `forex.riskOffDurationMonths` | `6` | `9` | Longer elevated risk-off period. |
+| `fx-capital-flight` | `forex.irpSensitivity` | `0.15` | `0.30` | Stronger exchange-rate response to rate differentials. |
+| `fx-capital-flight` | `forex.exRateAdjSpeed` | `0.02` | `0.05` | Faster exchange-rate adjustment. |
+| `fx-capital-flight` | `monetary.fxMaxMonthly` | `0.03` | `0.06` | Larger allowed monthly FX intervention. |
+| `quasi-fiscal-program` | `quasiFiscal.issuanceShare` | `0.40` | `0.65` | Higher BGK/PFR share of capital programs. |
+| `quasi-fiscal-program` | `quasiFiscal.lendingShare` | `0.50` | `0.70` | More issuance routed to subsidized lending. |
+| `quasi-fiscal-program` | `quasiFiscal.nbpAbsorptionShare` | `0.70` | `0.85` | Higher NBP absorption when QE is active. |
+| `quasi-fiscal-program` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share feeding quasi-fiscal issuance. |
+| `quasi-fiscal-program` | `monetary.qeMaxGdpShare` | `0.30` | `0.40` | Higher QE stock ceiling. |
+
+## Links To Other Research Artifacts
+
+- `docs/empirical-validation-report.md`: scenario outputs reuse the same
+  Monte Carlo columns and validation targets.
+- `docs/sensitivity-robustness-workflow.md`: robustness runs can wrap named
+  scenarios later, but the current sensitivity workflow remains local and
+  one-at-a-time.
+- `docs/calibration-register.md`: baseline parameter provenance remains there;
+  this document records scenario deltas from that baseline.

--- a/docs/sensitivity-robustness-workflow.md
+++ b/docs/sensitivity-robustness-workflow.md
@@ -1,0 +1,129 @@
+# Sensitivity And Robustness Workflow
+
+This workflow is the first lightweight reproducible path for seed uncertainty
+and one-at-a-time parameter sensitivity around Amor Fati outputs. It builds on
+the existing deterministic Monte Carlo runner and the output schema documented
+in `McTimeseriesSchema`.
+
+The workflow deliberately separates two questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Stochastic uncertainty | How much does the baseline move across seed bands? | Baseline rows in `envelope-summary.csv` and `robustness-report.md` |
+| Parameter sensitivity | How much does a selected one-at-a-time parameter change move terminal means versus baseline? | `sensitivity-summary.csv` and the parameter sensitivity section of `robustness-report.md` |
+
+This is not a full global sensitivity design. It is a local research-review
+workflow that should stay cheap enough to run before larger empirical and
+scenario work.
+
+## Command
+
+Local review default:
+
+```bash
+sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+Fast smoke check:
+
+```bash
+sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+## Output Artifacts
+
+The workflow writes all generated artifacts under the selected `--out`
+directory:
+
+| File | Purpose |
+| --- | --- |
+| `seed-metrics.csv` | Per scenario, seed, and metric terminal value plus path min/max/mean. |
+| `envelope-summary.csv` | Cross-seed envelopes by scenario and metric. |
+| `sensitivity-summary.csv` | Terminal mean deltas for each non-baseline scenario versus the baseline mean. |
+| `robustness-report.md` | Human-readable report separating stochastic uncertainty from parameter sensitivity. |
+
+These files are generated outputs and should normally remain under `target/`.
+
+## Scenario Sets
+
+| Scenario set | Contents | Intended use |
+| --- | --- | --- |
+| `smoke` | `baseline`, `mpc-high` | Fast CI/local sanity check that the workflow runs and writes artifacts. |
+| `core` | `baseline`, `mpc-low`, `mpc-high`, `markup-high`, `investment-fast`, `credit-tight`, `fiscal-stabilizer-strong`, `monetary-tight`, `external-risk-off` | First-pass local robustness review. |
+
+The core set covers the first parameters most likely to matter for early SFC-ABM
+review:
+
+| Category | Scenario | Parameter deltas |
+| --- | --- | --- |
+| Household propensity to consume | `mpc-low`, `mpc-high` | `household.mpc` around the baseline `0.82`. |
+| Firm markup/pricing | `markup-high` | Higher `pricing.baseMarkup` and `pricing.costPassthrough`. |
+| Investment response | `investment-fast` | Higher `capital.adjustSpeed`. |
+| Credit/default behavior | `credit-tight` | Higher `banking.baseSpread`, lower `banking.loanRecovery`, higher `banking.eclMigrationSensitivity`. |
+| Fiscal rules | `fiscal-stabilizer-strong` | Higher `fiscal.govAutoStabMult` and `fiscalConsolidationSpeed55`. |
+| Policy rates | `monetary-tight` | Higher `monetary.initialRate`, `neutralRate`, and `taylorAlpha`. |
+| External shocks | `external-risk-off` | Activates risk-off shock month and increases FX sensitivity. |
+
+Scenario definitions live in
+`src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala`.
+The runner lives in
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala`.
+
+## Metrics
+
+The workflow currently summarizes these Monte Carlo output columns:
+
+| Metric | Interpretation |
+| --- | --- |
+| `Inflation` | Annualized inflation rate. |
+| `Unemployment` | Unemployment share. |
+| `MarketWage` | Aggregate market wage. |
+| `DebtToGdp` | Government debt to annualized GDP. |
+| `DeficitToGdp` | Government deficit to annualized GDP. |
+| `CreditToGdpGap` | Macroprudential credit-to-GDP gap. |
+| `MinBankCAR` | Minimum bank capital adequacy ratio. |
+| `MinBankLCR` | Minimum bank liquidity coverage ratio. |
+| `CurrentAccount` | Current-account flow. |
+| `ExRate` | PLN/EUR exchange rate. |
+| `TotalAdoption` | Automation plus hybrid adoption share. |
+| `FirmDeaths` | Monthly firm deaths. |
+| `BankFailures` | Failed bank count. |
+
+These metrics are not a replacement for the empirical validation report in
+`docs/empirical-validation-report.md`. Robustness asks whether conclusions are
+stable across seeds and local parameter changes; empirical validation asks
+whether the model matches observed stylized facts.
+
+## Runtime Guidance
+
+Recommended local defaults are intentionally small:
+
+| Use | Command shape | Notes |
+| --- | --- | --- |
+| Smoke | `--scenario-set smoke --seeds 1 --months 6` | Confirms the workflow compiles, runs, and writes artifacts. |
+| Local review | `--scenario-set core --seeds 2 --months 24` | Good default before opening or reviewing a PR. |
+| Heavier review | `--scenario-set core --seeds 5 --months 60` | Useful before merging research-sensitive parameter changes. |
+| Publication prep | `--scenario-set core --seeds 10+ --months 120+` | Coordinate with the data bridge (#437), `docs/scenario-registry.md`, and `docs/empirical-validation-report.md`. |
+
+Runtime grows roughly with:
+
+```text
+scenario_count * seed_count * months
+```
+
+The default core run is therefore `9 * 2 * 24 = 432` simulated monthly steps.
+
+## Follow-Ups
+
+- `docs/empirical-validation-report.md` provides the empirical target table
+  that these robustness outputs should eventually feed.
+- `docs/scenario-registry.md` defines named scenario comparisons that can
+  reuse this output shape later.
+- #437 should provide source vintages and empirical transformations used to
+  interpret robustness against real-world data.

--- a/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
@@ -1,0 +1,153 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Lightweight one-at-a-time scenario definitions for local robustness work.
+  *
+  * This stays in the config package because SimParams has a config-private
+  * constructor/copy boundary.
+  */
+object RobustnessScenarios:
+
+  enum ScenarioSet(val cliName: String):
+    case Smoke extends ScenarioSet("smoke")
+    case Core  extends ScenarioSet("core")
+
+  object ScenarioSet:
+    val default: ScenarioSet = ScenarioSet.Core
+
+    def parse(value: String): Either[String, ScenarioSet] =
+      values.find(_.cliName == value.trim.toLowerCase) match
+        case Some(set) => Right(set)
+        case None      => Left(s"--scenario-set must be one of: ${values.map(_.cliName).mkString(", ")}")
+
+  final case class Scenario(
+      id: String,
+      label: String,
+      category: String,
+      variedParameter: String,
+      variation: String,
+      rationale: String,
+      params: SimParams,
+  )
+
+  def scenarios(set: ScenarioSet): Vector[Scenario] =
+    val baseline = SimParams.defaults
+
+    val all = Vector(
+      Scenario(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        variedParameter = "none",
+        variation = "default SimParams.defaults",
+        rationale = "Reference path for stochastic seed envelopes and one-at-a-time parameter comparisons.",
+        params = baseline,
+      ),
+      Scenario(
+        id = "mpc-low",
+        label = "Lower household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.72",
+        rationale = "First-pass demand sensitivity to lower household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.72))),
+      ),
+      Scenario(
+        id = "mpc-high",
+        label = "Higher household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.90",
+        rationale = "First-pass demand sensitivity to higher household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.90))),
+      ),
+      Scenario(
+        id = "markup-high",
+        label = "Higher markup and pass-through",
+        category = "firm markup/pricing",
+        variedParameter = "pricing.baseMarkup, pricing.costPassthrough",
+        variation = "1.15 -> 1.25, 0.40 -> 0.55",
+        rationale = "Tests price-level sensitivity to firm pricing power and cost pass-through.",
+        params = baseline.copy(
+          pricing = baseline.pricing.copy(
+            baseMarkup = Multiplier(1.25),
+            costPassthrough = Coefficient(0.55),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "investment-fast",
+        label = "Faster capital adjustment",
+        category = "investment response",
+        variedParameter = "capital.adjustSpeed",
+        variation = "0.10 -> 0.16",
+        rationale = "Tests output, imports, and balance-sheet sensitivity to faster investment adjustment.",
+        params = baseline.copy(capital = baseline.capital.copy(adjustSpeed = Coefficient(0.16))),
+      ),
+      Scenario(
+        id = "credit-tight",
+        label = "Tighter credit and lower recovery",
+        category = "credit/default behavior",
+        variedParameter = "banking.baseSpread, banking.loanRecovery, banking.eclMigrationSensitivity",
+        variation = "0.015 -> 0.030, 0.30 -> 0.20, 3.0 -> 4.0",
+        rationale = "Tests financial-stability sensitivity to tighter credit and weaker default recovery.",
+        params = baseline.copy(
+          banking = baseline.banking.copy(
+            baseSpread = Rate(0.030),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.0),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "fiscal-stabilizer-strong",
+        label = "Stronger automatic stabilizer",
+        category = "fiscal rules",
+        variedParameter = "fiscal.govAutoStabMult, fiscalConsolidationSpeed55",
+        variation = "3.0 -> 4.0, 0.10 -> 0.15",
+        rationale = "Tests unemployment, deficit, and debt sensitivity to stronger fiscal stabilization and consolidation.",
+        params = baseline.copy(
+          fiscal = baseline.fiscal.copy(
+            govAutoStabMult = Coefficient(4.0),
+            fiscalConsolidationSpeed55 = Share(0.15),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "monetary-tight",
+        label = "Tighter monetary stance",
+        category = "policy rates",
+        variedParameter = "monetary.initialRate, monetary.neutralRate, monetary.taylorAlpha",
+        variation = "0.0575 -> 0.075, 0.04 -> 0.05, 1.5 -> 1.8",
+        rationale = "Tests inflation, credit, debt-service, and unemployment sensitivity to tighter policy rates.",
+        params = baseline.copy(
+          monetary = baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "external-risk-off",
+        label = "External risk-off shock",
+        category = "external shocks",
+        variedParameter = "forex.riskOffShockMonth, forex.riskOffMagnitude, forex.irpSensitivity",
+        variation = "0 -> 6, 0.10 -> 0.16, 0.15 -> 0.25",
+        rationale = "Tests FX, current-account, reserves, and financial-market sensitivity to a risk-off episode.",
+        params = baseline.copy(
+          forex = baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.16),
+            irpSensitivity = Coefficient(0.25),
+          ),
+        ),
+      ),
+    )
+
+    set match
+      case ScenarioSet.Smoke => all.filter(scenario => scenario.id == "baseline" || scenario.id == "mpc-high")
+      case ScenarioSet.Core  => all
+
+end RobustnessScenarios

--- a/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
@@ -1,0 +1,276 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Named policy and shock scenarios for reproducible experiment runs.
+  *
+  * This lives in the config package because scenario composition needs the
+  * config-private SimParams copy boundary.
+  */
+object ScenarioRegistry:
+
+  final case class ParameterDelta(
+      parameter: String,
+      baseline: String,
+      scenario: String,
+      note: String,
+  )
+
+  final case class ScenarioSpec(
+      id: String,
+      label: String,
+      category: String,
+      purpose: String,
+      expectedChannels: Vector[String],
+      recommendedMonths: Int,
+      seedPolicy: String,
+      outputFolder: String,
+      deltas: Vector[ParameterDelta],
+      params: SimParams,
+  )
+
+  private val Baseline = SimParams.defaults
+
+  val defaultScenarioIds: Vector[String] =
+    Vector("baseline", "monetary-tightening", "fiscal-expansion")
+
+  val all: Vector[ScenarioSpec] =
+    Vector(
+      ScenarioSpec(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        purpose = "Reference scenario using SimParams.defaults.",
+        expectedChannels = Vector("all baseline model channels"),
+        recommendedMonths = 120,
+        seedPolicy = "Use fixed seed bands; default smoke command uses seed 1.",
+        outputFolder = "<out>/<run-id>/baseline",
+        deltas = Vector(ParameterDelta("SimParams", "SimParams.defaults", "SimParams.defaults", "No parameter change.")),
+        params = Baseline,
+      ),
+      ScenarioSpec(
+        id = "monetary-tightening",
+        label = "Monetary tightening",
+        category = "policy rates",
+        purpose = "Higher NBP policy stance for inflation and credit stress analysis.",
+        expectedChannels = Vector("RefRate", "Inflation", "CreditToGdpGap", "DebtService", "Unemployment", "ExRate"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/monetary-tightening",
+        deltas = Vector(
+          ParameterDelta("monetary.initialRate", "0.0575", "0.075", "Higher starting reference rate."),
+          ParameterDelta("monetary.neutralRate", "0.04", "0.05", "Higher neutral-rate anchor."),
+          ParameterDelta("monetary.taylorAlpha", "1.5", "1.8", "Stronger inflation response."),
+        ),
+        params = Baseline.copy(
+          monetary = Baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fiscal-expansion",
+        label = "Fiscal expansion",
+        category = "fiscal policy",
+        purpose = "Higher government demand and capital share for fiscal multiplier and debt-path comparisons.",
+        expectedChannels = Vector("GovCurrentSpend", "GovCapitalSpendDomestic", "DeficitToGdp", "DebtToGdp", "Unemployment", "Inflation"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/fiscal-expansion",
+        deltas = Vector(
+          ParameterDelta("fiscal.govBaseSpending", "scaled default", "scaled default * 1.15", "15% higher base government spending."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share."),
+          ParameterDelta("fiscal.govAutoStabMult", "3.0", "3.5", "Stronger automatic stabilization."),
+        ),
+        params = Baseline.copy(
+          fiscal = Baseline.fiscal.copy(
+            govBaseSpending = Baseline.fiscal.govBaseSpending * Multiplier(1.15),
+            govInvestShare = Share(0.30),
+            govAutoStabMult = Coefficient(3.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "credit-crunch",
+        label = "Credit crunch",
+        category = "banking stress",
+        purpose = "Tighter credit supply and weaker recovery assumptions for credit and default stress testing.",
+        expectedChannels = Vector("CreditToGdpGap", "ConsumerLoans", "MinBankCAR", "MaxBankNPL", "FirmDeaths", "Unemployment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/credit-crunch",
+        deltas = Vector(
+          ParameterDelta("banking.baseSpread", "0.015", "0.035", "Higher firm-loan spread."),
+          ParameterDelta("banking.minCar", "0.08", "0.10", "Higher capital constraint."),
+          ParameterDelta("banking.loanRecovery", "0.30", "0.20", "Lower corporate-loan recovery."),
+          ParameterDelta("banking.eclMigrationSensitivity", "3.0", "4.5", "Faster IFRS 9 migration under stress."),
+          ParameterDelta("household.ccMaxDti", "0.40", "0.30", "Tighter household credit affordability cap."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            baseSpread = Rate(0.035),
+            minCar = Multiplier(0.10),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.5),
+          ),
+          household = Baseline.household.copy(ccMaxDti = Share(0.30)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "energy-shock",
+        label = "Energy shock",
+        category = "climate and commodity shock",
+        purpose = "ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure.",
+        expectedChannels = Vector("CommodityPriceIndex", "GvcImportCostIndex", "AggEnergyCost", "Inflation", "CurrentAccount", "GreenInvestment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/energy-shock",
+        deltas = Vector(
+          ParameterDelta("climate.etsBasePrice", "80", "120", "Higher EU ETS starting price."),
+          ParameterDelta(
+            "climate.energyCostShares",
+            "[0.02,0.10,0.04,0.05,0.03,0.06]",
+            "[0.03,0.15,0.06,0.075,0.045,0.09]",
+            "50% higher sector energy-cost burden.",
+          ),
+          ParameterDelta("climate.greenBudgetShare", "0.20", "0.12", "Lower discretionary green investment capacity under stress."),
+          ParameterDelta("gvc.commodityShockMonth", "0", "6", "Commodity-price shock starts in month 6."),
+          ParameterDelta("gvc.commodityShockMag", "0.0", "1.5", "One-time commodity-price shock magnitude."),
+        ),
+        params = Baseline.copy(
+          climate = Baseline.climate.copy(
+            etsBasePrice = Multiplier(120.0),
+            energyCostShares = Vector(Share(0.03), Share(0.15), Share(0.06), Share(0.075), Share(0.045), Share(0.09)),
+            greenBudgetShare = Share(0.12),
+          ),
+          gvc = Baseline.gvc.copy(
+            commodityShockMonth = 6,
+            commodityShockMag = Multiplier(1.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "tourism-shock",
+        label = "Tourism shock",
+        category = "external demand shock",
+        purpose = "Tourism-demand loss for services demand, current account, employment, and FX flows.",
+        expectedChannels = Vector("TourismExport", "TourismImport", "NetTourismBalance", "CurrentAccount", "Unemployment", "Inflation"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/tourism-shock",
+        deltas = Vector(
+          ParameterDelta("tourism.shockMonth", "0", "6", "Tourism shock starts in month 6."),
+          ParameterDelta("tourism.shockSize", "0.80", "0.60", "60% tourism-demand loss in the named scenario."),
+          ParameterDelta("tourism.shockRecovery", "0.03", "0.05", "Faster monthly recovery than default COVID-style setting."),
+          ParameterDelta("tourism.inboundShare", "0.05", "0.04", "Lower inbound tourism baseline share."),
+        ),
+        params = Baseline.copy(
+          tourism = Baseline.tourism.copy(
+            shockMonth = 6,
+            shockSize = Share(0.60),
+            shockRecovery = Rate(0.05),
+            inboundShare = Share(0.04),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "bank-failure",
+        label = "Bank failure stress",
+        category = "financial stability",
+        purpose = "Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels.",
+        expectedChannels = Vector("BankFailures", "MinBankCAR", "MinBankLCR", "BfgFundBalance", "BailInLoss", "NPL"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/bank-failure",
+        deltas = Vector(
+          ParameterDelta("banking.initCapital", "scaled default", "scaled default * 0.55", "Lower opening banking-sector capital."),
+          ParameterDelta("banking.minCar", "0.08", "0.12", "Higher regulatory capital requirement."),
+          ParameterDelta("banking.depositPanicRate", "0.03", "0.08", "Higher deposit panic migration after failures."),
+          ParameterDelta("banking.maxDepositSwitchRate", "0.10", "0.18", "Higher maximum monthly deposit switching."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            initCapital = Baseline.banking.initCapital * Multiplier(0.55),
+            minCar = Multiplier(0.12),
+            depositPanicRate = Share(0.08),
+            maxDepositSwitchRate = Share(0.18),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fx-capital-flight",
+        label = "FX and capital-flight stress",
+        category = "external financial shock",
+        purpose = "Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand.",
+        expectedChannels = Vector("ExRate", "FxReserves", "FxInterventionAmt", "CurrentAccount", "ForeignBondHoldings", "BondYield"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/fx-capital-flight",
+        deltas = Vector(
+          ParameterDelta("forex.riskOffShockMonth", "0", "6", "Risk-off shock starts in month 6."),
+          ParameterDelta("forex.riskOffMagnitude", "0.10", "0.20", "Larger capital outflow shock."),
+          ParameterDelta("forex.riskOffDurationMonths", "6", "9", "Longer elevated risk-off period."),
+          ParameterDelta("forex.irpSensitivity", "0.15", "0.30", "Stronger exchange-rate response to rate differentials."),
+          ParameterDelta("forex.exRateAdjSpeed", "0.02", "0.05", "Faster exchange-rate adjustment."),
+          ParameterDelta("monetary.fxMaxMonthly", "0.03", "0.06", "Larger allowed monthly FX intervention."),
+        ),
+        params = Baseline.copy(
+          forex = Baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.20),
+            riskOffDurationMonths = 9,
+            irpSensitivity = Coefficient(0.30),
+            exRateAdjSpeed = Coefficient(0.05),
+          ),
+          monetary = Baseline.monetary.copy(fxMaxMonthly = Share(0.06)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "quasi-fiscal-program",
+        label = "Quasi-fiscal program",
+        category = "quasi-fiscal policy",
+        purpose = "BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending.",
+        expectedChannels = Vector("QfBondsOutstanding", "QfIssuance", "QfLoanPortfolio", "QfNbpHoldings", "Esa2010DebtToGdp", "DebtToGdp"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/quasi-fiscal-program",
+        deltas = Vector(
+          ParameterDelta("quasiFiscal.issuanceShare", "0.40", "0.65", "Higher BGK/PFR share of capital programs."),
+          ParameterDelta("quasiFiscal.lendingShare", "0.50", "0.70", "More issuance routed to subsidized lending."),
+          ParameterDelta("quasiFiscal.nbpAbsorptionShare", "0.70", "0.85", "Higher NBP absorption when QE is active."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share feeding quasi-fiscal issuance."),
+          ParameterDelta("monetary.qeMaxGdpShare", "0.30", "0.40", "Higher QE stock ceiling."),
+        ),
+        params = Baseline.copy(
+          quasiFiscal = Baseline.quasiFiscal.copy(
+            issuanceShare = Share(0.65),
+            lendingShare = Share(0.70),
+            nbpAbsorptionShare = Share(0.85),
+          ),
+          fiscal = Baseline.fiscal.copy(govInvestShare = Share(0.30)),
+          monetary = Baseline.monetary.copy(qeMaxGdpShare = Share(0.40)),
+        ),
+      ),
+    )
+
+  private val byId: Map[String, ScenarioSpec] = all.map(scenario => scenario.id -> scenario).toMap
+
+  def get(id: String): Either[String, ScenarioSpec] =
+    byId.get(id).toRight(s"Unknown scenario '$id'. Known scenarios: ${all.map(_.id).mkString(", ")}")
+
+  def select(value: String): Either[String, Vector[ScenarioSpec]] =
+    val normalized = value.trim
+    if normalized == "all" then Right(all)
+    else
+      val ids = normalized.split(",").iterator.map(_.trim).filter(_.nonEmpty).toVector
+      if ids.isEmpty then Left("--scenarios must contain at least one scenario id")
+      else
+        ids.foldLeft[Either[String, Vector[ScenarioSpec]]](Right(Vector.empty)): (acc, id) =>
+          for
+            selected <- acc
+            scenario <- get(id)
+          yield selected :+ scenario
+
+end ScenarioRegistry

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
@@ -1,0 +1,257 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.ScenarioRegistry
+import com.boombustgroup.amorfati.config.ScenarioRegistry.ScenarioSpec
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object ScenarioRunExport:
+
+  final case class Config(
+      scenarios: Vector[ScenarioSpec] = ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(id).toOption),
+      seedStart: Long = 1L,
+      seeds: Int = 1,
+      months: Int = 12,
+      runId: String = "scenario-registry",
+      out: Path = Path.of("target/scenarios"),
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int)
+
+  private final case class TerminalMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      value: Double,
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      Files.createDirectories(validConfig.runRoot)
+
+      val registryPath  = validConfig.runRoot.resolve("scenario-registry.md")
+      val deltasPath    = validConfig.runRoot.resolve("scenario-deltas.csv")
+      Files.writeString(registryPath, renderRegistry(validConfig.scenarios), StandardCharsets.UTF_8)
+      Files.writeString(deltasPath, renderDeltas(validConfig.scenarios), StandardCharsets.UTF_8)
+      val metadataPaths = validConfig.scenarios.map: scenario =>
+        val scenarioDir  = validConfig.runRoot.resolve(scenario.id)
+        val metadataPath = scenarioDir.resolve("metadata.md")
+        Files.createDirectories(scenarioDir)
+        Files.writeString(metadataPath, renderScenarioMetadata(validConfig, scenario), StandardCharsets.UTF_8)
+        metadataPath
+
+      val runAttempts =
+        for
+          scenario <- validConfig.scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(validConfig, scenario, seed)
+
+      runAttempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val outputs = runAttempts.collect { case Right(paths, metrics) => paths -> metrics }
+          val paths   = Vector(registryPath, deltasPath) ++ metadataPaths ++ outputs.flatMap(_._1)
+          val metrics = outputs.flatMap(_._2)
+          val summary = validConfig.runRoot.resolve("run-summary.csv")
+          Files.writeString(summary, renderRunSummary(metrics), StandardCharsets.UTF_8)
+          Right(ExportResult(paths :+ summary))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                                              => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")                           => missingValue(flag)
+            case Seq(value, next*) if flag == "--scenario" || flag == "--scenarios" =>
+              ScenarioRegistry.select(value).flatMap(scenarios => loop(next, config.copy(scenarios = scenarios)))
+            case Seq(value, next*) if flag == "--seed-start"                        =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"                             =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"                            =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--run-id"                            =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"                               =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                                         => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.scenarios.nonEmpty, config, "--scenarios must contain at least one scenario")
+      .flatMap(valid => Either.cond(valid.seeds > 0, valid, "--seeds must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+
+  private def runSeed(config: Config, scenario: ScenarioSpec, seed: Long): Either[String, (Vector[Path], Vector[TerminalMetric])] =
+    given SimParams = scenario.params
+
+    McRunner
+      .runSingle(seed, config.months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        val scenarioDir = config.runRoot.resolve(scenario.id)
+        Files.createDirectories(scenarioDir)
+
+        val csvPath = scenarioDir.resolve(f"${config.runId}_${scenario.id}_${config.months}m_seed$seed%03d.csv")
+        val rows    = result.timeSeries.map(row => row)
+        Files.writeString(csvPath, renderTimeSeriesCsv(rows), StandardCharsets.UTF_8)
+
+        val terminal = rows.last
+        val metrics  = Metrics.map(metric => TerminalMetric(scenario.id, seed, metric, terminal(metric.ordinal)))
+        Vector(csvPath) -> metrics
+
+  private def renderRegistry(scenarios: Vector[ScenarioSpec]): String =
+    val rows = scenarios.map: scenario =>
+      markdownRow(
+        Vector(
+          scenario.id,
+          scenario.label,
+          scenario.category,
+          scenario.recommendedMonths.toString,
+          scenario.seedPolicy,
+          scenario.outputFolder,
+        ),
+      )
+
+    val lines = Vector(
+      "# Scenario Registry",
+      "",
+      "Generated by `ScenarioRunExport` from `ScenarioRegistry`.",
+      "",
+      markdownRow(Vector("Scenario", "Label", "Category", "Recommended months", "Seed policy", "Output folder")),
+      markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+    ) ++ rows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderDeltas(scenarios: Vector[ScenarioSpec]): String =
+    val header = "Scenario;Parameter;Baseline;ScenarioValue;Note"
+    val rows   =
+      for
+        scenario <- scenarios
+        delta    <- scenario.deltas
+      yield Vector(scenario.id, delta.parameter, delta.baseline, delta.scenario, delta.note).map(csv).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderRunSummary(metrics: Vector[TerminalMetric]): String =
+    val header = "Scenario;Seed;Metric;TerminalValue"
+    val rows   = metrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.value)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderScenarioMetadata(config: Config, scenario: ScenarioSpec): String =
+    val channelRows = scenario.expectedChannels.map(channel => s"- `$channel`")
+    val deltaRows   = scenario.deltas.map: delta =>
+      markdownRow(Vector(delta.parameter, delta.baseline, delta.scenario, delta.note))
+    val lines       =
+      Vector(
+        s"# ${scenario.label}",
+        "",
+        s"- Scenario id: `${scenario.id}`",
+        s"- Category: `${scenario.category}`",
+        s"- Purpose: ${scenario.purpose}",
+        s"- Run id: `${config.runId}`",
+        s"- Months in this run: `${config.months}`",
+        s"- Recommended months: `${scenario.recommendedMonths}`",
+        s"- Seed policy: ${scenario.seedPolicy}",
+        s"- Output folder: `${config.runRoot.resolve(scenario.id)}`",
+        "",
+        "## Expected Channels",
+        "",
+      ) ++ channelRows ++ Vector(
+        "",
+        "## Parameter Deltas",
+        "",
+        markdownRow(Vector("Parameter", "Baseline", "Scenario", "Note")),
+        markdownRow(Vector("---", "---", "---", "---")),
+      ) ++ deltaRows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderTimeSeriesCsv(rows: Vector[Array[Double]]): String =
+    val header = McTimeseriesSchema.colNames.mkString(";")
+    val body   = rows.map: row =>
+      row.indices
+        .map: idx =>
+          if idx == 0 then row(idx).toInt.toString
+          else fmt(row(idx))
+        .mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--scenario" || flag == "--scenarios" || flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(_.replace("|", "\\|")).mkString("| ", " | ", " |")
+
+  private def csv(value: String): String =
+    if value.exists(ch => ch == ';' || ch == '"' || ch == '\n') then "\"" + value.replace("\"", "\"\"") + "\""
+    else value
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def metric(column: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation"),
+    metric("Unemployment"),
+    metric("MarketWage"),
+    metric("DebtToGdp"),
+    metric("DeficitToGdp"),
+    metric("CurrentAccount"),
+    metric("ExRate"),
+    metric("CreditToGdpGap"),
+    metric("MinBankCAR"),
+    metric("MinBankLCR"),
+    metric("BankFailures"),
+    metric("FirmDeaths"),
+  )
+
+  private val usage: String =
+    "Usage: ScenarioRunExport [--scenarios baseline,monetary-tightening|all] [--seed-start <long>] [--seeds <int>] [--months <int>] [--run-id <id>] [--out <path>]"
+
+end ScenarioRunExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
@@ -1,0 +1,368 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.RobustnessScenarios
+import com.boombustgroup.amorfati.config.RobustnessScenarios.{Scenario, ScenarioSet}
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object SensitivityRobustnessExport:
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 2,
+      months: Int = 24,
+      out: Path = Path.of("target/robustness"),
+      scenarioSet: ScenarioSet = ScenarioSet.default,
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int, description: String)
+
+  private final case class SeedMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      terminal: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class EnvelopeMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      terminalMean: Double,
+      terminalMin: Double,
+      terminalMax: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class SensitivityMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      baselineMean: Double,
+      scenarioMean: Double,
+      delta: Double,
+      deltaPct: Option[Double],
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      val scenarios = RobustnessScenarios.scenarios(validConfig.scenarioSet)
+      val attempts  =
+        for
+          scenario <- scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(scenario, seed, validConfig.months)
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val seedMetrics        = attempts.collect { case Right(metrics) => metrics }.flatten
+          val envelopeMetrics    = summarizeEnvelope(seedMetrics)
+          val sensitivityMetrics = summarizeSensitivity(envelopeMetrics)
+          val paths              = writeArtifacts(validConfig, scenarios, seedMetrics, envelopeMetrics, sensitivityMetrics)
+          Right(ExportResult(paths))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                         => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")      => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start"   =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"        =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"       =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--out"          =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(value, next*) if flag == "--scenario-set" =>
+              ScenarioSet.parse(value).flatMap(scenarioSet => loop(next, config.copy(scenarioSet = scenarioSet)))
+            case Seq(_, _*)                                    => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+
+  private def runSeed(scenario: Scenario, seed: Long, months: Int): Either[String, Vector[SeedMetric]] =
+    given SimParams = scenario.params
+    McRunner
+      .runSingle(seed, months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        Metrics.map: metric =>
+          val values = result.timeSeries.map(row => row(metric.ordinal))
+          SeedMetric(
+            scenario.id,
+            seed,
+            metric,
+            terminal = values.last,
+            pathMin = values.min,
+            pathMax = values.max,
+            pathMean = values.sum / values.length.toDouble,
+          )
+
+  private def summarizeEnvelope(seedMetrics: Vector[SeedMetric]): Vector[EnvelopeMetric] =
+    seedMetrics
+      .groupBy(metric => metric.scenarioId -> metric.metric.id)
+      .toVector
+      .sortBy { case ((scenarioId, metricId), _) => scenarioId -> metricId }
+      .map { case ((scenarioId, _), metrics) =>
+        val metric    = metrics.head.metric
+        val terminals = metrics.map(_.terminal)
+        EnvelopeMetric(
+          scenarioId = scenarioId,
+          metric = metric,
+          terminalMean = terminals.sum / terminals.length.toDouble,
+          terminalMin = terminals.min,
+          terminalMax = terminals.max,
+          pathMin = metrics.map(_.pathMin).min,
+          pathMax = metrics.map(_.pathMax).max,
+          pathMean = metrics.map(_.pathMean).sum / metrics.length.toDouble,
+        )
+      }
+
+  private def summarizeSensitivity(envelopeMetrics: Vector[EnvelopeMetric]): Vector[SensitivityMetric] =
+    val baseline = envelopeMetrics.filter(_.scenarioId == "baseline").map(metric => metric.metric.id -> metric).toMap
+    envelopeMetrics
+      .filterNot(_.scenarioId == "baseline")
+      .flatMap: metric =>
+        baseline
+          .get(metric.metric.id)
+          .map: base =>
+            val delta = metric.terminalMean - base.terminalMean
+            SensitivityMetric(
+              scenarioId = metric.scenarioId,
+              metric = metric.metric,
+              baselineMean = base.terminalMean,
+              scenarioMean = metric.terminalMean,
+              delta = delta,
+              deltaPct = if Math.abs(base.terminalMean) > 1e-12 then Some(delta / Math.abs(base.terminalMean)) else None,
+            )
+
+  private def writeArtifacts(
+      config: Config,
+      scenarios: Vector[Scenario],
+      seedMetrics: Vector[SeedMetric],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): Vector[Path] =
+    Files.createDirectories(config.out)
+    val seedMetricsPath = config.out.resolve("seed-metrics.csv")
+    val envelopePath    = config.out.resolve("envelope-summary.csv")
+    val sensitivityPath = config.out.resolve("sensitivity-summary.csv")
+    val reportPath      = config.out.resolve("robustness-report.md")
+
+    Files.writeString(seedMetricsPath, renderSeedMetrics(seedMetrics), StandardCharsets.UTF_8)
+    Files.writeString(envelopePath, renderEnvelopeMetrics(envelopeMetrics), StandardCharsets.UTF_8)
+    Files.writeString(sensitivityPath, renderSensitivityMetrics(sensitivityMetrics), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, scenarios, envelopeMetrics, sensitivityMetrics), StandardCharsets.UTF_8)
+
+    Vector(seedMetricsPath, envelopePath, sensitivityPath, reportPath)
+
+  private def renderSeedMetrics(seedMetrics: Vector[SeedMetric]): String =
+    val header = "Scenario;Seed;Metric;Terminal;PathMin;PathMax;PathMean"
+    val rows   = seedMetrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.terminal), fmt(row.pathMin), fmt(row.pathMax), fmt(row.pathMean)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderEnvelopeMetrics(envelopeMetrics: Vector[EnvelopeMetric]): String =
+    val header = "Scenario;Metric;TerminalMean;TerminalMin;TerminalMax;PathMin;PathMax;PathMean"
+    val rows   = envelopeMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.terminalMean),
+        fmt(row.terminalMin),
+        fmt(row.terminalMax),
+        fmt(row.pathMin),
+        fmt(row.pathMax),
+        fmt(row.pathMean),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderSensitivityMetrics(sensitivityMetrics: Vector[SensitivityMetric]): String =
+    val header = "Scenario;Metric;BaselineTerminalMean;ScenarioTerminalMean;Delta;DeltaPct"
+    val rows   = sensitivityMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.baselineMean),
+        fmt(row.scenarioMean),
+        fmt(row.delta),
+        row.deltaPct.map(fmt).getOrElse("NA"),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderReport(
+      config: Config,
+      scenarios: Vector[Scenario],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): String =
+    val baselineRows = envelopeMetrics
+      .filter(_.scenarioId == "baseline")
+      .map: row =>
+        markdownRow(Vector(row.metric.id, fmt(row.terminalMean), fmt(row.terminalMin), fmt(row.terminalMax), fmt(row.pathMin), fmt(row.pathMax)))
+
+    val sensitivityRows = sensitivityMetrics.map: row =>
+      markdownRow(
+        Vector(
+          row.scenarioId,
+          row.metric.id,
+          fmt(row.baselineMean),
+          fmt(row.scenarioMean),
+          signed(row.delta),
+          row.deltaPct.map(p => signed(p * 100.0) + "%").getOrElse("NA"),
+        ),
+      )
+
+    val scenarioRows = scenarios.map: scenario =>
+      markdownRow(Vector(scenario.id, scenario.label, scenario.category, scenario.variedParameter, scenario.variation, scenario.rationale))
+
+    val metricRows = Metrics.map: metric =>
+      markdownRow(Vector(metric.id, metric.description))
+
+    val lines =
+      Vector(
+        "# Sensitivity And Robustness Report",
+        "",
+        "Generated by `SensitivityRobustnessExport`.",
+        "",
+        "## Run Configuration",
+        "",
+        s"- Scenario set: `${config.scenarioSet.cliName}`",
+        s"- Seeds: `${config.seedRange.head}` to `${config.seedRange.last}` (${config.seeds} seeds)",
+        s"- Months: `${config.months}`",
+        s"- Output directory: `${config.out}`",
+        "",
+        "## Scenario Sweep",
+        "",
+        markdownRow(Vector("Scenario", "Label", "Category", "Varied parameter", "Variation", "Rationale")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ scenarioRows ++ Vector(
+        "",
+        "## Metrics",
+        "",
+        markdownRow(Vector("Metric", "Description")),
+        markdownRow(Vector("---", "---")),
+      ) ++ metricRows ++ Vector(
+        "",
+        "## Stochastic Uncertainty",
+        "",
+        "Baseline seed variation is summarized below. `TerminalMin` and",
+        "`TerminalMax` are cross-seed terminal envelopes; `PathMin` and `PathMax`",
+        "are the full within-run path envelope across all baseline seeds.",
+        "",
+        markdownRow(Vector("Metric", "TerminalMean", "TerminalMin", "TerminalMax", "PathMin", "PathMax")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ baselineRows ++ Vector(
+        "",
+        "## Parameter Sensitivity",
+        "",
+        "The table compares each non-baseline scenario's terminal cross-seed mean",
+        "against the baseline terminal cross-seed mean. This is one-at-a-time",
+        "sensitivity, not a full global sensitivity design.",
+        "",
+        markdownRow(Vector("Scenario", "Metric", "BaselineMean", "ScenarioMean", "Delta", "DeltaPct")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ sensitivityRows ++ Vector(
+        "",
+        "## Runtime Guidance",
+        "",
+        """- Smoke check: `sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"`""",
+        """- Local review default: `sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"`""",
+        "- Heavier review run: increase to 5-10 seeds and 60-120 months after checking runtime locally.",
+        "",
+        "## Output Files",
+        "",
+        "- `seed-metrics.csv`: per scenario, seed, and metric terminal/path statistics.",
+        "- `envelope-summary.csv`: cross-seed envelopes by scenario and metric.",
+        "- `sensitivity-summary.csv`: terminal mean deltas versus baseline.",
+        "- `robustness-report.md`: this human-readable summary.",
+      )
+
+    lines.mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--out" || flag == "--scenario-set"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(escapeMarkdown).mkString("| ", " | ", " |")
+
+  private def escapeMarkdown(value: String): String =
+    value.replace("|", "\\|")
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def signed(value: Double): String =
+    String.format(Locale.US, "%+.8f", Double.box(value))
+
+  private def metric(column: String, description: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal, description)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation", "annualized inflation rate"),
+    metric("Unemployment", "unemployment share"),
+    metric("MarketWage", "aggregate market wage"),
+    metric("DebtToGdp", "government debt to annualized GDP"),
+    metric("DeficitToGdp", "government deficit to annualized GDP"),
+    metric("CreditToGdpGap", "macroprudential credit-to-GDP gap"),
+    metric("MinBankCAR", "minimum bank capital adequacy ratio"),
+    metric("MinBankLCR", "minimum bank liquidity coverage ratio"),
+    metric("CurrentAccount", "current account flow"),
+    metric("ExRate", "PLN/EUR exchange rate"),
+    metric("TotalAdoption", "automation plus hybrid adoption share"),
+    metric("FirmDeaths", "monthly firm deaths"),
+    metric("BankFailures", "failed bank count"),
+  )
+
+  private val usage: String =
+    "Usage: SensitivityRobustnessExport [--seed-start <long>] [--seeds <int>] [--months <int>] [--out <path>] [--scenario-set smoke|core]"
+
+end SensitivityRobustnessExport


### PR DESCRIPTION
## Summary

- add paper-facing ODD / ODD+D model documentation under docs/
- cover purpose, entities, state variables, scale, scheduling, initialization, inputs, submodels, observation, and decision notes
- link the document from README and explicitly mark follow-up research-readiness gaps

## Verification

- git diff --check

Closes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `robustnessReport` command for running sensitivity and robustness analysis across parameter variations.
  * Added `scenarioRun` command for executing predefined experiment scenarios.
  * Registered scenario library covering monetary, fiscal, credit, energy, FX, and quasi-fiscal policy shocks.

* **Documentation**
  * Added comprehensive Model Documentation section to README linking all supporting guides.
  * Behavioral equations and decision rules documentation for all agent types and system dynamics.
  * Calibration register inventorying all model parameters with provenance and validation status.
  * Empirical validation report template for macro/meso/micro comparison workflows.
  * ODD protocol model documentation describing structure, timing, and design principles.
  * Scenario registry with parameter deltas and execution guidance.
  * Sensitivity and robustness workflow documentation with runtime scaling recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->