### PR TITLE
Upgrade CODE_NOTE_EMPIRICAL calibration provenance

### DIFF
--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -36,9 +36,9 @@ These counts are rendered from `CalibrationProvenance.Baseline` at generation ti
 
 | Status | Count |
 | --- | --- |
-| `EMPIRICAL` | 35 |
-| `EMPIRICAL_TRANSFORMED` | 12 |
-| `CODE_NOTE_EMPIRICAL` | 67 |
+| `EMPIRICAL` | 36 |
+| `EMPIRICAL_TRANSFORMED` | 17 |
+| `CODE_NOTE_EMPIRICAL` | 61 |
 | `ASSUMED` | 31 |
 | `TUNED_NEEDS_VALIDATION` | 85 |
 | `POLICY_SCENARIO` | 7 |
@@ -52,6 +52,19 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | Parameter | Decision | Reason | Validation impact | Follow-up path |
 | --- | --- | --- | --- | --- |
 | `immigration.initStock` | `StartupPlaceholder` | The baseline starts with zero immigrant households; migration enters through monthly inflow dynamics. | Opening migration-stock comparisons are not meaningful until a data-bridge initial stock is added. | Add a data-bridge initial stock for immigrant households before validating opening migration-stock levels. |
+
+## Structured Source Metadata
+
+Rows below have been migrated from informal code-note provenance to typed source metadata.
+
+| Parameter | Source family | Source table/code | Vintage/date | URL or manifest | Transformation notes |
+| --- | --- | --- | --- | --- | --- |
+| `pop.initialUnemploymentRate` | Labor market | `GUS registered unemployment` | March 2026 | https://stat.gov.pl/en/topics/labour-market/ | Registered-unemployment stock used as the opening household labor-force unemployment rate. |
+| `fiscal.govBaseSpending` | Fiscal stance | `MF state-budget 2026 spending plan` | 2026 budget plan | https://www.gov.pl/web/finance/state-budget | Annual expenditure plan 918.9bn PLN divided by 12 and scaled by gdpRatio at runtime. |
+| `banking.initGovBonds`, `initNbpGovBonds` | Banking and central-bank balance sheets | `NBP MFI and central-bank government securities bridge` | 2026-04-30 model-start bridge | https://nbp.pl/en/statistic-and-financial-reporting/monetary-and-financial-statistics/consolidated-balance-sheet-of-mfis/ | Bank and NBP government-bond opening stocks are mapped to model holder buckets and scaled by gdpRatio. |
+| `forex.importPropensity` | External sector | `GUS/NBP import-to-GDP bridge` | 2026-04-30 model-start bridge | docs/empirical-validation-source-manifest.csv target: Current account | Aggregate imports are normalized to GDP and used as the import-propensity coefficient. |
+| `equity.peMean`, `divYield` | Financial markets and non-bank finance | `policy-rates-market-yields-and-gpw` | 2026-04-30 model-start bridge | docs/empirical-validation-source-manifest.csv target: Monetary and financial market conditions | GPW valuation notes are reduced to long-run P/E and annual dividend-yield anchors. |
+| `housing.mortgageSpread` | Housing and mortgages | `NBP MIR housing-loan rate spread` | 2026-04-30 model-start bridge | https://nbp.pl/en/statistic-and-financial-reporting/monetary-and-financial-statistics/mir-statistics/ | Mortgage lending-rate spread over the policy-rate anchor is used directly. |
 
 ## Transformation Rules
 
