### PR TITLE
Create calibration register

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ The detailed behavioral equations and institutional decision rules are documente
 
 The calibration register is documented in [docs/calibration-register.md](docs/calibration-register.md). It records key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and explicit searchable gaps.
 
+The empirical validation report skeleton is documented in [docs/empirical-validation-report.md](docs/empirical-validation-report.md). It maps macro, meso, micro, financial, and external validation targets to Monte Carlo output columns and keeps missing data/output gaps visible.
+
+The sensitivity and robustness workflow is documented in [docs/sensitivity-robustness-workflow.md](docs/sensitivity-robustness-workflow.md). It generates seed envelopes and one-at-a-time parameter-sensitivity artifacts from the Monte Carlo runner.
+
+The reproducible scenario registry is documented in [docs/scenario-registry.md](docs/scenario-registry.md). It defines named policy and shock scenarios, exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path.
+
 ## Ledger-Derived Matrix Artifacts
 
 The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The paper-facing ODD / ODD+D model description is documented in [docs/odd-model-
 
 The detailed behavioral equations and institutional decision rules are documented in [docs/behavioral-equations-and-decision-rules.md](docs/behavioral-equations-and-decision-rules.md). It links household, firm, bank, fiscal, monetary, external, insurance, NBFI, quasi-fiscal, and JST rules to implementation modules and numeric output columns.
 
+The calibration register is documented in [docs/calibration-register.md](docs/calibration-register.md). It records key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and explicit searchable gaps.
+
 ## Ledger-Derived Matrix Artifacts
 
 The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import complete.DefaultParsers.spaceDelimited
 lazy val ledger = ProjectRef(file("modules/ledger"), "root")
 
 lazy val sfcMatrices = inputKey[Unit]("Generate symbolic SFC BSM/TFM matrix artifacts")
+lazy val robustnessReport = inputKey[Unit]("Generate lightweight sensitivity and robustness artifacts")
+lazy val scenarioRun = inputKey[Unit]("Run named scenario-registry experiments")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -56,6 +58,20 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<sfc matrix args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.SfcMatrixExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    robustnessReport := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<robustness args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    scenarioRun := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<scenario args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.ScenarioRunExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -934,8 +934,9 @@ The current rule book is intentionally explicit about areas that remain
 research hypotheses or calibration targets:
 
 - Many behavioral coefficients are calibrated in `SimParams` and domain config
-  files, but empirical validation against historical Polish macro and micro
-  series is tracked separately.
+  files. Their current values and provenance status are documented in
+  `docs/calibration-register.md`; empirical validation against historical
+  Polish macro and micro series is tracked separately.
 - Household decision rules are bounded procedural heuristics, not an estimated
   structural life-cycle model.
 - Firm technology adoption and entry include network, risk, and readiness

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -33,7 +33,8 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
   `Agriculture`.
 - Runtime numeric evidence comes from Monte Carlo output columns in
   `McTimeseriesSchema`; this register documents parameter provenance, not run
-  results.
+  results. Empirical validation targets and output mappings are documented in
+  `docs/empirical-validation-report.md`.
 
 ## Core Scale And Sectors
 
@@ -300,4 +301,5 @@ Priority gaps before publication:
 - Decide whether currently unscaled institutional monthly flows, such as PFRON
   monthly revenue/spending, should remain agent-scale values or be moved into
   the `gdpRatio`-scaled macro-stock convention.
-- Move scenario defaults into a scenario registry once #435 is implemented.
+- Keep scenario deltas in `docs/scenario-registry.md`; this register remains
+  the baseline parameter-provenance surface.

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -1,0 +1,303 @@
+# Calibration Register
+
+This register records the current calibration surface of Amor Fati. It is a
+paper-facing inventory of key parameters, their implementation owner, value,
+unit, provenance, empirical target, transformation, and calibration status.
+
+The register is intentionally useful before every value has a final data
+source. Missing or weak provenance is marked explicitly with searchable tokens:
+`UNKNOWN_SOURCE`, `TUNED_NEEDS_VALIDATION`, `ASSUMED`, `PLACEHOLDER`, or
+`POLICY_SCENARIO`.
+
+## Status Taxonomy
+
+| Status | Meaning |
+| --- | --- |
+| `EMPIRICAL` | Direct statutory, institutional, or data-note target is documented in code comments. |
+| `CODE_NOTE_EMPIRICAL` | Code comments name source institution/year, but no source table or URL is attached yet. |
+| `ASSUMED` | Structural modeling assumption or stylized calibration. |
+| `TUNED_NEEDS_VALIDATION` | Behavioral/dynamic coefficient chosen for model behavior; needs sensitivity and validation work. |
+| `POLICY_SCENARIO` | Scenario/shock switch or policy parameter, not a baseline empirical estimate. |
+| `PLACEHOLDER` | Explicit placeholder or simplified value awaiting data bridge. |
+| `UNKNOWN_SOURCE` | Parameter is active in the model but final provenance is not yet documented. |
+
+## Transformation Rules
+
+- Raw PLN stock values in config classes are scaled by `SimParams.gdpRatio` in
+  `SimParams.defaults` when they represent macro stocks or monthly macro flows.
+- Agent-level monetary values such as wages, rents, firm costs, and per-worker
+  values are not scaled by `gdpRatio`.
+- Rates are annual unless the consuming rule applies `.monthly`.
+- Vector parameters generally follow the six-sector order:
+  `BPO/SSC`, `Manufacturing`, `Retail/Services`, `Healthcare`, `Public`,
+  `Agriculture`.
+- Runtime numeric evidence comes from Monte Carlo output columns in
+  `McTimeseriesSchema`; this register documents parameter provenance, not run
+  results.
+
+## Core Scale And Sectors
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `pop.firmsCount` | `10000` | agents | Simulation design choice | Tractable heterogeneous firm population | Direct | `PopulationConfig` | `ASSUMED` |
+| `pop.workersPerFirm` | `10` | workers/firm normalizer | Simulation design choice | Normalizer for population and `gdpRatio` | Direct | `PopulationConfig` | `ASSUMED` |
+| `household.count` | `firmsCount * workersPerFirm = 100000` | agents | Derived from simulation scale | Household population tied to firm scale | Derived in `SimParams.defaults` | `SimParams` | `ASSUMED` |
+| `pop.firmSizeDist` | `Gus` | enum | Code note: GUS CEIDG/KRS 2024 | Polish firm-size distribution mode | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeMicroShare` | `0.962` | share | Code note: GUS CEIDG 2024 | Micro enterprise share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeSmallShare` | `0.028` | share | Code note: GUS | Small firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeMediumShare` | `0.008` | share | Code note: GUS residual | Medium firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.firmSizeLargeShare` | `0.002` | share | Code note: GUS | Large firm share | Direct | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.realGdp` | `3500e9` | PLN/year | Code note: GUS 2024 | Polish GDP scale | Feeds `gdpRatio` | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gdpRatio` | `computeGdpRatio(pop, firm.baseRevenue)` | scalar | Derived from agent flow scale and real GDP | Map agent flows to Polish macro scale | Derived | `SimParams` | `ASSUMED` |
+| `topology` | `Watts-Strogatz` | enum | Network modeling convention | Small-world interaction topology | Direct | `SimParams` | `ASSUMED` |
+| `sectorDefs` | 6 sectors | vector | Code note: GUS 2024 | Polish sector composition | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.share` | `[0.03, 0.16, 0.45, 0.06, 0.22, 0.08]` | share by sector | Code note: GUS 2024 | Firm/employment sector weights | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.sigma` | `[50, 10, 5, 2, 1, 3]` | CES elasticity | Structural automation/substitution assumption | Sectoral substitutability ranking | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
+| `sectorDefs.wageMultiplier` | `[1.35, 0.94, 0.79, 0.97, 0.91, 0.67]` | multiplier | Code note: GUS 2024 | Relative sector wages | Direct | `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `sectorDefs.revenueMultiplier` | `[1.50, 1.05, 0.91, 1.10, 1.08, 0.80]` | multiplier | UNKNOWN_SOURCE | Relative sector revenue/productivity | Direct | `SimParams` | `UNKNOWN_SOURCE` |
+
+## Household And Labor
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `household.baseWage` | `8266` | PLN/month | Code note: GUS 2024 | Mean monthly gross wage | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.baseReservationWage` | `4666` | PLN/month | Code note: 2025 minimum wage / legal act | Minimum acceptable wage | Direct | `HouseholdConfig` | `EMPIRICAL` |
+| `household.mpc` | `0.82` | share | UNKNOWN_SOURCE | Aggregate mean MPC | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.mpcAlpha`, `household.mpcBeta` | `8.2`, `1.8` | beta params | UNKNOWN_SOURCE | Heterogeneous MPC distribution | Beta draw | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.savingsMu`, `household.savingsSigma` | `9.6`, `1.2` | log PLN params | UNKNOWN_SOURCE | Initial savings distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.debtFraction` | `0.40` | share | Code note: BIK 2024 | Household positive debt share | Bernoulli init | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.debtMu`, `household.debtSigma` | `10.5`, `1.5` | log PLN params | UNKNOWN_SOURCE | Initial debt distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.rentMean`, `rentStd`, `rentFloor` | `1800`, `400`, `800` | PLN/month | Code note: Otodom/NBP 2024 | Rent distribution | Truncated normal draw | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.bufferTargetMonths` | `6.0` | months | Carroll-style buffer-stock model | Target liquid buffer | Direct | `HouseholdConfig` | `ASSUMED` |
+| `household.bufferSensitivity` | `0.4` | coefficient | UNKNOWN_SOURCE | MPC response to buffer gap | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.mpcUnemployedBoost` | `0.10` | share | UNKNOWN_SOURCE | Extra MPC while unemployed | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.skillDecayRate` | `0.02` | monthly share | UNKNOWN_SOURCE | Skill decay under unemployment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.scarringRate`, `scarringCap`, `scarringOnset` | `0.02`, `0.50`, `3` | share/months | Literature note in code | Long-run unemployment scarring | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.wageScarRate`, `wageScarCap`, `wageScarDecay` | `0.025`, `0.30`, `0.005` | share/month | Code note: Jacobson et al.; Davis and von Wachter | Wage scar accumulation and recovery | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.retrainingCost`, `retrainingDuration` | `5000`, `6` | PLN/months | UNKNOWN_SOURCE | Retraining cost and duration | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.retrainingBaseSuccess`, `retrainingProb` | `0.60`, `0.15` | share | UNKNOWN_SOURCE | Retraining success/enrollment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.bankruptcyDistressMonths` | `3` | months | ASSUMED | Distress persistence before bankruptcy | Direct | `HouseholdConfig` | `ASSUMED` |
+| `household.depositSpread` | `0.02` | annual rate | UNKNOWN_SOURCE | Deposit rate below policy rate | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.ccSpread` | `0.04` | annual rate | Code note: NBP MIR 2024 | Consumer credit spread | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.ccMaxDti` | `0.40` | share | Code note: KNF Recommendation T | Consumer credit DTI cap | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `household.ccMaxLoan` | `50000` | PLN | UNKNOWN_SOURCE | Maximum unsecured consumer loan | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.ccNplRecovery` | `0.15` | share | Code note: BIK 2024 | Consumer loan recovery | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.frictionMatrix` | `DefaultFrictionMatrix` | 6x6 share | Code note: GUS LFS 2024, Shimer 2005 | Cross-sector mobility friction | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.voluntarySearchProb` | `0.02` | monthly share | UNKNOWN_SOURCE | Employed voluntary sector search | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.voluntaryWageThreshold` | `0.20` | share | UNKNOWN_SOURCE | Required wage gain for voluntary search | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.unionDensity` | `[0.02, 0.15, 0.03, 0.12, 0.30, 0.04]` | share by sector | Code note: GUS 2024 | Union membership density | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.unionWagePremium` | `0.08` | share | Code note: empirical approx. | Union wage premium | Direct | `LaborConfig` | `CODE_NOTE_EMPIRICAL` |
+| `labor.unionRigidity` | `0.50` | share | UNKNOWN_SOURCE | Downward nominal wage rigidity | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.expLambda` | `0.70` | coefficient | Code note: Carroll 2003 | Adaptive expectations speed | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `labor.expCredibilityInit` | `0.80` | share | UNKNOWN_SOURCE | Initial NBP credibility | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
+| `social.zusContribRate`, `zusEmployeeRate` | `0.1952`, `0.1371` | annual rate/share | Code note: Social insurance law | ZUS payroll contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.zusBasePension` | `3500` | PLN/month | Code note: ZUS 2024 | Average pension payment | Direct | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.nfzContribRate` | `0.09` | rate | Code note: health-care law | NFZ contribution rate | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.nfzPerCapitaCost` | `1250` | PLN/month | Code note: NFZ 2024 | Health spending per capita | Direct | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.ppkEmployeeRate`, `ppkEmployerRate` | `0.02`, `0.015` | rate | Code note: PPK law | PPK contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.eduShares` | `[0.08, 0.25, 0.30, 0.37]` | share | Code note: GUS LFS 2024 | Education composition | CDF draw | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
+| `social.demInitialRetirees` | `0` | agents | Explicit startup simplification | Retiree stock built from flows during simulation | Direct | `SocialConfig`, `SimParams` | `PLACEHOLDER` |
+
+## Firm Production, Entry, Capital, And Climate
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `firm.baseRevenue` | `180000` | PLN/month/worker | Code note: GUS F-01 2024 | Revenue per worker before demand shocks | Direct, unscaled | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.otherCosts` | `16667` | PLN/month/worker | UNKNOWN_SOURCE | Fixed non-wage operating cost | Direct, unscaled | `FirmConfig` | `UNKNOWN_SOURCE` |
+| `firm.aiCapex` | `1200000` | PLN/firm | UNKNOWN_SOURCE | Full automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.hybridCapex` | `350000` | PLN/firm | UNKNOWN_SOURCE | Hybrid automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.aiOpex`, `firm.hybridOpex` | `30000`, `12000` | PLN/month/firm | UNKNOWN_SOURCE | AI/hybrid operating cost | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.hybridReadinessMin`, `fullAiReadinessMin` | `0.20`, `0.35` | share | UNKNOWN_SOURCE | Digital readiness adoption thresholds | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.entryRate` | `0.02` | monthly share | Code note: GUS CEIDG 2024 | Base vacant-slot entry rate | Direct | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.entrySectorBarriers` | `[0.8, 0.6, 1.2, 0.5, 0.1, 0.7]` | coefficient by sector | Code note: GUS CEIDG/KRS 2024 | Entry barriers | Direct | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
+| `firm.entryAiThreshold`, `entryAiProb` | `0.15`, `0.20` | share | UNKNOWN_SOURCE | AI-native entrant trigger/probability | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.entryStartupCash` | `50000` | PLN | UNKNOWN_SOURCE | Entrant liquidity | Direct | `FirmConfig` | `UNKNOWN_SOURCE` |
+| `firm.replacementEntryRate` | `0.35` | monthly share | UNKNOWN_SOURCE | Replacement of dead firm slots | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.netEntryRate` | `0.06` | monthly share | UNKNOWN_SOURCE | Expansionary net births | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.digiDrift` | `0.001` | monthly share | UNKNOWN_SOURCE | Exogenous digital readiness drift | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.digiInvestCost`, `digiInvestBoost` | `50000`, `0.05` | PLN/share | UNKNOWN_SOURCE | Discretionary digital investment | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.networkK`, `networkRewireP` | `6`, `0.10` | degree/share | Network design assumption | Watts-Strogatz firm network | Direct | `FirmConfig` | `ASSUMED` |
+| `firm.demoEffectThresh`, `demoEffectBoost` | `0.40`, `0.15` | share | UNKNOWN_SOURCE | Peer adoption demonstration effect | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.adoptionRampMonths` | `36` | months | UNKNOWN_SOURCE | Adoption willingness ramp | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.sigmaLambda` | `0.0` | coefficient | Scenario switch | Arthur-style sigma learning off by default | Direct | `FirmConfig` | `POLICY_SCENARIO` |
+| `capital.klRatios` | `[120000, 250000, 80000, 200000, 150000, 180000]` | PLN/worker | Code note: GUS F-01 2024 | Sector capital-labor ratios | Direct | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `capital.depRates` | `[0.15, 0.08, 0.10, 0.07, 0.05, 0.08]` | annual rate | Code note: GUS F-01 2024 | Sector depreciation rates | `.monthly` in use | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `capital.importShare` | `0.35` | share | UNKNOWN_SOURCE | Import share of investment | Direct | `CapitalConfig` | `UNKNOWN_SOURCE` |
+| `capital.adjustSpeed` | `0.10` | monthly coefficient | UNKNOWN_SOURCE | Capital partial-adjustment speed | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `capital.inventoryTargetRatios` | `[0.05, 0.25, 0.15, 0.10, 0.02, 0.30]` | share by sector | Code note: GUS 2024 | Inventory/revenue targets | Direct | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.energyCostShares` | `[0.02, 0.10, 0.04, 0.05, 0.03, 0.06]` | share of revenue | Code note: Eurostat/GUS 2023 | Energy burden by sector | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.etsBasePrice` | `80` | EUR/tCO2 | Code note: KOBiZE 2024 | EU ETS starting price | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.etsPriceDrift` | `0.03` | annual rate | Code note: EC Fit for 55 trajectory | ETS trend | `.monthly` in use | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.greenBudgetShare` | `0.20` | share | UNKNOWN_SOURCE | Green investment budget share | Direct | `ClimateConfig` | `TUNED_NEEDS_VALIDATION` |
+| `climate.greenImportShare` | `0.35` | share | UNKNOWN_SOURCE | Import share of green capex | Direct | `ClimateConfig` | `UNKNOWN_SOURCE` |
+
+## Fiscal, Monetary, And Banking
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `fiscal.citRate` | `0.19` | rate | Code note: MF 2024 / CIT law | Corporate income tax rate | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.vatRates` | `[0.23, 0.19, 0.12, 0.06, 0.10, 0.07]` | rate by sector | Code note: MF 2024 effective rates | Sector VAT rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.exciseRates` | `[0.01, 0.04, 0.03, 0.005, 0.002, 0.02]` | rate by sector | Code note: MF 2024 aggregate | Effective excise rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.customsDutyRate` | `0.04` | rate | Code note: EU CET/Eurostat TARIC | Average non-EU customs duty | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govBaseSpending` | `58.3e9` | raw PLN/month | Code note: MF 2024 | Government base spending | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govInvestShare` | `0.20` | share | Code note: MF 2024 | Capital share of government spending | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govCapitalMultiplier`, `govCurrentMultiplier` | `1.5`, `0.8` | multiplier | Code note: Ilzetzki, Mendoza and Vegh 2013 | Fiscal multipliers | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govInitCapital` | `0` | PLN | Explicit startup simplification | Initial public capital stock | Built from investment flows | `FiscalConfig` | `PLACEHOLDER` |
+| `fiscal.euFundsTotalEur` | `76e9` | EUR | Code note: EC 2021 | 2021-2027 EU allocation | Beta absorption path | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.euCofinanceRate`, `euCapitalShare` | `0.15`, `0.60` | share | Code note: MFiPR / EU funds | National cofinance and capex split | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.minWageTargetRatio` | `0.50` | share | Code note: minimum wage act | Target minimum/average wage ratio | Annual adjustment | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.govBenefitM1to3`, `govBenefitM4to6` | `1500`, `1200` | PLN/month | Code note: GUS 2024 | Unemployment benefit amounts | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govAvgMaturityMonths` | `54` | months | Code note: MF 2024 | Government debt average maturity | WAM coupon update | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.baseForeignShare`, `maxForeignShare` | `0.35`, `0.55` | share | Code note: NBP SPW holder structure 2024 | Foreign government-bond holdings | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.fiscalRuleDebtCeiling` | `0.60` | debt/GDP share | Code note: Polish constitution Art. 216 | Constitutional debt ceiling | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.fiscalRuleCautionThreshold` | `0.55` | debt/GDP share | Code note: public finance act Art. 86 | Caution threshold | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.sgpDeficitLimit` | `0.03` | deficit/GDP share | Maastricht / SGP | Deficit limit | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.initGovDebt` | `1600e9` | raw PLN | Code note: MF 2024 | Initial government debt | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.jstPitShare`, `jstCitShare` | `0.3846`, `0.0671` | share | Code note: JST revenue act | Local-government tax shares | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.pitRate1`, `pitRate2`, `pitBracket1Annual` | `0.12`, `0.32`, `120000` | rate/PLN/year | Code note: PIT law 2024 | PIT brackets | Annualized monthly PIT | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.social800` | `800` | PLN/month/child | Code note: legal act 2023 | 800+ benefit | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `monetary.initialRate` | `0.0575` | annual rate | Code note: NBP 2024 | NBP reference rate | Direct | `MonetaryConfig` | `CODE_NOTE_EMPIRICAL` |
+| `monetary.targetInfl` | `0.025` | annual rate | NBP inflation target | Inflation target | Direct | `MonetaryConfig` | `EMPIRICAL` |
+| `monetary.neutralRate` | `0.04` | annual rate | Estimated in code note | Long-run neutral rate | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorAlpha`, `taylorBeta`, `taylorDelta` | `1.5`, `0.8`, `0.5` | coefficients | Taylor-rule convention | Policy reaction coefficients | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorInertia` | `0.70` | share | UNKNOWN_SOURCE | Policy-rate smoothing | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.rateFloor`, `rateCeiling` | `0.001`, `0.15` | annual rate | Structural lower/upper bounds | Policy-rate corridor bounds | Direct | `MonetaryConfig` | `ASSUMED` |
+| `monetary.nairu` | `0.05` | share | Code note: estimated | NAIRU | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.reserveRateMult` | `0.5` | share | Code note: NBP 2024 | Reserve remuneration fraction | Direct | `MonetaryConfig` | `CODE_NOTE_EMPIRICAL` |
+| `monetary.depositFacilitySpread`, `lombardSpread` | `0.01`, `0.01` | annual rate | Code note: NBP corridor | Corridor +/- 100 bp | Direct | `MonetaryConfig` | `EMPIRICAL` |
+| `monetary.qePace` | `5e9` | raw PLN/month | UNKNOWN_SOURCE | QE monthly purchase pace | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `POLICY_SCENARIO` |
+| `monetary.qeMaxGdpShare` | `0.30` | GDP share | UNKNOWN_SOURCE | QE stock ceiling | Direct | `MonetaryConfig` | `POLICY_SCENARIO` |
+| `monetary.fxReserves` | `185e9` | raw PLN | Code note: NBP 2024 | Initial FX reserves | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initCapital` | `270e9` | raw PLN | Code note: KNF 2024 | Aggregate bank equity | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initDeposits` | `1900e9` | raw PLN | Code note: NBP M3 2024 | Aggregate deposits | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initLoans` | `700e9` | raw PLN | Code note: NBP 2024 | Corporate loans | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initGovBonds`, `initNbpGovBonds` | `400e9`, `300e9` | raw PLN | Code note: NBP 2024 | Bank/NBP government-bond holdings | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initConsumerLoans` | `200e9` | raw PLN | Code note: BIK 2024 | Consumer loan stock | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.baseSpread` | `0.015` | annual rate | UNKNOWN_SOURCE | Base firm-loan spread | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
+| `banking.minCar` | `0.08` | multiplier/share | Code note: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.loanRecovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate loan recovery | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
+| `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note: NBP 2024 maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.reserveReq` | `0.035` | share | Code note: NBP 2024 | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.lcrMin`, `nsfrMin` | `1.0`, `1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020]` | multiplier by bank | Code note: KNF 2024 | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.bfgLevyRate` | `0.0024` | annual rate | Code note: BFG 2024 | Resolution levy | `.monthly` in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.bfgDepositGuarantee` | `400000` | PLN/depositor | Code note: BFG guarantee | Deposit guarantee threshold | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.ccybMax` | `0.025` | multiplier | Code note: KNF 2024 | Max CCyB | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.htmShare` | `0.60` | share | Code note: NBP 2024 | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.depositPanicRate` | `0.03` | monthly share | Code note: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+
+## External Sector And Financial Markets
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `forex.baseExRate` | `4.33` | PLN/EUR | Code note: NBP 2024 | Starting exchange rate | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.foreignRate` | `0.04` | annual rate | UNKNOWN_SOURCE | Foreign reference rate | Direct | `ForexConfig` | `UNKNOWN_SOURCE` |
+| `forex.importPropensity` | `0.22` | GDP share | Code note: GUS/NBP 2024 | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.techImportShare` | `0.40` | share | UNKNOWN_SOURCE | Technology/capital goods share of imports | Direct | `ForexConfig` | `UNKNOWN_SOURCE` |
+| `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15`, `0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
+| `forex.riskOffShockMonth` | `0` | month | Scenario switch | No baseline risk-off shock | Direct | `ForexConfig` | `POLICY_SCENARIO` |
+| `openEcon.importContent` | `[0.15, 0.50, 0.20, 0.15, 0.05, 0.12]` | share by sector | Code note: GUS supply-use 2024 | Import content of production | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.exportBase` | `138.5e9` | raw PLN/month | Code note: NBP BoP 2024 | Monthly export base | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.foreignGdpGrowth` | `0.015` | annual rate | Code note: ECB/IMF projections | Foreign GDP growth | `.monthly` in export rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.exportPriceElasticity`, `importPriceElasticity` | `0.8`, `0.6` | coefficient | Code note: Marshall-Lerner / Campa-Goldberg | Trade price elasticities | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.erElasticity` | `0.5` | coefficient | UNKNOWN_SOURCE | Exchange-rate elasticity of trade | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.euTransfers` | `1.458e9` | raw PLN/month | Code note: MFiPR 2024 | EU transfer monthly flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.fdiBase` | `583.1e6` | raw PLN/month | Code note: NBP IIP 2024 | Monthly FDI base flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.portfolioSensitivity`, `riskPremiumSensitivity` | `0.20`, `0.10` | coefficient | UNKNOWN_SOURCE | Portfolio/risk premium response | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.pppSpeed` | `0.10` | annual coefficient | Code note: Rogoff 1996 | PPP convergence speed | `.monthly` in FX rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fdi.foreignShares` | `[0.15, 0.30, 0.10, 0.03, 0.00, 0.05]` | share by sector | Code note: NBP IIP 2024 and GUS 2024 | Foreign-owned firm share by sector | Direct | `FdiConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fdi.profitShiftRate`, `repatriationRate` | `0.15`, `0.70` | share | Code note: FDI outflow calibration | Profit shifting and dividend repatriation | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `fdi.maProb`, `maSizeMin` | `0.001`, `50` | monthly share / employees | UNKNOWN_SOURCE | Domestic firm acquisition probability and eligibility | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `gvc.euTradeShare` | `0.70` | share | Code note: GUS/NBP 2024 | EU share of total trade | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.exportShares` | `[0.05, 0.55, 0.15, 0.03, 0.02, 0.20]` | share by sector | Code note: GUS 2024 | Sector export shares | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.depth` | `[0.35, 0.75, 0.30, 0.40, 0.10, 0.45]` | share by sector | Code note: WIOD/OECD ICIO | GVC backward linkage | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02`, `0.015` | annual rate | Code note: ECB/IMF | Foreign inflation/growth | `.monthly` where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.demandShockMonth`, `commodityShockMonth` | `0`, `0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
+| `immigration.monthlyRate` | `0.001` | monthly share | UNKNOWN_SOURCE | Base immigration rate | Direct | `ImmigrationConfig` | `UNKNOWN_SOURCE` |
+| `immigration.wageElasticity` | `2.0` | coefficient | Code note: NBP 2023 survey | Wage differential migration response | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.remitRate` | `0.15` | income share | Code note: NBP 2023 | Immigrant remittance outflow | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.sectorShares` | `[0.05, 0.35, 0.25, 0.05, 0.05, 0.25]` | share by sector | Code note: GUS LFS 2024 | Immigrant sector allocation | CDF draw | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Immigration accumulates from monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
+| `remittance.perCapita` | `40` | PLN/person/month | Code note: NBP BoP 2024 | Diaspora remittance inflow | Direct | `RemittanceConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.inboundShare`, `outboundShare` | `0.05`, `0.03` | GDP share | Code note: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.seasonality`, `peakMonth` | `0.40`, `7` | share/month | Code note: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.initIndex`, `initMcap` | `2400`, `1.4e12` | index/raw PLN | Code note: GPW 2024 | WIG index and market cap | `initMcap` scaled by `gdpRatio` | `EquityConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `equity.peMean`, `divYield` | `10.0`, `0.057` | scalar/annual rate | Code note: GPW 2024 | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.foreignShare` | `0.67` | share | Code note: KNF/KDPW 2024 | Foreign ownership share | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.spread` | `0.025` | annual rate | Code note: RRRF 2024 BBB | Corporate bond spread | Direct | `CorpBondConfig` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.initStock` | `90e9` | raw PLN | Code note: KNF 2024 | Corporate bonds outstanding | Scaled by `gdpRatio` | `CorpBondConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `corpBond.recovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate bond recovery | Direct | `CorpBondConfig` | `UNKNOWN_SOURCE` |
+
+## Housing, Prices, Regions, IO, Informal, And SOE
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `housing.initHpi` | `100` | index | Base-index convention | National HPI starting point | Direct | `HousingConfig` | `ASSUMED` |
+| `housing.initValue` | `3.0e12` | raw PLN | Code note: NBP residential price survey 2024 | Aggregate housing stock value | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `housing.initMortgage` | `485e9` | raw PLN | Code note: NBP 2024 | Aggregate mortgage stock | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2`, `-0.8`, `0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.mortgageSpread` | `0.025` | annual rate | Code note: NBP 2024 | Mortgage spread over policy rate | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.mortgageMaturity`, `ltvMax` | `300`, `0.80` | months/share | Code note: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
+| `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003`, `0.001`, `0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.mortgageRecovery` | `0.70` | share | UNKNOWN_SOURCE | Defaulted mortgage recovery | Direct | `HousingConfig` | `UNKNOWN_SOURCE` |
+| `housing.wealthMpc`, `rentalYield` | `0.05`, `0.045` | share/annual rate | Code note: Case, Quigley and Shiller 2005; Otodom/NBP | Housing wealth consumption effect and rental yield | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.regionalMarkets` | 7 regional rows | vector | Code note: NBP/GUS 2024 | Regional HPI, value share, mortgage share, income multipliers | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `regional.baseMigrationRate` | `0.005` | monthly share | Code note: GUS 2024 | Internal migration probability for unemployed workers | Direct | `RegionalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `regional.housingBarrierThreshold` | `0.7` | share | UNKNOWN_SOURCE | Housing-cost migration barrier | Direct | `RegionalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.calvoTheta` | `0.15` | monthly share | Code note: Alvarez et al. 2006 | Average EU price duration around 6.7 months | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pricing.baseMarkup` | `1.15` | multiplier | Code note: Polish microdata approximation | Steady-state markup over marginal cost | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pricing.demandSensitivity`, `costPassthrough` | `0.5`, `0.4` | coefficients | UNKNOWN_SOURCE | Markup response to demand and cost shocks | Direct | `PricingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.minMarkup`, `maxMarkup` | `0.95`, `1.50` | multiplier | Structural bounds | Markup floor and ceiling | Direct | `PricingConfig` | `ASSUMED` |
+| `io.matrix` | 6x6 matrix | technical coefficients | Code note: GUS supply-use tables 2024 | Inter-sector intermediate demand | Direct | `IoConfig` | `CODE_NOTE_EMPIRICAL` |
+| `io.scale` | `1.0` | multiplier | Sensitivity switch | Full-strength I-O flows by default | Direct | `IoConfig` | `POLICY_SCENARIO` |
+| `informal.sectorShares` | `[0.05, 0.15, 0.30, 0.20, 0.02, 0.35]` | share by sector | Code note: Schneider 2023 | Shadow-economy sector shares | Direct | `InformalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `informal.citEvasion`, `vatEvasion`, `pitEvasion`, `exciseEvasion` | `0.80`, `0.90`, `0.85`, `0.70` | share | UNKNOWN_SOURCE | Tax evasion rates by tax channel | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `informal.unempThreshold`, `cyclicalSens`, `smoothing` | `0.05`, `0.50`, `0.92` | rate/coefficient | UNKNOWN_SOURCE | Counter-cyclical informal-sector response | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `soe.baseDividendMultiplier` | `1.3` | multiplier | Code note: MF | Baseline SOE dividend payout versus private firms | Direct | `SoeConfig` | `CODE_NOTE_EMPIRICAL` |
+| `soe.dividendFiscalThreshold`, `dividendFiscalSensitivity` | `0.03`, `5.0` | share/coefficient | UNKNOWN_SOURCE | Fiscal-pressure dividend response | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
+| `soe.firingReduction`, `investmentMultiplier`, `energyPassthrough` | `0.70`, `1.2`, `0.60` | share/multiplier | UNKNOWN_SOURCE | SOE labor buffer, directed investment, energy pass-through | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
+
+## Non-Bank Financials And Public Funds
+
+| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ins.lifeReserves`, `nonLifeReserves` | `110e9`, `90e9` | raw PLN | Code note: KNF 2024 | Insurance reserve pools | Scaled by `gdpRatio` | `InsuranceConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `ins.govBondShare`, `corpBondShare`, `equityShare` | `0.35`, `0.08`, `0.12` | share | UNKNOWN_SOURCE | Insurance asset allocation | Portfolio rebalance target | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifePremiumRate`, `nonLifePremiumRate` | `0.003`, `0.0025` | wage-bill share | UNKNOWN_SOURCE | Insurance premium flow | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifeLossRatio`, `nonLifeLossRatio` | `0.85`, `0.70` | share | UNKNOWN_SOURCE | Insurance claims/premiums | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.tfiInitAum` | `380e9` | raw PLN | Code note: KNF/IZFiA 2024 | TFI AUM | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `nbfi.creditInitStock` | `231e9` | raw PLN | Code note: KNF 2024 | NBFI credit stock | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40`, `0.10`, `0.10` | share | UNKNOWN_SOURCE | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.creditBaseRate` | `0.005` | monthly share | UNKNOWN_SOURCE | NBFI credit origination rate | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `nbfi.creditRate` | `0.10` | annual rate | UNKNOWN_SOURCE | NBFI loan rate | `.monthly` in income | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.defaultBase`, `defaultUnempSens` | `0.002`, `3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `quasiFiscal.issuanceShare` | `0.40` | share | Code note: NIK 2024 | BGK/PFR share of capital programs | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.avgMaturityMonths` | `72` | months | Code note: NIK/BGK/PFR | BGK/PFR bond maturity | Amortization `1/maturity` | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.nbpAbsorptionShare` | `0.70` | share | Code note: COVID quasi-QE | NBP absorption under QE | Active when NBP QE active | `QuasiFiscalConfig` | `POLICY_SCENARIO` |
+| `quasiFiscal.lendingShare` | `0.50` | share | Code note: BGK subsidized lending | Lending share of issuance | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `earmarked.fpRate` | `0.0245` | payroll rate | Code note: employment promotion law | Fundusz Pracy levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
+| `earmarked.pfronMonthlyRevenue`, `pfronMonthlySpending` | `460e6`, `420e6` | PLN/month | Code note: PFRON 2024 | PFRON revenue/spending | Direct, currently unscaled | `EarmarkedConfig` | `CODE_NOTE_EMPIRICAL` |
+| `earmarked.fgspRate` | `0.001` | payroll rate | Code note: employee claims law | FGSP levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
+| `earmarked.fgspPayoutPerWorker` | `10000` | PLN/worker | UNKNOWN_SOURCE | Bankruptcy wage payout | Direct | `EarmarkedConfig` | `UNKNOWN_SOURCE` |
+
+## Searchable Gaps
+
+Use the following commands to audit open provenance gaps:
+
+```bash
+rg "UNKNOWN_SOURCE|TUNED_NEEDS_VALIDATION|PLACEHOLDER|POLICY_SCENARIO" docs/calibration-register.md
+```
+
+Priority gaps before publication:
+
+- Replace `UNKNOWN_SOURCE` rows with source table, year, and transformation
+  notes.
+- Split `CODE_NOTE_EMPIRICAL` rows into source-specific evidence links once
+  the data bridge exists.
+- Validate `TUNED_NEEDS_VALIDATION` coefficients with historical fit,
+  stylized-fact matching, or sensitivity ranges.
+- Decide whether currently unscaled institutional monthly flows, such as PFRON
+  monthly revenue/spending, should remain agent-scale values or be moved into
+  the `gdpRatio`-scaled macro-stock convention.
+- Move scenario defaults into a scenario registry once #435 is implemented.

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -1,0 +1,152 @@
+# Empirical Validation Report Skeleton
+
+This report defines how Amor Fati outputs should be compared with empirical
+macro, meso, and micro stylized facts. It is deliberately a skeleton: the
+model already writes numeric simulation evidence, but the external data bridge
+and publication-grade source tables are still tracked separately in #437.
+
+The goal is to keep failed, missing, or weak validation targets visible. A row
+with `MISSING_OUTPUT`, `MISSING_DATA_BRIDGE`, or `NOT_RUN` is part of the report
+surface, not an omission.
+
+## Validation Boundary
+
+Accounting validation and empirical validation answer different questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Runtime ledger checks | Did emitted monetary flows conserve value through the ledger? | Engine runtime checks and SFC identity validation |
+| Paper-facing accounting structure | Are Balance Sheet Matrix and Transactions Flow Matrix rows documented and traceable to runtime mechanisms? | `docs/sfc-matrix-evidence.md` |
+| Empirical validation | Do simulated paths reproduce empirical Polish/EU macro, meso, and micro stylized facts? | This report |
+| Revaluation and other-change accounting | Do stocks reconcile with transactions plus independent revaluations or other changes? | Follow-up #436 |
+
+Empirical validation must not be used to relax accounting constraints. A model
+run can fit an empirical target and still be invalid if the ledger or SFC
+checks fail.
+
+## Status Taxonomy
+
+| Status | Meaning |
+| --- | --- |
+| `READY_FOR_BASELINE` | Output columns exist and the empirical target family is identified. |
+| `PARTIAL_OUTPUT` | Output exists but requires a derived metric, normalization, or additional aggregation. |
+| `MISSING_DATA_BRIDGE` | Model output exists, but external source extraction/transformation is not documented yet. |
+| `MISSING_OUTPUT` | Target is known, but the Monte Carlo output schema does not yet expose enough model state. |
+| `ACCOUNTING_ONLY` | This belongs to accounting validation, not empirical fit. |
+| `NOT_RUN` | The baseline validation run has not yet been summarized in this report. |
+
+## Reproducible Workflow
+
+Run a small deterministic baseline Monte Carlo batch:
+
+```bash
+sbt "run 3 validation-baseline --duration 120 --run-id validation-baseline"
+```
+
+Expected output files:
+
+```text
+mc/validation-baseline_validation-baseline_120m_seed001.csv
+mc/validation-baseline_validation-baseline_120m_seed002.csv
+mc/validation-baseline_validation-baseline_120m_seed003.csv
+mc/validation-baseline_validation-baseline_120m_hh.csv
+mc/validation-baseline_validation-baseline_120m_banks.csv
+```
+
+Use the per-seed CSV files for monthly macro, meso, financial, and mechanism
+paths. Use the `_hh.csv` and `_banks.csv` files for terminal household and bank
+cross-section summaries.
+
+Manual update procedure until #437 adds a formal data bridge:
+
+1. Run the command above from the repository root.
+2. Record commit hash, run id, duration, seed count, and parameter branch.
+3. For each target row below, compute the model statistic from the mapped CSV
+   column or terminal summary field.
+4. Fill empirical source, vintage, target value, model value, tolerance, and
+   status in the report snapshot.
+5. Keep rows with missing model output or missing empirical data in the table.
+
+## Output Mapping
+
+The primary numeric surface is
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala`.
+Terminal cross-sections come from
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala`.
+
+| Validation target | Empirical comparator | Model output mapping | Suggested statistic | Current status |
+| --- | --- | --- | --- | --- |
+| GDP growth | GUS national accounts real GDP growth | Engine state `world.cachedMonthlyGdpProxy`; no direct CSV column yet. `GovDebt` and `DebtToGdp` can imply annualized GDP only when both are valid. | Annual or quarterly growth of real/price-adjusted GDP proxy | `MISSING_OUTPUT` |
+| Inflation | GUS CPI / HICP, NBP inflation target | `Inflation`, `PriceLevel`, `ExpectedInflation`, `InflationForecastError` | Mean, volatility, target deviation, persistence | `READY_FOR_BASELINE` |
+| Unemployment | GUS BAEL / registered unemployment | `Unemployment`, `Unemp_Central`, `Unemp_South`, `Unemp_East`, `Unemp_Northwest`, `Unemp_Southwest`, `Unemp_North` | Mean level, volatility, regional dispersion | `READY_FOR_BASELINE` |
+| Wages | GUS average wage, sector wage indices | `MarketWage`, `MinWageLevel`; terminal household income distribution not directly emitted | Mean wage level and growth; minimum/market wage ratio | `PARTIAL_OUTPUT` |
+| Credit/GDP | NBP credit aggregates to GDP | `CreditToGdpGap`, `ConsumerLoans`, `MortgageToGdp`, `MortgageStock`, `NbfiLoanStock`; terminal `_banks.csv` field `Loans` | Credit/GDP level, gap, household/firm split | `PARTIAL_OUTPUT` |
+| Public debt/GDP | MF public debt, ESA2010 general-government debt | `DebtToGdp`, `Esa2010DebtToGdp`, `GovDebt`, `QfBondsOutstanding`, `BondsOutstanding` | Terminal debt/GDP and path against thresholds | `READY_FOR_BASELINE` |
+| Current account | NBP balance of payments | `CurrentAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NetRemittances`, `NetTourismBalance`, `FDI` | Annualized current-account/GDP and component signs | `PARTIAL_OUTPUT` |
+| Firm-size distribution | GUS/REGON firm-size distribution | Initialization config `PopulationConfig`; no monthly or terminal firm-size histogram CSV yet | Init distribution and survival-weighted terminal distribution | `MISSING_OUTPUT` |
+| Bankruptcies | GUS / Ministry of Justice corporate insolvencies, consumer bankruptcy statistics | `FirmDeaths`, `FirmBirths`, `NetEntry`, `BankFailures`; terminal `_hh.csv` fields `HH_Bankrupt`, `BankruptcyRate`, `MeanMonthsToRuin` | Firm exit rate, household bankruptcy rate, bank failures | `PARTIAL_OUTPUT` |
+| Bank capital and liquidity | KNF banking-sector CAR, LCR, NSFR, NPL | `MinBankCAR`, `MinBankLCR`, `MinBankNSFR`, `NPL`, `MaxBankNPL`; terminal `_banks.csv` fields `CAR`, `NPL`, `Capital`, `Deposits`, `Loans` | Minimum and distributional stress indicators | `READY_FOR_BASELINE` |
+| Inequality | GUS household surveys, EU-SILC, OECD income/wealth indicators | Terminal `_hh.csv` fields `Gini_Individual`, `Gini_Wealth`, `ConsumptionP10`, `ConsumptionP50`, `ConsumptionP90`, `PovertyRate_50pct`, `PovertyRate_30pct` | Terminal Gini, poverty rates, consumption percentile ratios | `MISSING_DATA_BRIDGE` |
+| Sectoral output | GUS national accounts by sector, supply-use tables | Sector columns currently expose `BPO_Auto`, `Manuf_Auto`, `Retail_Auto`, `Health_Auto`, `Public_Auto`, `Agri_Auto`, sector sigmas, and `IoFlows`; direct sector output is not emitted | Sector output shares and growth | `MISSING_OUTPUT` |
+| External prices and FX | NBP exchange rate, ECB/Eurostat external prices | `ExRate`, `ForeignPriceIndex`, `GvcImportCostIndex`, `CommodityPriceIndex`, `FxReserves`, `FxInterventionAmt` | FX level/volatility, reserve path, import-cost shocks | `READY_FOR_BASELINE` |
+| Housing and mortgages | NBP housing prices, mortgage stock, KNF mortgage risk | `HousingPriceIndex`, `WawHpi`, `KrkHpi`, `WroHpi`, `GdnHpi`, `LdzHpi`, `PozHpi`, `RestHpi`, `MortgageToGdp`, `MortgageDefault` | HPI path, regional dispersion, mortgage/GDP, defaults | `READY_FOR_BASELINE` |
+| Fiscal stance | MF budget execution, Eurostat deficit/GDP | `DeficitToGdp`, `GovCurrentSpend`, `GovCapitalSpendDomestic`, `DebtService`, `FiscalRuleBinding`, `GovSpendingCutRatio` | Deficit/GDP, expenditure mix, fiscal-rule episodes | `READY_FOR_BASELINE` |
+| Monetary and financial market conditions | NBP reference rate, WIBOR, bond yields, GPW | `RefRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BondYield`, `GpwIndex`, `GpwMarketCap`, `CorpBondYield`, `CorpBondSpread` | Policy-rate path, spread behavior, market stress | `READY_FOR_BASELINE` |
+
+## Baseline Report Snapshot
+
+This table is the publication-facing slot that should be filled after a
+baseline run. Placeholder values remain explicit until the empirical data
+bridge and baseline analysis have been completed.
+
+| Target | Empirical source and vintage | Empirical value | Model run | Model value | Tolerance / criterion | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| GDP growth | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct GDP output column still needed. |
+| Inflation | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use `Inflation` and `PriceLevel`. |
+| Unemployment | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Include regional dispersion. |
+| Wages | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Current output is aggregate market wage. |
+| Credit/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Firm-loan split depends partly on terminal bank summary. |
+| Public debt/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Compare `DebtToGdp` and `Esa2010DebtToGdp`. |
+| Current account | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Needs GDP denominator and annualization convention. |
+| Firm-size distribution | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal firm-size histogram not emitted yet. |
+| Bankruptcies | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use firm deaths and household bankruptcy separately. |
+| Bank capital/liquidity | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use minima and terminal bank distribution. |
+| Inequality | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal household summary has first-pass measures. |
+| Sectoral output | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct sector output columns still needed. |
+
+## Target-Specific Notes
+
+GDP growth should be reported only after the model exposes a direct GDP or
+monthly GDP proxy column. The engine already computes `world.cachedMonthlyGdpProxy`,
+but relying on `GovDebt / DebtToGdp` as a CSV reconstruction is too fragile for
+publication use.
+
+Inflation validation should use both the period inflation column and the price
+level path. The report should state whether the statistic is monthly,
+annualized, or year-over-year.
+
+Credit/GDP should distinguish bank firm loans, consumer loans, mortgage credit,
+and NBFI credit. Current outputs cover several pieces but do not yet provide a
+single total-credit-to-GDP series.
+
+Firm-size distribution and sectoral output are currently the most visible
+meso-level output gaps. The model has sector metadata, firm state, and
+population initialization, but the Monte Carlo CSV does not yet emit a terminal
+firm-size histogram or sector output shares.
+
+Inequality validation is terminal-only for now. The household summary already
+emits Gini, poverty, and consumption percentile fields, but external source
+mapping and frequency conventions belong in #437.
+
+## Follow-Up Links
+
+- #437: external data bridge, source vintages, licenses, transformations, and
+  empirical target values.
+- `docs/sensitivity-robustness-workflow.md`: stochastic uncertainty, parameter
+  sensitivity, confidence envelopes, and robustness metrics around this
+  baseline report.
+- `docs/scenario-registry.md`: named scenarios whose outputs should reuse the
+  same validation target table.
+- #436: stock-flow reconciliation and revaluation artifact; keep this separate
+  from empirical fit.
+- #438: milestone tracker for the full research-readiness spine.

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -345,7 +345,7 @@ surfaces. Detailed mathematical rules are documented in
 
 Decision rules are currently procedural and bounded. The project does not claim
 that every behavioral rule is empirically final. Parameter provenance and
-calibration status are tracked in #432.
+calibration status are documented in `docs/calibration-register.md`.
 
 ## 5. Initialization
 
@@ -378,8 +378,9 @@ Current inputs are:
 - scenario changes expressed by modifying/copying config values in code.
 
 The model contains many Poland-specific calibration comments and values, but a
-single structured calibration register is not yet available. That work is
-tracked in #432. A reproducible scenario registry is tracked in #435.
+structured calibration register is documented in
+`docs/calibration-register.md`. A reproducible scenario registry is tracked in
+#435.
 
 ## 7. Submodels
 
@@ -427,8 +428,6 @@ outputs.
 
 This document deliberately marks unfinished research-readiness work:
 
-- #432: calibration register with parameter provenance, units, targets, and
-  status;
 - #433: empirical validation report and stylized-fact mapping;
 - #434: sensitivity and robustness workflow;
 - #435: reproducible scenario registry;

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -69,7 +69,8 @@ The current model is expected to generate and expose:
   Flow Matrix (TFM), and runtime mapping generated from an executed simulation
   step.
 
-Empirical validation of these patterns is tracked separately in #433.
+Empirical validation of these patterns is structured in
+`docs/empirical-validation-report.md`.
 
 ## 2. Entities, State Variables, And Scales
 
@@ -375,12 +376,13 @@ Current inputs are:
 - explicit initialization seed;
 - explicit monthly randomness schedule;
 - Monte Carlo configuration (`nSeeds`, duration, run id, output prefix);
-- scenario changes expressed by modifying/copying config values in code.
+- named scenario changes from `docs/scenario-registry.md`, or direct config
+  changes in code for exploratory work.
 
 The model contains many Poland-specific calibration comments and values, but a
 structured calibration register is documented in
-`docs/calibration-register.md`. A reproducible scenario registry is tracked in
-#435.
+`docs/calibration-register.md`. The reproducible scenario registry is
+documented in `docs/scenario-registry.md`.
 
 ## 7. Submodels
 
@@ -405,6 +407,21 @@ protocol-level model description, while that rule book carries equations,
 algorithmic rules, implementation references, output columns, and explicit
 simplifications.
 
+The empirical validation report skeleton is documented in
+`docs/empirical-validation-report.md`. It maps the current Monte Carlo output
+surface to macro, meso, micro, financial, and external validation targets and
+keeps missing data or output coverage visible.
+
+The sensitivity and robustness workflow is documented in
+`docs/sensitivity-robustness-workflow.md`. It runs small Monte Carlo seed bands
+and one-at-a-time parameter sweeps, producing seed envelopes and sensitivity
+summaries under `target/`.
+
+The reproducible scenario registry is documented in
+`docs/scenario-registry.md`. It defines named baseline, policy, banking,
+external, energy, tourism, and quasi-fiscal experiments with exact parameter
+deltas and an executable `scenarioRun` command path.
+
 ## Accounting And Validation Boundary
 
 Amor Fati has two related but distinct accounting surfaces:
@@ -428,9 +445,6 @@ outputs.
 
 This document deliberately marks unfinished research-readiness work:
 
-- #433: empirical validation report and stylized-fact mapping;
-- #434: sensitivity and robustness workflow;
-- #435: reproducible scenario registry;
 - #436: stock-flow reconciliation and revaluation matrix artifact;
 - #437: data bridge to national and financial accounts.
 

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -1,0 +1,116 @@
+# Scenario Registry
+
+This registry defines named policy and shock experiments that can be inspected,
+run, and compared reproducibly. It is separate from the sensitivity workflow:
+scenario runs are named economic stories, while sensitivity runs are local
+one-at-a-time parameter checks.
+
+The source of truth is
+`src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala`.
+The executable runner is
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala`.
+
+## Command
+
+Run the baseline plus two nontrivial scenarios:
+
+```bash
+sbt "scenarioRun --scenarios baseline,monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+```
+
+Run every registered scenario:
+
+```bash
+sbt "scenarioRun --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+## Output Layout
+
+For `--out target/scenarios --run-id local-review`, the runner writes:
+
+```text
+target/scenarios/local-review/
+  scenario-registry.md
+  scenario-deltas.csv
+  run-summary.csv
+  baseline/
+    metadata.md
+    local-review_baseline_24m_seed001.csv
+  monetary-tightening/
+    metadata.md
+    local-review_monetary-tightening_24m_seed001.csv
+```
+
+Each per-seed CSV uses `McTimeseriesSchema.colNames` as the header, so scenario
+outputs can be compared directly with validation and robustness artifacts.
+
+## Registered Scenarios
+
+| Scenario | Label | Category | Recommended months | Purpose |
+| --- | --- | --- | --- | --- |
+| `baseline` | Baseline | baseline | 120 | Reference scenario using `SimParams.defaults`. |
+| `monetary-tightening` | Monetary tightening | policy rates | 60 | Higher NBP policy stance for inflation and credit stress analysis. |
+| `fiscal-expansion` | Fiscal expansion | fiscal policy | 60 | Higher government demand and capital share for fiscal multiplier and debt-path comparisons. |
+| `credit-crunch` | Credit crunch | banking stress | 60 | Tighter credit supply and weaker recovery assumptions for credit and default stress testing. |
+| `energy-shock` | Energy shock | climate and commodity shock | 60 | ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure. |
+| `tourism-shock` | Tourism shock | external demand shock | 36 | Tourism-demand loss for services demand, current account, employment, and FX flows. |
+| `bank-failure` | Bank failure stress | financial stability | 36 | Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels. |
+| `fx-capital-flight` | FX and capital-flight stress | external financial shock | 60 | Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand. |
+| `quasi-fiscal-program` | Quasi-fiscal program | quasi-fiscal policy | 60 | BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending. |
+
+## Parameter Deltas
+
+| Scenario | Parameter | Baseline | Scenario value | Note |
+| --- | --- | --- | --- | --- |
+| `baseline` | `SimParams` | `SimParams.defaults` | `SimParams.defaults` | No parameter change. |
+| `monetary-tightening` | `monetary.initialRate` | `0.0575` | `0.075` | Higher starting reference rate. |
+| `monetary-tightening` | `monetary.neutralRate` | `0.04` | `0.05` | Higher neutral-rate anchor. |
+| `monetary-tightening` | `monetary.taylorAlpha` | `1.5` | `1.8` | Stronger inflation response. |
+| `fiscal-expansion` | `fiscal.govBaseSpending` | scaled default | scaled default `* 1.15` | 15% higher base government spending. |
+| `fiscal-expansion` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share. |
+| `fiscal-expansion` | `fiscal.govAutoStabMult` | `3.0` | `3.5` | Stronger automatic stabilization. |
+| `credit-crunch` | `banking.baseSpread` | `0.015` | `0.035` | Higher firm-loan spread. |
+| `credit-crunch` | `banking.minCar` | `0.08` | `0.10` | Higher capital constraint. |
+| `credit-crunch` | `banking.loanRecovery` | `0.30` | `0.20` | Lower corporate-loan recovery. |
+| `credit-crunch` | `banking.eclMigrationSensitivity` | `3.0` | `4.5` | Faster IFRS 9 migration under stress. |
+| `credit-crunch` | `household.ccMaxDti` | `0.40` | `0.30` | Tighter household credit affordability cap. |
+| `energy-shock` | `climate.etsBasePrice` | `80` | `120` | Higher EU ETS starting price. |
+| `energy-shock` | `climate.energyCostShares` | `[0.02,0.10,0.04,0.05,0.03,0.06]` | `[0.03,0.15,0.06,0.075,0.045,0.09]` | 50% higher sector energy-cost burden. |
+| `energy-shock` | `climate.greenBudgetShare` | `0.20` | `0.12` | Lower discretionary green investment capacity under stress. |
+| `energy-shock` | `gvc.commodityShockMonth` | `0` | `6` | Commodity-price shock starts in month 6. |
+| `energy-shock` | `gvc.commodityShockMag` | `0.0` | `1.5` | One-time commodity-price shock magnitude. |
+| `tourism-shock` | `tourism.shockMonth` | `0` | `6` | Tourism shock starts in month 6. |
+| `tourism-shock` | `tourism.shockSize` | `0.80` | `0.60` | 60% tourism-demand loss in the named scenario. |
+| `tourism-shock` | `tourism.shockRecovery` | `0.03` | `0.05` | Faster monthly recovery than default COVID-style setting. |
+| `tourism-shock` | `tourism.inboundShare` | `0.05` | `0.04` | Lower inbound tourism baseline share. |
+| `bank-failure` | `banking.initCapital` | scaled default | scaled default `* 0.55` | Lower opening banking-sector capital. |
+| `bank-failure` | `banking.minCar` | `0.08` | `0.12` | Higher regulatory capital requirement. |
+| `bank-failure` | `banking.depositPanicRate` | `0.03` | `0.08` | Higher deposit panic migration after failures. |
+| `bank-failure` | `banking.maxDepositSwitchRate` | `0.10` | `0.18` | Higher maximum monthly deposit switching. |
+| `fx-capital-flight` | `forex.riskOffShockMonth` | `0` | `6` | Risk-off shock starts in month 6. |
+| `fx-capital-flight` | `forex.riskOffMagnitude` | `0.10` | `0.20` | Larger capital outflow shock. |
+| `fx-capital-flight` | `forex.riskOffDurationMonths` | `6` | `9` | Longer elevated risk-off period. |
+| `fx-capital-flight` | `forex.irpSensitivity` | `0.15` | `0.30` | Stronger exchange-rate response to rate differentials. |
+| `fx-capital-flight` | `forex.exRateAdjSpeed` | `0.02` | `0.05` | Faster exchange-rate adjustment. |
+| `fx-capital-flight` | `monetary.fxMaxMonthly` | `0.03` | `0.06` | Larger allowed monthly FX intervention. |
+| `quasi-fiscal-program` | `quasiFiscal.issuanceShare` | `0.40` | `0.65` | Higher BGK/PFR share of capital programs. |
+| `quasi-fiscal-program` | `quasiFiscal.lendingShare` | `0.50` | `0.70` | More issuance routed to subsidized lending. |
+| `quasi-fiscal-program` | `quasiFiscal.nbpAbsorptionShare` | `0.70` | `0.85` | Higher NBP absorption when QE is active. |
+| `quasi-fiscal-program` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share feeding quasi-fiscal issuance. |
+| `quasi-fiscal-program` | `monetary.qeMaxGdpShare` | `0.30` | `0.40` | Higher QE stock ceiling. |
+
+## Links To Other Research Artifacts
+
+- `docs/empirical-validation-report.md`: scenario outputs reuse the same
+  Monte Carlo columns and validation targets.
+- `docs/sensitivity-robustness-workflow.md`: robustness runs can wrap named
+  scenarios later, but the current sensitivity workflow remains local and
+  one-at-a-time.
+- `docs/calibration-register.md`: baseline parameter provenance remains there;
+  this document records scenario deltas from that baseline.

--- a/docs/sensitivity-robustness-workflow.md
+++ b/docs/sensitivity-robustness-workflow.md
@@ -1,0 +1,129 @@
+# Sensitivity And Robustness Workflow
+
+This workflow is the first lightweight reproducible path for seed uncertainty
+and one-at-a-time parameter sensitivity around Amor Fati outputs. It builds on
+the existing deterministic Monte Carlo runner and the output schema documented
+in `McTimeseriesSchema`.
+
+The workflow deliberately separates two questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Stochastic uncertainty | How much does the baseline move across seed bands? | Baseline rows in `envelope-summary.csv` and `robustness-report.md` |
+| Parameter sensitivity | How much does a selected one-at-a-time parameter change move terminal means versus baseline? | `sensitivity-summary.csv` and the parameter sensitivity section of `robustness-report.md` |
+
+This is not a full global sensitivity design. It is a local research-review
+workflow that should stay cheap enough to run before larger empirical and
+scenario work.
+
+## Command
+
+Local review default:
+
+```bash
+sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+Fast smoke check:
+
+```bash
+sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+## Output Artifacts
+
+The workflow writes all generated artifacts under the selected `--out`
+directory:
+
+| File | Purpose |
+| --- | --- |
+| `seed-metrics.csv` | Per scenario, seed, and metric terminal value plus path min/max/mean. |
+| `envelope-summary.csv` | Cross-seed envelopes by scenario and metric. |
+| `sensitivity-summary.csv` | Terminal mean deltas for each non-baseline scenario versus the baseline mean. |
+| `robustness-report.md` | Human-readable report separating stochastic uncertainty from parameter sensitivity. |
+
+These files are generated outputs and should normally remain under `target/`.
+
+## Scenario Sets
+
+| Scenario set | Contents | Intended use |
+| --- | --- | --- |
+| `smoke` | `baseline`, `mpc-high` | Fast CI/local sanity check that the workflow runs and writes artifacts. |
+| `core` | `baseline`, `mpc-low`, `mpc-high`, `markup-high`, `investment-fast`, `credit-tight`, `fiscal-stabilizer-strong`, `monetary-tight`, `external-risk-off` | First-pass local robustness review. |
+
+The core set covers the first parameters most likely to matter for early SFC-ABM
+review:
+
+| Category | Scenario | Parameter deltas |
+| --- | --- | --- |
+| Household propensity to consume | `mpc-low`, `mpc-high` | `household.mpc` around the baseline `0.82`. |
+| Firm markup/pricing | `markup-high` | Higher `pricing.baseMarkup` and `pricing.costPassthrough`. |
+| Investment response | `investment-fast` | Higher `capital.adjustSpeed`. |
+| Credit/default behavior | `credit-tight` | Higher `banking.baseSpread`, lower `banking.loanRecovery`, higher `banking.eclMigrationSensitivity`. |
+| Fiscal rules | `fiscal-stabilizer-strong` | Higher `fiscal.govAutoStabMult` and `fiscalConsolidationSpeed55`. |
+| Policy rates | `monetary-tight` | Higher `monetary.initialRate`, `neutralRate`, and `taylorAlpha`. |
+| External shocks | `external-risk-off` | Activates risk-off shock month and increases FX sensitivity. |
+
+Scenario definitions live in
+`src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala`.
+The runner lives in
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala`.
+
+## Metrics
+
+The workflow currently summarizes these Monte Carlo output columns:
+
+| Metric | Interpretation |
+| --- | --- |
+| `Inflation` | Annualized inflation rate. |
+| `Unemployment` | Unemployment share. |
+| `MarketWage` | Aggregate market wage. |
+| `DebtToGdp` | Government debt to annualized GDP. |
+| `DeficitToGdp` | Government deficit to annualized GDP. |
+| `CreditToGdpGap` | Macroprudential credit-to-GDP gap. |
+| `MinBankCAR` | Minimum bank capital adequacy ratio. |
+| `MinBankLCR` | Minimum bank liquidity coverage ratio. |
+| `CurrentAccount` | Current-account flow. |
+| `ExRate` | PLN/EUR exchange rate. |
+| `TotalAdoption` | Automation plus hybrid adoption share. |
+| `FirmDeaths` | Monthly firm deaths. |
+| `BankFailures` | Failed bank count. |
+
+These metrics are not a replacement for the empirical validation report in
+`docs/empirical-validation-report.md`. Robustness asks whether conclusions are
+stable across seeds and local parameter changes; empirical validation asks
+whether the model matches observed stylized facts.
+
+## Runtime Guidance
+
+Recommended local defaults are intentionally small:
+
+| Use | Command shape | Notes |
+| --- | --- | --- |
+| Smoke | `--scenario-set smoke --seeds 1 --months 6` | Confirms the workflow compiles, runs, and writes artifacts. |
+| Local review | `--scenario-set core --seeds 2 --months 24` | Good default before opening or reviewing a PR. |
+| Heavier review | `--scenario-set core --seeds 5 --months 60` | Useful before merging research-sensitive parameter changes. |
+| Publication prep | `--scenario-set core --seeds 10+ --months 120+` | Coordinate with the data bridge (#437), `docs/scenario-registry.md`, and `docs/empirical-validation-report.md`. |
+
+Runtime grows roughly with:
+
+```text
+scenario_count * seed_count * months
+```
+
+The default core run is therefore `9 * 2 * 24 = 432` simulated monthly steps.
+
+## Follow-Ups
+
+- `docs/empirical-validation-report.md` provides the empirical target table
+  that these robustness outputs should eventually feed.
+- `docs/scenario-registry.md` defines named scenario comparisons that can
+  reuse this output shape later.
+- #437 should provide source vintages and empirical transformations used to
+  interpret robustness against real-world data.

--- a/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
@@ -1,0 +1,153 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Lightweight one-at-a-time scenario definitions for local robustness work.
+  *
+  * This stays in the config package because SimParams has a config-private
+  * constructor/copy boundary.
+  */
+object RobustnessScenarios:
+
+  enum ScenarioSet(val cliName: String):
+    case Smoke extends ScenarioSet("smoke")
+    case Core  extends ScenarioSet("core")
+
+  object ScenarioSet:
+    val default: ScenarioSet = ScenarioSet.Core
+
+    def parse(value: String): Either[String, ScenarioSet] =
+      values.find(_.cliName == value.trim.toLowerCase) match
+        case Some(set) => Right(set)
+        case None      => Left(s"--scenario-set must be one of: ${values.map(_.cliName).mkString(", ")}")
+
+  final case class Scenario(
+      id: String,
+      label: String,
+      category: String,
+      variedParameter: String,
+      variation: String,
+      rationale: String,
+      params: SimParams,
+  )
+
+  def scenarios(set: ScenarioSet): Vector[Scenario] =
+    val baseline = SimParams.defaults
+
+    val all = Vector(
+      Scenario(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        variedParameter = "none",
+        variation = "default SimParams.defaults",
+        rationale = "Reference path for stochastic seed envelopes and one-at-a-time parameter comparisons.",
+        params = baseline,
+      ),
+      Scenario(
+        id = "mpc-low",
+        label = "Lower household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.72",
+        rationale = "First-pass demand sensitivity to lower household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.72))),
+      ),
+      Scenario(
+        id = "mpc-high",
+        label = "Higher household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.90",
+        rationale = "First-pass demand sensitivity to higher household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.90))),
+      ),
+      Scenario(
+        id = "markup-high",
+        label = "Higher markup and pass-through",
+        category = "firm markup/pricing",
+        variedParameter = "pricing.baseMarkup, pricing.costPassthrough",
+        variation = "1.15 -> 1.25, 0.40 -> 0.55",
+        rationale = "Tests price-level sensitivity to firm pricing power and cost pass-through.",
+        params = baseline.copy(
+          pricing = baseline.pricing.copy(
+            baseMarkup = Multiplier(1.25),
+            costPassthrough = Coefficient(0.55),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "investment-fast",
+        label = "Faster capital adjustment",
+        category = "investment response",
+        variedParameter = "capital.adjustSpeed",
+        variation = "0.10 -> 0.16",
+        rationale = "Tests output, imports, and balance-sheet sensitivity to faster investment adjustment.",
+        params = baseline.copy(capital = baseline.capital.copy(adjustSpeed = Coefficient(0.16))),
+      ),
+      Scenario(
+        id = "credit-tight",
+        label = "Tighter credit and lower recovery",
+        category = "credit/default behavior",
+        variedParameter = "banking.baseSpread, banking.loanRecovery, banking.eclMigrationSensitivity",
+        variation = "0.015 -> 0.030, 0.30 -> 0.20, 3.0 -> 4.0",
+        rationale = "Tests financial-stability sensitivity to tighter credit and weaker default recovery.",
+        params = baseline.copy(
+          banking = baseline.banking.copy(
+            baseSpread = Rate(0.030),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.0),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "fiscal-stabilizer-strong",
+        label = "Stronger automatic stabilizer",
+        category = "fiscal rules",
+        variedParameter = "fiscal.govAutoStabMult, fiscalConsolidationSpeed55",
+        variation = "3.0 -> 4.0, 0.10 -> 0.15",
+        rationale = "Tests unemployment, deficit, and debt sensitivity to stronger fiscal stabilization and consolidation.",
+        params = baseline.copy(
+          fiscal = baseline.fiscal.copy(
+            govAutoStabMult = Coefficient(4.0),
+            fiscalConsolidationSpeed55 = Share(0.15),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "monetary-tight",
+        label = "Tighter monetary stance",
+        category = "policy rates",
+        variedParameter = "monetary.initialRate, monetary.neutralRate, monetary.taylorAlpha",
+        variation = "0.0575 -> 0.075, 0.04 -> 0.05, 1.5 -> 1.8",
+        rationale = "Tests inflation, credit, debt-service, and unemployment sensitivity to tighter policy rates.",
+        params = baseline.copy(
+          monetary = baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "external-risk-off",
+        label = "External risk-off shock",
+        category = "external shocks",
+        variedParameter = "forex.riskOffShockMonth, forex.riskOffMagnitude, forex.irpSensitivity",
+        variation = "0 -> 6, 0.10 -> 0.16, 0.15 -> 0.25",
+        rationale = "Tests FX, current-account, reserves, and financial-market sensitivity to a risk-off episode.",
+        params = baseline.copy(
+          forex = baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.16),
+            irpSensitivity = Coefficient(0.25),
+          ),
+        ),
+      ),
+    )
+
+    set match
+      case ScenarioSet.Smoke => all.filter(scenario => scenario.id == "baseline" || scenario.id == "mpc-high")
+      case ScenarioSet.Core  => all
+
+end RobustnessScenarios

--- a/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
@@ -1,0 +1,276 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Named policy and shock scenarios for reproducible experiment runs.
+  *
+  * This lives in the config package because scenario composition needs the
+  * config-private SimParams copy boundary.
+  */
+object ScenarioRegistry:
+
+  final case class ParameterDelta(
+      parameter: String,
+      baseline: String,
+      scenario: String,
+      note: String,
+  )
+
+  final case class ScenarioSpec(
+      id: String,
+      label: String,
+      category: String,
+      purpose: String,
+      expectedChannels: Vector[String],
+      recommendedMonths: Int,
+      seedPolicy: String,
+      outputFolder: String,
+      deltas: Vector[ParameterDelta],
+      params: SimParams,
+  )
+
+  private val Baseline = SimParams.defaults
+
+  val defaultScenarioIds: Vector[String] =
+    Vector("baseline", "monetary-tightening", "fiscal-expansion")
+
+  val all: Vector[ScenarioSpec] =
+    Vector(
+      ScenarioSpec(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        purpose = "Reference scenario using SimParams.defaults.",
+        expectedChannels = Vector("all baseline model channels"),
+        recommendedMonths = 120,
+        seedPolicy = "Use fixed seed bands; default smoke command uses seed 1.",
+        outputFolder = "<out>/<run-id>/baseline",
+        deltas = Vector(ParameterDelta("SimParams", "SimParams.defaults", "SimParams.defaults", "No parameter change.")),
+        params = Baseline,
+      ),
+      ScenarioSpec(
+        id = "monetary-tightening",
+        label = "Monetary tightening",
+        category = "policy rates",
+        purpose = "Higher NBP policy stance for inflation and credit stress analysis.",
+        expectedChannels = Vector("RefRate", "Inflation", "CreditToGdpGap", "DebtService", "Unemployment", "ExRate"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/monetary-tightening",
+        deltas = Vector(
+          ParameterDelta("monetary.initialRate", "0.0575", "0.075", "Higher starting reference rate."),
+          ParameterDelta("monetary.neutralRate", "0.04", "0.05", "Higher neutral-rate anchor."),
+          ParameterDelta("monetary.taylorAlpha", "1.5", "1.8", "Stronger inflation response."),
+        ),
+        params = Baseline.copy(
+          monetary = Baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fiscal-expansion",
+        label = "Fiscal expansion",
+        category = "fiscal policy",
+        purpose = "Higher government demand and capital share for fiscal multiplier and debt-path comparisons.",
+        expectedChannels = Vector("GovCurrentSpend", "GovCapitalSpendDomestic", "DeficitToGdp", "DebtToGdp", "Unemployment", "Inflation"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/fiscal-expansion",
+        deltas = Vector(
+          ParameterDelta("fiscal.govBaseSpending", "scaled default", "scaled default * 1.15", "15% higher base government spending."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share."),
+          ParameterDelta("fiscal.govAutoStabMult", "3.0", "3.5", "Stronger automatic stabilization."),
+        ),
+        params = Baseline.copy(
+          fiscal = Baseline.fiscal.copy(
+            govBaseSpending = Baseline.fiscal.govBaseSpending * Multiplier(1.15),
+            govInvestShare = Share(0.30),
+            govAutoStabMult = Coefficient(3.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "credit-crunch",
+        label = "Credit crunch",
+        category = "banking stress",
+        purpose = "Tighter credit supply and weaker recovery assumptions for credit and default stress testing.",
+        expectedChannels = Vector("CreditToGdpGap", "ConsumerLoans", "MinBankCAR", "MaxBankNPL", "FirmDeaths", "Unemployment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/credit-crunch",
+        deltas = Vector(
+          ParameterDelta("banking.baseSpread", "0.015", "0.035", "Higher firm-loan spread."),
+          ParameterDelta("banking.minCar", "0.08", "0.10", "Higher capital constraint."),
+          ParameterDelta("banking.loanRecovery", "0.30", "0.20", "Lower corporate-loan recovery."),
+          ParameterDelta("banking.eclMigrationSensitivity", "3.0", "4.5", "Faster IFRS 9 migration under stress."),
+          ParameterDelta("household.ccMaxDti", "0.40", "0.30", "Tighter household credit affordability cap."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            baseSpread = Rate(0.035),
+            minCar = Multiplier(0.10),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.5),
+          ),
+          household = Baseline.household.copy(ccMaxDti = Share(0.30)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "energy-shock",
+        label = "Energy shock",
+        category = "climate and commodity shock",
+        purpose = "ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure.",
+        expectedChannels = Vector("CommodityPriceIndex", "GvcImportCostIndex", "AggEnergyCost", "Inflation", "CurrentAccount", "GreenInvestment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/energy-shock",
+        deltas = Vector(
+          ParameterDelta("climate.etsBasePrice", "80", "120", "Higher EU ETS starting price."),
+          ParameterDelta(
+            "climate.energyCostShares",
+            "[0.02,0.10,0.04,0.05,0.03,0.06]",
+            "[0.03,0.15,0.06,0.075,0.045,0.09]",
+            "50% higher sector energy-cost burden.",
+          ),
+          ParameterDelta("climate.greenBudgetShare", "0.20", "0.12", "Lower discretionary green investment capacity under stress."),
+          ParameterDelta("gvc.commodityShockMonth", "0", "6", "Commodity-price shock starts in month 6."),
+          ParameterDelta("gvc.commodityShockMag", "0.0", "1.5", "One-time commodity-price shock magnitude."),
+        ),
+        params = Baseline.copy(
+          climate = Baseline.climate.copy(
+            etsBasePrice = Multiplier(120.0),
+            energyCostShares = Vector(Share(0.03), Share(0.15), Share(0.06), Share(0.075), Share(0.045), Share(0.09)),
+            greenBudgetShare = Share(0.12),
+          ),
+          gvc = Baseline.gvc.copy(
+            commodityShockMonth = 6,
+            commodityShockMag = Multiplier(1.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "tourism-shock",
+        label = "Tourism shock",
+        category = "external demand shock",
+        purpose = "Tourism-demand loss for services demand, current account, employment, and FX flows.",
+        expectedChannels = Vector("TourismExport", "TourismImport", "NetTourismBalance", "CurrentAccount", "Unemployment", "Inflation"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/tourism-shock",
+        deltas = Vector(
+          ParameterDelta("tourism.shockMonth", "0", "6", "Tourism shock starts in month 6."),
+          ParameterDelta("tourism.shockSize", "0.80", "0.60", "60% tourism-demand loss in the named scenario."),
+          ParameterDelta("tourism.shockRecovery", "0.03", "0.05", "Faster monthly recovery than default COVID-style setting."),
+          ParameterDelta("tourism.inboundShare", "0.05", "0.04", "Lower inbound tourism baseline share."),
+        ),
+        params = Baseline.copy(
+          tourism = Baseline.tourism.copy(
+            shockMonth = 6,
+            shockSize = Share(0.60),
+            shockRecovery = Rate(0.05),
+            inboundShare = Share(0.04),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "bank-failure",
+        label = "Bank failure stress",
+        category = "financial stability",
+        purpose = "Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels.",
+        expectedChannels = Vector("BankFailures", "MinBankCAR", "MinBankLCR", "BfgFundBalance", "BailInLoss", "NPL"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/bank-failure",
+        deltas = Vector(
+          ParameterDelta("banking.initCapital", "scaled default", "scaled default * 0.55", "Lower opening banking-sector capital."),
+          ParameterDelta("banking.minCar", "0.08", "0.12", "Higher regulatory capital requirement."),
+          ParameterDelta("banking.depositPanicRate", "0.03", "0.08", "Higher deposit panic migration after failures."),
+          ParameterDelta("banking.maxDepositSwitchRate", "0.10", "0.18", "Higher maximum monthly deposit switching."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            initCapital = Baseline.banking.initCapital * Multiplier(0.55),
+            minCar = Multiplier(0.12),
+            depositPanicRate = Share(0.08),
+            maxDepositSwitchRate = Share(0.18),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fx-capital-flight",
+        label = "FX and capital-flight stress",
+        category = "external financial shock",
+        purpose = "Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand.",
+        expectedChannels = Vector("ExRate", "FxReserves", "FxInterventionAmt", "CurrentAccount", "ForeignBondHoldings", "BondYield"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/fx-capital-flight",
+        deltas = Vector(
+          ParameterDelta("forex.riskOffShockMonth", "0", "6", "Risk-off shock starts in month 6."),
+          ParameterDelta("forex.riskOffMagnitude", "0.10", "0.20", "Larger capital outflow shock."),
+          ParameterDelta("forex.riskOffDurationMonths", "6", "9", "Longer elevated risk-off period."),
+          ParameterDelta("forex.irpSensitivity", "0.15", "0.30", "Stronger exchange-rate response to rate differentials."),
+          ParameterDelta("forex.exRateAdjSpeed", "0.02", "0.05", "Faster exchange-rate adjustment."),
+          ParameterDelta("monetary.fxMaxMonthly", "0.03", "0.06", "Larger allowed monthly FX intervention."),
+        ),
+        params = Baseline.copy(
+          forex = Baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.20),
+            riskOffDurationMonths = 9,
+            irpSensitivity = Coefficient(0.30),
+            exRateAdjSpeed = Coefficient(0.05),
+          ),
+          monetary = Baseline.monetary.copy(fxMaxMonthly = Share(0.06)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "quasi-fiscal-program",
+        label = "Quasi-fiscal program",
+        category = "quasi-fiscal policy",
+        purpose = "BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending.",
+        expectedChannels = Vector("QfBondsOutstanding", "QfIssuance", "QfLoanPortfolio", "QfNbpHoldings", "Esa2010DebtToGdp", "DebtToGdp"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/quasi-fiscal-program",
+        deltas = Vector(
+          ParameterDelta("quasiFiscal.issuanceShare", "0.40", "0.65", "Higher BGK/PFR share of capital programs."),
+          ParameterDelta("quasiFiscal.lendingShare", "0.50", "0.70", "More issuance routed to subsidized lending."),
+          ParameterDelta("quasiFiscal.nbpAbsorptionShare", "0.70", "0.85", "Higher NBP absorption when QE is active."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share feeding quasi-fiscal issuance."),
+          ParameterDelta("monetary.qeMaxGdpShare", "0.30", "0.40", "Higher QE stock ceiling."),
+        ),
+        params = Baseline.copy(
+          quasiFiscal = Baseline.quasiFiscal.copy(
+            issuanceShare = Share(0.65),
+            lendingShare = Share(0.70),
+            nbpAbsorptionShare = Share(0.85),
+          ),
+          fiscal = Baseline.fiscal.copy(govInvestShare = Share(0.30)),
+          monetary = Baseline.monetary.copy(qeMaxGdpShare = Share(0.40)),
+        ),
+      ),
+    )
+
+  private val byId: Map[String, ScenarioSpec] = all.map(scenario => scenario.id -> scenario).toMap
+
+  def get(id: String): Either[String, ScenarioSpec] =
+    byId.get(id).toRight(s"Unknown scenario '$id'. Known scenarios: ${all.map(_.id).mkString(", ")}")
+
+  def select(value: String): Either[String, Vector[ScenarioSpec]] =
+    val normalized = value.trim
+    if normalized == "all" then Right(all)
+    else
+      val ids = normalized.split(",").iterator.map(_.trim).filter(_.nonEmpty).toVector
+      if ids.isEmpty then Left("--scenarios must contain at least one scenario id")
+      else
+        ids.foldLeft[Either[String, Vector[ScenarioSpec]]](Right(Vector.empty)): (acc, id) =>
+          for
+            selected <- acc
+            scenario <- get(id)
+          yield selected :+ scenario
+
+end ScenarioRegistry

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
@@ -1,0 +1,257 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.ScenarioRegistry
+import com.boombustgroup.amorfati.config.ScenarioRegistry.ScenarioSpec
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object ScenarioRunExport:
+
+  final case class Config(
+      scenarios: Vector[ScenarioSpec] = ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(id).toOption),
+      seedStart: Long = 1L,
+      seeds: Int = 1,
+      months: Int = 12,
+      runId: String = "scenario-registry",
+      out: Path = Path.of("target/scenarios"),
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int)
+
+  private final case class TerminalMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      value: Double,
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      Files.createDirectories(validConfig.runRoot)
+
+      val registryPath  = validConfig.runRoot.resolve("scenario-registry.md")
+      val deltasPath    = validConfig.runRoot.resolve("scenario-deltas.csv")
+      Files.writeString(registryPath, renderRegistry(validConfig.scenarios), StandardCharsets.UTF_8)
+      Files.writeString(deltasPath, renderDeltas(validConfig.scenarios), StandardCharsets.UTF_8)
+      val metadataPaths = validConfig.scenarios.map: scenario =>
+        val scenarioDir  = validConfig.runRoot.resolve(scenario.id)
+        val metadataPath = scenarioDir.resolve("metadata.md")
+        Files.createDirectories(scenarioDir)
+        Files.writeString(metadataPath, renderScenarioMetadata(validConfig, scenario), StandardCharsets.UTF_8)
+        metadataPath
+
+      val runAttempts =
+        for
+          scenario <- validConfig.scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(validConfig, scenario, seed)
+
+      runAttempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val outputs = runAttempts.collect { case Right(paths, metrics) => paths -> metrics }
+          val paths   = Vector(registryPath, deltasPath) ++ metadataPaths ++ outputs.flatMap(_._1)
+          val metrics = outputs.flatMap(_._2)
+          val summary = validConfig.runRoot.resolve("run-summary.csv")
+          Files.writeString(summary, renderRunSummary(metrics), StandardCharsets.UTF_8)
+          Right(ExportResult(paths :+ summary))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                                              => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")                           => missingValue(flag)
+            case Seq(value, next*) if flag == "--scenario" || flag == "--scenarios" =>
+              ScenarioRegistry.select(value).flatMap(scenarios => loop(next, config.copy(scenarios = scenarios)))
+            case Seq(value, next*) if flag == "--seed-start"                        =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"                             =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"                            =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--run-id"                            =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"                               =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                                         => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.scenarios.nonEmpty, config, "--scenarios must contain at least one scenario")
+      .flatMap(valid => Either.cond(valid.seeds > 0, valid, "--seeds must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+
+  private def runSeed(config: Config, scenario: ScenarioSpec, seed: Long): Either[String, (Vector[Path], Vector[TerminalMetric])] =
+    given SimParams = scenario.params
+
+    McRunner
+      .runSingle(seed, config.months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        val scenarioDir = config.runRoot.resolve(scenario.id)
+        Files.createDirectories(scenarioDir)
+
+        val csvPath = scenarioDir.resolve(f"${config.runId}_${scenario.id}_${config.months}m_seed$seed%03d.csv")
+        val rows    = result.timeSeries.map(row => row)
+        Files.writeString(csvPath, renderTimeSeriesCsv(rows), StandardCharsets.UTF_8)
+
+        val terminal = rows.last
+        val metrics  = Metrics.map(metric => TerminalMetric(scenario.id, seed, metric, terminal(metric.ordinal)))
+        Vector(csvPath) -> metrics
+
+  private def renderRegistry(scenarios: Vector[ScenarioSpec]): String =
+    val rows = scenarios.map: scenario =>
+      markdownRow(
+        Vector(
+          scenario.id,
+          scenario.label,
+          scenario.category,
+          scenario.recommendedMonths.toString,
+          scenario.seedPolicy,
+          scenario.outputFolder,
+        ),
+      )
+
+    val lines = Vector(
+      "# Scenario Registry",
+      "",
+      "Generated by `ScenarioRunExport` from `ScenarioRegistry`.",
+      "",
+      markdownRow(Vector("Scenario", "Label", "Category", "Recommended months", "Seed policy", "Output folder")),
+      markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+    ) ++ rows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderDeltas(scenarios: Vector[ScenarioSpec]): String =
+    val header = "Scenario;Parameter;Baseline;ScenarioValue;Note"
+    val rows   =
+      for
+        scenario <- scenarios
+        delta    <- scenario.deltas
+      yield Vector(scenario.id, delta.parameter, delta.baseline, delta.scenario, delta.note).map(csv).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderRunSummary(metrics: Vector[TerminalMetric]): String =
+    val header = "Scenario;Seed;Metric;TerminalValue"
+    val rows   = metrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.value)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderScenarioMetadata(config: Config, scenario: ScenarioSpec): String =
+    val channelRows = scenario.expectedChannels.map(channel => s"- `$channel`")
+    val deltaRows   = scenario.deltas.map: delta =>
+      markdownRow(Vector(delta.parameter, delta.baseline, delta.scenario, delta.note))
+    val lines       =
+      Vector(
+        s"# ${scenario.label}",
+        "",
+        s"- Scenario id: `${scenario.id}`",
+        s"- Category: `${scenario.category}`",
+        s"- Purpose: ${scenario.purpose}",
+        s"- Run id: `${config.runId}`",
+        s"- Months in this run: `${config.months}`",
+        s"- Recommended months: `${scenario.recommendedMonths}`",
+        s"- Seed policy: ${scenario.seedPolicy}",
+        s"- Output folder: `${config.runRoot.resolve(scenario.id)}`",
+        "",
+        "## Expected Channels",
+        "",
+      ) ++ channelRows ++ Vector(
+        "",
+        "## Parameter Deltas",
+        "",
+        markdownRow(Vector("Parameter", "Baseline", "Scenario", "Note")),
+        markdownRow(Vector("---", "---", "---", "---")),
+      ) ++ deltaRows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderTimeSeriesCsv(rows: Vector[Array[Double]]): String =
+    val header = McTimeseriesSchema.colNames.mkString(";")
+    val body   = rows.map: row =>
+      row.indices
+        .map: idx =>
+          if idx == 0 then row(idx).toInt.toString
+          else fmt(row(idx))
+        .mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--scenario" || flag == "--scenarios" || flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(_.replace("|", "\\|")).mkString("| ", " | ", " |")
+
+  private def csv(value: String): String =
+    if value.exists(ch => ch == ';' || ch == '"' || ch == '\n') then "\"" + value.replace("\"", "\"\"") + "\""
+    else value
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def metric(column: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation"),
+    metric("Unemployment"),
+    metric("MarketWage"),
+    metric("DebtToGdp"),
+    metric("DeficitToGdp"),
+    metric("CurrentAccount"),
+    metric("ExRate"),
+    metric("CreditToGdpGap"),
+    metric("MinBankCAR"),
+    metric("MinBankLCR"),
+    metric("BankFailures"),
+    metric("FirmDeaths"),
+  )
+
+  private val usage: String =
+    "Usage: ScenarioRunExport [--scenarios baseline,monetary-tightening|all] [--seed-start <long>] [--seeds <int>] [--months <int>] [--run-id <id>] [--out <path>]"
+
+end ScenarioRunExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
@@ -1,0 +1,368 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.RobustnessScenarios
+import com.boombustgroup.amorfati.config.RobustnessScenarios.{Scenario, ScenarioSet}
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object SensitivityRobustnessExport:
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 2,
+      months: Int = 24,
+      out: Path = Path.of("target/robustness"),
+      scenarioSet: ScenarioSet = ScenarioSet.default,
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int, description: String)
+
+  private final case class SeedMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      terminal: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class EnvelopeMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      terminalMean: Double,
+      terminalMin: Double,
+      terminalMax: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class SensitivityMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      baselineMean: Double,
+      scenarioMean: Double,
+      delta: Double,
+      deltaPct: Option[Double],
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      val scenarios = RobustnessScenarios.scenarios(validConfig.scenarioSet)
+      val attempts  =
+        for
+          scenario <- scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(scenario, seed, validConfig.months)
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val seedMetrics        = attempts.collect { case Right(metrics) => metrics }.flatten
+          val envelopeMetrics    = summarizeEnvelope(seedMetrics)
+          val sensitivityMetrics = summarizeSensitivity(envelopeMetrics)
+          val paths              = writeArtifacts(validConfig, scenarios, seedMetrics, envelopeMetrics, sensitivityMetrics)
+          Right(ExportResult(paths))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                         => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")      => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start"   =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"        =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"       =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--out"          =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(value, next*) if flag == "--scenario-set" =>
+              ScenarioSet.parse(value).flatMap(scenarioSet => loop(next, config.copy(scenarioSet = scenarioSet)))
+            case Seq(_, _*)                                    => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+
+  private def runSeed(scenario: Scenario, seed: Long, months: Int): Either[String, Vector[SeedMetric]] =
+    given SimParams = scenario.params
+    McRunner
+      .runSingle(seed, months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        Metrics.map: metric =>
+          val values = result.timeSeries.map(row => row(metric.ordinal))
+          SeedMetric(
+            scenario.id,
+            seed,
+            metric,
+            terminal = values.last,
+            pathMin = values.min,
+            pathMax = values.max,
+            pathMean = values.sum / values.length.toDouble,
+          )
+
+  private def summarizeEnvelope(seedMetrics: Vector[SeedMetric]): Vector[EnvelopeMetric] =
+    seedMetrics
+      .groupBy(metric => metric.scenarioId -> metric.metric.id)
+      .toVector
+      .sortBy { case ((scenarioId, metricId), _) => scenarioId -> metricId }
+      .map { case ((scenarioId, _), metrics) =>
+        val metric    = metrics.head.metric
+        val terminals = metrics.map(_.terminal)
+        EnvelopeMetric(
+          scenarioId = scenarioId,
+          metric = metric,
+          terminalMean = terminals.sum / terminals.length.toDouble,
+          terminalMin = terminals.min,
+          terminalMax = terminals.max,
+          pathMin = metrics.map(_.pathMin).min,
+          pathMax = metrics.map(_.pathMax).max,
+          pathMean = metrics.map(_.pathMean).sum / metrics.length.toDouble,
+        )
+      }
+
+  private def summarizeSensitivity(envelopeMetrics: Vector[EnvelopeMetric]): Vector[SensitivityMetric] =
+    val baseline = envelopeMetrics.filter(_.scenarioId == "baseline").map(metric => metric.metric.id -> metric).toMap
+    envelopeMetrics
+      .filterNot(_.scenarioId == "baseline")
+      .flatMap: metric =>
+        baseline
+          .get(metric.metric.id)
+          .map: base =>
+            val delta = metric.terminalMean - base.terminalMean
+            SensitivityMetric(
+              scenarioId = metric.scenarioId,
+              metric = metric.metric,
+              baselineMean = base.terminalMean,
+              scenarioMean = metric.terminalMean,
+              delta = delta,
+              deltaPct = if Math.abs(base.terminalMean) > 1e-12 then Some(delta / Math.abs(base.terminalMean)) else None,
+            )
+
+  private def writeArtifacts(
+      config: Config,
+      scenarios: Vector[Scenario],
+      seedMetrics: Vector[SeedMetric],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): Vector[Path] =
+    Files.createDirectories(config.out)
+    val seedMetricsPath = config.out.resolve("seed-metrics.csv")
+    val envelopePath    = config.out.resolve("envelope-summary.csv")
+    val sensitivityPath = config.out.resolve("sensitivity-summary.csv")
+    val reportPath      = config.out.resolve("robustness-report.md")
+
+    Files.writeString(seedMetricsPath, renderSeedMetrics(seedMetrics), StandardCharsets.UTF_8)
+    Files.writeString(envelopePath, renderEnvelopeMetrics(envelopeMetrics), StandardCharsets.UTF_8)
+    Files.writeString(sensitivityPath, renderSensitivityMetrics(sensitivityMetrics), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, scenarios, envelopeMetrics, sensitivityMetrics), StandardCharsets.UTF_8)
+
+    Vector(seedMetricsPath, envelopePath, sensitivityPath, reportPath)
+
+  private def renderSeedMetrics(seedMetrics: Vector[SeedMetric]): String =
+    val header = "Scenario;Seed;Metric;Terminal;PathMin;PathMax;PathMean"
+    val rows   = seedMetrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.terminal), fmt(row.pathMin), fmt(row.pathMax), fmt(row.pathMean)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderEnvelopeMetrics(envelopeMetrics: Vector[EnvelopeMetric]): String =
+    val header = "Scenario;Metric;TerminalMean;TerminalMin;TerminalMax;PathMin;PathMax;PathMean"
+    val rows   = envelopeMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.terminalMean),
+        fmt(row.terminalMin),
+        fmt(row.terminalMax),
+        fmt(row.pathMin),
+        fmt(row.pathMax),
+        fmt(row.pathMean),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderSensitivityMetrics(sensitivityMetrics: Vector[SensitivityMetric]): String =
+    val header = "Scenario;Metric;BaselineTerminalMean;ScenarioTerminalMean;Delta;DeltaPct"
+    val rows   = sensitivityMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.baselineMean),
+        fmt(row.scenarioMean),
+        fmt(row.delta),
+        row.deltaPct.map(fmt).getOrElse("NA"),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderReport(
+      config: Config,
+      scenarios: Vector[Scenario],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): String =
+    val baselineRows = envelopeMetrics
+      .filter(_.scenarioId == "baseline")
+      .map: row =>
+        markdownRow(Vector(row.metric.id, fmt(row.terminalMean), fmt(row.terminalMin), fmt(row.terminalMax), fmt(row.pathMin), fmt(row.pathMax)))
+
+    val sensitivityRows = sensitivityMetrics.map: row =>
+      markdownRow(
+        Vector(
+          row.scenarioId,
+          row.metric.id,
+          fmt(row.baselineMean),
+          fmt(row.scenarioMean),
+          signed(row.delta),
+          row.deltaPct.map(p => signed(p * 100.0) + "%").getOrElse("NA"),
+        ),
+      )
+
+    val scenarioRows = scenarios.map: scenario =>
+      markdownRow(Vector(scenario.id, scenario.label, scenario.category, scenario.variedParameter, scenario.variation, scenario.rationale))
+
+    val metricRows = Metrics.map: metric =>
+      markdownRow(Vector(metric.id, metric.description))
+
+    val lines =
+      Vector(
+        "# Sensitivity And Robustness Report",
+        "",
+        "Generated by `SensitivityRobustnessExport`.",
+        "",
+        "## Run Configuration",
+        "",
+        s"- Scenario set: `${config.scenarioSet.cliName}`",
+        s"- Seeds: `${config.seedRange.head}` to `${config.seedRange.last}` (${config.seeds} seeds)",
+        s"- Months: `${config.months}`",
+        s"- Output directory: `${config.out}`",
+        "",
+        "## Scenario Sweep",
+        "",
+        markdownRow(Vector("Scenario", "Label", "Category", "Varied parameter", "Variation", "Rationale")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ scenarioRows ++ Vector(
+        "",
+        "## Metrics",
+        "",
+        markdownRow(Vector("Metric", "Description")),
+        markdownRow(Vector("---", "---")),
+      ) ++ metricRows ++ Vector(
+        "",
+        "## Stochastic Uncertainty",
+        "",
+        "Baseline seed variation is summarized below. `TerminalMin` and",
+        "`TerminalMax` are cross-seed terminal envelopes; `PathMin` and `PathMax`",
+        "are the full within-run path envelope across all baseline seeds.",
+        "",
+        markdownRow(Vector("Metric", "TerminalMean", "TerminalMin", "TerminalMax", "PathMin", "PathMax")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ baselineRows ++ Vector(
+        "",
+        "## Parameter Sensitivity",
+        "",
+        "The table compares each non-baseline scenario's terminal cross-seed mean",
+        "against the baseline terminal cross-seed mean. This is one-at-a-time",
+        "sensitivity, not a full global sensitivity design.",
+        "",
+        markdownRow(Vector("Scenario", "Metric", "BaselineMean", "ScenarioMean", "Delta", "DeltaPct")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ sensitivityRows ++ Vector(
+        "",
+        "## Runtime Guidance",
+        "",
+        """- Smoke check: `sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"`""",
+        """- Local review default: `sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"`""",
+        "- Heavier review run: increase to 5-10 seeds and 60-120 months after checking runtime locally.",
+        "",
+        "## Output Files",
+        "",
+        "- `seed-metrics.csv`: per scenario, seed, and metric terminal/path statistics.",
+        "- `envelope-summary.csv`: cross-seed envelopes by scenario and metric.",
+        "- `sensitivity-summary.csv`: terminal mean deltas versus baseline.",
+        "- `robustness-report.md`: this human-readable summary.",
+      )
+
+    lines.mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--out" || flag == "--scenario-set"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(escapeMarkdown).mkString("| ", " | ", " |")
+
+  private def escapeMarkdown(value: String): String =
+    value.replace("|", "\\|")
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def signed(value: Double): String =
+    String.format(Locale.US, "%+.8f", Double.box(value))
+
+  private def metric(column: String, description: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal, description)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation", "annualized inflation rate"),
+    metric("Unemployment", "unemployment share"),
+    metric("MarketWage", "aggregate market wage"),
+    metric("DebtToGdp", "government debt to annualized GDP"),
+    metric("DeficitToGdp", "government deficit to annualized GDP"),
+    metric("CreditToGdpGap", "macroprudential credit-to-GDP gap"),
+    metric("MinBankCAR", "minimum bank capital adequacy ratio"),
+    metric("MinBankLCR", "minimum bank liquidity coverage ratio"),
+    metric("CurrentAccount", "current account flow"),
+    metric("ExRate", "PLN/EUR exchange rate"),
+    metric("TotalAdoption", "automation plus hybrid adoption share"),
+    metric("FirmDeaths", "monthly firm deaths"),
+    metric("BankFailures", "failed bank count"),
+  )
+
+  private val usage: String =
+    "Usage: SensitivityRobustnessExport [--seed-start <long>] [--seeds <int>] [--months <int>] [--out <path>] [--scenario-set smoke|core]"
+
+end SensitivityRobustnessExport


### PR DESCRIPTION
## Summary
- add a Markdown calibration register with parameter values, units, provenance status, owners, targets, and transformations
- mark unknown/tuned/scenario/placeholder values with searchable status tokens
- link the register from README, ODD docs, and behavioral rule book

## Verification
- git diff --cached --check
- docs-only change; no test suite run

Stacked on #440 / feature/behavioral-rule-book.

Closes #432