### PR TITLE
Generate calibration register from provenance registry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val sfcMatrices = inputKey[Unit]("Generate symbolic SFC BSM/TFM matrix arti
 lazy val robustnessReport = inputKey[Unit]("Generate lightweight sensitivity and robustness artifacts")
 lazy val scenarioRun = inputKey[Unit]("Run named scenario-registry experiments")
 lazy val empiricalValidation = inputKey[Unit]("Generate empirical validation baseline snapshot artifacts")
+lazy val calibrationRegister = inputKey[Unit]("Generate calibration register docs from typed provenance registry")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -80,6 +81,13 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<empirical validation args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.EmpiricalValidationExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    calibrationRegister := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<calibration register args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.CalibrationRegisterExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -8,6 +8,10 @@ Production defaults are calibrated directly to the Poland snapshot as of
 2026-04-30. There is no alternate baseline profile in the production parameter
 surface.
 
+The register is generated from `CalibrationProvenance.Baseline`; edit the
+typed provenance registry first, then regenerate this Markdown artifact with
+`sbt calibrationRegister`.
+
 The register is intentionally useful before every value has a final data
 source. Missing or weak provenance is marked explicitly with searchable tokens:
 `UNKNOWN_SOURCE`, `TUNED_NEEDS_VALIDATION`, `ASSUMED`, `PLACEHOLDER`,
@@ -25,6 +29,21 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `POLICY_SCENARIO` | Scenario/shock switch or policy parameter, not a baseline empirical estimate. |
 | `PLACEHOLDER` | Explicit placeholder or simplified value awaiting data bridge. |
 | `UNKNOWN_SOURCE` | Parameter is active in the model but final provenance is not yet documented. |
+
+## Status Counts
+
+These counts are rendered from `CalibrationProvenance.Baseline` at generation time.
+
+| Status | Count |
+| --- | --- |
+| `EMPIRICAL` | 35 |
+| `EMPIRICAL_TRANSFORMED` | 12 |
+| `CODE_NOTE_EMPIRICAL` | 67 |
+| `ASSUMED` | 11 |
+| `TUNED_NEEDS_VALIDATION` | 85 |
+| `POLICY_SCENARIO` | 7 |
+| `PLACEHOLDER` | 1 |
+| `UNKNOWN_SOURCE` | 20 |
 
 ## Transformation Rules
 
@@ -50,18 +69,18 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `pop.firmsCount` | `10000` | agents | Simulation design choice | Tractable heterogeneous firm population | Direct | `PopulationConfig` | `ASSUMED` |
-| `pop.workersPerFirm` | `10` | workers/firm normalizer | Simulation design choice | Normalizer for population and `gdpRatio` | Direct | `PopulationConfig` | `ASSUMED` |
-| `household.count` | `firmsCount * workersPerFirm = 100000` | agents | Derived from simulation scale | Household population tied to firm scale | Derived in `SimParams.defaults` | `SimParams` | `ASSUMED` |
+| `pop.workersPerFirm` | `10` | workers/firm normalizer | Simulation design choice | Normalizer for population and gdpRatio | Direct | `PopulationConfig` | `ASSUMED` |
+| `household.count` | `firmsCount * workersPerFirm = 100000` | agents | Derived from simulation scale | Household population tied to firm scale | Derived in SimParams.defaults | `SimParams` | `ASSUMED` |
 | `pop.firmSizeDist` | `Gus` | enum | 2026-04-30 enterprise-size bridge | Polish firm-size distribution mode | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeMicroShare` | `0.962` | share | 2026-04-30 enterprise-size bridge | Micro enterprise share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeSmallShare` | `0.028` | share | 2026-04-30 enterprise-size bridge | Small firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeMediumShare` | `0.008` | share | 2026-04-30 enterprise-size bridge residual | Medium firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeLargeShare` | `0.002` | share | 2026-04-30 enterprise-size bridge | Large firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
-| `pop.realGdp` | `4160e9` | PLN/year | MF 2026 budget macro scale / GDP-implied budget ratios | Polish current-price GDP scale | Feeds `gdpRatio` | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
+| `pop.realGdp` | `4160e9` | PLN/year | MF 2026 budget macro scale / GDP-implied budget ratios | Polish current-price GDP scale | Feeds gdpRatio | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
 | `pop.initialUnemploymentRate` | `0.061` | share | GUS registered unemployment, March 2026 | Starting unemployment stock | Initial household labor-force stock | `PopulationConfig`, `Household.Init` | `CODE_NOTE_EMPIRICAL` |
 | `gdpRatio` | `computeGdpRatio(pop, firm.baseRevenue)` | scalar | Derived from agent flow scale and current-price GDP | Map agent flows to Polish macro scale | Derived | `SimParams` | `ASSUMED` |
 | `topology` | `Watts-Strogatz` | enum | Network modeling convention | Small-world interaction topology | Direct | `SimParams` | `ASSUMED` |
-| `sectorDefs` | 6 sectors | vector | 2026-04-30 sector bridge | Polish sector composition | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
+| `sectorDefs` | `6 sectors` | vector | 2026-04-30 sector bridge | Polish sector composition | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
 | `sectorDefs.share` | `[0.03, 0.16, 0.45, 0.06, 0.22, 0.08]` | share by sector | 2026-04-30 sector bridge | Firm/employment sector weights | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
 | `sectorDefs.sigma` | `[50, 10, 5, 2, 1, 3]` | CES elasticity | Structural automation/substitution assumption | Sectoral substitutability ranking | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
 | `sectorDefs.wageMultiplier` | `[1.35, 0.94, 0.79, 0.97, 0.91, 0.67]` | multiplier | 2026-04-30 sector bridge | Relative sector wages | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
@@ -74,20 +93,20 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `household.baseWage` | `9652` | PLN/month | GUS March 2026 enterprise-sector wage, rounded from 9652.19 PLN | Mean monthly gross wage | Direct | `HouseholdConfig` | `EMPIRICAL` |
 | `household.baseReservationWage` | `4806` | PLN/month | Statutory 2026 minimum wage | Minimum acceptable wage | Direct | `HouseholdConfig` | `EMPIRICAL` |
 | `household.mpc` | `0.92` | share | #461 demand-side calibration | Aggregate mean MPC supporting Poland 2026 consumption-led growth | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
-| `household.mpcAlpha`, `household.mpcBeta` | `9.2`, `0.8` | beta params | #461 demand-side calibration | Heterogeneous MPC distribution centered on stronger private-consumption channel | Beta draw | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
-| `household.savingsMu`, `household.savingsSigma` | `9.6`, `1.2` | log PLN params | UNKNOWN_SOURCE | Initial savings distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.mpcAlpha`, `mpcBeta` | `9.2, 0.8` | beta params | #461 demand-side calibration | Heterogeneous MPC distribution centered on stronger private-consumption channel | Beta draw | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.savingsMu`, `savingsSigma` | `9.6, 1.2` | log PLN params | UNKNOWN_SOURCE | Initial savings distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
 | `household.debtFraction` | `0.40` | share | Code note bridge: BIK bridge prior | Household positive debt share | Bernoulli init | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
-| `household.debtMu`, `household.debtSigma` | `10.5`, `1.5` | log PLN params | UNKNOWN_SOURCE | Initial debt distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
-| `household.rentMean`, `rentStd`, `rentFloor` | `3500`, `800`, `1200` | PLN/month | Otodom March 2026 provincial-city asking-rent bridge | Rent distribution | Truncated normal draw | `HouseholdConfig` | `EMPIRICAL_TRANSFORMED` |
+| `household.debtMu`, `debtSigma` | `10.5, 1.5` | log PLN params | UNKNOWN_SOURCE | Initial debt distribution | Lognormal draw | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.rentMean`, `rentStd`, `rentFloor` | `3500, 800, 1200` | PLN/month | Otodom March 2026 provincial-city asking-rent bridge | Rent distribution | Truncated normal draw | `HouseholdConfig` | `EMPIRICAL_TRANSFORMED` |
 | `household.bufferTargetMonths` | `6.0` | months | Carroll-style buffer-stock model | Target liquid buffer | Direct | `HouseholdConfig` | `ASSUMED` |
 | `household.laborSupplySteepness` | `4.0` | coefficient | #461 labor-market calibration | Labor-supply response steepness; calibrated so wage clearing supports strong 2026 growth without forcing persistent labor shedding | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
 | `household.bufferSensitivity` | `0.2` | coefficient | #461 calibration | MPC response to buffer gap | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
 | `household.mpcUnemployedBoost` | `0.10` | share | UNKNOWN_SOURCE | Extra MPC while unemployed | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
 | `household.skillDecayRate` | `0.02` | monthly share | UNKNOWN_SOURCE | Skill decay under unemployment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
-| `household.scarringRate`, `scarringCap`, `scarringOnset` | `0.02`, `0.50`, `3` | share/months | Literature note in code | Long-run unemployment scarring | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
-| `household.wageScarRate`, `wageScarCap`, `wageScarDecay` | `0.025`, `0.30`, `0.005` | share/month | Code note bridge: Jacobson et al.; Davis and von Wachter | Wage scar accumulation and recovery | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
-| `household.retrainingCost`, `retrainingDuration` | `5000`, `6` | PLN/months | UNKNOWN_SOURCE | Retraining cost and duration | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
-| `household.retrainingBaseSuccess`, `retrainingProb` | `0.60`, `0.15` | share | UNKNOWN_SOURCE | Retraining success/enrollment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.scarringRate`, `scarringCap`, `scarringOnset` | `0.02, 0.50, 3` | share/months | Literature note in code | Long-run unemployment scarring | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.wageScarRate`, `wageScarCap`, `wageScarDecay` | `0.025, 0.30, 0.005` | share/month | Code note bridge: Jacobson et al.; Davis and von Wachter | Wage scar accumulation and recovery | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
+| `household.retrainingCost`, `retrainingDuration` | `5000, 6` | PLN/months | UNKNOWN_SOURCE | Retraining cost and duration | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
+| `household.retrainingBaseSuccess`, `retrainingProb` | `0.60, 0.15` | share | UNKNOWN_SOURCE | Retraining success/enrollment | Direct | `HouseholdConfig` | `TUNED_NEEDS_VALIDATION` |
 | `household.bankruptcyDistressMonths` | `3` | months | ASSUMED | Distress persistence before bankruptcy | Direct | `HouseholdConfig` | `ASSUMED` |
 | `household.depositSpread` | `0.02` | annual rate | UNKNOWN_SOURCE | Deposit rate below policy rate | Direct | `HouseholdConfig` | `UNKNOWN_SOURCE` |
 | `household.ccSpread` | `0.04` | annual rate | Code note bridge: NBP MIR bridge prior | Consumer credit spread | Direct | `HouseholdConfig` | `CODE_NOTE_EMPIRICAL` |
@@ -102,49 +121,49 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `labor.unionRigidity` | `0.50` | share | UNKNOWN_SOURCE | Downward nominal wage rigidity | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
 | `labor.expLambda` | `0.70` | coefficient | Code note bridge: Carroll 2003 | Adaptive expectations speed | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
 | `labor.expCredibilityInit` | `0.80` | share | UNKNOWN_SOURCE | Initial NBP credibility | Direct | `LaborConfig` | `TUNED_NEEDS_VALIDATION` |
-| `labor.expWagePassthrough`, `tightLaborWageSensitivity` | `0.75`, `0.06` | coefficient | #461 GDP-growth calibration | Nominal wage-setting pass-through from anchored expected inflation, plus a separately calibrated wage-pressure response when observed unemployment is below NAIRU; split after 48m runs showed the earlier shared-speed floor created a wage-cost spiral and later labor shedding | Monthly transform plus unemployment-below-NAIRU wage pressure | `LaborConfig`, `LaborEconomics` | `TUNED_NEEDS_VALIDATION` |
-| `labor.structuralMatchRate`, `cyclicalMatchRate` | `0.005`, `0.15` | monthly share | Poland 2026-04-30 labor-market matching calibration | Beveridge-style matching capacity: structural unemployment near NAIRU clears slowly while unemployment above NAIRU is more matchable; prevents vacancy matching from treating all unemployed workers as immediately placeable | Monthly cap on job-search matches | `LaborConfig`, `LaborMarket`, `FirmEconomics` | `TUNED_NEEDS_VALIDATION` |
-| `social.zusContribRate`, `zusEmployeeRate` | `0.1952`, `0.1371` | annual rate/share | Code note bridge: Social insurance law | ZUS payroll contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `labor.expWagePassthrough`, `tightLaborWageSensitivity` | `0.75, 0.06` | coefficient | #461 GDP-growth calibration / wage-pressure response | Nominal wage-setting pass-through and unemployment-below-NAIRU wage pressure | Monthly transform plus labor tightness pressure | `LaborConfig`, `LaborEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `labor.structuralMatchRate`, `cyclicalMatchRate` | `0.005, 0.15` | monthly share | Poland 2026-04-30 labor-market matching calibration | Beveridge-style matching capacity | Monthly cap on job-search matches | `LaborConfig`, `LaborMarket`, `FirmEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `social.zusContribRate`, `zusEmployeeRate` | `0.1952, 0.1371` | annual rate/share | Code note bridge: Social insurance law | ZUS payroll contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
 | `social.zusBasePension` | `4321` | PLN/month | GUS Q1 2026 non-agricultural social-insurance pension/rent, rounded | Average pension payment | Direct | `SocialConfig` | `EMPIRICAL` |
 | `social.nfzContribRate` | `0.09` | rate | Code note bridge: health-care law | NFZ contribution rate | Direct | `SocialConfig` | `EMPIRICAL` |
-| `social.nfzPerCapitaCost` | `500` | PLN/month | #461 pension-stock recalibration | Health spending per effective capita after activating initial retirees; avoids double-counting retiree health demand in NFZ subvention | Direct, with `nfzAgingElasticity` | `SocialConfig` | `TUNED_NEEDS_VALIDATION` |
-| `social.ppkEmployeeRate`, `ppkEmployerRate` | `0.02`, `0.015` | rate | Code note bridge: PPK law | PPK contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
+| `social.nfzPerCapitaCost` | `500` | PLN/month | #461 pension-stock recalibration | Health spending per effective capita | Direct, with nfzAgingElasticity | `SocialConfig` | `TUNED_NEEDS_VALIDATION` |
+| `social.ppkEmployeeRate`, `ppkEmployerRate` | `0.02, 0.015` | rate | Code note bridge: PPK law | PPK contribution rates | Direct | `SocialConfig` | `EMPIRICAL` |
 | `social.eduShares` | `[0.08, 0.25, 0.30, 0.37]` | share | Code note bridge: GUS LFS bridge prior | Education composition | CDF draw | `SocialConfig` | `CODE_NOTE_EMPIRICAL` |
-| `social.demInitialRetirees` | `pop.firmsCount * pop.workersPerFirm / 3` | agents | #461 pension-consumption/GDP calibration | Effective initial retiree stock; pension payments feed aggregate household consumption so the Poland demand channel includes retiree income | Derived in `SimParams.defaults`; consumed by `HouseholdIncomeEconomics` via ZUS pension flow | `SocialConfig`, `SimParams`, `HouseholdIncomeEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `social.demInitialRetirees` | `pop.firmsCount * pop.workersPerFirm / 3` | agents | #461 pension-consumption/GDP calibration | Effective initial retiree stock | Derived in SimParams.defaults; consumed by HouseholdIncomeEconomics | `SocialConfig`, `SimParams`, `HouseholdIncomeEconomics` | `TUNED_NEEDS_VALIDATION` |
 
 ## Firm Production, Entry, Capital, And Climate
 
 | Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `firm.baseRevenue` | `180000` | PLN/month/worker | Code note bridge: GUS F-01 bridge prior | Revenue per worker before demand shocks | Direct, unscaled | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
-| `firm.productivityGrowth` | `0.020` | annual rate | #461 GDP-growth calibration | Baseline productivity/catch-up trend; reduced after 48m diagnostics showed 3% exogenous productivity plus entry and capital accumulation double-counted Poland 2026+ real growth | `.monthly` in use | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.productivityGrowth` | `0.020` | annual rate | #461 GDP-growth calibration | Baseline productivity/catch-up trend | .monthly in use | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.otherCosts` | `16667` | PLN/month/worker | UNKNOWN_SOURCE | Fixed non-wage operating cost | Direct, unscaled | `FirmConfig` | `UNKNOWN_SOURCE` |
 | `firm.aiCapex` | `1200000` | PLN/firm | UNKNOWN_SOURCE | Full automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.hybridCapex` | `350000` | PLN/firm | UNKNOWN_SOURCE | Hybrid automation capex | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
-| `firm.aiOpex`, `firm.hybridOpex` | `30000`, `12000` | PLN/month/firm | UNKNOWN_SOURCE | AI/hybrid operating cost | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
-| `firm.hybridReadinessMin`, `fullAiReadinessMin` | `0.20`, `0.55` | share | #461 calibration | Digital readiness adoption thresholds | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.aiOpex`, `hybridOpex` | `30000, 12000` | PLN/month/firm | UNKNOWN_SOURCE | AI/hybrid operating cost | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.hybridReadinessMin`, `fullAiReadinessMin` | `0.20, 0.55` | share | #461 calibration | Digital readiness adoption thresholds | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.entrySectorBarriers` | `[0.8, 0.6, 1.2, 0.5, 0.1, 0.7]` | coefficient by sector | Code note bridge: enterprise-size bridge prior | Entry barriers | Direct | `FirmConfig` | `CODE_NOTE_EMPIRICAL` |
-| `firm.entryAiThreshold`, `entryAiProb` | `0.15`, `0.20` | share | UNKNOWN_SOURCE | AI-native entrant trigger/probability | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.entryAiThreshold`, `entryAiProb` | `0.15, 0.20` | share | UNKNOWN_SOURCE | AI-native entrant trigger/probability | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.entryStartupCash` | `50000` | PLN | UNKNOWN_SOURCE | Entrant liquidity | Direct | `FirmConfig` | `UNKNOWN_SOURCE` |
 | `firm.replacementEntryRate` | `0.35` | monthly share | UNKNOWN_SOURCE | Replacement of dead firm slots | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
-| `firm.netEntryRate`, `netEntryMaxMonthly` | `0.08`, `175` | monthly share / firms | #461 labor/GDP calibration | Utilization-backed net births constrained by staffing feasibility; high unemployment is labor availability, not a standalone entry impulse | Direct | `FirmConfig`, `FirmEntry` | `TUNED_NEEDS_VALIDATION` |
-| `firm.laborAdjustSpeed`, `hiringWorkingCapitalMonths`, `startupHiringWorkingCapitalMonths` | `0.15`, `3`, `4` | monthly share / wage-months | #461 GDP-growth calibration | Firm hiring absorption and payroll working-capital runway; avoids under-absorbing labor supply when order books are positive | Direct in firm workforce decision | `FirmConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
+| `firm.netEntryRate`, `netEntryMaxMonthly` | `0.08, 175` | monthly share / firms | #461 labor/GDP calibration | Utilization-backed net births constrained by staffing feasibility | Direct | `FirmConfig`, `FirmEntry` | `TUNED_NEEDS_VALIDATION` |
+| `firm.laborAdjustSpeed`, `hiringWorkingCapitalMonths`, `startupHiringWorkingCapitalMonths` | `0.15, 3, 4` | monthly share / wage-months | #461 GDP-growth calibration | Firm hiring absorption and payroll working-capital runway | Direct in firm workforce decision | `FirmConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
 | `firm.digiDrift` | `0.001` | monthly share | UNKNOWN_SOURCE | Exogenous digital readiness drift | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
-| `firm.digiInvestCost`, `digiInvestBoost` | `50000`, `0.05` | PLN/share | UNKNOWN_SOURCE | Discretionary digital investment | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
-| `firm.networkK`, `networkRewireP` | `6`, `0.10` | degree/share | Network design assumption | Watts-Strogatz firm network | Direct | `FirmConfig` | `ASSUMED` |
-| `firm.demoEffectThresh`, `demoEffectBoost` | `0.40`, `0.15` | share | UNKNOWN_SOURCE | Peer adoption demonstration effect | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.digiInvestCost`, `digiInvestBoost` | `50000, 0.05` | PLN/share | UNKNOWN_SOURCE | Discretionary digital investment | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
+| `firm.networkK`, `networkRewireP` | `6, 0.10` | degree/share | Network design assumption | Watts-Strogatz firm network | Direct | `FirmConfig` | `ASSUMED` |
+| `firm.demoEffectThresh`, `demoEffectBoost` | `0.40, 0.15` | share | UNKNOWN_SOURCE | Peer adoption demonstration effect | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.adoptionRampMonths` | `60` | months | #461 calibration | Adoption willingness ramp | Direct | `FirmConfig` | `TUNED_NEEDS_VALIDATION` |
 | `firm.sigmaLambda` | `0.0` | coefficient | Scenario switch | Arthur-style sigma learning off by default | Direct | `FirmConfig` | `POLICY_SCENARIO` |
-| `capital.klRatios` | `[180000, 375000, 120000, 300000, 225000, 270000]` | PLN/worker | GUS F-01 bridge prior note + #461 K/GDP calibration | Sector capital-labor ratios; lifted after fiscal-investment audit showed private capital stock around 60-66% of GDP and total GFCF below the 2026-04-30 bridge reference range; investment targets use structural firm scale so temporary headcount cuts do not immediately erase planned capital intensity | Direct via `Firm.capitalPlanningWorkers` | `CapitalConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
-| `capital.depRates` | `[0.15, 0.08, 0.10, 0.07, 0.05, 0.08]` | annual rate | Code note bridge: GUS F-01 bridge prior | Sector depreciation rates | `.monthly` in use | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `capital.importShare` | `0.18` | share | #461 GDP-growth calibration | Import share of investment; lowered after runs showed excessive domestic-demand leakage and a widening trade deficit during the 2026-2027 investment window | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
-| `capital.adjustSpeed` | `0.10` | monthly coefficient | #461 fiscal-investment/GDP calibration | Capital partial-adjustment speed; reduced after 48m diagnostics showed a year-2 real-GDP surge from front-loaded private GFCF rather than sustained production growth | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
-| `capital.demandExpansionSensitivity` | `0.30` | coefficient | #461 GDP-growth calibration | Target-capital uplift under persistent excess demand; moderated after the production audit showed the earlier response over-amplified bottleneck-sector capital targets in the first 18-24 months | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `capital.klRatios` | `[180000, 375000, 120000, 300000, 225000, 270000]` | PLN/worker | GUS F-01 bridge prior note + #461 K/GDP calibration | Sector capital-labor ratios | Direct via Firm.capitalPlanningWorkers | `CapitalConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
+| `capital.depRates` | `[0.15, 0.08, 0.10, 0.07, 0.05, 0.08]` | annual rate | Code note bridge: GUS F-01 bridge prior | Sector depreciation rates | .monthly in use | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `capital.importShare` | `0.18` | share | #461 GDP-growth calibration | Import share of investment | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `capital.adjustSpeed` | `0.10` | monthly coefficient | #461 fiscal-investment/GDP calibration | Capital partial-adjustment speed | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `capital.demandExpansionSensitivity` | `0.30` | coefficient | #461 GDP-growth calibration | Target-capital uplift under persistent excess demand | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
 | `capital.investmentCreditShare` | `1.0` | share | #461 calibration | Credit-financed share of cash-unfunded desired investment | Direct | `CapitalConfig` | `TUNED_NEEDS_VALIDATION` |
 | `capital.inventoryTargetRatios` | `[0.05, 0.25, 0.15, 0.10, 0.02, 0.30]` | share by sector | Code note bridge: GUS bridge prior | Inventory/revenue targets | Direct | `CapitalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `climate.energyCostShares` | `[0.02, 0.10, 0.04, 0.05, 0.03, 0.06]` | share of revenue | Code note bridge: Eurostat/GUS 2023 | Energy burden by sector | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
 | `climate.etsBasePrice` | `80` | EUR/tCO2 | Code note bridge: KOBiZE bridge prior | EU ETS starting price | Direct | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
-| `climate.etsPriceDrift` | `0.03` | annual rate | Code note bridge: EC Fit for 55 trajectory | ETS trend | `.monthly` in use | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
+| `climate.etsPriceDrift` | `0.03` | annual rate | Code note bridge: EC Fit for 55 trajectory | ETS trend | .monthly in use | `ClimateConfig` | `CODE_NOTE_EMPIRICAL` |
 | `climate.greenBudgetShare` | `0.20` | share | UNKNOWN_SOURCE | Green investment budget share | Direct | `ClimateConfig` | `TUNED_NEEDS_VALIDATION` |
 | `climate.greenImportShare` | `0.35` | share | UNKNOWN_SOURCE | Import share of green capex | Direct | `ClimateConfig` | `UNKNOWN_SOURCE` |
 
@@ -156,29 +175,29 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `fiscal.vatRates` | `[0.23, 0.19, 0.12, 0.06, 0.10, 0.07]` | rate by sector | Code note bridge: MF bridge prior effective rates | Sector VAT rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.exciseRates` | `[0.01, 0.04, 0.03, 0.005, 0.002, 0.02]` | rate by sector | Code note bridge: MF bridge prior aggregate | Effective excise rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.customsDutyRate` | `0.04` | rate | Code note bridge: EU CET/Eurostat TARIC | Average non-EU customs duty | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (`918.9e9 / 12`) | Government base spending | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govWageIndexShare` | `0.75` | share | #461 GDP-growth calibration | Labor-cost indexation of government purchases so public-service demand is not mechanically deflated when wages outpace CPI | CPI/wage blended cost index in `DemandEconomics.computeGovPurchases` | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
-| `fiscal.fofConsWeights`, `fofGovWeights` | `[0.02, 0.18, 0.59, 0.06, 0.07, 0.08]`, `[0.04, 0.08, 0.08, 0.20, 0.58, 0.02]` | sector shares | #461 demand-allocation calibration | Flow-of-funds allocation of household consumption and government purchases; shifted toward slack domestic services/public-health sectors after probe showed excess demand was overallocated to already constrained manufacturing/agriculture | Direct sector allocation | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
-| `io.crossSectorSpillover` | `0.65` | share | #461 GDP-growth calibration | Substitutable share of unmet sector demand that can be reallocated to I-O-linked slack sectors; avoids treating all sectors as perfect substitutes | I-O-weighted partial spillover inside `DemandEconomics.applySpillover` | `DemandEconomics`, `IoConfig` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (918.9e9 / 12) | Government base spending | Scaled by gdpRatio | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govWageIndexShare` | `0.75` | share | #461 GDP-growth calibration | Labor-cost indexation of government purchases | CPI/wage blended cost index in DemandEconomics.computeGovPurchases | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.fofConsWeights`, `fofGovWeights` | `[0.02, 0.18, 0.59, 0.06, 0.07, 0.08], [0.04, 0.08, 0.08, 0.20, 0.58, 0.02]` | sector shares | #461 demand-allocation calibration | Flow-of-funds allocation of household consumption and government purchases | Direct sector allocation | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `io.crossSectorSpillover` | `0.65` | share | #461 GDP-growth calibration | Substitutable share of unmet sector demand | I-O-weighted partial spillover inside DemandEconomics.applySpillover | `DemandEconomics`, `IoConfig` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.govInvestShare` | `0.20` | share | Code note bridge: MF bridge prior | Capital share of government spending | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govCapitalMultiplier`, `govCurrentMultiplier` | `1.5`, `0.8` | multiplier | Code note bridge: Ilzetzki, Mendoza and Vegh 2013 | Fiscal multipliers | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govInitCapital` | `0` | PLN | Explicit startup simplification | Initial public capital stock | Built from investment flows | `FiscalConfig` | `PLACEHOLDER` |
-| `fiscal.euFundsTotalEur`, `euFundsAlpha`, `euFundsBeta` | `110e9`, `2`, `3` | EUR / beta shape | #461 GDP-growth calibration | EU cohesion plus KPO-style investment absorption window, with peak shifted toward the 2026-2027 investment cycle | Beta absorption path | `FiscalConfig`, `EuFunds` | `TUNED_NEEDS_VALIDATION` |
-| `fiscal.euCofinanceRate`, `euCapitalShare` | `0.15`, `0.60` | share | Code note bridge: MFiPR / EU funds | National cofinance and capex split | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govCapitalMultiplier`, `govCurrentMultiplier` | `1.5, 0.8` | multiplier | Code note bridge: Ilzetzki, Mendoza and Vegh 2013 | Fiscal multipliers | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govInitCapital` | `2332e9` | raw PLN | #461 fiscal-investment/GDP calibration | Initial public capital stock | Scaled by gdpRatio in SimParams.defaults; seeded into WorldInit public capital stock | `FiscalConfig`, `SimParams`, `WorldInit` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.euFundsTotalEur`, `euFundsAlpha`, `euFundsBeta` | `110e9, 2, 3` | EUR / beta shape | #461 GDP-growth calibration | EU cohesion plus KPO-style investment absorption window | Beta absorption path | `FiscalConfig`, `EuFunds` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.euCofinanceRate`, `euCapitalShare` | `0.15, 0.60` | share | Code note bridge: MFiPR / EU funds | National cofinance and capex split | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.minWageTargetRatio` | `0.50` | share | Code note bridge: minimum wage act | Target minimum/average wage ratio | Annual adjustment | `FiscalConfig` | `EMPIRICAL` |
-| `fiscal.govBenefitM1to3`, `govBenefitM4to6` | `1784`, `1401` | PLN/month | 2026 statutory unemployment benefit schedule, rounded | Unemployment benefit amounts | Direct | `FiscalConfig` | `EMPIRICAL` |
-| `fiscal.govFiscalRiskBeta`, `fiscalRiskBeta55`, `fiscalRiskBeta60` | `0.03`, `0.04`, `0.08` | coefficient | #461 Poland debt-service calibration | Bond-yield sensitivity to public-debt pressure without a 60% debt cliff | Direct | `FiscalConfig`, `Nbp.bondYield` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.govBenefitM1to3`, `govBenefitM4to6` | `1784, 1401` | PLN/month | 2026 statutory unemployment benefit schedule, rounded | Unemployment benefit amounts | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.govFiscalRiskBeta`, `fiscalRiskBeta55`, `fiscalRiskBeta60` | `0.03, 0.04, 0.08` | coefficient | #461 Poland debt-service calibration | Bond-yield sensitivity to public-debt pressure without a 60% debt cliff | Direct | `FiscalConfig`, `Nbp.bondYield` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.govInitialWeightedCoupon` | `0.04` | annual rate | #461 calibration | Opening weighted coupon on Treasury debt stock | Direct | `FiscalConfig`, `WorldInit` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.govAvgMaturityMonths` | `69` | months | MF public-debt bridge prior | Total State Treasury debt average maturity; domestic-only maturity is shorter | WAM coupon update | `FiscalConfig`, `OpenEconEconomics` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.baseForeignShare`, `maxForeignShare` | `0.35`, `0.55` | share | Code note bridge: NBP SPW holder bridge prior | Foreign government-bond holdings | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.baseForeignShare`, `maxForeignShare` | `0.35, 0.55` | share | Code note bridge: NBP SPW holder bridge prior | Foreign government-bond holdings | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.fiscalRuleDebtCeiling` | `0.60` | debt/GDP share | Code note bridge: Polish constitution Art. 216 | Constitutional debt ceiling | Direct | `FiscalConfig` | `EMPIRICAL` |
 | `fiscal.fiscalRuleCautionThreshold` | `0.55` | debt/GDP share | Code note bridge: public finance act Art. 86 | Caution threshold | Direct | `FiscalConfig` | `EMPIRICAL` |
 | `fiscal.sgpDeficitLimit` | `0.03` | deficit/GDP share | Maastricht / SGP | Deficit limit | Direct | `FiscalConfig` | `EMPIRICAL` |
-| `fiscal.sgpCorrectionSpeed` | `0.85` | annual share | #461 Poland EDP/GDP calibration | Gradual excessive-deficit correction speed applied to discretionary purchases after prior non-purchase outlays; monthly speed scales with the deficit overshoot versus the 3% path | Direct | `FiscalConfig`, `FiscalRules` | `TUNED_NEEDS_VALIDATION` |
-| `fiscal.fiscalConsolidationSpeed55`, `fiscalConsolidationSpeed60` | `0.18`, `0.45` | annual share | #461 Poland EDP/GDP calibration | Debt-threshold discretionary-spending consolidation path after 55%/60% debt-to-GDP; softened to avoid excessive GDP drag while retaining a debt-feedback channel | Direct | `FiscalConfig`, `FiscalRules` | `TUNED_NEEDS_VALIDATION` |
-| `fiscal.initGovDebt` | `1913.5e9` | raw PLN | MF public-debt release for IV kw. 2025: państwowy dług publiczny (PDP) 1913.5 mld PLN | Initial domestic fiscal-rule debt metric used for Polish 55%/60% thresholds | Scaled by `gdpRatio`; ESA/EDP bridge is carried in `quasiFiscal.initBondsOutstanding` | `FiscalConfig`, `SimParams`, `FiscalRules` | `EMPIRICAL` |
-| `fiscal.jstPitShare`, `jstCitShare` | `0.3846`, `0.0671` | share | Code note bridge: JST revenue act | Local-government tax shares | Direct | `FiscalConfig` | `EMPIRICAL` |
-| `fiscal.pitRate1`, `pitRate2`, `pitBracket1Annual` | `0.12`, `0.32`, `120000` | rate/PLN/year | Current PIT-law bridge prior | PIT brackets | Annualized monthly PIT | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.sgpCorrectionSpeed` | `0.85` | annual share | #461 Poland EDP/GDP calibration | Gradual excessive-deficit correction speed | Direct | `FiscalConfig`, `FiscalRules` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.fiscalConsolidationSpeed55`, `fiscalConsolidationSpeed60` | `0.18, 0.45` | annual share | #461 Poland EDP/GDP calibration | Debt-threshold discretionary-spending consolidation path | Direct | `FiscalConfig`, `FiscalRules` | `TUNED_NEEDS_VALIDATION` |
+| `fiscal.initGovDebt` | `1913.5e9` | raw PLN | MF public-debt release for IV kw. 2025: PDP 1913.5 mld PLN | Initial domestic fiscal-rule debt metric | Scaled by gdpRatio; ESA/EDP bridge is carried in quasiFiscal.initBondsOutstanding | `FiscalConfig`, `SimParams`, `FiscalRules` | `EMPIRICAL` |
+| `fiscal.jstPitShare`, `jstCitShare` | `0.3846, 0.0671` | share | Code note bridge: JST revenue act | Local-government tax shares | Direct | `FiscalConfig` | `EMPIRICAL` |
+| `fiscal.pitRate1`, `pitRate2`, `pitBracket1Annual` | `0.12, 0.32, 120000` | rate/PLN/year | Current PIT-law bridge prior | PIT brackets | Annualized monthly PIT | `FiscalConfig` | `EMPIRICAL` |
 | `fiscal.social800` | `800` | PLN/month/child | Code note bridge: legal act 2023 | 800+ benefit | Direct | `FiscalConfig` | `EMPIRICAL` |
 | `monetary.initialRate` | `0.0375` | annual rate | NBP MPC decision, April 2026 | NBP reference rate | Direct | `MonetaryConfig` | `EMPIRICAL` |
 | `monetary.initialInflation` | `0.030` | annual rate | GUS CPI, March 2026 | Starting CPI inflation stock | Direct | `MonetaryConfig`, `WorldInit` | `EMPIRICAL` |
@@ -186,36 +205,36 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `monetary.initialExpectedRate` | `0.0375` | annual rate | NBP MPC decision, April 2026 | Starting expected policy-rate stock | Direct | `MonetaryConfig`, `Expectations` | `EMPIRICAL` |
 | `monetary.targetInfl` | `0.025` | annual rate | NBP inflation target | Inflation target | Direct | `MonetaryConfig` | `EMPIRICAL` |
 | `monetary.neutralRate` | `0.03` | annual rate | #461 calibration | Long-run neutral policy-rate anchor | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
-| `monetary.taylorAlpha`, `taylorBeta`, `taylorDelta` | `1.2`, `0.8`, `0.1` | coefficients | #461 calibration / Taylor-rule convention | Policy reaction coefficients; unemployment-gap response is intentionally modest to match NBP's inflation-focused reaction pattern | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
-| `monetary.taylorExpectedInflationWeight` | `0.80` | share | #461 2026-04-30 disinflation calibration | Forward-looking inflation weight in the policy reaction; allows cuts during disinflation when expectations are near target despite elevated current CPI | Direct | `MonetaryConfig`, `Nbp.updateRate` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorAlpha`, `taylorBeta`, `taylorDelta` | `1.2, 0.8, 0.1` | coefficients | #461 calibration / Taylor-rule convention | Policy reaction coefficients | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
+| `monetary.taylorExpectedInflationWeight` | `0.80` | share | #461 2026-04-30 disinflation calibration | Forward-looking inflation weight in the policy reaction | Direct | `MonetaryConfig`, `Nbp.updateRate` | `TUNED_NEEDS_VALIDATION` |
 | `monetary.taylorInertia` | `0.70` | share | UNKNOWN_SOURCE | Policy-rate smoothing | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
-| `monetary.rateFloor`, `rateCeiling` | `0.001`, `0.15` | annual rate | Structural lower/upper bounds | Policy-rate corridor bounds | Direct | `MonetaryConfig` | `ASSUMED` |
+| `monetary.rateFloor`, `rateCeiling` | `0.001, 0.15` | annual rate | Structural lower/upper bounds | Policy-rate corridor bounds | Direct | `MonetaryConfig` | `ASSUMED` |
 | `monetary.maxRateChange` | `0.0025` | monthly annual-rate step | #461 calibration | Monthly policy-rate adjustment cap | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
 | `monetary.nairu` | `0.05` | share | Code note bridge: estimated | NAIRU | Direct | `MonetaryConfig` | `TUNED_NEEDS_VALIDATION` |
 | `monetary.reserveRateMult` | `0.5` | share | Code note bridge: NBP bridge prior | Reserve remuneration fraction | Direct | `MonetaryConfig` | `CODE_NOTE_EMPIRICAL` |
-| `monetary.depositFacilitySpread`, `lombardSpread` | `0.01`, `0.01` | annual rate | Code note bridge: NBP corridor | Corridor +/- 100 bp | Direct | `MonetaryConfig` | `EMPIRICAL` |
-| `monetary.qePace` | `5e9` | raw PLN/month | UNKNOWN_SOURCE | QE monthly purchase pace | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `POLICY_SCENARIO` |
+| `monetary.depositFacilitySpread`, `lombardSpread` | `0.01, 0.01` | annual rate | Code note bridge: NBP corridor | Corridor +/- 100 bp | Direct | `MonetaryConfig` | `EMPIRICAL` |
+| `monetary.qePace` | `5e9` | raw PLN/month | UNKNOWN_SOURCE | QE monthly purchase pace | Scaled by gdpRatio | `MonetaryConfig`, `SimParams` | `POLICY_SCENARIO` |
 | `monetary.qeMaxGdpShare` | `0.30` | GDP share | UNKNOWN_SOURCE | QE stock ceiling | Direct | `MonetaryConfig` | `POLICY_SCENARIO` |
-| `monetary.fxReserves` | `1078.313e9` | raw PLN | NBP March 2026 official reserve assets, EUR 253.5bn converted at model-start PLN/EUR 4.2537 | Initial official reserve assets | Scaled by `gdpRatio` | `MonetaryConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `banking.initCapital` | `168e9` | raw PLN | KNF February 2026 TCR 21.1%, mapped to model RWA proxy | Aggregate regulatory-capital proxy | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `banking.initDeposits` | `2542.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate banking-sector deposits | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL` |
-| `banking.initLoans` | `557.4e9` | raw PLN | KNF monthly banking data, February 2026: SME + large enterprises + individual entrepreneurs + individual farmers | Corporate/nonfinancial business loans | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `banking.initGovBonds`, `initNbpGovBonds` | `400e9`, `300e9` | raw PLN | Code note bridge: NBP bridge prior | Bank/NBP government-bond holdings | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
-| `banking.initConsumerLoans` | `225.2e9` | raw PLN | KNF monthly banking data, February 2026 | Consumer loan stock | Scaled by `gdpRatio`; household opening consumer loans are normalized to this target | `BankingConfig`, `SimParams`, `Household.Init` | `EMPIRICAL` |
+| `monetary.fxReserves` | `1078.313e9` | raw PLN | NBP March 2026 official reserve assets, EUR 253.5bn converted at model-start PLN/EUR 4.2537 | Initial official reserve assets | Scaled by gdpRatio | `MonetaryConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `banking.initCapital` | `168e9` | raw PLN | KNF February 2026 TCR 21.1%, mapped to model RWA proxy | Aggregate regulatory-capital proxy | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `banking.initDeposits` | `2542.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate banking-sector deposits | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL` |
+| `banking.initLoans` | `557.4e9` | raw PLN | KNF monthly banking data, February 2026: SME + large enterprises + individual entrepreneurs + individual farmers | Corporate/nonfinancial business loans | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `banking.initGovBonds`, `initNbpGovBonds` | `400e9, 300e9` | raw PLN | Code note bridge: NBP bridge prior | Bank/NBP government-bond holdings | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initConsumerLoans` | `225.2e9` | raw PLN | KNF monthly banking data, February 2026 | Consumer loan stock | Scaled by gdpRatio; household opening consumer loans are normalized to this target | `BankingConfig`, `SimParams`, `Household.Init` | `EMPIRICAL` |
 | `banking.baseSpread` | `0.015` | annual rate | UNKNOWN_SOURCE | Base firm-loan spread | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
 | `banking.minCar` | `0.08` | multiplier/share | Code note bridge: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.loanRecovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate loan recovery | Direct | `BankingConfig` | `UNKNOWN_SOURCE` |
 | `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note bridge: NBP bridge prior maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.reserveReq` | `0.035` | share | Code note bridge: NBP bridge prior | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
-| `banking.lcrMin`, `nsfrMin` | `1.0`, `1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
+| `banking.lcrMin`, `nsfrMin` | `1.0, 1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `banking.bfgLevyRate` | `0.0024` | annual rate | Code note bridge: BFG bridge prior | Resolution levy | `.monthly` in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.bfgLevyRate` | `0.0024` | annual rate | Code note bridge: BFG bridge prior | Resolution levy | .monthly in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.bfgDepositGuarantee` | `425370` | PLN/depositor | BFG EUR 100,000 guarantee converted at model-start PLN/EUR 4.2537 | Deposit guarantee threshold | Direct | `BankingConfig` | `EMPIRICAL_TRANSFORMED` |
 | `banking.ccybMax` | `0.025` | multiplier | Code note bridge: KNF bridge prior | Max CCyB | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.osiiBuffers` | `[0.020, 0.010, 0.005, 0.010, 0.015, 0.0025, 0.0025]` | multiplier by bank | KNF O-SII decisions announced November 2025 | O-SII buffers for default bank archetypes | Direct | `BankingConfig`, `Macroprudential` | `EMPIRICAL_TRANSFORMED` |
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
-| `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01, 0.08, 0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 
 ## External Sector And Financial Markets
 
@@ -225,43 +244,43 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `forex.foreignRate` | `0.0215` | annual rate | ECB main refinancing rate | Foreign reference rate | Direct | `ForexConfig` | `EMPIRICAL` |
 | `forex.importPropensity` | `0.22` | GDP share | Code note bridge: GUS/NBP bridge prior | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
 | `forex.techImportShare` | `0.40` | share | UNKNOWN_SOURCE | Technology/capital goods share of imports | Direct | `ForexConfig` | `UNKNOWN_SOURCE` |
-| `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15`, `0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
+| `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15, 0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
 | `forex.riskOffShockMonth` | `0` | month | Scenario switch | No baseline risk-off shock | Direct | `ForexConfig` | `POLICY_SCENARIO` |
 | `openEcon.importContent` | `[0.15, 0.50, 0.20, 0.15, 0.05, 0.12]` | share by sector | Code note bridge: supply-use bridge prior | Import content of production | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
-| `priceLevel.importPush` | `FX depreciation + GVC import-cost pressure` | monthly coefficient | #461 inflation audit | Imported inflation pass-through to CPI | Scaled by `forex.importPropensity` and capped by `openEcon.importPushCap` | `PriceLevel`, `PriceEquityEconomics` | `TUNED_NEEDS_VALIDATION` |
-| `openEcon.exportBase` | `157.6e9` | raw PLN/month | NBP BoP January 2026 goods-and-services export bridge | Monthly export base | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `openEcon.foreignGdpGrowth` | `0.015` | annual rate | Code note bridge: ECB/IMF projections | Foreign GDP growth | `.monthly` in export rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
-| `openEcon.exportPriceElasticity`, `importPriceElasticity` | `0.8`, `0.6` | coefficient | Code note bridge: Marshall-Lerner / Campa-Goldberg | Trade price elasticities | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `priceLevel.importPush` | `FX depreciation + GVC import-cost pressure` | monthly coefficient | #461 inflation audit | Imported inflation pass-through to CPI | Scaled by forex.importPropensity and capped by openEcon.importPushCap | `PriceLevel`, `PriceEquityEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.exportBase` | `157.6e9` | raw PLN/month | NBP BoP January 2026 goods-and-services export bridge | Monthly export base | Scaled by gdpRatio | `OpenEconConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `openEcon.foreignGdpGrowth` | `0.015` | annual rate | Code note bridge: ECB/IMF projections | Foreign GDP growth | .monthly in export rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.exportPriceElasticity`, `importPriceElasticity` | `0.8, 0.6` | coefficient | Code note bridge: Marshall-Lerner / Campa-Goldberg | Trade price elasticities | Direct | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
 | `openEcon.erElasticity` | `0.5` | coefficient | UNKNOWN_SOURCE | Exchange-rate elasticity of trade | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
-| `openEcon.euTransfers` | `1.458e9` | raw PLN/month | Code note bridge: MFiPR bridge prior | EU transfer monthly flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
-| `openEcon.fdiBase` | `4.963e9` | raw PLN/month | NBP BoP trailing-12-month FDI bridge through January 2026, monthly average converted at model-start FX | Monthly FDI base flow | Scaled by `gdpRatio` | `OpenEconConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `openEcon.portfolioSensitivity`, `riskPremiumSensitivity` | `0.20`, `0.10` | coefficient | UNKNOWN_SOURCE | Portfolio/risk premium response | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
-| `openEcon.pppSpeed` | `0.10` | annual coefficient | Code note bridge: Rogoff 1996 | PPP convergence speed | `.monthly` in FX rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.euTransfers` | `1.458e9` | raw PLN/month | Code note bridge: MFiPR bridge prior | EU transfer monthly flow | Scaled by gdpRatio | `OpenEconConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `openEcon.fdiBase` | `4.963e9` | raw PLN/month | NBP BoP trailing-12-month FDI bridge through January 2026, monthly average converted at model-start FX | Monthly FDI base flow | Scaled by gdpRatio | `OpenEconConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `openEcon.portfolioSensitivity`, `riskPremiumSensitivity` | `0.20, 0.10` | coefficient | UNKNOWN_SOURCE | Portfolio/risk premium response | Direct | `OpenEconConfig` | `TUNED_NEEDS_VALIDATION` |
+| `openEcon.pppSpeed` | `0.10` | annual coefficient | Code note bridge: Rogoff 1996 | PPP convergence speed | .monthly in FX rule | `OpenEconConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fdi.foreignShares` | `[0.15, 0.30, 0.10, 0.03, 0.00, 0.05]` | share by sector | Code note bridge: NBP IIP bridge prior and GUS bridge prior | Foreign-owned firm share by sector | Direct | `FdiConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fdi.profitShiftRate`, `repatriationRate` | `0.15`, `0.70` | share | Code note bridge: FDI outflow calibration | Profit shifting and dividend repatriation | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
-| `fdi.maProb`, `maSizeMin` | `0.001`, `50` | monthly share / employees | UNKNOWN_SOURCE | Domestic firm acquisition probability and eligibility | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `fdi.profitShiftRate`, `repatriationRate` | `0.15, 0.70` | share | Code note bridge: FDI outflow calibration | Profit shifting and dividend repatriation | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `fdi.maProb`, `maSizeMin` | `0.001, 50` | monthly share / employees | UNKNOWN_SOURCE | Domestic firm acquisition probability and eligibility | Direct | `FdiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `gvc.euTradeShare` | `0.70` | share | Code note bridge: GUS/NBP bridge prior | EU share of total trade | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.exportShares` | `[0.05, 0.55, 0.15, 0.03, 0.02, 0.20]` | share by sector | Code note bridge: GUS bridge prior | Sector export shares | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.depth` | `[0.35, 0.75, 0.30, 0.40, 0.10, 0.45]` | share by sector | Code note bridge: WIOD/OECD ICIO | GVC backward linkage | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
-| `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02`, `0.015` | annual rate | Code note bridge: ECB/IMF | Foreign inflation/growth | `.monthly` where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
-| `gvc.commodityVolatility`, `commodityMeanReversion` | `0.015`, `0.08` | monthly sigma / share | #461 GDP-growth calibration | No-shock baseline commodity path; explicit `energy-shock` scenario carries crisis dynamics | Mean-reverting stochastic process plus scenario shock | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
-| `gvc.demandShockMonth`, `commodityShockMonth` | `0`, `0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
-| `immigration.monthlyRate`, `foreignWage` | `0.0008`, `6500` | monthly share / PLN | #461 labor/GDP calibration | Base labor-immigration rate and reference wage; moderated after 48m diagnostics showed the prior pull channel added roughly 3% of represented working-age population per year and over-amplified real GDP catch-up | Direct | `ImmigrationConfig` | `TUNED_NEEDS_VALIDATION` |
+| `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02, 0.015` | annual rate | Code note bridge: ECB/IMF | Foreign inflation/growth | .monthly where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.commodityVolatility`, `commodityMeanReversion` | `0.015, 0.08` | monthly sigma / share | #461 GDP-growth calibration | No-shock baseline commodity path; explicit energy-shock scenario carries crisis dynamics | Mean-reverting stochastic process plus scenario shock | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
+| `gvc.demandShockMonth`, `commodityShockMonth` | `0, 0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
+| `immigration.monthlyRate`, `foreignWage` | `0.0008, 6500` | monthly share / PLN | #461 labor/GDP calibration | Base labor-immigration rate and reference wage; moderated after 48m diagnostics showed the prior pull channel added roughly 3% of represented working-age population per year and over-amplified real GDP catch-up | Direct | `ImmigrationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `immigration.wageElasticity` | `2.0` | coefficient | Code note bridge: NBP 2023 survey | Wage differential migration response | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
 | `immigration.remitRate` | `0.15` | income share | Code note bridge: NBP 2023 | Immigrant remittance outflow | Direct | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
-| `immigration.returnRate`, `returnUnempThreshold`, `returnUnempSensitivity` | `0.005`, `0.20`, `0.10` | monthly share / coefficient | #461 labor-market calibration | Baseline and unemployment-sensitive return migration | Direct | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
+| `immigration.returnRate`, `returnUnempThreshold`, `returnUnempSensitivity` | `0.005, 0.20, 0.10` | monthly share / coefficient | #461 labor-market calibration | Baseline and unemployment-sensitive return migration | Direct | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
 | `immigration.sectorShares` | `[0.05, 0.35, 0.25, 0.05, 0.05, 0.25]` | share by sector | Code note bridge: GUS LFS bridge prior | Immigrant sector allocation | CDF draw | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
 | `immigration.skillMean` | `0.55` | share | #461 labor-market calibration | New immigrant productivity distribution used by job matching | Gaussian draw clamped by education tier | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
 | `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Immigration accumulates from monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
 | `remittance.perCapita` | `40` | PLN/person/month | Code note bridge: NBP BoP bridge prior | Diaspora remittance inflow | Direct | `RemittanceConfig` | `CODE_NOTE_EMPIRICAL` |
-| `tourism.inboundShare`, `outboundShare` | `0.05`, `0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
-| `tourism.seasonality`, `peakMonth` | `0.40`, `7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
-| `equity.initIndex`, `initMcap` | `128508.77`, `1232.99264e9` | index/raw PLN | GPW Benchmark WIG close and GPW domestic-company market capitalization on 2026-04-30 | WIG index and market cap | `initMcap` scaled by `gdpRatio` | `EquityConfig`, `SimParams` | `EMPIRICAL` |
-| `equity.peMean`, `divYield` | `10.0`, `0.057` | scalar/annual rate | Code note bridge: GPW bridge prior | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.inboundShare`, `outboundShare` | `0.05, 0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `tourism.seasonality`, `peakMonth` | `0.40, 7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.initIndex`, `initMcap` | `128508.77, 1232.99264e9` | index/raw PLN | GPW Benchmark WIG close and GPW domestic-company market capitalization on 2026-04-30 | WIG index and market cap | initMcap scaled by gdpRatio | `EquityConfig`, `SimParams` | `EMPIRICAL` |
+| `equity.peMean`, `divYield` | `10.0, 0.057` | scalar/annual rate | Code note bridge: GPW bridge prior | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.foreignShare` | `0.67` | share | Code note bridge: KNF/KDPW bridge prior | Foreign ownership share | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.listedProfitShare` | `0.10` | share | #461 calibration | Listed-company slice of aggregate modeled firm profits | Direct | `EquityConfig`, `EquityMarket` | `TUNED_NEEDS_VALIDATION` |
 | `corpBond.spread` | `0.025` | annual rate | Code note bridge: RRRF bridge prior BBB | Corporate bond spread | Direct | `CorpBondConfig` | `CODE_NOTE_EMPIRICAL` |
-| `corpBond.initStock` | `108.5e9` | raw PLN | Catalyst corporate instruments on 2026-04-30, PLN stock plus EUR stock converted at model-start FX | Corporate bonds outstanding | Scaled by `gdpRatio` | `CorpBondConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `corpBond.initStock` | `108.5e9` | raw PLN | Catalyst corporate instruments on 2026-04-30, PLN stock plus EUR stock converted at model-start FX | Corporate bonds outstanding | Scaled by gdpRatio | `CorpBondConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `corpBond.recovery` | `0.30` | share | UNKNOWN_SOURCE | Corporate bond recovery | Direct | `CorpBondConfig` | `UNKNOWN_SOURCE` |
 
 ## Housing, Prices, Regions, IO, Informal, And SOE
@@ -269,52 +288,52 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `housing.initHpi` | `100` | index | Base-index convention | National HPI starting point | Direct | `HousingConfig` | `ASSUMED` |
-| `housing.initValue` | `7.8e12` | raw PLN | Latest NBP comprehensive residential-property stock estimate | Aggregate housing stock value | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `housing.initMortgage` | `506.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate mortgage stock | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `EMPIRICAL` |
-| `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2`, `-0.8`, `0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.initValue` | `7.8e12` | raw PLN | Latest NBP comprehensive residential-property stock estimate | Aggregate housing stock value | Scaled by gdpRatio | `HousingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `housing.initMortgage` | `506.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate mortgage stock | Scaled by gdpRatio | `HousingConfig`, `SimParams` | `EMPIRICAL` |
+| `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2, -0.8, 0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `housing.mortgageSpread` | `0.025` | annual rate | Code note bridge: NBP bridge prior | Mortgage spread over policy rate | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `housing.mortgageMaturity`, `ltvMax` | `300`, `0.80` | months/share | Code note bridge: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
-| `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003`, `0.001`, `0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `housing.mortgageMaturity`, `ltvMax` | `300, 0.80` | months/share | Code note bridge: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
+| `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003, 0.001, 0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `housing.mortgageRecovery` | `0.70` | share | UNKNOWN_SOURCE | Defaulted mortgage recovery | Direct | `HousingConfig` | `UNKNOWN_SOURCE` |
-| `housing.wealthMpc`, `rentalYield` | `0.05`, `0.045` | share/annual rate | Code note bridge: Case, Quigley and Shiller 2005; Otodom/NBP | Housing wealth consumption effect and rental yield | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `housing.regionalMarkets` | 7 regional rows | vector | Code note bridge: NBP/GUS bridge prior | Regional HPI, value share, mortgage share, income multipliers | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.wealthMpc`, `rentalYield` | `0.05, 0.045` | share/annual rate | Code note bridge: Case, Quigley and Shiller 2005; Otodom/NBP | Housing wealth consumption effect and rental yield | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.regionalMarkets` | `7 regional rows` | vector | Code note bridge: NBP/GUS bridge prior | Regional HPI, value share, mortgage share, income multipliers | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `regional.baseMigrationRate` | `0.005` | monthly share | Code note bridge: GUS bridge prior | Internal migration probability for unemployed workers | Direct | `RegionalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `regional.housingBarrierThreshold` | `0.7` | share | UNKNOWN_SOURCE | Housing-cost migration barrier | Direct | `RegionalConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pricing.calvoTheta` | `0.15` | monthly share | Code note bridge: Alvarez et al. 2006 | Average EU price duration around 6.7 months | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `pricing.baseMarkup` | `1.15` | multiplier | Code note bridge: Polish microdata approximation | Steady-state markup over marginal cost | Direct | `PricingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `pricing.demandSensitivity`, `costPassthrough` | `0.10`, `0.4` | coefficients | #461 calibration | Markup response to demand and cost shocks | Direct | `PricingConfig` | `TUNED_NEEDS_VALIDATION` |
-| `pricing.minMarkup`, `maxMarkup` | `0.95`, `1.50` | multiplier | Structural bounds | Markup floor and ceiling | Direct | `PricingConfig` | `ASSUMED` |
-| `io.matrix` | 6x6 matrix | technical coefficients | 2026-04-30 six-sector IO bridge prior | Inter-sector intermediate demand | Direct | `IoConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.demandSensitivity`, `costPassthrough` | `0.10, 0.4` | coefficients | #461 calibration | Markup response to demand and cost shocks | Direct | `PricingConfig` | `TUNED_NEEDS_VALIDATION` |
+| `pricing.minMarkup`, `maxMarkup` | `0.95, 1.50` | multiplier | Structural bounds | Markup floor and ceiling | Direct | `PricingConfig` | `ASSUMED` |
+| `io.matrix` | `6x6 matrix` | technical coefficients | 2026-04-30 six-sector IO bridge prior | Inter-sector intermediate demand | Direct | `IoConfig` | `TUNED_NEEDS_VALIDATION` |
 | `io.scale` | `1.0` | multiplier | Sensitivity switch | Full-strength I-O flows by default | Direct | `IoConfig` | `POLICY_SCENARIO` |
 | `informal.sectorShares` | `[0.05, 0.15, 0.30, 0.20, 0.02, 0.35]` | share by sector | Code note bridge: Schneider 2023 | Shadow-economy sector shares | Direct | `InformalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `informal.citEvasion`, `vatEvasion`, `pitEvasion`, `exciseEvasion` | `0.50`, `0.30`, `0.40`, `0.30` | share | #461 calibration | Tax evasion rates by tax channel | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
-| `informal.unempThreshold`, `cyclicalSens`, `smoothing` | `0.05`, `0.50`, `0.92` | rate/coefficient | UNKNOWN_SOURCE | Counter-cyclical informal-sector response | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `informal.citEvasion`, `vatEvasion`, `pitEvasion`, `exciseEvasion` | `0.50, 0.30, 0.40, 0.30` | share | #461 calibration | Tax evasion rates by tax channel | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
+| `informal.unempThreshold`, `cyclicalSens`, `smoothing` | `0.05, 0.50, 0.92` | rate/coefficient | UNKNOWN_SOURCE | Counter-cyclical informal-sector response | Direct | `InformalConfig` | `TUNED_NEEDS_VALIDATION` |
 | `soe.baseDividendMultiplier` | `1.3` | multiplier | Code note bridge: MF | Baseline SOE dividend payout versus private firms | Direct | `SoeConfig` | `CODE_NOTE_EMPIRICAL` |
-| `soe.dividendFiscalThreshold`, `dividendFiscalSensitivity` | `0.03`, `5.0` | share/coefficient | UNKNOWN_SOURCE | Fiscal-pressure dividend response | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
-| `soe.firingReduction`, `investmentMultiplier`, `energyPassthrough` | `0.70`, `1.2`, `0.60` | share/multiplier | UNKNOWN_SOURCE | SOE labor buffer, directed investment, energy pass-through | Firing buffer applies to standard workforce adjustment and insolvency downsizing | `SoeConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
+| `soe.dividendFiscalThreshold`, `dividendFiscalSensitivity` | `0.03, 5.0` | share/coefficient | UNKNOWN_SOURCE | Fiscal-pressure dividend response | Direct | `SoeConfig` | `TUNED_NEEDS_VALIDATION` |
+| `soe.firingReduction`, `investmentMultiplier`, `energyPassthrough` | `0.70, 1.2, 0.60` | share/multiplier | UNKNOWN_SOURCE | SOE labor buffer, directed investment, energy pass-through | Firing buffer applies to standard workforce adjustment and insolvency downsizing | `SoeConfig`, `Firm` | `TUNED_NEEDS_VALIDATION` |
 
 ## Non-Bank Financials And Public Funds
 
 | Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `ins.lifeReserves`, `nonLifeReserves` | `76.981e9`, `105.869e9` | raw PLN | KNF insurance financial report, 2025Q4 technical provisions by life and non-life segment | Insurance reserve pools | Scaled by `gdpRatio` | `InsuranceConfig`, `SimParams` | `EMPIRICAL` |
-| `ins.govBondShare`, `corpBondShare`, `equityShare` | `0.35`, `0.08`, `0.12` | share | UNKNOWN_SOURCE | Insurance asset allocation | Portfolio rebalance target | `InsuranceConfig` | `UNKNOWN_SOURCE` |
-| `ins.lifePremiumRate`, `nonLifePremiumRate` | `0.003`, `0.0025` | wage-bill share | UNKNOWN_SOURCE | Insurance premium flow | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
-| `ins.lifeLossRatio`, `nonLifeLossRatio` | `0.85`, `0.70` | share | UNKNOWN_SOURCE | Insurance claims/premiums | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
-| `nbfi.tfiInitAum` | `448.3e9` | raw PLN | Analizy/IZFiA fund assets, March 2026 | TFI AUM | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `EMPIRICAL` |
-| `nbfi.creditInitStock` | `234e9` | raw PLN | ZPL active leasing and leasing-loan portfolio, end-2025 | NBFI credit stock | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40`, `0.10`, `0.10` | share | UNKNOWN_SOURCE | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifeReserves`, `nonLifeReserves` | `76.981e9, 105.869e9` | raw PLN | KNF insurance financial report, 2025Q4 technical provisions by life and non-life segment | Insurance reserve pools | Scaled by gdpRatio | `InsuranceConfig`, `SimParams` | `EMPIRICAL` |
+| `ins.govBondShare`, `corpBondShare`, `equityShare` | `0.35, 0.08, 0.12` | share | UNKNOWN_SOURCE | Insurance asset allocation | Portfolio rebalance target | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifePremiumRate`, `nonLifePremiumRate` | `0.003, 0.0025` | wage-bill share | UNKNOWN_SOURCE | Insurance premium flow | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `ins.lifeLossRatio`, `nonLifeLossRatio` | `0.85, 0.70` | share | UNKNOWN_SOURCE | Insurance claims/premiums | Direct | `InsuranceConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.tfiInitAum` | `448.3e9` | raw PLN | Analizy/IZFiA fund assets, March 2026 | TFI AUM | Scaled by gdpRatio | `NbfiConfig`, `SimParams` | `EMPIRICAL` |
+| `nbfi.creditInitStock` | `234e9` | raw PLN | ZPL active leasing and leasing-loan portfolio, end-2025 | NBFI credit stock | Scaled by gdpRatio | `NbfiConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
+| `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40, 0.10, 0.10` | share | UNKNOWN_SOURCE | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `UNKNOWN_SOURCE` |
 | `nbfi.creditBaseRate` | `0.005` | monthly share | UNKNOWN_SOURCE | NBFI credit origination rate | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
-| `nbfi.creditRate` | `0.10` | annual rate | UNKNOWN_SOURCE | NBFI loan rate | `.monthly` in income | `NbfiConfig` | `UNKNOWN_SOURCE` |
-| `nbfi.defaultBase`, `defaultUnempSens` | `0.002`, `3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `nbfi.creditRate` | `0.10` | annual rate | UNKNOWN_SOURCE | NBFI loan rate | .monthly in income | `NbfiConfig` | `UNKNOWN_SOURCE` |
+| `nbfi.defaultBase`, `defaultUnempSens` | `0.002, 3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `quasiFiscal.issuanceShare` | `0.40` | share | Code note bridge: NIK bridge prior | BGK/PFR share of capital programs | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `quasiFiscal.initBondsOutstanding` | `421.653e9` | raw PLN | MF public-debt release for IV kw. 2025: EDP debt ca. 2335.2 mld PLN less PDP 1913.5 mld PLN; exact bridge retains prior 2335.153 mld PLN EDP baseline | Opening BGK/PFR-style quasi-fiscal stock bridging PDP to ESA/EDP debt | Scaled by `gdpRatio`; added to domestic fiscal debt only in `Esa2010DebtToGdp` | `QuasiFiscalConfig`, `WorldInit`, `McTimeseriesSchema` | `EMPIRICAL_TRANSFORMED` |
-| `quasiFiscal.initNbpBondHoldings` | `106e9` | raw PLN | Code note bridge: NBP COVID quasi-QE purchase stock | Opening NBP holdings of quasi-fiscal bonds | Scaled by `gdpRatio`; residual opening stock is attributed to the bank holder slot | `QuasiFiscalConfig`, `WorldInit` | `CODE_NOTE_EMPIRICAL` |
-| `quasiFiscal.avgMaturityMonths` | `72` | months | Code note bridge: NIK/BGK/PFR | BGK/PFR bond maturity | Amortization `1/maturity` | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.initBondsOutstanding` | `421.653e9` | raw PLN | MF public-debt release for IV kw. 2025: EDP debt ca. 2335.2 mld PLN less PDP 1913.5 mld PLN; exact bridge retains prior 2335.153 mld PLN EDP baseline | Opening BGK/PFR-style quasi-fiscal stock bridging PDP to ESA/EDP debt | Scaled by gdpRatio; added to domestic fiscal debt only in Esa2010DebtToGdp | `QuasiFiscalConfig`, `WorldInit`, `McTimeseriesSchema` | `EMPIRICAL_TRANSFORMED` |
+| `quasiFiscal.initNbpBondHoldings` | `106e9` | raw PLN | Code note bridge: NBP COVID quasi-QE purchase stock | Opening NBP holdings of quasi-fiscal bonds | Scaled by gdpRatio; residual opening stock is attributed to the bank holder slot | `QuasiFiscalConfig`, `WorldInit` | `CODE_NOTE_EMPIRICAL` |
+| `quasiFiscal.avgMaturityMonths` | `72` | months | Code note bridge: NIK/BGK/PFR | BGK/PFR bond maturity | Amortization 1/maturity | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `quasiFiscal.nbpAbsorptionShare` | `0.70` | share | Code note bridge: COVID quasi-QE | NBP absorption under QE | Active when NBP QE active | `QuasiFiscalConfig` | `POLICY_SCENARIO` |
 | `quasiFiscal.lendingShare` | `0.50` | share | Code note bridge: BGK subsidized lending | Lending share of issuance | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `earmarked.fpRate` | `0.0245` | payroll rate | Code note bridge: employment promotion law | Fundusz Pracy levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
-| `earmarked.pfronMonthlyRevenue`, `pfronMonthlySpending` | `460e6`, `420e6` | PLN/month | Code note bridge: PFRON bridge prior | PFRON revenue/spending | Direct, currently unscaled | `EarmarkedConfig` | `CODE_NOTE_EMPIRICAL` |
+| `earmarked.pfronMonthlyRevenue`, `pfronMonthlySpending` | `460e6, 420e6` | PLN/month | Code note bridge: PFRON bridge prior | PFRON revenue/spending | Direct, currently unscaled | `EarmarkedConfig` | `CODE_NOTE_EMPIRICAL` |
 | `earmarked.fgspRate` | `0.001` | payroll rate | Code note bridge: employee claims law | FGSP levy | Direct | `EarmarkedConfig` | `EMPIRICAL` |
 | `earmarked.fgspPayoutPerWorker` | `10000` | PLN/worker | UNKNOWN_SOURCE | Bankruptcy wage payout | Direct | `EarmarkedConfig` | `UNKNOWN_SOURCE` |
 
@@ -323,7 +342,7 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 Use the following commands to audit open provenance gaps:
 
 ```bash
-rg "UNKNOWN_SOURCE|TUNED_NEEDS_VALIDATION|ASSUMED|PLACEHOLDER|EMPIRICAL_TRANSFORMED|POLICY_SCENARIO" docs/calibration-register.md
+rg "UNKNOWN_SOURCE|TUNED_NEEDS_VALIDATION|ASSUMED|PLACEHOLDER|EMPIRICAL_TRANSFORMED|POLICY_SCENARIO" src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala docs/calibration-register.md
 ```
 
 Priority gaps before publication:

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -235,7 +235,7 @@ object CalibrationProvenance:
 | `io.crossSectorSpillover` | `0.65` | share | #461 GDP-growth calibration | Substitutable share of unmet sector demand | I-O-weighted partial spillover inside `DemandEconomics.applySpillover` | `DemandEconomics`, `IoConfig` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.govInvestShare` | `0.20` | share | Code note bridge: MF bridge prior | Capital share of government spending | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.govCapitalMultiplier`, `govCurrentMultiplier` | `1.5`, `0.8` | multiplier | Code note bridge: Ilzetzki, Mendoza and Vegh 2013 | Fiscal multipliers | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govInitCapital` | `0` | PLN | Explicit startup simplification | Initial public capital stock | Built from investment flows | `FiscalConfig` | `PLACEHOLDER` |
+| `fiscal.govInitCapital` | `2332e9` | raw PLN | #461 fiscal-investment/GDP calibration | Initial public capital stock | Scaled by `gdpRatio` in `SimParams.defaults`; seeded into `WorldInit` public capital stock | `FiscalConfig`, `SimParams`, `WorldInit` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.euFundsTotalEur`, `euFundsAlpha`, `euFundsBeta` | `110e9`, `2`, `3` | EUR / beta shape | #461 GDP-growth calibration | EU cohesion plus KPO-style investment absorption window | Beta absorption path | `FiscalConfig`, `EuFunds` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.euCofinanceRate`, `euCapitalShare` | `0.15`, `0.60` | share | Code note bridge: MFiPR / EU funds | National cofinance and capex split | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.minWageTargetRatio` | `0.50` | share | Code note bridge: minimum wage act | Target minimum/average wage ratio | Annual adjustment | `FiscalConfig` | `EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
@@ -1,0 +1,220 @@
+package com.boombustgroup.amorfati.config
+
+object CalibrationRegisterRenderer:
+
+  import CalibrationProvenance.*
+
+  private val ParameterHeader: Vector[String] = Vector(
+    "| Parameter | Value | Unit | Source / provenance | Empirical target | Transformation | Owner module | Status |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+  )
+
+  private val Sections: Vector[(String, CalibrationParameter => Boolean)] = Vector(
+    "Core Scale And Sectors"                          -> { parameter =>
+      hasId(parameter, "household.count") ||
+      hasId(parameter, "gdpRatio") ||
+      hasId(parameter, "topology") ||
+      hasPrefix(parameter, "pop.", "sectorDefs")
+    },
+    "Household And Labor"                             -> { parameter =>
+      hasPrefix(parameter, "household.", "labor.", "social.") &&
+      !hasId(parameter, "household.count")
+    },
+    "Firm Production, Entry, Capital, And Climate"    -> { parameter =>
+      hasPrefix(parameter, "firm.", "capital.", "climate.")
+    },
+    "Fiscal, Monetary, And Banking"                   -> { parameter =>
+      hasPrefix(parameter, "fiscal.", "monetary.", "banking.") ||
+      hasId(parameter, "io.crossSectorSpillover")
+    },
+    "External Sector And Financial Markets"           -> { parameter =>
+      hasPrefix(parameter, "forex.", "openEcon.", "fdi.", "gvc.", "immigration.", "remittance.", "tourism.", "equity.", "corpBond.") ||
+      hasId(parameter, "priceLevel.importPush")
+    },
+    "Housing, Prices, Regions, IO, Informal, And SOE" -> { parameter =>
+      hasPrefix(parameter, "housing.", "regional.", "pricing.", "informal.", "soe.") ||
+      (hasPrefix(parameter, "io.") && !hasId(parameter, "io.crossSectorSpillover"))
+    },
+    "Non-Bank Financials And Public Funds"            -> { parameter =>
+      hasPrefix(parameter, "ins.", "nbfi.", "quasiFiscal.", "earmarked.")
+    },
+  )
+
+  def render(parameters: Vector[CalibrationParameter] = CalibrationProvenance.Baseline.parameters): String =
+    validateSectionCoverage(parameters)
+    val lines = Vector.newBuilder[String]
+    lines ++= header
+    lines ++= statusTaxonomy
+    lines ++= statusCounts(parameters)
+    lines ++= transformationRules
+    Sections.foreach: (title, predicate) =>
+      val sectionParameters = parameters.filter(predicate)
+      if sectionParameters.nonEmpty then
+        lines += s"## $title"
+        lines += ""
+        lines ++= ParameterHeader
+        sectionParameters.foreach(parameter => lines += renderParameter(parameter))
+        lines += ""
+    lines ++= searchableGaps
+    lines.result().mkString("\n") + "\n"
+
+  private def header: Vector[String] =
+    Vector(
+      "# Calibration Register",
+      "",
+      "This register records the current calibration surface of Amor Fati. It is a",
+      "paper-facing inventory of key parameters, their implementation owner, value,",
+      "unit, provenance, empirical target, transformation, and calibration status.",
+      "",
+      "Production defaults are calibrated directly to the Poland snapshot as of",
+      "2026-04-30. There is no alternate baseline profile in the production parameter",
+      "surface.",
+      "",
+      "The register is generated from `CalibrationProvenance.Baseline`; edit the",
+      "typed provenance registry first, then regenerate this Markdown artifact with",
+      "`sbt calibrationRegister`.",
+      "",
+      "The register is intentionally useful before every value has a final data",
+      "source. Missing or weak provenance is marked explicitly with searchable tokens:",
+      "`UNKNOWN_SOURCE`, `TUNED_NEEDS_VALIDATION`, `ASSUMED`, `PLACEHOLDER`,",
+      "`EMPIRICAL_TRANSFORMED`, or `POLICY_SCENARIO`.",
+      "",
+    )
+
+  private def statusTaxonomy: Vector[String] =
+    Vector(
+      "## Status Taxonomy",
+      "",
+      "| Status | Meaning |",
+      "| --- | --- |",
+    ) ++ CalibrationStatus.values.toVector.map(status => s"| `${status.token}` | ${statusMeaning(status)} |") :+
+      ""
+
+  private def statusCounts(parameters: Vector[CalibrationParameter]): Vector[String] =
+    val counts = parameters.groupMapReduce(_.status)(_ => 1)(_ + _)
+    Vector(
+      "## Status Counts",
+      "",
+      "These counts are rendered from `CalibrationProvenance.Baseline` at generation time.",
+      "",
+      "| Status | Count |",
+      "| --- | --- |",
+    ) ++ CalibrationStatus.values.toVector.map(status => s"| `${status.token}` | ${counts.getOrElse(status, 0)} |") :+
+      ""
+
+  private def transformationRules: Vector[String] =
+    Vector(
+      "## Transformation Rules",
+      "",
+      "- Raw PLN stock values in config classes are scaled by `SimParams.gdpRatio` in",
+      "  `SimParams.defaults` when they represent macro stocks or monthly macro flows.",
+      "- Agent-level monetary values such as wages, rents, firm costs, and per-worker",
+      "  values are not scaled by `gdpRatio`.",
+      "- Rates are annual unless the consuming rule applies `.monthly`.",
+      "- Vector parameters generally follow the six-sector order:",
+      "  `BPO/SSC`, `Manufacturing`, `Retail/Services`, `Healthcare`, `Public`,",
+      "  `Agriculture`.",
+      "- Runtime numeric evidence comes from Monte Carlo output columns in",
+      "  `McTimeseriesSchema`; this register documents parameter provenance, not run",
+      "  results. Empirical validation targets and output mappings are documented in",
+      "  `docs/empirical-validation-report.md`.",
+      "- External source selection, unit/frequency conversion, sector/instrument",
+      "  crosswalks, source vintages, license/reuse notes, and prioritized empirical",
+      "  gaps are documented in",
+      "  `docs/data-bridge-national-financial-accounts.md`.",
+      "",
+    )
+
+  private def searchableGaps: Vector[String] =
+    Vector(
+      "## Searchable Gaps",
+      "",
+      "Use the following commands to audit open provenance gaps:",
+      "",
+      "```bash",
+      "rg \"UNKNOWN_SOURCE|TUNED_NEEDS_VALIDATION|ASSUMED|PLACEHOLDER|EMPIRICAL_TRANSFORMED|POLICY_SCENARIO\" src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala docs/calibration-register.md",
+      "```",
+      "",
+      "Priority gaps before publication:",
+      "",
+      "- Replace `UNKNOWN_SOURCE` rows with source table, year, and transformation",
+      "  notes.",
+      "- Split `CODE_NOTE_EMPIRICAL` rows into source-specific evidence links once",
+      "  the data bridge identifies the target source family and extraction rule.",
+      "- Validate `TUNED_NEEDS_VALIDATION` coefficients with point-in-time validation,",
+      "  stylized-fact matching, or sensitivity ranges.",
+      "- Decide whether currently unscaled institutional monthly flows, such as PFRON",
+      "  monthly revenue/spending, should remain agent-scale values or be moved into",
+      "  the `gdpRatio`-scaled macro-stock convention.",
+      "- Keep scenario deltas in `docs/scenario-registry.md`; this register remains",
+      "  the baseline parameter-provenance surface.",
+    )
+
+  private def renderParameter(parameter: CalibrationParameter): String =
+    Vector(
+      renderParameterIds(parameter.parameterIds),
+      codeCell(parameter.renderedValue),
+      plainCell(parameter.unit),
+      plainCell(parameter.provenance),
+      plainCell(parameter.empiricalTarget),
+      plainCell(parameter.transformation),
+      parameter.ownerModules.map(codeCell).mkString(", "),
+      codeCell(parameter.status.token),
+    ).mkString("| ", " | ", " |")
+
+  private def renderParameterIds(ids: Vector[String]): String =
+    val prefix = ids.headOption.flatMap: id =>
+      val dotIndex = id.lastIndexOf('.')
+      if dotIndex < 0 then None else Some(id.take(dotIndex + 1))
+
+    ids.zipWithIndex
+      .map: (id, index) =>
+        val rendered =
+          if index == 0 then id
+          else prefix.filter(id.startsWith).fold(id)(prefix => id.drop(prefix.length))
+        codeCell(rendered)
+      .mkString(", ")
+
+  private def statusMeaning(status: CalibrationStatus): String =
+    status match
+      case CalibrationStatus.Empirical            =>
+        "Direct statutory, institutional, or data-note target is documented in code comments."
+      case CalibrationStatus.EmpiricalTransformed =>
+        "Institutional/data target transformed to match the model perimeter or units."
+      case CalibrationStatus.CodeNoteEmpirical    =>
+        "Code comments name source institution/year, but no source table or URL is attached yet."
+      case CalibrationStatus.Assumed              =>
+        "Structural modeling assumption or stylized calibration."
+      case CalibrationStatus.TunedNeedsValidation =>
+        "Behavioral/dynamic coefficient chosen for model behavior; needs sensitivity and validation work."
+      case CalibrationStatus.PolicyScenario       =>
+        "Scenario/shock switch or policy parameter, not a baseline empirical estimate."
+      case CalibrationStatus.Placeholder          =>
+        "Explicit placeholder or simplified value awaiting data bridge."
+      case CalibrationStatus.UnknownSource        =>
+        "Parameter is active in the model but final provenance is not yet documented."
+
+  private def hasId(parameter: CalibrationParameter, id: String): Boolean =
+    parameter.parameterIds.contains(id)
+
+  private def hasPrefix(parameter: CalibrationParameter, prefixes: String*): Boolean =
+    parameter.parameterIds.exists(parameterId => prefixes.exists(parameterId.startsWith))
+
+  private def validateSectionCoverage(parameters: Vector[CalibrationParameter]): Unit =
+    val unmatched = parameters.filter: parameter =>
+      !Sections.exists { case (_, predicate) => predicate(parameter) }
+    val repeated  = parameters.filter: parameter =>
+      Sections.count { case (_, predicate) => predicate(parameter) } > 1
+    require(unmatched.isEmpty, s"Unsectioned calibration parameters: ${unmatched.map(_.id).mkString(", ")}")
+    require(repeated.isEmpty, s"Calibration parameters matched multiple sections: ${repeated.map(_.id).mkString(", ")}")
+
+  private def plainCell(value: String): String =
+    escapeCell(value)
+
+  private def codeCell(value: String): String =
+    s"`${escapeCell(value)}`"
+
+  private def escapeCell(value: String): String =
+    value.replace("\n", " ").replace("|", "\\|")
+
+end CalibrationRegisterRenderer

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
@@ -1,0 +1,47 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.CalibrationRegisterRenderer
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.util.Try
+
+object CalibrationRegisterExport:
+
+  final case class Config(out: Path = Path.of("docs/calibration-register.md"))
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)   =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(path) =>
+            println(path.toString)
+
+  def run(config: Config): Either[String, Path] =
+    Try {
+      val parent = config.out.getParent
+      if parent != null then Files.createDirectories(parent)
+      Files.writeString(config.out, CalibrationRegisterRenderer.render(), StandardCharsets.UTF_8)
+      config.out
+    }.toEither.left.map(error => s"Failed to write calibration register: ${error.getMessage}")
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    args match
+      case Vector()                                  => Right(Config())
+      case Vector("--out", path)                     => Right(Config(Path.of(path)))
+      case Vector("--help")                          => Left(usage)
+      case Vector(flag, _*) if flag.startsWith("--") =>
+        Left(s"Unknown argument: $flag")
+      case Vector(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+  private val usage: String =
+    "Usage: sbt 'calibrationRegister [--out docs/calibration-register.md]'"
+
+end CalibrationRegisterExport

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
@@ -36,6 +36,7 @@ object CalibrationRegisterExport:
     args match
       case Vector()                                  => Right(Config())
       case Vector("--out", path)                     => Right(Config(Path.of(path)))
+      case Vector("--out")                           => Left("Missing path for --out")
       case Vector("--help")                          => Left(usage)
       case Vector(flag, _*) if flag.startsWith("--") =>
         Left(s"Unknown argument: $flag")

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExport.scala
@@ -10,13 +10,19 @@ object CalibrationRegisterExport:
 
   final case class Config(out: Path = Path.of("docs/calibration-register.md"))
 
+  enum CliCommand:
+    case Export(config: Config)
+    case Help
+
   def main(args: Array[String]): Unit =
     parseArgs(args.toVector) match
-      case Left(err)     =>
+      case Left(err)                        =>
         Console.err.println(err)
         Console.err.println(usage)
         sys.exit(2)
-      case Right(config) =>
+      case Right(CliCommand.Help)           =>
+        println(usage)
+      case Right(CliCommand.Export(config)) =>
         run(config) match
           case Left(err)   =>
             Console.err.println(err)
@@ -32,12 +38,12 @@ object CalibrationRegisterExport:
       config.out
     }.toEither.left.map(error => s"Failed to write calibration register: ${error.getMessage}")
 
-  def parseArgs(args: Vector[String]): Either[String, Config] =
+  def parseArgs(args: Vector[String]): Either[String, CliCommand] =
     args match
-      case Vector()                                  => Right(Config())
-      case Vector("--out", path)                     => Right(Config(Path.of(path)))
+      case Vector()                                  => Right(CliCommand.Export(Config()))
+      case Vector("--out", path)                     => Right(CliCommand.Export(Config(Path.of(path))))
       case Vector("--out")                           => Left("Missing path for --out")
-      case Vector("--help")                          => Left(usage)
+      case Vector("--help")                          => Right(CliCommand.Help)
       case Vector(flag, _*) if flag.startsWith("--") =>
         Left(s"Unknown argument: $flag")
       case Vector(value, _*)                         => Left(s"Unexpected positional argument: $value")

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -42,9 +42,9 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 35)
     CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 12)
     CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 67)