@@ -85,7 +98,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | `pop.firmSizeMediumShare` | `0.008` | share | 2026-04-30 enterprise-size bridge residual | Medium firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeLargeShare` | `0.002` | share | 2026-04-30 enterprise-size bridge | Large firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.realGdp` | `4160e9` | PLN/year | MF 2026 budget macro scale / GDP-implied budget ratios | Polish current-price GDP scale | Feeds gdpRatio | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
-| `pop.initialUnemploymentRate` | `0.061` | share | GUS registered unemployment, March 2026 | Starting unemployment stock | Initial household labor-force stock | `PopulationConfig`, `Household.Init` | `CODE_NOTE_EMPIRICAL` |
+| `pop.initialUnemploymentRate` | `0.061` | share | GUS registered unemployment, March 2026 | Starting unemployment stock | Initial household labor-force stock | `PopulationConfig`, `Household.Init` | `EMPIRICAL` |
 | `gdpRatio` | `computeGdpRatio(pop, firm.baseRevenue)` | scalar | Derived from agent flow scale and current-price GDP | Map agent flows to Polish macro scale | Derived | `SimParams` | `ASSUMED` |
 | `topology` | `Watts-Strogatz` | enum | Network modeling convention | Small-world interaction topology | Direct | `SimParams` | `ASSUMED` |
 | `sectorDefs` | `6 sectors` | vector | 2026-04-30 sector bridge | Polish sector composition | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
@@ -183,7 +196,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | `fiscal.vatRates` | `[0.23, 0.19, 0.12, 0.06, 0.10, 0.07]` | rate by sector | Code note bridge: MF bridge prior effective rates | Sector VAT rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.exciseRates` | `[0.01, 0.04, 0.03, 0.005, 0.002, 0.02]` | rate by sector | Code note bridge: MF bridge prior aggregate | Effective excise rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.customsDutyRate` | `0.04` | rate | Code note bridge: EU CET/Eurostat TARIC | Average non-EU customs duty | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (918.9e9 / 12) | Government base spending | Scaled by gdpRatio | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (918.9e9 / 12) | Government base spending | Scaled by gdpRatio | `FiscalConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `fiscal.govWageIndexShare` | `0.75` | share | #461 GDP-growth calibration | Labor-cost indexation of government purchases | CPI/wage blended cost index in DemandEconomics.computeGovPurchases | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.fofConsWeights`, `fofGovWeights` | `[0.02, 0.18, 0.59, 0.06, 0.07, 0.08], [0.04, 0.08, 0.08, 0.20, 0.58, 0.02]` | sector shares | #461 demand-allocation calibration | Flow-of-funds allocation of household consumption and government purchases | Direct sector allocation | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
 | `io.crossSectorSpillover` | `0.65` | share | #461 GDP-growth calibration | Substitutable share of unmet sector demand | I-O-weighted partial spillover inside DemandEconomics.applySpillover | `DemandEconomics`, `IoConfig` | `TUNED_NEEDS_VALIDATION` |
