### PR TITLE
Add Nix development shell

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/scala-3.8.2/scoverage-report/scoverage.xml
           fail_ci_if_error: false
+
+  nix-dev-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Validate Nix development shell
+        run: |
+          nix flake check --print-build-logs
+          nix develop --command bash -lc '
+            set -euo pipefail
+            java -version 2>&1 | grep "version \"21"
+            sbt scalafmtCheckAll
+            sbt test
+            python3 --version
+            z3 --version
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@v31.10.6
 
       - name: Check Nix flake
         run: nix flake check --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,31 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
+      - uses: cachix/install-nix-action@v31
 
-      - name: Install sbt
+      - name: Check Nix flake
+        run: nix flake check --print-build-logs
+
+      - name: Validate Nix development shell
         run: |
-          curl -fsSL "https://github.com/sbt/sbt/releases/download/v1.11.6/sbt-1.11.6.tgz" | sudo tar xz -C /usr/local
-          echo "/usr/local/sbt/bin" >> "$GITHUB_PATH"
+          nix develop --command bash -lc '
+            set -euo pipefail
+            java -version 2>&1 | grep "version \"21"
+            python3 --version
+            z3 --version
+          '
 
       - name: Check formatting
-        run: sbt scalafmtCheckAll
+        run: nix develop --command sbt scalafmtCheckAll
 
       - name: Run non-heavy unit tests with coverage
-        run: sbt coverage "root / Test / test" coverageReport
+        run: nix develop --command sbt coverage "root / Test / test" coverageReport
 
       - name: Run heavy unit tests without coverage
-        run: sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
+        run: nix develop --command sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
 
       - name: Run integration tests
-        run: sbt "integrationTests / Test / test"
+        run: nix develop --command sbt "integrationTests / Test / test"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -42,24 +46,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/scala-3.8.2/scoverage-report/scoverage.xml
           fail_ci_if_error: false
-
-  nix-dev-shell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - uses: cachix/install-nix-action@v31
-
-      - name: Validate Nix development shell
-        run: |
-          nix flake check --print-build-logs
-          nix develop --command bash -lc '
-            set -euo pipefail
-            java -version 2>&1 | grep "version \"21"
-            sbt scalafmtCheckAll
-            sbt test
-            python3 --version
-            z3 --version
-          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      SBT_OPTS: "-Xmx4G -XX:+UseG1GC"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,26 +17,18 @@ jobs:
       - name: Check Nix flake
         run: nix flake check --print-build-logs
 
-      - name: Validate Nix development shell
+      - name: Run CI in Nix development shell
         run: |
-          nix develop --command bash -lc '
+          nix develop --command bash -c '
             set -euo pipefail
-            java -version 2>&1 | grep "version \"21"
+            java -version 2>&1 | head -1 | grep -E "^openjdk version \"21\\."
             python3 --version
             z3 --version
+            sbt scalafmtCheckAll
+            sbt coverage "root / Test / test" coverageReport
+            sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
+            sbt "integrationTests / Test / test"
           '
-
-      - name: Check formatting
-        run: nix develop --command sbt scalafmtCheckAll
-
-      - name: Run non-heavy unit tests with coverage
-        run: nix develop --command sbt coverage "root / Test / test" coverageReport
-
-      - name: Run heavy unit tests without coverage
-        run: nix develop --command sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
-
-      - name: Run integration tests
-        run: nix develop --command sbt "integrationTests / Test / test"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,26 @@ jobs:
       - name: Check Nix flake
         run: nix flake check --print-build-logs
 
-      - name: Run CI in Nix development shell
+      - name: Validate Nix development shell
         run: |
           nix develop --command bash -c '
             set -euo pipefail
             java -version 2>&1 | head -1 | grep -E "^openjdk version \"21\\."
             python3 --version
             z3 --version
-            sbt scalafmtCheckAll
-            sbt coverage "root / Test / test" coverageReport
-            sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
-            sbt "integrationTests / Test / test"
           '
+
+      - name: Check formatting
+        run: nix develop --command sbt scalafmtCheckAll
+
+      - name: Run non-heavy unit tests with coverage
+        run: nix develop --command sbt coverage "root / Test / test" coverageReport
+
+      - name: Run heavy unit tests without coverage
+        run: nix develop --command sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"
+
+      - name: Run integration tests
+        run: nix develop --command sbt "integrationTests / Test / test"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ project/project/
 .bsp/
 .metals/
 .vscode/
+.envrc
 *.iml
 
 # OS

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Requirements:
 - JDK 21 as the supported baseline, matching CI's Temurin 21 runtime
 - sbt 1.11.6, pinned in `project/build.properties`
 
