### PR TITLE
Document startup placeholder decisions

### DIFF
--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -27,7 +27,7 @@ source. Missing or weak provenance is marked explicitly with searchable tokens:
 | `ASSUMED` | Structural modeling assumption or stylized calibration. |
 | `TUNED_NEEDS_VALIDATION` | Behavioral/dynamic coefficient chosen for model behavior; needs sensitivity and validation work. |
 | `POLICY_SCENARIO` | Scenario/shock switch or policy parameter, not a baseline empirical estimate. |
-| `PLACEHOLDER` | Explicit placeholder or simplified value awaiting data bridge. |
+| `PLACEHOLDER` | Explicit placeholder or simplified value with a typed decision and follow-up path. |
 | `UNKNOWN_SOURCE` | Parameter is active in the model but final provenance is not yet documented. |
 
 ## Status Counts
@@ -44,6 +44,14 @@ These counts are rendered from `CalibrationProvenance.Baseline` at generation ti
 | `POLICY_SCENARIO` | 7 |
 | `PLACEHOLDER` | 1 |
 | `UNKNOWN_SOURCE` | 20 |
+
+## Placeholder Decisions
+
+Remaining placeholders are explicit startup decisions carried in typed provenance metadata.
+
+| Parameter | Decision | Reason | Validation impact | Follow-up path |
+| --- | --- | --- | --- | --- |
+| `immigration.initStock` | `StartupPlaceholder` | The baseline starts with zero immigrant households; migration enters through monthly inflow dynamics. | Opening migration-stock comparisons are not meaningful until a data-bridge initial stock is added. | Add a data-bridge initial stock for immigrant households before validating opening migration-stock levels. |
 
 ## Transformation Rules
 
@@ -271,7 +279,7 @@ These counts are rendered from `CalibrationProvenance.Baseline` at generation ti
 | `immigration.returnRate`, `returnUnempThreshold`, `returnUnempSensitivity` | `0.005, 0.20, 0.10` | monthly share / coefficient | #461 labor-market calibration | Baseline and unemployment-sensitive return migration | Direct | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
 | `immigration.sectorShares` | `[0.05, 0.35, 0.25, 0.05, 0.05, 0.25]` | share by sector | Code note bridge: GUS LFS bridge prior | Immigrant sector allocation | CDF draw | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
 | `immigration.skillMean` | `0.55` | share | #461 labor-market calibration | New immigrant productivity distribution used by job matching | Gaussian draw clamped by education tier | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
-| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Immigration accumulates from monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
+| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Zero opening stock; migration enters through monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
 | `remittance.perCapita` | `40` | PLN/person/month | Code note bridge: NBP BoP bridge prior | Diaspora remittance inflow | Direct | `RemittanceConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.inboundShare`, `outboundShare` | `0.05, 0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.seasonality`, `peakMonth` | `0.40, 7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -51,6 +51,14 @@ object CalibrationProvenance:
     private def cleanToken(value: String): String =
       value.trim.stripPrefix("`").stripSuffix("`")
 
+  final case class PlaceholderDecision(
+      parameterId: String,
+      decision: CalibrationExemptionKind,
+      reason: String,
+      validationImpact: String,
+      followUpPath: String,
+  )
+
   final case class CalibrationParameter(
       id: String,
       parameterIds: Vector[String],
@@ -63,6 +71,7 @@ object CalibrationProvenance:
       status: CalibrationStatus,
       validationPath: Option[String] = None,
       exemption: Option[CalibrationExemptionKind] = None,
+      placeholderDecision: Option[PlaceholderDecision] = None,
   ):
     def effectiveExemption: Option[CalibrationExemptionKind] =
       exemption.orElse(status.inferredExemption)
@@ -92,6 +101,15 @@ object CalibrationProvenance:
     def rowsWithStatus(status: CalibrationStatus): Vector[CalibrationParameter] =
       parameters.filter(_.status == status)
 
+    lazy val placeholderDecisions: Vector[PlaceholderDecision] =
+      rowsWithStatus(CalibrationStatus.Placeholder).flatMap(_.placeholderDecision)
+
+    lazy val placeholderDecisionErrors: Vector[String] =
+      val placeholderIds = rowsWithStatus(CalibrationStatus.Placeholder).map(_.id).toSet
+      val decisionIds    = placeholderDecisionById.keySet
+      (placeholderIds -- decisionIds).toVector.sorted.map(id => s"Missing placeholder decision for $id") ++
+        (decisionIds -- placeholderIds).toVector.sorted.map(id => s"Placeholder decision is stale for non-placeholder $id")
+
     private def parseRow(line: String): Either[String, CalibrationParameter] =
       val cells = line.trim.stripPrefix("|").stripSuffix("|").split("\\|", -1).iterator.map(_.trim).toVector
       if cells.length != 8 then Left(s"Expected 8 calibration columns, got ${cells.length}: $line")
@@ -111,7 +129,19 @@ object CalibrationProvenance:
           transformation = stripCode(cells(5)),
           ownerModules = ownerModules,
           status = status,
+          placeholderDecision = placeholderDecisionById.get(id),
         )
+
+    private val placeholderDecisionById: Map[String, PlaceholderDecision] =
+      Vector(
+        PlaceholderDecision(
+          parameterId = "immigration.initStock",
+          decision = CalibrationExemptionKind.StartupPlaceholder,
+          reason = "The baseline starts with zero immigrant households; migration enters through monthly inflow dynamics.",
+          validationImpact = "Opening migration-stock comparisons are not meaningful until a data-bridge initial stock is added.",
+          followUpPath = "Add a data-bridge initial stock for immigrant households before validating opening migration-stock levels.",
+        ),
+      ).map(decision => decision.parameterId -> decision).toMap
 
     private def splitCodeList(value: String): Vector[String] =
       stripCode(value)
@@ -320,7 +350,7 @@ object CalibrationProvenance:
 | `immigration.returnRate`, `returnUnempThreshold`, `returnUnempSensitivity` | `0.005`, `0.20`, `0.10` | monthly share / coefficient | #461 labor-market calibration | Baseline and unemployment-sensitive return migration | Direct | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
 | `immigration.sectorShares` | `[0.05, 0.35, 0.25, 0.05, 0.05, 0.25]` | share by sector | Code note bridge: GUS LFS bridge prior | Immigrant sector allocation | CDF draw | `ImmigrationConfig` | `CODE_NOTE_EMPIRICAL` |
 | `immigration.skillMean` | `0.55` | share | #461 labor-market calibration | New immigrant productivity distribution used by job matching | Gaussian draw clamped by education tier | `ImmigrationConfig`, `Immigration` | `TUNED_NEEDS_VALIDATION` |
-| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Immigration accumulates from monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
+| `immigration.initStock` | `0` | agents | Explicit startup simplification | Initial immigrant stock | Zero opening stock; migration enters through monthly flows | `ImmigrationConfig` | `PLACEHOLDER` |
 | `remittance.perCapita` | `40` | PLN/person/month | Code note bridge: NBP BoP bridge prior | Diaspora remittance inflow | Direct | `RemittanceConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.inboundShare`, `outboundShare` | `0.05`, `0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.seasonality`, `peakMonth` | `0.40`, `7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -129,7 +129,9 @@ object CalibrationProvenance:
           transformation = stripCode(cells(5)),
           ownerModules = ownerModules,
           status = status,
-          placeholderDecision = placeholderDecisionById.get(id),
+          placeholderDecision =
+            if status == CalibrationStatus.Placeholder then placeholderDecisionById.get(id)
+            else None,
         )
 
     private val placeholderDecisionById: Map[String, PlaceholderDecision] =

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
@@ -46,6 +46,7 @@ object CalibrationRegisterRenderer:
     lines ++= header
     lines ++= statusTaxonomy
     lines ++= statusCounts(parameters)
+    lines ++= placeholderDecisions(parameters)
     lines ++= transformationRules
     Sections.foreach: (title, predicate) =>
       val sectionParameters = parameters.filter(predicate)
@@ -190,9 +191,32 @@ object CalibrationRegisterRenderer:
       case CalibrationStatus.PolicyScenario       =>
         "Scenario/shock switch or policy parameter, not a baseline empirical estimate."
       case CalibrationStatus.Placeholder          =>
-        "Explicit placeholder or simplified value awaiting data bridge."
+        "Explicit placeholder or simplified value with a typed decision and follow-up path."
       case CalibrationStatus.UnknownSource        =>
         "Parameter is active in the model but final provenance is not yet documented."
+
+  private def placeholderDecisions(parameters: Vector[CalibrationParameter]): Vector[String] =
+    val decisions = parameters.filter(_.status == CalibrationStatus.Placeholder).flatMap(_.placeholderDecision)
+    if decisions.isEmpty then Vector.empty
+    else
+      Vector(
+        "## Placeholder Decisions",
+        "",
+        "Remaining placeholders are explicit startup decisions carried in typed provenance metadata.",
+        "",
+        "| Parameter | Decision | Reason | Validation impact | Follow-up path |",
+        "| --- | --- | --- | --- | --- |",
+      ) ++ decisions.map(renderPlaceholderDecision) :+
+        ""
+
+  private def renderPlaceholderDecision(decision: PlaceholderDecision): String =
+    Vector(
+      codeCell(decision.parameterId),
+      codeCell(decision.decision.toString),
+      plainCell(decision.reason),
+      plainCell(decision.validationImpact),
+      plainCell(decision.followUpPath),
+    ).mkString("| ", " | ", " |")
 
   private def hasId(parameter: CalibrationParameter, id: String): Boolean =
     parameter.parameterIds.contains(id)

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
@@ -196,7 +196,13 @@ object CalibrationRegisterRenderer:
         "Parameter is active in the model but final provenance is not yet documented."
 
   private def placeholderDecisions(parameters: Vector[CalibrationParameter]): Vector[String] =