@@ -227,7 +240,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | `banking.initCapital` | `168e9` | raw PLN | KNF February 2026 TCR 21.1%, mapped to model RWA proxy | Aggregate regulatory-capital proxy | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `banking.initDeposits` | `2542.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate banking-sector deposits | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL` |
 | `banking.initLoans` | `557.4e9` | raw PLN | KNF monthly banking data, February 2026: SME + large enterprises + individual entrepreneurs + individual farmers | Corporate/nonfinancial business loans | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `banking.initGovBonds`, `initNbpGovBonds` | `400e9, 300e9` | raw PLN | Code note bridge: NBP bridge prior | Bank/NBP government-bond holdings | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initGovBonds`, `initNbpGovBonds` | `400e9, 300e9` | raw PLN | NBP MFI and central-bank balance-sheet bridge, 2026-04-30 | Bank/NBP government-bond holdings | Scaled by gdpRatio | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `banking.initConsumerLoans` | `225.2e9` | raw PLN | KNF monthly banking data, February 2026 | Consumer loan stock | Scaled by gdpRatio; household opening consumer loans are normalized to this target | `BankingConfig`, `SimParams`, `Household.Init` | `EMPIRICAL` |
 | `banking.baseSpread` | `0.015` | annual rate | Structural bank-pricing spread prior | Base firm-loan spread | Direct | `BankingConfig` | `ASSUMED` |
 | `banking.minCar` | `0.08` | multiplier/share | Code note bridge: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
@@ -250,7 +263,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `forex.baseExRate` | `4.2537` | PLN/EUR | NBP table A, 2026-04-29 | Starting exchange rate | Direct | `ForexConfig` | `EMPIRICAL` |
 | `forex.foreignRate` | `0.0215` | annual rate | ECB main refinancing rate | Foreign reference rate | Direct | `ForexConfig` | `EMPIRICAL` |
-| `forex.importPropensity` | `0.22` | GDP share | Code note bridge: GUS/NBP bridge prior | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.importPropensity` | `0.22` | GDP share | GUS/NBP imports-to-GDP bridge, 2026-04-30 | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `EMPIRICAL_TRANSFORMED` |
 | `forex.techImportShare` | `0.40` | share | Structural import-composition prior | Technology/capital goods share of imports | Direct | `ForexConfig` | `ASSUMED` |
 | `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15, 0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
 | `forex.riskOffShockMonth` | `0` | month | Scenario switch | No baseline risk-off shock | Direct | `ForexConfig` | `POLICY_SCENARIO` |
@@ -284,7 +297,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | `tourism.inboundShare`, `outboundShare` | `0.05, 0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.seasonality`, `peakMonth` | `0.40, 7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.initIndex`, `initMcap` | `128508.77, 1232.99264e9` | index/raw PLN | GPW Benchmark WIG close and GPW domestic-company market capitalization on 2026-04-30 | WIG index and market cap | initMcap scaled by gdpRatio | `EquityConfig`, `SimParams` | `EMPIRICAL` |
-| `equity.peMean`, `divYield` | `10.0, 0.057` | scalar/annual rate | Code note bridge: GPW bridge prior | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.peMean`, `divYield` | `10.0, 0.057` | scalar/annual rate | GPW market valuation bridge, 2026-04-30 | Long-run P/E and dividend yield | Direct | `EquityConfig` | `EMPIRICAL_TRANSFORMED` |
 | `equity.foreignShare` | `0.67` | share | Code note bridge: KNF/KDPW bridge prior | Foreign ownership share | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.listedProfitShare` | `0.10` | share | #461 calibration | Listed-company slice of aggregate modeled firm profits | Direct | `EquityConfig`, `EquityMarket` | `TUNED_NEEDS_VALIDATION` |
 | `corpBond.spread` | `0.025` | annual rate | Code note bridge: RRRF bridge prior BBB | Corporate bond spread | Direct | `CorpBondConfig` | `CODE_NOTE_EMPIRICAL` |
@@ -299,7 +312,7 @@ Remaining placeholders are explicit startup decisions carried in typed provenanc
 | `housing.initValue` | `7.8e12` | raw PLN | Latest NBP comprehensive residential-property stock estimate | Aggregate housing stock value | Scaled by gdpRatio | `HousingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `housing.initMortgage` | `506.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate mortgage stock | Scaled by gdpRatio | `HousingConfig`, `SimParams` | `EMPIRICAL` |
 | `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2, -0.8, 0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
-| `housing.mortgageSpread` | `0.025` | annual rate | Code note bridge: NBP bridge prior | Mortgage spread over policy rate | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.mortgageSpread` | `0.025` | annual rate | NBP MIR housing-loan spread bridge, 2026-04-30 | Mortgage spread over policy rate | Direct | `HousingConfig` | `EMPIRICAL_TRANSFORMED` |
 | `housing.mortgageMaturity`, `ltvMax` | `300, 0.80` | months/share | Code note bridge: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
 | `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003, 0.001, 0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `housing.mortgageRecovery` | `0.70` | share | Structural mortgage workout recovery prior | Defaulted mortgage recovery | Direct | `HousingConfig` | `ASSUMED` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -59,6 +59,14 @@ object CalibrationProvenance:
       followUpPath: String,
   )
 
+  final case class SourceMetadata(
+      sourceFamily: String,
+      sourceTableOrCode: String,
+      vintage: String,
+      sourceReference: String,
+      transformationNotes: String,
+  )
+
   final case class CalibrationParameter(
       id: String,
       parameterIds: Vector[String],
@@ -72,6 +80,7 @@ object CalibrationProvenance:
       validationPath: Option[String] = None,
       exemption: Option[CalibrationExemptionKind] = None,
       placeholderDecision: Option[PlaceholderDecision] = None,
+      sourceMetadata: Option[SourceMetadata] = None,
   ):
     def effectiveExemption: Option[CalibrationExemptionKind] =
       exemption.orElse(status.inferredExemption)