-    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 84)
+    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 85)
     CalibrationProvenance.Baseline.statusCounts should contain(UnknownSource -> 20)
-    CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 2)
+    CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 1)
     CalibrationProvenance.Baseline.statusCounts should contain(Assumed -> 11)
     CalibrationProvenance.Baseline.statusCounts should contain(PolicyScenario -> 7)
   }
@@ -87,13 +87,20 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "infer exemptions for structural, scenario, and startup-placeholder rows" in {
-    val bufferTarget = baselineParameter("household.bufferTargetMonths")
-    val riskOff      = baselineParameter("forex.riskOffShockMonth")
-    val govCapital   = baselineParameter("fiscal.govInitCapital")
+    val bufferTarget   = baselineParameter("household.bufferTargetMonths")
+    val riskOff        = baselineParameter("forex.riskOffShockMonth")
+    val govCapital     = baselineParameter("fiscal.govInitCapital")
+    val immigrantStock = baselineParameter("immigration.initStock")
 
     bufferTarget.effectiveExemption shouldBe Some(StructuralAssumption)
     riskOff.effectiveExemption shouldBe Some(ScenarioSwitch)
-    govCapital.effectiveExemption shouldBe Some(StartupPlaceholder)
+    immigrantStock.effectiveExemption shouldBe Some(StartupPlaceholder)
+    govCapital.status shouldBe TunedNeedsValidation
+    govCapital.renderedValue shouldBe "2332e9"
+    govCapital.ownerModules should contain("FiscalConfig")
+    govCapital.ownerModules should contain("SimParams")
+    govCapital.ownerModules should contain("WorldInit")
+    govCapital.effectiveExemption shouldBe None
   }
 
 end CalibrationProvenanceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
