### PR TITLE
Remove stale research readiness tracker link

### DIFF
--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -152,4 +152,3 @@ mapping and frequency conventions are documented in
   baseline report.
 - `docs/scenario-registry.md`: named scenarios whose outputs should reuse the
   same validation target table.
-- #438: milestone tracker for the full research-readiness spine.


### PR DESCRIPTION
## Summary
- remove the remaining #438 follow-up link now that the research-readiness tracker is closed

## Validation
- rg -n "#436|#437|#438|tracked separately|tracked in #|until #|TBD via #|Follow-up #436|data bridge \(#437\)|stock-flow reconciliation and revaluation artifact" README.md docs src/main/scala/com/boombustgroup/amorfati/engine/README.md
- git diff --check