@@ -132,6 +141,7 @@ object CalibrationProvenance:
           placeholderDecision =
             if status == CalibrationStatus.Placeholder then placeholderDecisionById.get(id)
             else None,
+          sourceMetadata = sourceMetadataById.get(id),
         )
 
     private val placeholderDecisionById: Map[String, PlaceholderDecision] =
@@ -144,6 +154,52 @@ object CalibrationProvenance:
           followUpPath = "Add a data-bridge initial stock for immigrant households before validating opening migration-stock levels.",
         ),
       ).map(decision => decision.parameterId -> decision).toMap
+
+    private val sourceMetadataById: Map[String, SourceMetadata] =
+      Vector(
+        "pop.initialUnemploymentRate" -> SourceMetadata(
+          sourceFamily = "Labor market",
+          sourceTableOrCode = "GUS registered unemployment",
+          vintage = "March 2026",
+          sourceReference = "https://stat.gov.pl/en/topics/labour-market/",
+          transformationNotes = "Registered-unemployment stock used as the opening household labor-force unemployment rate.",
+        ),
+        "fiscal.govBaseSpending"      -> SourceMetadata(
+          sourceFamily = "Fiscal stance",
+          sourceTableOrCode = "MF state-budget 2026 spending plan",
+          vintage = "2026 budget plan",
+          sourceReference = "https://www.gov.pl/web/finance/state-budget",
+          transformationNotes = "Annual expenditure plan 918.9bn PLN divided by 12 and scaled by gdpRatio at runtime.",
+        ),
+        "banking.initGovBonds"        -> SourceMetadata(
+          sourceFamily = "Banking and central-bank balance sheets",
+          sourceTableOrCode = "NBP MFI and central-bank government securities bridge",
+          vintage = "2026-04-30 model-start bridge",
+          sourceReference = "https://nbp.pl/en/statistic-and-financial-reporting/monetary-and-financial-statistics/consolidated-balance-sheet-of-mfis/",
+          transformationNotes = "Bank and NBP government-bond opening stocks are mapped to model holder buckets and scaled by gdpRatio.",
+        ),
+        "forex.importPropensity"      -> SourceMetadata(
+          sourceFamily = "External sector",
+          sourceTableOrCode = "GUS/NBP import-to-GDP bridge",
+          vintage = "2026-04-30 model-start bridge",
+          sourceReference = "docs/empirical-validation-source-manifest.csv target: Current account",
+          transformationNotes = "Aggregate imports are normalized to GDP and used as the import-propensity coefficient.",
+        ),
+        "equity.peMean"               -> SourceMetadata(
+          sourceFamily = "Financial markets and non-bank finance",
+          sourceTableOrCode = "policy-rates-market-yields-and-gpw",
+          vintage = "2026-04-30 model-start bridge",
+          sourceReference = "docs/empirical-validation-source-manifest.csv target: Monetary and financial market conditions",
+          transformationNotes = "GPW valuation notes are reduced to long-run P/E and annual dividend-yield anchors.",
+        ),
+        "housing.mortgageSpread"      -> SourceMetadata(
+          sourceFamily = "Housing and mortgages",
+          sourceTableOrCode = "NBP MIR housing-loan rate spread",
+          vintage = "2026-04-30 model-start bridge",
+          sourceReference = "https://nbp.pl/en/statistic-and-financial-reporting/monetary-and-financial-statistics/mir-statistics/",
+          transformationNotes = "Mortgage lending-rate spread over the policy-rate anchor is used directly.",
+        ),
+      ).toMap
 
     private def splitCodeList(value: String): Vector[String] =
       stripCode(value)