@@ -1,0 +1,28 @@
+package com.boombustgroup.amorfati.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+class CalibrationRegisterRendererSpec extends AnyFlatSpec with Matchers:
+
+  import CalibrationProvenance.CalibrationStatus
+
+  "CalibrationRegisterRenderer" should "match the checked-in calibration register" in {
+    val rendered  = CalibrationRegisterRenderer.render()
+    val checkedIn = Files.readString(Path.of("docs/calibration-register.md"), StandardCharsets.UTF_8)
+
+    checkedIn shouldBe rendered
+  }
+
+  it should "render status counts from the typed registry" in {
+    val rendered = CalibrationRegisterRenderer.render()
+    val counts   = CalibrationProvenance.Baseline.statusCounts
+
+    CalibrationStatus.values.foreach: status =>
+      rendered should include(s"| `${status.token}` | ${counts.getOrElse(status, 0)} |")
+  }
+
+end CalibrationRegisterRendererSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExportSpec.scala
@@ -7,10 +7,16 @@ import java.nio.file.Path
 
 class CalibrationRegisterExportSpec extends AnyFlatSpec with Matchers:
 
+  import CalibrationRegisterExport.CliCommand
+
   "CalibrationRegisterExport" should "parse CLI output path arguments" in {
-    CalibrationRegisterExport.parseArgs(Vector()) shouldBe Right(CalibrationRegisterExport.Config())
+    CalibrationRegisterExport.parseArgs(Vector()) shouldBe Right(CliCommand.Export(CalibrationRegisterExport.Config()))
     CalibrationRegisterExport.parseArgs(Vector("--out", "target/register.md")) shouldBe
-      Right(CalibrationRegisterExport.Config(out = Path.of("target/register.md")))
+      Right(CliCommand.Export(CalibrationRegisterExport.Config(out = Path.of("target/register.md"))))
+  }
+
+  it should "parse help as a successful command" in {
+    CalibrationRegisterExport.parseArgs(Vector("--help")) shouldBe Right(CliCommand.Help)
   }
 
   it should "report a missing output path" in {

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/CalibrationRegisterExportSpec.scala
@@ -1,0 +1,20 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Path
+
+class CalibrationRegisterExportSpec extends AnyFlatSpec with Matchers:
+
+  "CalibrationRegisterExport" should "parse CLI output path arguments" in {
+    CalibrationRegisterExport.parseArgs(Vector()) shouldBe Right(CalibrationRegisterExport.Config())
+    CalibrationRegisterExport.parseArgs(Vector("--out", "target/register.md")) shouldBe
+      Right(CalibrationRegisterExport.Config(out = Path.of("target/register.md")))
+  }
+
+  it should "report a missing output path" in {
+    CalibrationRegisterExport.parseArgs(Vector("--out")) shouldBe Left("Missing path for --out")
+  }
+
+end CalibrationRegisterExportSpec


### PR DESCRIPTION
Closes #483
Refs #458

Summary:
- add a renderer/export path for docs/calibration-register.md from CalibrationProvenance.Baseline
- include generated status counts and drift coverage against the checked-in Markdown
- reconcile fiscal.govInitCapital with SimParams.defaults, leaving immigration.initStock as the remaining placeholder

Validation:
- sbt scalafmtAll
- sbt calibrationRegister
- sbt "testOnly com.boombustgroup.amorfati.config.CalibrationProvenanceSpec com.boombustgroup.amorfati.config.CalibrationRegisterRendererSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an sbt command to generate the calibration register Markdown from the typed provenance registry.
  * Added a standalone export utility to write the generated register to disk.

* **Documentation**
  * Fully refreshed calibration register: expanded tables across sectors, households, fiscal, and external/financial sections.
  * Added a “Status Counts” table and explicit regen instructions.

* **Tests**
  * Added tests validating register rendering and CLI arg parsing; updated provenance expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->