-    val decisions = parameters.filter(_.status == CalibrationStatus.Placeholder).flatMap(_.placeholderDecision)
+    val placeholders = parameters.filter(_.status == CalibrationStatus.Placeholder)
+    val missing      = placeholders.filter(_.placeholderDecision.isEmpty)
+    require(
+      missing.isEmpty,
+      s"Missing placeholder decision for calibration parameter(s): ${missing.map(_.id).mkString(", ")}",
+    )
+    val decisions    = placeholders.flatMap(_.placeholderDecision)
     if decisions.isEmpty then Vector.empty
     else
       Vector(

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -103,4 +103,20 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     govCapital.effectiveExemption shouldBe None
   }
 
+  it should "make remaining placeholder decisions visible as typed metadata" in {
+    val placeholders = CalibrationProvenance.Baseline.rowsWithStatus(Placeholder)
+
+    placeholders.map(_.id) shouldBe Vector("immigration.initStock")
+    CalibrationProvenance.Baseline.placeholderDecisionErrors shouldBe empty
+
+    val decision = CalibrationProvenance.Baseline.placeholderDecisions.headOption
+      .getOrElse(fail("Expected typed placeholder decision for immigration.initStock"))
+    decision.parameterId shouldBe "immigration.initStock"
+    decision.decision shouldBe StartupPlaceholder
+    decision.reason should include("zero immigrant households")
+    decision.validationImpact should include("Opening migration-stock comparisons")
+    decision.followUpPath should include("data-bridge initial stock")
+    placeholders.head.placeholderDecision shouldBe Some(decision)
+  }
+
 end CalibrationProvenanceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -117,6 +117,9 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     decision.validationImpact should include("Opening migration-stock comparisons")
     decision.followUpPath should include("data-bridge initial stock")
     placeholders.head.placeholderDecision shouldBe Some(decision)
+    CalibrationProvenance.Baseline.parameters
+      .filterNot(_.status == Placeholder)
+      .flatMap(_.placeholderDecision) shouldBe empty
   }
 
 end CalibrationProvenanceSpec

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
@@ -33,4 +33,24 @@ class CalibrationRegisterRendererSpec extends AnyFlatSpec with Matchers:
     rendered should include("Opening migration-stock comparisons")
   }
 
+  it should "fail fast when a placeholder row lacks typed decision metadata" in {
+    val brokenPlaceholder = CalibrationProvenance.CalibrationParameter(
+      id = "immigration.initStock",
+      parameterIds = Vector("immigration.initStock"),
+      renderedValue = "0",
+      unit = "agents",
+      provenance = "test",
+      empiricalTarget = "test",
+      transformation = "test",
+      ownerModules = Vector("ImmigrationConfig"),
+      status = CalibrationProvenance.CalibrationStatus.Placeholder,
+    )
+
+    val thrown = intercept[IllegalArgumentException]:
+      CalibrationRegisterRenderer.render(Vector(brokenPlaceholder))
+
+    thrown.getMessage should include("Missing placeholder decision")
+    thrown.getMessage should include("immigration.initStock")
+  }
+
 end CalibrationRegisterRendererSpec

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
@@ -25,4 +25,12 @@ class CalibrationRegisterRendererSpec extends AnyFlatSpec with Matchers:
       rendered should include(s"| `${status.token}` | ${counts.getOrElse(status, 0)} |")
   }
 
+  it should "render typed placeholder decisions" in {
+    val rendered = CalibrationRegisterRenderer.render()
+
+    rendered should include("## Placeholder Decisions")
+    rendered should include("| `immigration.initStock` | `StartupPlaceholder` |")
+    rendered should include("Opening migration-stock comparisons")
+  }
+
 end CalibrationRegisterRendererSpec


### PR DESCRIPTION
Closes #484
Refs #458
Stacked on #496

Summary:
- adds typed placeholder-decision metadata for the remaining immigration.initStock startup placeholder
- renders placeholder decisions in the generated calibration register
- adds tests that expose remaining PLACEHOLDER rows and verify their reason, validation impact, and follow-up path without grepping Markdown

Validation:
- sbt scalafmtAll
- sbt calibrationRegister
- sbt "testOnly com.boombustgroup.amorfati.config.CalibrationProvenanceSpec com.boombustgroup.amorfati.config.CalibrationRegisterRendererSpec com.boombustgroup.amorfati.diagnostics.CalibrationRegisterExportSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Placeholder calibration parameters now display as typed startup decisions with documented rationales, validation impacts, and follow-up paths in the calibration register.

* **Documentation**
  * Enhanced placeholder parameter documentation with clarified status definitions and decision tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->