@@ -178,7 +234,7 @@ object CalibrationProvenance:
 | `pop.firmSizeMediumShare` | `0.008` | share | 2026-04-30 enterprise-size bridge residual | Medium firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.firmSizeLargeShare` | `0.002` | share | 2026-04-30 enterprise-size bridge | Large firm share | Direct | `PopulationConfig` | `TUNED_NEEDS_VALIDATION` |
 | `pop.realGdp` | `4160e9` | PLN/year | MF 2026 budget macro scale / GDP-implied budget ratios | Polish current-price GDP scale | Feeds `gdpRatio` | `PopulationConfig` | `CODE_NOTE_EMPIRICAL` |
-| `pop.initialUnemploymentRate` | `0.061` | share | GUS registered unemployment, March 2026 | Starting unemployment stock | Initial household labor-force stock | `PopulationConfig`, `Household.Init` | `CODE_NOTE_EMPIRICAL` |
+| `pop.initialUnemploymentRate` | `0.061` | share | GUS registered unemployment, March 2026 | Starting unemployment stock | Initial household labor-force stock | `PopulationConfig`, `Household.Init` | `EMPIRICAL` |
 | `gdpRatio` | `computeGdpRatio(pop, firm.baseRevenue)` | scalar | Derived from agent flow scale and current-price GDP | Map agent flows to Polish macro scale | Derived | `SimParams` | `ASSUMED` |
 | `topology` | `Watts-Strogatz` | enum | Network modeling convention | Small-world interaction topology | Direct | `SimParams` | `ASSUMED` |
 | `sectorDefs` | 6 sectors | vector | 2026-04-30 sector bridge | Polish sector composition | Direct | `SimParams` | `TUNED_NEEDS_VALIDATION` |
@@ -261,7 +317,7 @@ object CalibrationProvenance:
 | `fiscal.vatRates` | `[0.23, 0.19, 0.12, 0.06, 0.10, 0.07]` | rate by sector | Code note bridge: MF bridge prior effective rates | Sector VAT rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.exciseRates` | `[0.01, 0.04, 0.03, 0.005, 0.002, 0.02]` | rate by sector | Code note bridge: MF bridge prior aggregate | Effective excise rates | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
 | `fiscal.customsDutyRate` | `0.04` | rate | Code note bridge: EU CET/Eurostat TARIC | Average non-EU customs duty | Direct | `FiscalConfig` | `CODE_NOTE_EMPIRICAL` |
-| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (918.9e9 / 12) | Government base spending | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `fiscal.govBaseSpending` | `76.575e9` | raw PLN/month | MF 2026 budget spending plan (918.9e9 / 12) | Government base spending | Scaled by `gdpRatio` | `FiscalConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `fiscal.govWageIndexShare` | `0.75` | share | #461 GDP-growth calibration | Labor-cost indexation of government purchases | CPI/wage blended cost index in `DemandEconomics.computeGovPurchases` | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
 | `fiscal.fofConsWeights`, `fofGovWeights` | `[0.02, 0.18, 0.59, 0.06, 0.07, 0.08]`, `[0.04, 0.08, 0.08, 0.20, 0.58, 0.02]` | sector shares | #461 demand-allocation calibration | Flow-of-funds allocation of household consumption and government purchases | Direct sector allocation | `FiscalConfig`, `DemandEconomics` | `TUNED_NEEDS_VALIDATION` |
 | `io.crossSectorSpillover` | `0.65` | share | #461 GDP-growth calibration | Substitutable share of unmet sector demand | I-O-weighted partial spillover inside `DemandEconomics.applySpillover` | `DemandEconomics`, `IoConfig` | `TUNED_NEEDS_VALIDATION` |
@@ -305,7 +361,7 @@ object CalibrationProvenance:
 | `banking.initCapital` | `168e9` | raw PLN | KNF February 2026 TCR 21.1%, mapped to model RWA proxy | Aggregate regulatory-capital proxy | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `banking.initDeposits` | `2542.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate banking-sector deposits | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL` |
 | `banking.initLoans` | `557.4e9` | raw PLN | KNF monthly banking data, February 2026: SME + large enterprises + individual entrepreneurs + individual farmers | Corporate/nonfinancial business loans | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
-| `banking.initGovBonds`, `initNbpGovBonds` | `400e9`, `300e9` | raw PLN | Code note bridge: NBP bridge prior | Bank/NBP government-bond holdings | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `CODE_NOTE_EMPIRICAL` |
+| `banking.initGovBonds`, `initNbpGovBonds` | `400e9`, `300e9` | raw PLN | NBP MFI and central-bank balance-sheet bridge, 2026-04-30 | Bank/NBP government-bond holdings | Scaled by `gdpRatio` | `BankingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `banking.initConsumerLoans` | `225.2e9` | raw PLN | KNF monthly banking data, February 2026 | Consumer loan stock | Scaled by `gdpRatio`; household opening consumer loans are normalized to this target | `BankingConfig`, `SimParams`, `Household.Init` | `EMPIRICAL` |
 | `banking.baseSpread` | `0.015` | annual rate | Structural bank-pricing spread prior | Base firm-loan spread | Direct | `BankingConfig` | `ASSUMED` |
 | `banking.minCar` | `0.08` | multiplier/share | Code note bridge: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
