### PR TITLE
Document ledger submodule setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The key design principle is simple:
 
 > **Macro stories can be wrong. The ledger cannot.**
 
-This engine is built on top of the separately verified [amor-fati-ledger](https://github.com/boombustgroup/amor-fati-ledger) flow interpreter, vendored here under `modules/ledger`. The practical consequence is that the strongest invariant in the entire project is not "inflation should look smooth" or "GDP should converge nicely after 10 years". It is this:
+This engine is built on top of the separately verified [amor-fati-ledger](https://github.com/boombustgroup/amor-fati-ledger) flow interpreter, checked out as a Git submodule under `modules/ledger`. The practical consequence is that the strongest invariant in the entire project is not "inflation should look smooth" or "GDP should converge nicely after 10 years". It is this:
 
 > **The books must balance to the end of the universe.**
 
@@ -56,6 +56,19 @@ Requirements:
 
 - JDK 21 as the supported baseline, matching CI's Temurin 21 runtime
 - sbt 1.11.6, pinned in `project/build.properties`
+
+Clone the repository with its ledger submodule:
+
+```bash
+git clone --recurse-submodules https://github.com/boombustgroup/amor-fati.git
+cd amor-fati
+```
+
+If the repository was cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
 
 Validate the checkout:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,9 +18,25 @@ first.
 No Docker, Nix, or binary release artifact is required for the current local
 workflow.
 
+The runtime depends on `amor-fati-ledger`, checked out as the Git submodule at
+`modules/ledger`. A checkout without that submodule is incomplete.
+
 ## First Run
 
-From the repository root:
+Clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/boombustgroup/amor-fati.git
+cd amor-fati
+```
+
+If the repository was cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+Then validate the checkout from the repository root:
 
 ```bash
 sbt test
@@ -39,7 +55,7 @@ canonical repository.
 Clone the repository directly:
 
 ```bash
-git clone git@github.com:boombustgroup/amor-fati.git
+git clone --recurse-submodules git@github.com:boombustgroup/amor-fati.git
 cd amor-fati
 ```
 
@@ -47,7 +63,7 @@ Or clone your own fork and keep the canonical repository as `upstream` so you
 can refresh the baseline when needed:
 
 ```bash
-git clone git@github.com:<user>/amor-fati.git
+git clone --recurse-submodules git@github.com:<user>/amor-fati.git
 cd amor-fati
 git remote add upstream git@github.com:boombustgroup/amor-fati.git
 git fetch upstream
@@ -60,6 +76,7 @@ experiment branch:
 ```bash
 git checkout main
 git pull --ff-only origin main
+git submodule update --init --recursive
 git checkout -b experiment/<short-name>
 ```
 
@@ -69,6 +86,7 @@ For a fork, refresh from `upstream` instead:
 git checkout main
 git fetch upstream
 git merge --ff-only upstream/main
+git submodule update --init --recursive
 git checkout -b experiment/<short-name>
 ```
 


### PR DESCRIPTION
## Summary
- clarify that amor-fati-ledger is checked out as the modules/ledger Git submodule
- update quick start and operations docs to use clone --recurse-submodules
- add git submodule update --init --recursive to existing-checkout and baseline refresh flows

## Testing
- git diff --check main...HEAD
- not run: full sbt test, docs-only change