### PR TITLE
Add empirical validation report skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The detailed behavioral equations and institutional decision rules are documente
 
 The calibration register is documented in [docs/calibration-register.md](docs/calibration-register.md). It records key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and explicit searchable gaps.
 
+The empirical validation report skeleton is documented in [docs/empirical-validation-report.md](docs/empirical-validation-report.md). It maps macro, meso, micro, financial, and external validation targets to Monte Carlo output columns and keeps missing data/output gaps visible.
+
 ## Ledger-Derived Matrix Artifacts
 
 The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ The calibration register is documented in [docs/calibration-register.md](docs/ca
 
 The empirical validation report skeleton is documented in [docs/empirical-validation-report.md](docs/empirical-validation-report.md). It maps macro, meso, micro, financial, and external validation targets to Monte Carlo output columns and keeps missing data/output gaps visible.
 
+The sensitivity and robustness workflow is documented in [docs/sensitivity-robustness-workflow.md](docs/sensitivity-robustness-workflow.md). It generates seed envelopes and one-at-a-time parameter-sensitivity artifacts from the Monte Carlo runner.
+
+The reproducible scenario registry is documented in [docs/scenario-registry.md](docs/scenario-registry.md). It defines named policy and shock scenarios, exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path.
+
 ## Ledger-Derived Matrix Artifacts
 
 The project can regenerate paper-facing symbolic SFC matrices from an executed deterministic simulation step:

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import complete.DefaultParsers.spaceDelimited
 lazy val ledger = ProjectRef(file("modules/ledger"), "root")
 
 lazy val sfcMatrices = inputKey[Unit]("Generate symbolic SFC BSM/TFM matrix artifacts")
+lazy val robustnessReport = inputKey[Unit]("Generate lightweight sensitivity and robustness artifacts")
+lazy val scenarioRun = inputKey[Unit]("Run named scenario-registry experiments")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -56,6 +58,20 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<sfc matrix args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.SfcMatrixExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    robustnessReport := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<robustness args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    scenarioRun := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<scenario args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.ScenarioRunExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -301,4 +301,5 @@ Priority gaps before publication:
 - Decide whether currently unscaled institutional monthly flows, such as PFRON
   monthly revenue/spending, should remain agent-scale values or be moved into
   the `gdpRatio`-scaled macro-stock convention.
-- Move scenario defaults into a scenario registry once #435 is implemented.
+- Keep scenario deltas in `docs/scenario-registry.md`; this register remains
+  the baseline parameter-provenance surface.

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -33,7 +33,8 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
   `Agriculture`.
 - Runtime numeric evidence comes from Monte Carlo output columns in
   `McTimeseriesSchema`; this register documents parameter provenance, not run
-  results.
+  results. Empirical validation targets and output mappings are documented in
+  `docs/empirical-validation-report.md`.
 
 ## Core Scale And Sectors
 

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -142,10 +142,11 @@ mapping and frequency conventions belong in #437.
 
 - #437: external data bridge, source vintages, licenses, transformations, and
   empirical target values.
-- #434: stochastic uncertainty, parameter sensitivity, confidence envelopes,
-  and robustness metrics around this baseline report.
-- #435: named scenarios whose outputs should reuse the same validation target
-  table.
+- `docs/sensitivity-robustness-workflow.md`: stochastic uncertainty, parameter
+  sensitivity, confidence envelopes, and robustness metrics around this
+  baseline report.
+- `docs/scenario-registry.md`: named scenarios whose outputs should reuse the
+  same validation target table.
 - #436: stock-flow reconciliation and revaluation artifact; keep this separate
   from empirical fit.
 - #438: milestone tracker for the full research-readiness spine.

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -1,0 +1,151 @@
+# Empirical Validation Report Skeleton
+
+This report defines how Amor Fati outputs should be compared with empirical
+macro, meso, and micro stylized facts. It is deliberately a skeleton: the
+model already writes numeric simulation evidence, but the external data bridge
+and publication-grade source tables are still tracked separately in #437.
+
+The goal is to keep failed, missing, or weak validation targets visible. A row
+with `MISSING_OUTPUT`, `MISSING_DATA_BRIDGE`, or `NOT_RUN` is part of the report
+surface, not an omission.
+
+## Validation Boundary
+
+Accounting validation and empirical validation answer different questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Runtime ledger checks | Did emitted monetary flows conserve value through the ledger? | Engine runtime checks and SFC identity validation |
+| Paper-facing accounting structure | Are Balance Sheet Matrix and Transactions Flow Matrix rows documented and traceable to runtime mechanisms? | `docs/sfc-matrix-evidence.md` |
+| Empirical validation | Do simulated paths reproduce empirical Polish/EU macro, meso, and micro stylized facts? | This report |
+| Revaluation and other-change accounting | Do stocks reconcile with transactions plus independent revaluations or other changes? | Follow-up #436 |
+
+Empirical validation must not be used to relax accounting constraints. A model
+run can fit an empirical target and still be invalid if the ledger or SFC
+checks fail.
+
+## Status Taxonomy
+
+| Status | Meaning |
+| --- | --- |
+| `READY_FOR_BASELINE` | Output columns exist and the empirical target family is identified. |
+| `PARTIAL_OUTPUT` | Output exists but requires a derived metric, normalization, or additional aggregation. |
+| `MISSING_DATA_BRIDGE` | Model output exists, but external source extraction/transformation is not documented yet. |
+| `MISSING_OUTPUT` | Target is known, but the Monte Carlo output schema does not yet expose enough model state. |
+| `ACCOUNTING_ONLY` | This belongs to accounting validation, not empirical fit. |
+| `NOT_RUN` | The baseline validation run has not yet been summarized in this report. |
+
+## Reproducible Workflow
+
+Run a small deterministic baseline Monte Carlo batch:
+
+```bash
+sbt "run 3 validation-baseline --duration 120 --run-id validation-baseline"
+```
+
+Expected output files:
+
+```text
+mc/validation-baseline_validation-baseline_120m_seed001.csv
+mc/validation-baseline_validation-baseline_120m_seed002.csv
+mc/validation-baseline_validation-baseline_120m_seed003.csv
+mc/validation-baseline_validation-baseline_120m_hh.csv
+mc/validation-baseline_validation-baseline_120m_banks.csv
+```
+
+Use the per-seed CSV files for monthly macro, meso, financial, and mechanism
+paths. Use the `_hh.csv` and `_banks.csv` files for terminal household and bank
+cross-section summaries.
+
+Manual update procedure until #437 adds a formal data bridge:
+
+1. Run the command above from the repository root.
+2. Record commit hash, run id, duration, seed count, and parameter branch.
+3. For each target row below, compute the model statistic from the mapped CSV
+   column or terminal summary field.
+4. Fill empirical source, vintage, target value, model value, tolerance, and
+   status in the report snapshot.
+5. Keep rows with missing model output or missing empirical data in the table.
+
+## Output Mapping
+
+The primary numeric surface is
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala`.
+Terminal cross-sections come from
+`src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala`.
+
+| Validation target | Empirical comparator | Model output mapping | Suggested statistic | Current status |
+| --- | --- | --- | --- | --- |
+| GDP growth | GUS national accounts real GDP growth | Engine state `world.cachedMonthlyGdpProxy`; no direct CSV column yet. `GovDebt` and `DebtToGdp` can imply annualized GDP only when both are valid. | Annual or quarterly growth of real/price-adjusted GDP proxy | `MISSING_OUTPUT` |
+| Inflation | GUS CPI / HICP, NBP inflation target | `Inflation`, `PriceLevel`, `ExpectedInflation`, `InflationForecastError` | Mean, volatility, target deviation, persistence | `READY_FOR_BASELINE` |
+| Unemployment | GUS BAEL / registered unemployment | `Unemployment`, `Unemp_Central`, `Unemp_South`, `Unemp_East`, `Unemp_Northwest`, `Unemp_Southwest`, `Unemp_North` | Mean level, volatility, regional dispersion | `READY_FOR_BASELINE` |
+| Wages | GUS average wage, sector wage indices | `MarketWage`, `MinWageLevel`; terminal household income distribution not directly emitted | Mean wage level and growth; minimum/market wage ratio | `PARTIAL_OUTPUT` |
+| Credit/GDP | NBP credit aggregates to GDP | `CreditToGdpGap`, `ConsumerLoans`, `MortgageToGdp`, `MortgageStock`, `NbfiLoanStock`; terminal `_banks.csv` field `Loans` | Credit/GDP level, gap, household/firm split | `PARTIAL_OUTPUT` |
+| Public debt/GDP | MF public debt, ESA2010 general-government debt | `DebtToGdp`, `Esa2010DebtToGdp`, `GovDebt`, `QfBondsOutstanding`, `BondsOutstanding` | Terminal debt/GDP and path against thresholds | `READY_FOR_BASELINE` |
+| Current account | NBP balance of payments | `CurrentAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NetRemittances`, `NetTourismBalance`, `FDI` | Annualized current-account/GDP and component signs | `PARTIAL_OUTPUT` |
+| Firm-size distribution | GUS/REGON firm-size distribution | Initialization config `PopulationConfig`; no monthly or terminal firm-size histogram CSV yet | Init distribution and survival-weighted terminal distribution | `MISSING_OUTPUT` |
+| Bankruptcies | GUS / Ministry of Justice corporate insolvencies, consumer bankruptcy statistics | `FirmDeaths`, `FirmBirths`, `NetEntry`, `BankFailures`; terminal `_hh.csv` fields `HH_Bankrupt`, `BankruptcyRate`, `MeanMonthsToRuin` | Firm exit rate, household bankruptcy rate, bank failures | `PARTIAL_OUTPUT` |
+| Bank capital and liquidity | KNF banking-sector CAR, LCR, NSFR, NPL | `MinBankCAR`, `MinBankLCR`, `MinBankNSFR`, `NPL`, `MaxBankNPL`; terminal `_banks.csv` fields `CAR`, `NPL`, `Capital`, `Deposits`, `Loans` | Minimum and distributional stress indicators | `READY_FOR_BASELINE` |
+| Inequality | GUS household surveys, EU-SILC, OECD income/wealth indicators | Terminal `_hh.csv` fields `Gini_Individual`, `Gini_Wealth`, `ConsumptionP10`, `ConsumptionP50`, `ConsumptionP90`, `PovertyRate_50pct`, `PovertyRate_30pct` | Terminal Gini, poverty rates, consumption percentile ratios | `MISSING_DATA_BRIDGE` |
+| Sectoral output | GUS national accounts by sector, supply-use tables | Sector columns currently expose `BPO_Auto`, `Manuf_Auto`, `Retail_Auto`, `Health_Auto`, `Public_Auto`, `Agri_Auto`, sector sigmas, and `IoFlows`; direct sector output is not emitted | Sector output shares and growth | `MISSING_OUTPUT` |
+| External prices and FX | NBP exchange rate, ECB/Eurostat external prices | `ExRate`, `ForeignPriceIndex`, `GvcImportCostIndex`, `CommodityPriceIndex`, `FxReserves`, `FxInterventionAmt` | FX level/volatility, reserve path, import-cost shocks | `READY_FOR_BASELINE` |
+| Housing and mortgages | NBP housing prices, mortgage stock, KNF mortgage risk | `HousingPriceIndex`, `WawHpi`, `KrkHpi`, `WroHpi`, `GdnHpi`, `LdzHpi`, `PozHpi`, `RestHpi`, `MortgageToGdp`, `MortgageDefault` | HPI path, regional dispersion, mortgage/GDP, defaults | `READY_FOR_BASELINE` |
+| Fiscal stance | MF budget execution, Eurostat deficit/GDP | `DeficitToGdp`, `GovCurrentSpend`, `GovCapitalSpendDomestic`, `DebtService`, `FiscalRuleBinding`, `GovSpendingCutRatio` | Deficit/GDP, expenditure mix, fiscal-rule episodes | `READY_FOR_BASELINE` |
+| Monetary and financial market conditions | NBP reference rate, WIBOR, bond yields, GPW | `RefRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BondYield`, `GpwIndex`, `GpwMarketCap`, `CorpBondYield`, `CorpBondSpread` | Policy-rate path, spread behavior, market stress | `READY_FOR_BASELINE` |
+
+## Baseline Report Snapshot
+
+This table is the publication-facing slot that should be filled after a
+baseline run. Placeholder values remain explicit until the empirical data
+bridge and baseline analysis have been completed.
+
+| Target | Empirical source and vintage | Empirical value | Model run | Model value | Tolerance / criterion | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| GDP growth | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct GDP output column still needed. |
+| Inflation | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use `Inflation` and `PriceLevel`. |
+| Unemployment | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Include regional dispersion. |
+| Wages | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Current output is aggregate market wage. |
+| Credit/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Firm-loan split depends partly on terminal bank summary. |
+| Public debt/GDP | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Compare `DebtToGdp` and `Esa2010DebtToGdp`. |
+| Current account | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Needs GDP denominator and annualization convention. |
+| Firm-size distribution | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal firm-size histogram not emitted yet. |
+| Bankruptcies | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use firm deaths and household bankruptcy separately. |
+| Bank capital/liquidity | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Use minima and terminal bank distribution. |
+| Inequality | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Terminal household summary has first-pass measures. |
+| Sectoral output | TBD via #437 | TBD | `validation-baseline` | TBD | TBD | `NOT_RUN` | Direct sector output columns still needed. |
+
+## Target-Specific Notes
+
+GDP growth should be reported only after the model exposes a direct GDP or
+monthly GDP proxy column. The engine already computes `world.cachedMonthlyGdpProxy`,
+but relying on `GovDebt / DebtToGdp` as a CSV reconstruction is too fragile for
+publication use.
+
+Inflation validation should use both the period inflation column and the price
+level path. The report should state whether the statistic is monthly,
+annualized, or year-over-year.
+
+Credit/GDP should distinguish bank firm loans, consumer loans, mortgage credit,
+and NBFI credit. Current outputs cover several pieces but do not yet provide a
+single total-credit-to-GDP series.
+
+Firm-size distribution and sectoral output are currently the most visible
+meso-level output gaps. The model has sector metadata, firm state, and
+population initialization, but the Monte Carlo CSV does not yet emit a terminal
+firm-size histogram or sector output shares.
+
+Inequality validation is terminal-only for now. The household summary already
+emits Gini, poverty, and consumption percentile fields, but external source
+mapping and frequency conventions belong in #437.
+
+## Follow-Up Links
+
+- #437: external data bridge, source vintages, licenses, transformations, and
+  empirical target values.
+- #434: stochastic uncertainty, parameter sensitivity, confidence envelopes,
+  and robustness metrics around this baseline report.
+- #435: named scenarios whose outputs should reuse the same validation target
+  table.
+- #436: stock-flow reconciliation and revaluation artifact; keep this separate
+  from empirical fit.
+- #438: milestone tracker for the full research-readiness spine.

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -376,12 +376,13 @@ Current inputs are:
 - explicit initialization seed;
 - explicit monthly randomness schedule;
 - Monte Carlo configuration (`nSeeds`, duration, run id, output prefix);
-- scenario changes expressed by modifying/copying config values in code.
+- named scenario changes from `docs/scenario-registry.md`, or direct config
+  changes in code for exploratory work.
 
 The model contains many Poland-specific calibration comments and values, but a
 structured calibration register is documented in
-`docs/calibration-register.md`. A reproducible scenario registry is tracked in
-#435.
+`docs/calibration-register.md`. The reproducible scenario registry is
+documented in `docs/scenario-registry.md`.
 
 ## 7. Submodels
 
@@ -411,6 +412,16 @@ The empirical validation report skeleton is documented in
 surface to macro, meso, micro, financial, and external validation targets and
 keeps missing data or output coverage visible.
 
+The sensitivity and robustness workflow is documented in
+`docs/sensitivity-robustness-workflow.md`. It runs small Monte Carlo seed bands
+and one-at-a-time parameter sweeps, producing seed envelopes and sensitivity
+summaries under `target/`.
+
+The reproducible scenario registry is documented in
+`docs/scenario-registry.md`. It defines named baseline, policy, banking,
+external, energy, tourism, and quasi-fiscal experiments with exact parameter
+deltas and an executable `scenarioRun` command path.
+
 ## Accounting And Validation Boundary
 
 Amor Fati has two related but distinct accounting surfaces:
@@ -434,8 +445,6 @@ outputs.
 
 This document deliberately marks unfinished research-readiness work:
 
-- #434: sensitivity and robustness workflow;
-- #435: reproducible scenario registry;
 - #436: stock-flow reconciliation and revaluation matrix artifact;
 - #437: data bridge to national and financial accounts.
 

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -69,7 +69,8 @@ The current model is expected to generate and expose:
   Flow Matrix (TFM), and runtime mapping generated from an executed simulation
   step.
 
-Empirical validation of these patterns is tracked separately in #433.
+Empirical validation of these patterns is structured in
+`docs/empirical-validation-report.md`.
 
 ## 2. Entities, State Variables, And Scales
 
@@ -405,6 +406,11 @@ protocol-level model description, while that rule book carries equations,
 algorithmic rules, implementation references, output columns, and explicit
 simplifications.
 
+The empirical validation report skeleton is documented in
+`docs/empirical-validation-report.md`. It maps the current Monte Carlo output
+surface to macro, meso, micro, financial, and external validation targets and
+keeps missing data or output coverage visible.
+
 ## Accounting And Validation Boundary
 
 Amor Fati has two related but distinct accounting surfaces:
@@ -428,7 +434,6 @@ outputs.
 
 This document deliberately marks unfinished research-readiness work:
 
-- #433: empirical validation report and stylized-fact mapping;
 - #434: sensitivity and robustness workflow;
 - #435: reproducible scenario registry;
 - #436: stock-flow reconciliation and revaluation matrix artifact;

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -1,0 +1,116 @@
+# Scenario Registry
+
+This registry defines named policy and shock experiments that can be inspected,
+run, and compared reproducibly. It is separate from the sensitivity workflow:
+scenario runs are named economic stories, while sensitivity runs are local
+one-at-a-time parameter checks.
+
+The source of truth is
+`src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala`.
+The executable runner is
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala`.
+
+## Command
+
+Run the baseline plus two nontrivial scenarios:
+
+```bash
+sbt "scenarioRun --scenarios baseline,monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+```
+
+Run every registered scenario:
+
+```bash
+sbt "scenarioRun --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+```
+
+## Output Layout
+
+For `--out target/scenarios --run-id local-review`, the runner writes:
+
+```text
+target/scenarios/local-review/
+  scenario-registry.md
+  scenario-deltas.csv
+  run-summary.csv
+  baseline/
+    metadata.md
+    local-review_baseline_24m_seed001.csv
+  monetary-tightening/
+    metadata.md
+    local-review_monetary-tightening_24m_seed001.csv
+```
+
+Each per-seed CSV uses `McTimeseriesSchema.colNames` as the header, so scenario
+outputs can be compared directly with validation and robustness artifacts.
+
+## Registered Scenarios
+
+| Scenario | Label | Category | Recommended months | Purpose |
+| --- | --- | --- | --- | --- |
+| `baseline` | Baseline | baseline | 120 | Reference scenario using `SimParams.defaults`. |
+| `monetary-tightening` | Monetary tightening | policy rates | 60 | Higher NBP policy stance for inflation and credit stress analysis. |
+| `fiscal-expansion` | Fiscal expansion | fiscal policy | 60 | Higher government demand and capital share for fiscal multiplier and debt-path comparisons. |
+| `credit-crunch` | Credit crunch | banking stress | 60 | Tighter credit supply and weaker recovery assumptions for credit and default stress testing. |
+| `energy-shock` | Energy shock | climate and commodity shock | 60 | ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure. |
+| `tourism-shock` | Tourism shock | external demand shock | 36 | Tourism-demand loss for services demand, current account, employment, and FX flows. |
+| `bank-failure` | Bank failure stress | financial stability | 36 | Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels. |
+| `fx-capital-flight` | FX and capital-flight stress | external financial shock | 60 | Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand. |
+| `quasi-fiscal-program` | Quasi-fiscal program | quasi-fiscal policy | 60 | BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending. |
+
+## Parameter Deltas
+
+| Scenario | Parameter | Baseline | Scenario value | Note |
+| --- | --- | --- | --- | --- |
+| `baseline` | `SimParams` | `SimParams.defaults` | `SimParams.defaults` | No parameter change. |
+| `monetary-tightening` | `monetary.initialRate` | `0.0575` | `0.075` | Higher starting reference rate. |
+| `monetary-tightening` | `monetary.neutralRate` | `0.04` | `0.05` | Higher neutral-rate anchor. |
+| `monetary-tightening` | `monetary.taylorAlpha` | `1.5` | `1.8` | Stronger inflation response. |
+| `fiscal-expansion` | `fiscal.govBaseSpending` | scaled default | scaled default `* 1.15` | 15% higher base government spending. |
+| `fiscal-expansion` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share. |
+| `fiscal-expansion` | `fiscal.govAutoStabMult` | `3.0` | `3.5` | Stronger automatic stabilization. |
+| `credit-crunch` | `banking.baseSpread` | `0.015` | `0.035` | Higher firm-loan spread. |
+| `credit-crunch` | `banking.minCar` | `0.08` | `0.10` | Higher capital constraint. |
+| `credit-crunch` | `banking.loanRecovery` | `0.30` | `0.20` | Lower corporate-loan recovery. |
+| `credit-crunch` | `banking.eclMigrationSensitivity` | `3.0` | `4.5` | Faster IFRS 9 migration under stress. |
+| `credit-crunch` | `household.ccMaxDti` | `0.40` | `0.30` | Tighter household credit affordability cap. |
+| `energy-shock` | `climate.etsBasePrice` | `80` | `120` | Higher EU ETS starting price. |
+| `energy-shock` | `climate.energyCostShares` | `[0.02,0.10,0.04,0.05,0.03,0.06]` | `[0.03,0.15,0.06,0.075,0.045,0.09]` | 50% higher sector energy-cost burden. |
+| `energy-shock` | `climate.greenBudgetShare` | `0.20` | `0.12` | Lower discretionary green investment capacity under stress. |
+| `energy-shock` | `gvc.commodityShockMonth` | `0` | `6` | Commodity-price shock starts in month 6. |
+| `energy-shock` | `gvc.commodityShockMag` | `0.0` | `1.5` | One-time commodity-price shock magnitude. |
+| `tourism-shock` | `tourism.shockMonth` | `0` | `6` | Tourism shock starts in month 6. |
+| `tourism-shock` | `tourism.shockSize` | `0.80` | `0.60` | 60% tourism-demand loss in the named scenario. |
+| `tourism-shock` | `tourism.shockRecovery` | `0.03` | `0.05` | Faster monthly recovery than default COVID-style setting. |
+| `tourism-shock` | `tourism.inboundShare` | `0.05` | `0.04` | Lower inbound tourism baseline share. |
+| `bank-failure` | `banking.initCapital` | scaled default | scaled default `* 0.55` | Lower opening banking-sector capital. |
+| `bank-failure` | `banking.minCar` | `0.08` | `0.12` | Higher regulatory capital requirement. |
+| `bank-failure` | `banking.depositPanicRate` | `0.03` | `0.08` | Higher deposit panic migration after failures. |
+| `bank-failure` | `banking.maxDepositSwitchRate` | `0.10` | `0.18` | Higher maximum monthly deposit switching. |
+| `fx-capital-flight` | `forex.riskOffShockMonth` | `0` | `6` | Risk-off shock starts in month 6. |
+| `fx-capital-flight` | `forex.riskOffMagnitude` | `0.10` | `0.20` | Larger capital outflow shock. |
+| `fx-capital-flight` | `forex.riskOffDurationMonths` | `6` | `9` | Longer elevated risk-off period. |
+| `fx-capital-flight` | `forex.irpSensitivity` | `0.15` | `0.30` | Stronger exchange-rate response to rate differentials. |
+| `fx-capital-flight` | `forex.exRateAdjSpeed` | `0.02` | `0.05` | Faster exchange-rate adjustment. |
+| `fx-capital-flight` | `monetary.fxMaxMonthly` | `0.03` | `0.06` | Larger allowed monthly FX intervention. |
+| `quasi-fiscal-program` | `quasiFiscal.issuanceShare` | `0.40` | `0.65` | Higher BGK/PFR share of capital programs. |
+| `quasi-fiscal-program` | `quasiFiscal.lendingShare` | `0.50` | `0.70` | More issuance routed to subsidized lending. |
+| `quasi-fiscal-program` | `quasiFiscal.nbpAbsorptionShare` | `0.70` | `0.85` | Higher NBP absorption when QE is active. |
+| `quasi-fiscal-program` | `fiscal.govInvestShare` | `0.20` | `0.30` | Higher capital-spending share feeding quasi-fiscal issuance. |
+| `quasi-fiscal-program` | `monetary.qeMaxGdpShare` | `0.30` | `0.40` | Higher QE stock ceiling. |
+
+## Links To Other Research Artifacts
+
+- `docs/empirical-validation-report.md`: scenario outputs reuse the same
+  Monte Carlo columns and validation targets.
+- `docs/sensitivity-robustness-workflow.md`: robustness runs can wrap named
+  scenarios later, but the current sensitivity workflow remains local and
+  one-at-a-time.
+- `docs/calibration-register.md`: baseline parameter provenance remains there;
+  this document records scenario deltas from that baseline.

--- a/docs/sensitivity-robustness-workflow.md
+++ b/docs/sensitivity-robustness-workflow.md
@@ -1,0 +1,129 @@
+# Sensitivity And Robustness Workflow
+
+This workflow is the first lightweight reproducible path for seed uncertainty
+and one-at-a-time parameter sensitivity around Amor Fati outputs. It builds on
+the existing deterministic Monte Carlo runner and the output schema documented
+in `McTimeseriesSchema`.
+
+The workflow deliberately separates two questions:
+
+| Surface | Question | Artifact |
+| --- | --- | --- |
+| Stochastic uncertainty | How much does the baseline move across seed bands? | Baseline rows in `envelope-summary.csv` and `robustness-report.md` |
+| Parameter sensitivity | How much does a selected one-at-a-time parameter change move terminal means versus baseline? | `sensitivity-summary.csv` and the parameter sensitivity section of `robustness-report.md` |
+
+This is not a full global sensitivity design. It is a local research-review
+workflow that should stay cheap enough to run before larger empirical and
+scenario work.
+
+## Command
+
+Local review default:
+
+```bash
+sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+Fast smoke check:
+
+```bash
+sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"
+```
+
+Equivalent direct entrypoint:
+
+```bash
+sbt "runMain com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport --scenario-set core --seeds 2 --months 24 --out target/robustness"
+```
+
+## Output Artifacts
+
+The workflow writes all generated artifacts under the selected `--out`
+directory:
+
+| File | Purpose |
+| --- | --- |
+| `seed-metrics.csv` | Per scenario, seed, and metric terminal value plus path min/max/mean. |
+| `envelope-summary.csv` | Cross-seed envelopes by scenario and metric. |
+| `sensitivity-summary.csv` | Terminal mean deltas for each non-baseline scenario versus the baseline mean. |
+| `robustness-report.md` | Human-readable report separating stochastic uncertainty from parameter sensitivity. |
+
+These files are generated outputs and should normally remain under `target/`.
+
+## Scenario Sets
+
+| Scenario set | Contents | Intended use |
+| --- | --- | --- |
+| `smoke` | `baseline`, `mpc-high` | Fast CI/local sanity check that the workflow runs and writes artifacts. |
+| `core` | `baseline`, `mpc-low`, `mpc-high`, `markup-high`, `investment-fast`, `credit-tight`, `fiscal-stabilizer-strong`, `monetary-tight`, `external-risk-off` | First-pass local robustness review. |
+
+The core set covers the first parameters most likely to matter for early SFC-ABM
+review:
+
+| Category | Scenario | Parameter deltas |
+| --- | --- | --- |
+| Household propensity to consume | `mpc-low`, `mpc-high` | `household.mpc` around the baseline `0.82`. |
+| Firm markup/pricing | `markup-high` | Higher `pricing.baseMarkup` and `pricing.costPassthrough`. |
+| Investment response | `investment-fast` | Higher `capital.adjustSpeed`. |
+| Credit/default behavior | `credit-tight` | Higher `banking.baseSpread`, lower `banking.loanRecovery`, higher `banking.eclMigrationSensitivity`. |
+| Fiscal rules | `fiscal-stabilizer-strong` | Higher `fiscal.govAutoStabMult` and `fiscalConsolidationSpeed55`. |
+| Policy rates | `monetary-tight` | Higher `monetary.initialRate`, `neutralRate`, and `taylorAlpha`. |
+| External shocks | `external-risk-off` | Activates risk-off shock month and increases FX sensitivity. |
+
+Scenario definitions live in
+`src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala`.
+The runner lives in
+`src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala`.
+
+## Metrics
+
+The workflow currently summarizes these Monte Carlo output columns:
+
+| Metric | Interpretation |
+| --- | --- |
+| `Inflation` | Annualized inflation rate. |
+| `Unemployment` | Unemployment share. |
+| `MarketWage` | Aggregate market wage. |
+| `DebtToGdp` | Government debt to annualized GDP. |
+| `DeficitToGdp` | Government deficit to annualized GDP. |
+| `CreditToGdpGap` | Macroprudential credit-to-GDP gap. |
+| `MinBankCAR` | Minimum bank capital adequacy ratio. |
+| `MinBankLCR` | Minimum bank liquidity coverage ratio. |
+| `CurrentAccount` | Current-account flow. |
+| `ExRate` | PLN/EUR exchange rate. |
+| `TotalAdoption` | Automation plus hybrid adoption share. |
+| `FirmDeaths` | Monthly firm deaths. |
+| `BankFailures` | Failed bank count. |
+
+These metrics are not a replacement for the empirical validation report in
+`docs/empirical-validation-report.md`. Robustness asks whether conclusions are
+stable across seeds and local parameter changes; empirical validation asks
+whether the model matches observed stylized facts.
+
+## Runtime Guidance
+
+Recommended local defaults are intentionally small:
+
+| Use | Command shape | Notes |
+| --- | --- | --- |
+| Smoke | `--scenario-set smoke --seeds 1 --months 6` | Confirms the workflow compiles, runs, and writes artifacts. |
+| Local review | `--scenario-set core --seeds 2 --months 24` | Good default before opening or reviewing a PR. |
+| Heavier review | `--scenario-set core --seeds 5 --months 60` | Useful before merging research-sensitive parameter changes. |
+| Publication prep | `--scenario-set core --seeds 10+ --months 120+` | Coordinate with the data bridge (#437), `docs/scenario-registry.md`, and `docs/empirical-validation-report.md`. |
+
+Runtime grows roughly with:
+
+```text
+scenario_count * seed_count * months
+```
+
+The default core run is therefore `9 * 2 * 24 = 432` simulated monthly steps.
+
+## Follow-Ups
+
+- `docs/empirical-validation-report.md` provides the empirical target table
+  that these robustness outputs should eventually feed.
+- `docs/scenario-registry.md` defines named scenario comparisons that can
+  reuse this output shape later.
+- #437 should provide source vintages and empirical transformations used to
+  interpret robustness against real-world data.

--- a/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala
@@ -1,0 +1,153 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Lightweight one-at-a-time scenario definitions for local robustness work.
+  *
+  * This stays in the config package because SimParams has a config-private
+  * constructor/copy boundary.
+  */
+object RobustnessScenarios:
+
+  enum ScenarioSet(val cliName: String):
+    case Smoke extends ScenarioSet("smoke")
+    case Core  extends ScenarioSet("core")
+
+  object ScenarioSet:
+    val default: ScenarioSet = ScenarioSet.Core
+
+    def parse(value: String): Either[String, ScenarioSet] =
+      values.find(_.cliName == value.trim.toLowerCase) match
+        case Some(set) => Right(set)
+        case None      => Left(s"--scenario-set must be one of: ${values.map(_.cliName).mkString(", ")}")
+
+  final case class Scenario(
+      id: String,
+      label: String,
+      category: String,
+      variedParameter: String,
+      variation: String,
+      rationale: String,
+      params: SimParams,
+  )
+
+  def scenarios(set: ScenarioSet): Vector[Scenario] =
+    val baseline = SimParams.defaults
+
+    val all = Vector(
+      Scenario(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        variedParameter = "none",
+        variation = "default SimParams.defaults",
+        rationale = "Reference path for stochastic seed envelopes and one-at-a-time parameter comparisons.",
+        params = baseline,
+      ),
+      Scenario(
+        id = "mpc-low",
+        label = "Lower household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.72",
+        rationale = "First-pass demand sensitivity to lower household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.72))),
+      ),
+      Scenario(
+        id = "mpc-high",
+        label = "Higher household MPC",
+        category = "household propensity to consume",
+        variedParameter = "household.mpc",
+        variation = "0.82 -> 0.90",
+        rationale = "First-pass demand sensitivity to higher household consumption out of income.",
+        params = baseline.copy(household = baseline.household.copy(mpc = Share(0.90))),
+      ),
+      Scenario(
+        id = "markup-high",
+        label = "Higher markup and pass-through",
+        category = "firm markup/pricing",
+        variedParameter = "pricing.baseMarkup, pricing.costPassthrough",
+        variation = "1.15 -> 1.25, 0.40 -> 0.55",
+        rationale = "Tests price-level sensitivity to firm pricing power and cost pass-through.",
+        params = baseline.copy(
+          pricing = baseline.pricing.copy(
+            baseMarkup = Multiplier(1.25),
+            costPassthrough = Coefficient(0.55),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "investment-fast",
+        label = "Faster capital adjustment",
+        category = "investment response",
+        variedParameter = "capital.adjustSpeed",
+        variation = "0.10 -> 0.16",
+        rationale = "Tests output, imports, and balance-sheet sensitivity to faster investment adjustment.",
+        params = baseline.copy(capital = baseline.capital.copy(adjustSpeed = Coefficient(0.16))),
+      ),
+      Scenario(
+        id = "credit-tight",
+        label = "Tighter credit and lower recovery",
+        category = "credit/default behavior",
+        variedParameter = "banking.baseSpread, banking.loanRecovery, banking.eclMigrationSensitivity",
+        variation = "0.015 -> 0.030, 0.30 -> 0.20, 3.0 -> 4.0",
+        rationale = "Tests financial-stability sensitivity to tighter credit and weaker default recovery.",
+        params = baseline.copy(
+          banking = baseline.banking.copy(
+            baseSpread = Rate(0.030),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.0),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "fiscal-stabilizer-strong",
+        label = "Stronger automatic stabilizer",
+        category = "fiscal rules",
+        variedParameter = "fiscal.govAutoStabMult, fiscalConsolidationSpeed55",
+        variation = "3.0 -> 4.0, 0.10 -> 0.15",
+        rationale = "Tests unemployment, deficit, and debt sensitivity to stronger fiscal stabilization and consolidation.",
+        params = baseline.copy(
+          fiscal = baseline.fiscal.copy(
+            govAutoStabMult = Coefficient(4.0),
+            fiscalConsolidationSpeed55 = Share(0.15),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "monetary-tight",
+        label = "Tighter monetary stance",
+        category = "policy rates",
+        variedParameter = "monetary.initialRate, monetary.neutralRate, monetary.taylorAlpha",
+        variation = "0.0575 -> 0.075, 0.04 -> 0.05, 1.5 -> 1.8",
+        rationale = "Tests inflation, credit, debt-service, and unemployment sensitivity to tighter policy rates.",
+        params = baseline.copy(
+          monetary = baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      Scenario(
+        id = "external-risk-off",
+        label = "External risk-off shock",
+        category = "external shocks",
+        variedParameter = "forex.riskOffShockMonth, forex.riskOffMagnitude, forex.irpSensitivity",
+        variation = "0 -> 6, 0.10 -> 0.16, 0.15 -> 0.25",
+        rationale = "Tests FX, current-account, reserves, and financial-market sensitivity to a risk-off episode.",
+        params = baseline.copy(
+          forex = baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.16),
+            irpSensitivity = Coefficient(0.25),
+          ),
+        ),
+      ),
+    )
+
+    set match
+      case ScenarioSet.Smoke => all.filter(scenario => scenario.id == "baseline" || scenario.id == "mpc-high")
+      case ScenarioSet.Core  => all
+
+end RobustnessScenarios

--- a/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
@@ -1,0 +1,276 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Named policy and shock scenarios for reproducible experiment runs.
+  *
+  * This lives in the config package because scenario composition needs the
+  * config-private SimParams copy boundary.
+  */
+object ScenarioRegistry:
+
+  final case class ParameterDelta(
+      parameter: String,
+      baseline: String,
+      scenario: String,
+      note: String,
+  )
+
+  final case class ScenarioSpec(
+      id: String,
+      label: String,
+      category: String,
+      purpose: String,
+      expectedChannels: Vector[String],
+      recommendedMonths: Int,
+      seedPolicy: String,
+      outputFolder: String,
+      deltas: Vector[ParameterDelta],
+      params: SimParams,
+  )
+
+  private val Baseline = SimParams.defaults
+
+  val defaultScenarioIds: Vector[String] =
+    Vector("baseline", "monetary-tightening", "fiscal-expansion")
+
+  val all: Vector[ScenarioSpec] =
+    Vector(
+      ScenarioSpec(
+        id = "baseline",
+        label = "Baseline",
+        category = "baseline",
+        purpose = "Reference scenario using SimParams.defaults.",
+        expectedChannels = Vector("all baseline model channels"),
+        recommendedMonths = 120,
+        seedPolicy = "Use fixed seed bands; default smoke command uses seed 1.",
+        outputFolder = "<out>/<run-id>/baseline",
+        deltas = Vector(ParameterDelta("SimParams", "SimParams.defaults", "SimParams.defaults", "No parameter change.")),
+        params = Baseline,
+      ),
+      ScenarioSpec(
+        id = "monetary-tightening",
+        label = "Monetary tightening",
+        category = "policy rates",
+        purpose = "Higher NBP policy stance for inflation and credit stress analysis.",
+        expectedChannels = Vector("RefRate", "Inflation", "CreditToGdpGap", "DebtService", "Unemployment", "ExRate"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/monetary-tightening",
+        deltas = Vector(
+          ParameterDelta("monetary.initialRate", "0.0575", "0.075", "Higher starting reference rate."),
+          ParameterDelta("monetary.neutralRate", "0.04", "0.05", "Higher neutral-rate anchor."),
+          ParameterDelta("monetary.taylorAlpha", "1.5", "1.8", "Stronger inflation response."),
+        ),
+        params = Baseline.copy(
+          monetary = Baseline.monetary.copy(
+            initialRate = Rate(0.075),
+            neutralRate = Rate(0.050),
+            taylorAlpha = Coefficient(1.8),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fiscal-expansion",
+        label = "Fiscal expansion",
+        category = "fiscal policy",
+        purpose = "Higher government demand and capital share for fiscal multiplier and debt-path comparisons.",
+        expectedChannels = Vector("GovCurrentSpend", "GovCapitalSpendDomestic", "DeficitToGdp", "DebtToGdp", "Unemployment", "Inflation"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/fiscal-expansion",
+        deltas = Vector(
+          ParameterDelta("fiscal.govBaseSpending", "scaled default", "scaled default * 1.15", "15% higher base government spending."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share."),
+          ParameterDelta("fiscal.govAutoStabMult", "3.0", "3.5", "Stronger automatic stabilization."),
+        ),
+        params = Baseline.copy(
+          fiscal = Baseline.fiscal.copy(
+            govBaseSpending = Baseline.fiscal.govBaseSpending * Multiplier(1.15),
+            govInvestShare = Share(0.30),
+            govAutoStabMult = Coefficient(3.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "credit-crunch",
+        label = "Credit crunch",
+        category = "banking stress",
+        purpose = "Tighter credit supply and weaker recovery assumptions for credit and default stress testing.",
+        expectedChannels = Vector("CreditToGdpGap", "ConsumerLoans", "MinBankCAR", "MaxBankNPL", "FirmDeaths", "Unemployment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/credit-crunch",
+        deltas = Vector(
+          ParameterDelta("banking.baseSpread", "0.015", "0.035", "Higher firm-loan spread."),
+          ParameterDelta("banking.minCar", "0.08", "0.10", "Higher capital constraint."),
+          ParameterDelta("banking.loanRecovery", "0.30", "0.20", "Lower corporate-loan recovery."),
+          ParameterDelta("banking.eclMigrationSensitivity", "3.0", "4.5", "Faster IFRS 9 migration under stress."),
+          ParameterDelta("household.ccMaxDti", "0.40", "0.30", "Tighter household credit affordability cap."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            baseSpread = Rate(0.035),
+            minCar = Multiplier(0.10),
+            loanRecovery = Share(0.20),
+            eclMigrationSensitivity = Coefficient(4.5),
+          ),
+          household = Baseline.household.copy(ccMaxDti = Share(0.30)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "energy-shock",
+        label = "Energy shock",
+        category = "climate and commodity shock",
+        purpose = "ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure.",
+        expectedChannels = Vector("CommodityPriceIndex", "GvcImportCostIndex", "AggEnergyCost", "Inflation", "CurrentAccount", "GreenInvestment"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/energy-shock",
+        deltas = Vector(
+          ParameterDelta("climate.etsBasePrice", "80", "120", "Higher EU ETS starting price."),
+          ParameterDelta(
+            "climate.energyCostShares",
+            "[0.02,0.10,0.04,0.05,0.03,0.06]",
+            "[0.03,0.15,0.06,0.075,0.045,0.09]",
+            "50% higher sector energy-cost burden.",
+          ),
+          ParameterDelta("climate.greenBudgetShare", "0.20", "0.12", "Lower discretionary green investment capacity under stress."),
+          ParameterDelta("gvc.commodityShockMonth", "0", "6", "Commodity-price shock starts in month 6."),
+          ParameterDelta("gvc.commodityShockMag", "0.0", "1.5", "One-time commodity-price shock magnitude."),
+        ),
+        params = Baseline.copy(
+          climate = Baseline.climate.copy(
+            etsBasePrice = Multiplier(120.0),
+            energyCostShares = Vector(Share(0.03), Share(0.15), Share(0.06), Share(0.075), Share(0.045), Share(0.09)),
+            greenBudgetShare = Share(0.12),
+          ),
+          gvc = Baseline.gvc.copy(
+            commodityShockMonth = 6,
+            commodityShockMag = Multiplier(1.5),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "tourism-shock",
+        label = "Tourism shock",
+        category = "external demand shock",
+        purpose = "Tourism-demand loss for services demand, current account, employment, and FX flows.",
+        expectedChannels = Vector("TourismExport", "TourismImport", "NetTourismBalance", "CurrentAccount", "Unemployment", "Inflation"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/tourism-shock",
+        deltas = Vector(
+          ParameterDelta("tourism.shockMonth", "0", "6", "Tourism shock starts in month 6."),
+          ParameterDelta("tourism.shockSize", "0.80", "0.60", "60% tourism-demand loss in the named scenario."),
+          ParameterDelta("tourism.shockRecovery", "0.03", "0.05", "Faster monthly recovery than default COVID-style setting."),
+          ParameterDelta("tourism.inboundShare", "0.05", "0.04", "Lower inbound tourism baseline share."),
+        ),
+        params = Baseline.copy(
+          tourism = Baseline.tourism.copy(
+            shockMonth = 6,
+            shockSize = Share(0.60),
+            shockRecovery = Rate(0.05),
+            inboundShare = Share(0.04),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "bank-failure",
+        label = "Bank failure stress",
+        category = "financial stability",
+        purpose = "Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels.",
+        expectedChannels = Vector("BankFailures", "MinBankCAR", "MinBankLCR", "BfgFundBalance", "BailInLoss", "NPL"),
+        recommendedMonths = 36,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/bank-failure",
+        deltas = Vector(
+          ParameterDelta("banking.initCapital", "scaled default", "scaled default * 0.55", "Lower opening banking-sector capital."),
+          ParameterDelta("banking.minCar", "0.08", "0.12", "Higher regulatory capital requirement."),
+          ParameterDelta("banking.depositPanicRate", "0.03", "0.08", "Higher deposit panic migration after failures."),
+          ParameterDelta("banking.maxDepositSwitchRate", "0.10", "0.18", "Higher maximum monthly deposit switching."),
+        ),
+        params = Baseline.copy(
+          banking = Baseline.banking.copy(
+            initCapital = Baseline.banking.initCapital * Multiplier(0.55),
+            minCar = Multiplier(0.12),
+            depositPanicRate = Share(0.08),
+            maxDepositSwitchRate = Share(0.18),
+          ),
+        ),
+      ),
+      ScenarioSpec(
+        id = "fx-capital-flight",
+        label = "FX and capital-flight stress",
+        category = "external financial shock",
+        purpose = "Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand.",
+        expectedChannels = Vector("ExRate", "FxReserves", "FxInterventionAmt", "CurrentAccount", "ForeignBondHoldings", "BondYield"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
+        outputFolder = "<out>/<run-id>/fx-capital-flight",
+        deltas = Vector(
+          ParameterDelta("forex.riskOffShockMonth", "0", "6", "Risk-off shock starts in month 6."),
+          ParameterDelta("forex.riskOffMagnitude", "0.10", "0.20", "Larger capital outflow shock."),
+          ParameterDelta("forex.riskOffDurationMonths", "6", "9", "Longer elevated risk-off period."),
+          ParameterDelta("forex.irpSensitivity", "0.15", "0.30", "Stronger exchange-rate response to rate differentials."),
+          ParameterDelta("forex.exRateAdjSpeed", "0.02", "0.05", "Faster exchange-rate adjustment."),
+          ParameterDelta("monetary.fxMaxMonthly", "0.03", "0.06", "Larger allowed monthly FX intervention."),
+        ),
+        params = Baseline.copy(
+          forex = Baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share(0.20),
+            riskOffDurationMonths = 9,
+            irpSensitivity = Coefficient(0.30),
+            exRateAdjSpeed = Coefficient(0.05),
+          ),
+          monetary = Baseline.monetary.copy(fxMaxMonthly = Share(0.06)),
+        ),
+      ),
+      ScenarioSpec(
+        id = "quasi-fiscal-program",
+        label = "Quasi-fiscal program",
+        category = "quasi-fiscal policy",
+        purpose = "BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending.",
+        expectedChannels = Vector("QfBondsOutstanding", "QfIssuance", "QfLoanPortfolio", "QfNbpHoldings", "Esa2010DebtToGdp", "DebtToGdp"),
+        recommendedMonths = 60,
+        seedPolicy = "Compare on the same seed band as baseline.",
+        outputFolder = "<out>/<run-id>/quasi-fiscal-program",
+        deltas = Vector(
+          ParameterDelta("quasiFiscal.issuanceShare", "0.40", "0.65", "Higher BGK/PFR share of capital programs."),
+          ParameterDelta("quasiFiscal.lendingShare", "0.50", "0.70", "More issuance routed to subsidized lending."),
+          ParameterDelta("quasiFiscal.nbpAbsorptionShare", "0.70", "0.85", "Higher NBP absorption when QE is active."),
+          ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share feeding quasi-fiscal issuance."),
+          ParameterDelta("monetary.qeMaxGdpShare", "0.30", "0.40", "Higher QE stock ceiling."),
+        ),
+        params = Baseline.copy(
+          quasiFiscal = Baseline.quasiFiscal.copy(
+            issuanceShare = Share(0.65),
+            lendingShare = Share(0.70),
+            nbpAbsorptionShare = Share(0.85),
+          ),
+          fiscal = Baseline.fiscal.copy(govInvestShare = Share(0.30)),
+          monetary = Baseline.monetary.copy(qeMaxGdpShare = Share(0.40)),
+        ),
+      ),
+    )
+
+  private val byId: Map[String, ScenarioSpec] = all.map(scenario => scenario.id -> scenario).toMap
+
+  def get(id: String): Either[String, ScenarioSpec] =
+    byId.get(id).toRight(s"Unknown scenario '$id'. Known scenarios: ${all.map(_.id).mkString(", ")}")
+
+  def select(value: String): Either[String, Vector[ScenarioSpec]] =
+    val normalized = value.trim
+    if normalized == "all" then Right(all)
+    else
+      val ids = normalized.split(",").iterator.map(_.trim).filter(_.nonEmpty).toVector
+      if ids.isEmpty then Left("--scenarios must contain at least one scenario id")
+      else
+        ids.foldLeft[Either[String, Vector[ScenarioSpec]]](Right(Vector.empty)): (acc, id) =>
+          for
+            selected <- acc
+            scenario <- get(id)
+          yield selected :+ scenario
+
+end ScenarioRegistry

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
@@ -1,0 +1,257 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.ScenarioRegistry
+import com.boombustgroup.amorfati.config.ScenarioRegistry.ScenarioSpec
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object ScenarioRunExport:
+
+  final case class Config(
+      scenarios: Vector[ScenarioSpec] = ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(id).toOption),
+      seedStart: Long = 1L,
+      seeds: Int = 1,
+      months: Int = 12,
+      runId: String = "scenario-registry",
+      out: Path = Path.of("target/scenarios"),
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int)
+
+  private final case class TerminalMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      value: Double,
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      Files.createDirectories(validConfig.runRoot)
+
+      val registryPath  = validConfig.runRoot.resolve("scenario-registry.md")
+      val deltasPath    = validConfig.runRoot.resolve("scenario-deltas.csv")
+      Files.writeString(registryPath, renderRegistry(validConfig.scenarios), StandardCharsets.UTF_8)
+      Files.writeString(deltasPath, renderDeltas(validConfig.scenarios), StandardCharsets.UTF_8)
+      val metadataPaths = validConfig.scenarios.map: scenario =>
+        val scenarioDir  = validConfig.runRoot.resolve(scenario.id)
+        val metadataPath = scenarioDir.resolve("metadata.md")
+        Files.createDirectories(scenarioDir)
+        Files.writeString(metadataPath, renderScenarioMetadata(validConfig, scenario), StandardCharsets.UTF_8)
+        metadataPath
+
+      val runAttempts =
+        for
+          scenario <- validConfig.scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(validConfig, scenario, seed)
+
+      runAttempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val outputs = runAttempts.collect { case Right(paths, metrics) => paths -> metrics }
+          val paths   = Vector(registryPath, deltasPath) ++ metadataPaths ++ outputs.flatMap(_._1)
+          val metrics = outputs.flatMap(_._2)
+          val summary = validConfig.runRoot.resolve("run-summary.csv")
+          Files.writeString(summary, renderRunSummary(metrics), StandardCharsets.UTF_8)
+          Right(ExportResult(paths :+ summary))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                                              => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")                           => missingValue(flag)
+            case Seq(value, next*) if flag == "--scenario" || flag == "--scenarios" =>
+              ScenarioRegistry.select(value).flatMap(scenarios => loop(next, config.copy(scenarios = scenarios)))
+            case Seq(value, next*) if flag == "--seed-start"                        =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"                             =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"                            =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--run-id"                            =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"                               =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                                         => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.scenarios.nonEmpty, config, "--scenarios must contain at least one scenario")
+      .flatMap(valid => Either.cond(valid.seeds > 0, valid, "--seeds must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+
+  private def runSeed(config: Config, scenario: ScenarioSpec, seed: Long): Either[String, (Vector[Path], Vector[TerminalMetric])] =
+    given SimParams = scenario.params
+
+    McRunner
+      .runSingle(seed, config.months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        val scenarioDir = config.runRoot.resolve(scenario.id)
+        Files.createDirectories(scenarioDir)
+
+        val csvPath = scenarioDir.resolve(f"${config.runId}_${scenario.id}_${config.months}m_seed$seed%03d.csv")
+        val rows    = result.timeSeries.map(row => row)
+        Files.writeString(csvPath, renderTimeSeriesCsv(rows), StandardCharsets.UTF_8)
+
+        val terminal = rows.last
+        val metrics  = Metrics.map(metric => TerminalMetric(scenario.id, seed, metric, terminal(metric.ordinal)))
+        Vector(csvPath) -> metrics
+
+  private def renderRegistry(scenarios: Vector[ScenarioSpec]): String =
+    val rows = scenarios.map: scenario =>
+      markdownRow(
+        Vector(
+          scenario.id,
+          scenario.label,
+          scenario.category,
+          scenario.recommendedMonths.toString,
+          scenario.seedPolicy,
+          scenario.outputFolder,
+        ),
+      )
+
+    val lines = Vector(
+      "# Scenario Registry",
+      "",
+      "Generated by `ScenarioRunExport` from `ScenarioRegistry`.",
+      "",
+      markdownRow(Vector("Scenario", "Label", "Category", "Recommended months", "Seed policy", "Output folder")),
+      markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+    ) ++ rows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderDeltas(scenarios: Vector[ScenarioSpec]): String =
+    val header = "Scenario;Parameter;Baseline;ScenarioValue;Note"
+    val rows   =
+      for
+        scenario <- scenarios
+        delta    <- scenario.deltas
+      yield Vector(scenario.id, delta.parameter, delta.baseline, delta.scenario, delta.note).map(csv).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderRunSummary(metrics: Vector[TerminalMetric]): String =
+    val header = "Scenario;Seed;Metric;TerminalValue"
+    val rows   = metrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.value)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderScenarioMetadata(config: Config, scenario: ScenarioSpec): String =
+    val channelRows = scenario.expectedChannels.map(channel => s"- `$channel`")
+    val deltaRows   = scenario.deltas.map: delta =>
+      markdownRow(Vector(delta.parameter, delta.baseline, delta.scenario, delta.note))
+    val lines       =
+      Vector(
+        s"# ${scenario.label}",
+        "",
+        s"- Scenario id: `${scenario.id}`",
+        s"- Category: `${scenario.category}`",
+        s"- Purpose: ${scenario.purpose}",
+        s"- Run id: `${config.runId}`",
+        s"- Months in this run: `${config.months}`",
+        s"- Recommended months: `${scenario.recommendedMonths}`",
+        s"- Seed policy: ${scenario.seedPolicy}",
+        s"- Output folder: `${config.runRoot.resolve(scenario.id)}`",
+        "",
+        "## Expected Channels",
+        "",
+      ) ++ channelRows ++ Vector(
+        "",
+        "## Parameter Deltas",
+        "",
+        markdownRow(Vector("Parameter", "Baseline", "Scenario", "Note")),
+        markdownRow(Vector("---", "---", "---", "---")),
+      ) ++ deltaRows
+
+    lines.mkString("\n") + "\n"
+
+  private def renderTimeSeriesCsv(rows: Vector[Array[Double]]): String =
+    val header = McTimeseriesSchema.colNames.mkString(";")
+    val body   = rows.map: row =>
+      row.indices
+        .map: idx =>
+          if idx == 0 then row(idx).toInt.toString
+          else fmt(row(idx))
+        .mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--scenario" || flag == "--scenarios" || flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(_.replace("|", "\\|")).mkString("| ", " | ", " |")
+
+  private def csv(value: String): String =
+    if value.exists(ch => ch == ';' || ch == '"' || ch == '\n') then "\"" + value.replace("\"", "\"\"") + "\""
+    else value
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def metric(column: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation"),
+    metric("Unemployment"),
+    metric("MarketWage"),
+    metric("DebtToGdp"),
+    metric("DeficitToGdp"),
+    metric("CurrentAccount"),
+    metric("ExRate"),
+    metric("CreditToGdpGap"),
+    metric("MinBankCAR"),
+    metric("MinBankLCR"),
+    metric("BankFailures"),
+    metric("FirmDeaths"),
+  )
+
+  private val usage: String =
+    "Usage: ScenarioRunExport [--scenarios baseline,monetary-tightening|all] [--seed-start <long>] [--seeds <int>] [--months <int>] [--run-id <id>] [--out <path>]"
+
+end ScenarioRunExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/SensitivityRobustnessExport.scala
@@ -1,0 +1,368 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.RobustnessScenarios
+import com.boombustgroup.amorfati.config.RobustnessScenarios.{Scenario, ScenarioSet}
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Locale
+import scala.util.Try
+
+object SensitivityRobustnessExport:
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 2,
+      months: Int = 24,
+      out: Path = Path.of("target/robustness"),
+      scenarioSet: ScenarioSet = ScenarioSet.default,
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+
+  final case class ExportResult(paths: Vector[Path])
+
+  private final case class MetricDef(id: String, ordinal: Int, description: String)
+
+  private final case class SeedMetric(
+      scenarioId: String,
+      seed: Long,
+      metric: MetricDef,
+      terminal: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class EnvelopeMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      terminalMean: Double,
+      terminalMin: Double,
+      terminalMax: Double,
+      pathMin: Double,
+      pathMax: Double,
+      pathMean: Double,
+  )
+
+  private final case class SensitivityMetric(
+      scenarioId: String,
+      metric: MetricDef,
+      baselineMean: Double,
+      scenarioMean: Double,
+      delta: Double,
+      deltaPct: Option[Double],
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      val scenarios = RobustnessScenarios.scenarios(validConfig.scenarioSet)
+      val attempts  =
+        for
+          scenario <- scenarios
+          seed     <- validConfig.seedRange
+        yield runSeed(scenario, seed, validConfig.months)
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val seedMetrics        = attempts.collect { case Right(metrics) => metrics }.flatten
+          val envelopeMetrics    = summarizeEnvelope(seedMetrics)
+          val sensitivityMetrics = summarizeSensitivity(envelopeMetrics)
+          val paths              = writeArtifacts(validConfig, scenarios, seedMetrics, envelopeMetrics, sensitivityMetrics)
+          Right(ExportResult(paths))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                         => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")      => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start"   =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"        =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"       =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--out"          =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(value, next*) if flag == "--scenario-set" =>
+              ScenarioSet.parse(value).flatMap(scenarioSet => loop(next, config.copy(scenarioSet = scenarioSet)))
+            case Seq(_, _*)                                    => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+
+  private def runSeed(scenario: Scenario, seed: Long, months: Int): Either[String, Vector[SeedMetric]] =
+    given SimParams = scenario.params
+    McRunner
+      .runSingle(seed, months)
+      .left
+      .map(err => s"Scenario ${scenario.id}, seed $seed failed: $err")
+      .map: result =>
+        Metrics.map: metric =>
+          val values = result.timeSeries.map(row => row(metric.ordinal))
+          SeedMetric(
+            scenario.id,
+            seed,
+            metric,
+            terminal = values.last,
+            pathMin = values.min,
+            pathMax = values.max,
+            pathMean = values.sum / values.length.toDouble,
+          )
+
+  private def summarizeEnvelope(seedMetrics: Vector[SeedMetric]): Vector[EnvelopeMetric] =
+    seedMetrics
+      .groupBy(metric => metric.scenarioId -> metric.metric.id)
+      .toVector
+      .sortBy { case ((scenarioId, metricId), _) => scenarioId -> metricId }
+      .map { case ((scenarioId, _), metrics) =>
+        val metric    = metrics.head.metric
+        val terminals = metrics.map(_.terminal)
+        EnvelopeMetric(
+          scenarioId = scenarioId,
+          metric = metric,
+          terminalMean = terminals.sum / terminals.length.toDouble,
+          terminalMin = terminals.min,
+          terminalMax = terminals.max,
+          pathMin = metrics.map(_.pathMin).min,
+          pathMax = metrics.map(_.pathMax).max,
+          pathMean = metrics.map(_.pathMean).sum / metrics.length.toDouble,
+        )
+      }
+
+  private def summarizeSensitivity(envelopeMetrics: Vector[EnvelopeMetric]): Vector[SensitivityMetric] =
+    val baseline = envelopeMetrics.filter(_.scenarioId == "baseline").map(metric => metric.metric.id -> metric).toMap
+    envelopeMetrics
+      .filterNot(_.scenarioId == "baseline")
+      .flatMap: metric =>
+        baseline
+          .get(metric.metric.id)
+          .map: base =>
+            val delta = metric.terminalMean - base.terminalMean
+            SensitivityMetric(
+              scenarioId = metric.scenarioId,
+              metric = metric.metric,
+              baselineMean = base.terminalMean,
+              scenarioMean = metric.terminalMean,
+              delta = delta,
+              deltaPct = if Math.abs(base.terminalMean) > 1e-12 then Some(delta / Math.abs(base.terminalMean)) else None,
+            )
+
+  private def writeArtifacts(
+      config: Config,
+      scenarios: Vector[Scenario],
+      seedMetrics: Vector[SeedMetric],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): Vector[Path] =
+    Files.createDirectories(config.out)
+    val seedMetricsPath = config.out.resolve("seed-metrics.csv")
+    val envelopePath    = config.out.resolve("envelope-summary.csv")
+    val sensitivityPath = config.out.resolve("sensitivity-summary.csv")
+    val reportPath      = config.out.resolve("robustness-report.md")
+
+    Files.writeString(seedMetricsPath, renderSeedMetrics(seedMetrics), StandardCharsets.UTF_8)
+    Files.writeString(envelopePath, renderEnvelopeMetrics(envelopeMetrics), StandardCharsets.UTF_8)
+    Files.writeString(sensitivityPath, renderSensitivityMetrics(sensitivityMetrics), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, scenarios, envelopeMetrics, sensitivityMetrics), StandardCharsets.UTF_8)
+
+    Vector(seedMetricsPath, envelopePath, sensitivityPath, reportPath)
+
+  private def renderSeedMetrics(seedMetrics: Vector[SeedMetric]): String =
+    val header = "Scenario;Seed;Metric;Terminal;PathMin;PathMax;PathMean"
+    val rows   = seedMetrics.map: row =>
+      Vector(row.scenarioId, row.seed.toString, row.metric.id, fmt(row.terminal), fmt(row.pathMin), fmt(row.pathMax), fmt(row.pathMean)).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderEnvelopeMetrics(envelopeMetrics: Vector[EnvelopeMetric]): String =
+    val header = "Scenario;Metric;TerminalMean;TerminalMin;TerminalMax;PathMin;PathMax;PathMean"
+    val rows   = envelopeMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.terminalMean),
+        fmt(row.terminalMin),
+        fmt(row.terminalMax),
+        fmt(row.pathMin),
+        fmt(row.pathMax),
+        fmt(row.pathMean),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderSensitivityMetrics(sensitivityMetrics: Vector[SensitivityMetric]): String =
+    val header = "Scenario;Metric;BaselineTerminalMean;ScenarioTerminalMean;Delta;DeltaPct"
+    val rows   = sensitivityMetrics.map: row =>
+      Vector(
+        row.scenarioId,
+        row.metric.id,
+        fmt(row.baselineMean),
+        fmt(row.scenarioMean),
+        fmt(row.delta),
+        row.deltaPct.map(fmt).getOrElse("NA"),
+      ).mkString(";")
+    (header +: rows).mkString("\n") + "\n"
+
+  private def renderReport(
+      config: Config,
+      scenarios: Vector[Scenario],
+      envelopeMetrics: Vector[EnvelopeMetric],
+      sensitivityMetrics: Vector[SensitivityMetric],
+  ): String =
+    val baselineRows = envelopeMetrics
+      .filter(_.scenarioId == "baseline")
+      .map: row =>
+        markdownRow(Vector(row.metric.id, fmt(row.terminalMean), fmt(row.terminalMin), fmt(row.terminalMax), fmt(row.pathMin), fmt(row.pathMax)))
+
+    val sensitivityRows = sensitivityMetrics.map: row =>
+      markdownRow(
+        Vector(
+          row.scenarioId,
+          row.metric.id,
+          fmt(row.baselineMean),
+          fmt(row.scenarioMean),
+          signed(row.delta),
+          row.deltaPct.map(p => signed(p * 100.0) + "%").getOrElse("NA"),
+        ),
+      )
+
+    val scenarioRows = scenarios.map: scenario =>
+      markdownRow(Vector(scenario.id, scenario.label, scenario.category, scenario.variedParameter, scenario.variation, scenario.rationale))
+
+    val metricRows = Metrics.map: metric =>
+      markdownRow(Vector(metric.id, metric.description))
+
+    val lines =
+      Vector(
+        "# Sensitivity And Robustness Report",
+        "",
+        "Generated by `SensitivityRobustnessExport`.",
+        "",
+        "## Run Configuration",
+        "",
+        s"- Scenario set: `${config.scenarioSet.cliName}`",
+        s"- Seeds: `${config.seedRange.head}` to `${config.seedRange.last}` (${config.seeds} seeds)",
+        s"- Months: `${config.months}`",
+        s"- Output directory: `${config.out}`",
+        "",
+        "## Scenario Sweep",
+        "",
+        markdownRow(Vector("Scenario", "Label", "Category", "Varied parameter", "Variation", "Rationale")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ scenarioRows ++ Vector(
+        "",
+        "## Metrics",
+        "",
+        markdownRow(Vector("Metric", "Description")),
+        markdownRow(Vector("---", "---")),
+      ) ++ metricRows ++ Vector(
+        "",
+        "## Stochastic Uncertainty",
+        "",
+        "Baseline seed variation is summarized below. `TerminalMin` and",
+        "`TerminalMax` are cross-seed terminal envelopes; `PathMin` and `PathMax`",
+        "are the full within-run path envelope across all baseline seeds.",
+        "",
+        markdownRow(Vector("Metric", "TerminalMean", "TerminalMin", "TerminalMax", "PathMin", "PathMax")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ baselineRows ++ Vector(
+        "",
+        "## Parameter Sensitivity",
+        "",
+        "The table compares each non-baseline scenario's terminal cross-seed mean",
+        "against the baseline terminal cross-seed mean. This is one-at-a-time",
+        "sensitivity, not a full global sensitivity design.",
+        "",
+        markdownRow(Vector("Scenario", "Metric", "BaselineMean", "ScenarioMean", "Delta", "DeltaPct")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
+      ) ++ sensitivityRows ++ Vector(
+        "",
+        "## Runtime Guidance",
+        "",
+        """- Smoke check: `sbt "robustnessReport --scenario-set smoke --seeds 1 --months 6 --out target/robustness-smoke"`""",
+        """- Local review default: `sbt "robustnessReport --scenario-set core --seeds 2 --months 24 --out target/robustness"`""",
+        "- Heavier review run: increase to 5-10 seeds and 60-120 months after checking runtime locally.",
+        "",
+        "## Output Files",
+        "",
+        "- `seed-metrics.csv`: per scenario, seed, and metric terminal/path statistics.",
+        "- `envelope-summary.csv`: cross-seed envelopes by scenario and metric.",
+        "- `sensitivity-summary.csv`: terminal mean deltas versus baseline.",
+        "- `robustness-report.md`: this human-readable summary.",
+      )
+
+    lines.mkString("\n") + "\n"
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--out" || flag == "--scenario-set"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(escapeMarkdown).mkString("| ", " | ", " |")
+
+  private def escapeMarkdown(value: String): String =
+    value.replace("|", "\\|")
+
+  private def fmt(value: Double): String =
+    String.format(Locale.US, "%.8f", Double.box(value))
+
+  private def signed(value: Double): String =
+    String.format(Locale.US, "%+.8f", Double.box(value))
+
+  private def metric(column: String, description: String): MetricDef =
+    val ordinal = McTimeseriesSchema.colNames.indexOf(column)
+    require(ordinal >= 0, s"Unknown Monte Carlo output column: $column")
+    MetricDef(column, ordinal, description)
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("Inflation", "annualized inflation rate"),
+    metric("Unemployment", "unemployment share"),
+    metric("MarketWage", "aggregate market wage"),
+    metric("DebtToGdp", "government debt to annualized GDP"),
+    metric("DeficitToGdp", "government deficit to annualized GDP"),
+    metric("CreditToGdpGap", "macroprudential credit-to-GDP gap"),
+    metric("MinBankCAR", "minimum bank capital adequacy ratio"),
+    metric("MinBankLCR", "minimum bank liquidity coverage ratio"),
+    metric("CurrentAccount", "current account flow"),
+    metric("ExRate", "PLN/EUR exchange rate"),
+    metric("TotalAdoption", "automation plus hybrid adoption share"),
+    metric("FirmDeaths", "monthly firm deaths"),
+    metric("BankFailures", "failed bank count"),
+  )
+
+  private val usage: String =
+    "Usage: SensitivityRobustnessExport [--seed-start <long>] [--seeds <int>] [--months <int>] [--out <path>] [--scenario-set smoke|core]"
+
+end SensitivityRobustnessExport


### PR DESCRIPTION
## Summary
- add a Markdown empirical validation report skeleton with accounting-vs-empirical boundaries
- map macro, meso, micro, financial, and external validation targets to current Monte Carlo outputs
- make missing data bridge and missing output coverage explicit, with links to follow-up issues
- link the report from README, ODD docs, and the calibration register

## Verification
- git diff --cached --check
- checked the new report is ASCII-only
- docs-only change; no test suite run

Stacked on #441 / feature/calibration-register.

Closes #433