@@ -323,7 +379,7 @@ object CalibrationProvenance:
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `forex.baseExRate` | `4.2537` | PLN/EUR | NBP table A, 2026-04-29 | Starting exchange rate | Direct | `ForexConfig` | `EMPIRICAL` |
 | `forex.foreignRate` | `0.0215` | annual rate | ECB main refinancing rate | Foreign reference rate | Direct | `ForexConfig` | `EMPIRICAL` |
-| `forex.importPropensity` | `0.22` | GDP share | Code note bridge: GUS/NBP bridge prior | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `CODE_NOTE_EMPIRICAL` |
+| `forex.importPropensity` | `0.22` | GDP share | GUS/NBP imports-to-GDP bridge, 2026-04-30 | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `EMPIRICAL_TRANSFORMED` |
 | `forex.techImportShare` | `0.40` | share | Structural import-composition prior | Technology/capital goods share of imports | Direct | `ForexConfig` | `ASSUMED` |
 | `forex.irpSensitivity`, `exRateAdjSpeed` | `0.15`, `0.02` | coefficient | IRP / FX adjustment model | Exchange-rate response speed | Direct | `ForexConfig` | `TUNED_NEEDS_VALIDATION` |
 | `forex.riskOffShockMonth` | `0` | month | Scenario switch | No baseline risk-off shock | Direct | `ForexConfig` | `POLICY_SCENARIO` |
@@ -357,7 +413,7 @@ object CalibrationProvenance:
 | `tourism.inboundShare`, `outboundShare` | `0.05`, `0.03` | GDP share | Code note bridge: GUS TSA 2023 / NBP BoP 2023 | Tourism exports/imports | GDP-proportional | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `tourism.seasonality`, `peakMonth` | `0.40`, `7` | share/month | Code note bridge: GUS TSA | Tourism seasonality | Cosine seasonal factor | `TourismConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.initIndex`, `initMcap` | `128508.77`, `1232.99264e9` | index/raw PLN | GPW Benchmark WIG close and GPW domestic-company market capitalization on 2026-04-30 | WIG index and market cap | `initMcap` scaled by `gdpRatio` | `EquityConfig`, `SimParams` | `EMPIRICAL` |
-| `equity.peMean`, `divYield` | `10.0`, `0.057` | scalar/annual rate | Code note bridge: GPW bridge prior | Long-run P/E and dividend yield | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
+| `equity.peMean`, `divYield` | `10.0`, `0.057` | scalar/annual rate | GPW market valuation bridge, 2026-04-30 | Long-run P/E and dividend yield | Direct | `EquityConfig` | `EMPIRICAL_TRANSFORMED` |
 | `equity.foreignShare` | `0.67` | share | Code note bridge: KNF/KDPW bridge prior | Foreign ownership share | Direct | `EquityConfig` | `CODE_NOTE_EMPIRICAL` |
 | `equity.listedProfitShare` | `0.10` | share | #461 calibration | Listed-company slice of aggregate modeled firm profits | Direct | `EquityConfig`, `EquityMarket` | `TUNED_NEEDS_VALIDATION` |
 | `corpBond.spread` | `0.025` | annual rate | Code note bridge: RRRF bridge prior BBB | Corporate bond spread | Direct | `CorpBondConfig` | `CODE_NOTE_EMPIRICAL` |