+Alternatively, enter the optional Nix developer shell:
+
+```bash
+nix develop
+```
+
+The flake provides JDK 21, an sbt launcher compatible with the pinned project
+version, Python 3, Z3, Git, standard shell utilities, and the same `SBT_OPTS`
+baseline used by CI.
+
 Clone the repository with its ledger submodule:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Alternatively, enter the optional Nix developer shell:
 nix develop
 ```
 
-The flake provides JDK 21, an sbt launcher compatible with the pinned project
-version, Python 3, Z3, Git, standard shell utilities, and the same `SBT_OPTS`
-baseline used by CI.
+The flake provides JDK 21, the nixpkgs sbt launcher, Python 3, Z3, Git,
+standard shell utilities, and the same `SBT_OPTS` baseline used by CI. The sbt
+launcher respects `project/build.properties`, so the root build still runs with
+the pinned sbt version. `flake.lock` pins the nixpkgs revision used by both
+local Nix shells and CI.
 
 Clone the repository with its ledger submodule:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,6 +99,10 @@ ignored by git so non-Nix workflows do not see `direnv` warnings by default.
 
 The Nix shell includes Z3 for ledger verification workflows. Stainless remains
 controlled by `STAINLESS_DIR` and is not required for normal `sbt test` runs.
+With the current `flake.lock`, the `z3` package resolves to Z3 4.15.4 from the
+pinned nixos-25.11 snapshot. Treat Z3 version changes as verification-relevant:
+Stainless proof search can be solver-version sensitive, so re-run ledger
+verification after intentional Nix lock updates.
 The ledger verification script defaults to `/tmp/stainless-standalone`:
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -58,12 +58,15 @@ nix develop
 The shell provides:
 
 - JDK 21
-- an sbt launcher that uses the versions pinned by `project/build.properties`
-  and `modules/ledger/project/build.properties`
+- the nixpkgs sbt launcher, which respects the versions pinned by
+  `project/build.properties` and `modules/ledger/project/build.properties`
 - Python 3
 - Z3
 - Git, Bash, curl, unzip, and standard GNU shell utilities
 - `SBT_OPTS=-Xmx4G -XX:+UseG1GC`, matching CI
+
+`flake.lock` pins the nixpkgs revision used by both local Nix shells and CI.
+Update it intentionally with `nix flake update`.
 
 Validate the shell with the same commands used outside Nix:
 
@@ -106,9 +109,8 @@ STAINLESS_DIR=/tmp/stainless-standalone ./verify.sh
 
 Install or download the Stainless standalone distribution separately and point
 `STAINLESS_DIR` at that directory. When running from `nix develop`, `z3` is on
-`PATH`; if a Stainless bundle insists on its bundled solver, match the CI
-workflow by replacing the bundle's `z3` binary with the one from
-`command -v z3`.
+`PATH`; if a Stainless bundle insists on its bundled solver, replace the
+bundle's `z3` binary with the one from `command -v z3`.
 
 ## Independent Clone Or Fork Workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,12 +11,14 @@ Use the same toolchain shape as CI:
 - JDK 21 as the supported baseline, Temurin in CI
 - sbt 1.11.6, pinned in `project/build.properties`
 - Scala 3.8.2, pinned in `build.sbt`
+- Python 3 for local scripts such as `scripts/complexity.py`
 
 Newer local JDKs may work, but diagnose toolchain failures against JDK 21
 first.
 
-No Docker, Nix, or binary release artifact is required for the current local
-workflow.
+No Docker or binary release artifact is required for the current local
+workflow. Nix is optional; `flake.nix` provides a reproducible developer shell
+for users who want CI-like tooling without installing the stack globally.
 
 The runtime depends on `amor-fati-ledger`, checked out as the Git submodule at
 `modules/ledger`. A checkout without that submodule is incomplete.
@@ -44,6 +46,68 @@ sbt test
 
 The first run may spend most of its time downloading the sbt launcher,
 plugins, Scala compiler artifacts, and library dependencies through Coursier.
+
+## Nix Development Shell
+
+The repository includes a flake-based developer shell:
+
+```bash
+nix develop
+```
+
+The shell provides:
+
+- JDK 21
+- an sbt launcher that uses the versions pinned by `project/build.properties`
+  and `modules/ledger/project/build.properties`
+- Python 3
+- Z3
+- Git, Bash, curl, unzip, and standard GNU shell utilities
+- `SBT_OPTS=-Xmx4G -XX:+UseG1GC`, matching CI
+
+Validate the shell with the same commands used outside Nix:
+
+```bash
+java -version
+sbt scalafmtCheckAll
+sbt test
+z3 --version
+```
+
+This is a developer and CI-like validation shell, not a hermetic sbt/Nix
+package build. sbt still resolves Scala, plugins, and library dependencies
+through its normal Coursier path. Existing non-Nix workflows continue to work.
+GitHub Actions also validates the flake in a separate `nix-dev-shell` job while
+leaving the existing CI and Codecov workflow unchanged.
+
+For `direnv` users, create a local `.envrc` from the checked-in example and
+approve it:
+
+```bash
+cp .envrc.example .envrc
+direnv allow
+```
+
+to enter the shell automatically when changing into the repository. `.envrc` is
+ignored by git so non-Nix workflows do not see `direnv` warnings by default.
+
+### Ledger Verification Tools
+
+The Nix shell includes Z3 for ledger verification workflows. Stainless remains
+controlled by `STAINLESS_DIR` and is not required for normal `sbt test` runs.
+The ledger verification script defaults to `/tmp/stainless-standalone`:
+
+```bash
+nix develop
+cd modules/ledger
+STAINLESS_DIR=/tmp/stainless-standalone ./verify.sh
+```
+
+Install or download the Stainless standalone distribution separately and point
+`STAINLESS_DIR` at that directory. When running from `nix develop`, `z3` is on
+`PATH`; if a Stainless bundle insists on its bundled solver, match the CI
+workflow by replacing the bundle's `z3` binary with the one from
+`command -v z3`.
 
 ## Independent Clone Or Fork Workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -77,8 +77,9 @@ z3 --version
 This is a developer and CI-like validation shell, not a hermetic sbt/Nix
 package build. sbt still resolves Scala, plugins, and library dependencies
 through its normal Coursier path. Existing non-Nix workflows continue to work.
-GitHub Actions also validates the flake in a separate `nix-dev-shell` job while
-leaving the existing CI and Codecov workflow unchanged.
+GitHub Actions runs the project CI commands through `nix develop` so the
+checked shell is the same baseline used for formatting, tests, heavy tests,
+and integration tests.
 
 For `direnv` users, create a local `.envrc` from the checked-in example and
 approve it:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
           default = pkgs.mkShell {
             packages = with pkgs; [
               bashInteractive
-              cacert
               coreutils
               curl
               findutils
@@ -46,12 +45,6 @@
             SBT_OPTS = "-Xmx4G -XX:+UseG1GC";
             SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
             GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-
-            shellHook = ''
-              export PATH="$JAVA_HOME/bin:$PATH"
-              echo "Amor Fati dev shell: JDK 21, sbt, Python 3, Z3"
-              echo "SBT_OPTS=$SBT_OPTS"
-            '';
           };
         });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
               sbt
               unzip
               which
+              # flake.lock currently pins z3 4.15.4 from nixos-25.11. Changes
+              # can affect Stainless/ledger verification behavior.
               z3
             ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Development shell for Amor Fati";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              bashInteractive
+              cacert
+              coreutils
+              curl
+              findutils
+              gawk
+              git
+              gnugrep
+              gnused
+              gnutar
+              gzip
+              jdk21
+              python3
+              sbt
+              unzip
+              which
+              z3
+            ];
+
+            JAVA_HOME = pkgs.jdk21.home;
+            SBT_OPTS = "-Xmx4G -XX:+UseG1GC";
+            SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+            GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+
+            shellHook = ''
+              export PATH="$JAVA_HOME/bin:$PATH"
+              echo "Amor Fati dev shell: JDK 21, sbt, Python 3, Z3"
+              echo "SBT_OPTS=$SBT_OPTS"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary
- add a flake-based Nix developer shell with JDK 21, sbt launcher, Python 3, Z3, Git, and shell utilities
- document nix develop, optional direnv setup, and Stainless/Z3 expectations
- run GitHub Actions CI commands through nix develop with flake.lock pinned

## Validation
- local: git diff --check
- local: sbt scalafmtCheckAll
- local: sbt test
- GitHub Actions: https://github.com/boombustgroup/amor-fati/actions/runs/25623339932

Closes #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional Nix-based developer shell providing a consistent development environment with JDK 21, sbt, Python 3, Z3, and standard utilities.

* **Documentation**
  * Updated setup guides with instructions for using the Nix developer shell.
  * Added tool availability and validation procedures.

* **Chores**
  * CI pipeline now uses Nix flake for test execution and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->