@@ -367,7 +423,7 @@ object CalibrationProvenance:
 | `housing.initValue` | `7.8e12` | raw PLN | Latest NBP comprehensive residential-property stock estimate | Aggregate housing stock value | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `housing.initMortgage` | `506.3e9` | raw PLN | KNF monthly banking data, February 2026 | Aggregate mortgage stock | Scaled by `gdpRatio` | `HousingConfig`, `SimParams` | `EMPIRICAL` |
 | `housing.priceIncomeElast`, `priceRateElast`, `priceReversion` | `1.2`, `-0.8`, `0.05` | coefficients | UNKNOWN_SOURCE | HPI response to income, rates, and fundamentals | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
-| `housing.mortgageSpread` | `0.025` | annual rate | Code note bridge: NBP bridge prior | Mortgage spread over policy rate | Direct | `HousingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `housing.mortgageSpread` | `0.025` | annual rate | NBP MIR housing-loan spread bridge, 2026-04-30 | Mortgage spread over policy rate | Direct | `HousingConfig` | `EMPIRICAL_TRANSFORMED` |
 | `housing.mortgageMaturity`, `ltvMax` | `300`, `0.80` | months/share | Code note bridge: KNF Recommendation S | Mortgage maturity and LTV cap | Direct | `HousingConfig` | `EMPIRICAL` |
 | `housing.originationRate`, `defaultBase`, `defaultUnempSens` | `0.003`, `0.001`, `0.05` | share/coefficient | UNKNOWN_SOURCE | Mortgage origination and default dynamics | Direct | `HousingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `housing.mortgageRecovery` | `0.70` | share | Structural mortgage workout recovery prior | Defaulted mortgage recovery | Direct | `HousingConfig` | `ASSUMED` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRenderer.scala
@@ -47,6 +47,7 @@ object CalibrationRegisterRenderer:
     lines ++= statusTaxonomy
     lines ++= statusCounts(parameters)
     lines ++= placeholderDecisions(parameters)
+    lines ++= structuredSourceMetadata(parameters)
     lines ++= transformationRules
     Sections.foreach: (title, predicate) =>
       val sectionParameters = parameters.filter(predicate)
@@ -222,6 +223,32 @@ object CalibrationRegisterRenderer:
       plainCell(decision.reason),
       plainCell(decision.validationImpact),
       plainCell(decision.followUpPath),
+    ).mkString("| ", " | ", " |")
+
+  private def structuredSourceMetadata(parameters: Vector[CalibrationParameter]): Vector[String] =
+    val sourced = parameters.filter(_.sourceMetadata.nonEmpty)
+    if sourced.isEmpty then Vector.empty
+    else
+      Vector(
+        "## Structured Source Metadata",
+        "",
+        "Rows below have been migrated from informal code-note provenance to typed source metadata.",
+        "",
+        "| Parameter | Source family | Source table/code | Vintage/date | URL or manifest | Transformation notes |",
+        "| --- | --- | --- | --- | --- | --- |",
+      ) ++ sourced.map(renderSourceMetadata) :+
+        ""
+
+  private def renderSourceMetadata(parameter: CalibrationParameter): String =
+    val source = parameter.sourceMetadata.getOrElse:
+      throw new IllegalArgumentException(s"Missing source metadata for calibration parameter: ${parameter.id}")
+    Vector(
+      renderParameterIds(parameter.parameterIds),
+      plainCell(source.sourceFamily),
+      codeCell(source.sourceTableOrCode),
+      plainCell(source.vintage),
+      plainCell(source.sourceReference),
+      plainCell(source.transformationNotes),
     ).mkString("| ", " | ", " |")
 
   private def hasId(parameter: CalibrationParameter, id: String): Boolean =

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -39,9 +39,9 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
   "Baseline calibration provenance" should "preserve the active default inventory status counts in code" in {
     CalibrationProvenance.Baseline.parseErrors shouldBe empty
     CalibrationProvenance.Baseline.parameters should have size 238
-    CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 35)
-    CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 12)
-    CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 67)
+    CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 36)
+    CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 17)
+    CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 61)
     CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 85)
     CalibrationProvenance.Baseline.statusCounts.getOrElse(UnknownSource, 0) shouldBe 0
     CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 1)
@@ -68,6 +68,45 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     baseWage.transformation shouldBe "Direct"
     baseWage.ownerModules shouldBe Vector("HouseholdConfig")
     baseWage.status shouldBe Empirical
+  }
+
+  it should "carry typed source metadata for migrated code-note empirical rows" in {
+    val expectedSources = Vector(
+      ("pop.initialUnemploymentRate", "Labor market", "GUS registered unemployment", "March 2026", "stat.gov.pl", "opening household"),
+      ("fiscal.govBaseSpending", "Fiscal stance", "MF state-budget 2026 spending plan", "2026 budget plan", "gov.pl", "divided by 12"),
+      (
+        "banking.initGovBonds",
+        "Banking and central-bank balance sheets",
+        "NBP MFI and central-bank government securities bridge",
+        "2026-04-30",
+        "nbp.pl",
+        "model holder buckets",
+      ),
+      ("forex.importPropensity", "External sector", "GUS/NBP import-to-GDP bridge", "2026-04-30", "Current account", "normalized to GDP"),
+      (
+        "equity.peMean",
+        "Financial markets and non-bank finance",
+        "policy-rates-market-yields-and-gpw",
+        "2026-04-30",
+        "Monetary and financial market conditions",
+        "P/E",
+      ),
+      ("housing.mortgageSpread", "Housing and mortgages", "NBP MIR housing-loan rate spread", "2026-04-30", "mir-statistics", "spread over the policy-rate"),
+    )
+
+    expectedSources.foreach: (id, family, tableOrCode, vintage, referenceFragment, transformFragment) =>
+      withClue(id) {
+        val parameter = baselineParameter(id)
+        parameter.status should not equal CodeNoteEmpirical
+        val source    = parameter.sourceMetadata.getOrElse(fail(s"Expected typed source metadata for '$id'"))
+        source.sourceFamily shouldBe family
+        source.sourceTableOrCode shouldBe tableOrCode
+        source.vintage should include(vintage)
+        source.sourceReference should include(referenceFragment)
+        source.transformationNotes should include(transformFragment)
+      }
+
+    CalibrationProvenance.Baseline.rowsWithStatus(CodeNoteEmpirical).flatMap(_.sourceMetadata) shouldBe empty
   }
 
   it should "expand grouped shorthand parameter ids to stable fully-qualified ids" in {

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationRegisterRendererSpec.scala
@@ -33,6 +33,14 @@ class CalibrationRegisterRendererSpec extends AnyFlatSpec with Matchers:
     rendered should include("Opening migration-stock comparisons")
   }
 
+  it should "render structured source metadata" in {
+    val rendered = CalibrationRegisterRenderer.render()
+
+    rendered should include("## Structured Source Metadata")
+    rendered should include("| `fiscal.govBaseSpending` | Fiscal stance | `MF state-budget 2026 spending plan` |")
+    rendered should include("| `banking.initGovBonds`, `initNbpGovBonds` | Banking and central-bank balance sheets |")
+  }
+
   it should "fail fast when a placeholder row lacks typed decision metadata" in {
     val brokenPlaceholder = CalibrationProvenance.CalibrationParameter(
       id = "immigration.initStock",


### PR DESCRIPTION
Closes #487.

## Summary

- Add typed source metadata fields to baseline calibration provenance rows.
- Migrate six representative `CODE_NOTE_EMPIRICAL` rows across labor, fiscal, banking, external-sector, financial-market, and housing domains.
- Render migrated rows in the generated `Structured Source Metadata` section.
- Keep remaining `CODE_NOTE_EMPIRICAL` rows visible as publication-readiness gaps until source extraction manifests exist.

## Scope

- Rows backed by a concrete official source page record the provider/source page, date or source vintage, and transformation note.
- Rows that still reference a manifest target family record the model-start bridge and manifest target, not a final source-extraction vintage. These remain follow-up candidates for full manifest-backed extraction.

## Validation

- `sbt scalafmtAll`
- `sbt calibrationRegister`
- `sbt "testOnly com.boombustgroup.amorfati.config.CalibrationProvenanceSpec com.boombustgroup.amorfati.config.CalibrationRegisterRendererSpec"`
- `git diff --check`
