### PR TITLE
Clarify banking-sector row semantics

### DIFF
--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -32,8 +32,11 @@ adaptation in households, firms, banks, and policy institutions.
 Amor Fati is designed to support executable counterfactual analysis of a
 monetary production economy under strict stock-flow consistency. The immediate
 domain is the Polish economy with heterogeneous households, heterogeneous firms,
-seven banks, public-sector institutions, financial markets, non-bank financial
-institutions, insurance, and a rest-of-world sector.
+seven banking-sector rows, public-sector institutions, financial markets,
+non-bank financial institutions, insurance, and a rest-of-world sector. The
+banking rows are not seven separate commercial-bank case studies: they consist
+of six named bank archetypes plus an aggregate `Others` bucket for the remaining
+banking sector.
 
 The model is intended to answer questions of the following kind:
 
@@ -80,7 +83,7 @@ Empirical validation of these patterns is structured in
 | --- | --- | --- | --- |
 | Households | Individual agents | employment/activity status, wage, skill, health penalty, MPC, rent, social neighbors, bank assignment, region, education, contract type, household financial stocks projected from the ledger | `agents/Household.scala` |
 | Firms | Individual agents | sector, technology regime, workers, productivity/capacity, capital stock, inventory, cash/debt/equity projections, digital readiness, network position, bankruptcy state | `agents/Firm.scala` |
-| Banks | Seven named bank agents | operational status, capital diagnostics, NPLs, risk buckets, regulatory ratios, per-bank rates, resolution state; financial stocks projected from ledger rows | `agents/Banking.scala` |
+| Banks | Seven banking-sector rows: six named bank archetypes plus `Others` | operational status, capital diagnostics, NPLs, risk buckets, regulatory ratios, per-row rates, resolution state; financial stocks projected from ledger rows | `agents/Banking.scala` |
 | Government | Aggregate institution | spending, tax revenue, debt, fiscal rules, bond issuance, benefits, transfers, capital investment | `engine/markets/FiscalBudget.scala`, `engine/flows/GovBudgetFlows.scala` |
 | NBP | Central bank institution | reference rate, QE policy, FX operations, reserve/standing-facility plumbing, government-bond and foreign-asset stocks | `agents/Nbp.scala`, `engine/flows/BankingFlows.scala` |
 | Social funds | Aggregate public-fund agents | ZUS/FUS, NFZ, PPK, FP, PFRON, FGSP balances and monthly contribution/spending flows | `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` |
@@ -124,7 +127,8 @@ The default scale is:
 - firms: 10,000 default firm agents;
 - households: default total population equals `firmsCount * workersPerFirm`,
   currently 100,000 household agents under default parameters;
-- banks: seven bank agents;
+- banks: seven banking-sector rows: PKO BP, Pekao, mBank, ING BSK,
+  Santander, BPS/Coop, and aggregate `Others`;
 - production sectors: BPO/SSC, Manufacturing, Retail/Services, Healthcare,
   Public, Agriculture;
 - regions: six NUTS-1 macroregions used for regional labor and housing
@@ -312,11 +316,14 @@ and Monte Carlo seeds. Randomness is not hidden in global mutable state.
 
 ### Collectives
 
-Some entities are true individual agents: households, firms, banks. Others are
-collective or institutional sectors represented at aggregate resolution:
-government, NBP, social funds, insurance, NBFI/funds, quasi-fiscal bodies, and
-rest of world. This is intentional: the model allocates agent detail where it
-is expected to affect macro dynamics or distributional outcomes.
+Some entities are true individual agents: households and firms. The banking
+sector is represented by seven bank rows/archetypes, including one aggregate
+`Others` bucket, which behave as bank decision units but should not be read as
+seven individual commercial banks. Other entities are collective or
+institutional sectors represented at aggregate resolution: government, NBP,
+social funds, insurance, NBFI/funds, quasi-fiscal bodies, and rest of world.
+This is intentional: the model allocates agent detail where it is expected to
+affect macro dynamics or distributional outcomes.
 
 ### Observation
 
@@ -339,7 +346,7 @@ surfaces. Detailed mathematical rules are documented in
 | --- | --- | --- | --- | --- |
 | Households | consume, save/draw buffers, pay rent/debt, use consumer credit, retrain, change sector, become bankrupt | wage, employment status, bank rates, debt service, deposits, social-neighbor distress, region, education, sector signals | income, deposits, debt, credit terms, unemployment duration, retraining cost and success probability | skill, health, MPC, education, region, contract type, immigrant status, social network |
 | Firms | produce, hire/fire, price/markup, invest, adopt hybrid/AI technology, borrow, issue equity/bonds, enter or exit | demand pressure, capacity, wages, costs, credit rates, cash, debt, sector, network effects, digital readiness | cash, working capital, labor availability, bank lending, profitability thresholds, technology failure risk | sector, size, technology regime, readiness, productivity, bank relation, network position |
-| Banks | price loans/deposits, approve credit, manage liquidity, absorb losses, provision, resolve failures, participate in interbank and bond markets | deposits, loans, reserves, capital, NPLs, bond yields, regulatory buffers, failed-bank state | CAR, LCR/NSFR inputs, reserve requirement, BFG/bail-in rules, failed-bank exclusion | seven bank rows with bank-specific buffers, spreads, capital, balance sheets |
+| Banks | price loans/deposits, approve credit, manage liquidity, absorb losses, provision, resolve failures, participate in interbank and bond markets | deposits, loans, reserves, capital, NPLs, bond yields, regulatory buffers, failed-bank state | CAR, LCR/NSFR inputs, reserve requirement, BFG/bail-in rules, failed-bank exclusion | seven bank rows: six named archetypes plus aggregate `Others`, with row-specific buffers, spreads, capital, and balance sheets |
 | Government | tax, spend, transfer, invest, issue debt, service debt, respond to fiscal rules | fiscal balance, debt, unemployment, tax bases, bond demand, social fund balances | fiscal-rule severity, debt brake, spending cuts, financing needs | aggregate institution with policy parameters |
 | NBP | set rate channel inputs, provide reserve interest and standing facilities, QE/FX operations | inflation, output, forex, reserves, bond market, interbank state | policy corridor, reserves, QE pace, FX reserve stock | aggregate institution |
 | Funds and insurance | collect contributions/premiums, pay claims/benefits, allocate holdings, issue/absorb quasi-fiscal instruments | payroll, unemployment, bankruptcies, AUM, reserves, bond/equity returns | statutory contribution/spending rules, portfolio shares, reserve/liability constraints | aggregate institution by fund family |
@@ -357,7 +364,8 @@ The initialized state is produced by `WorldInit.initialize`, using
 - builds firm and household populations from `PopulationConfig`, `FirmConfig`,
   `HouseholdConfig`, sector definitions, firm-size distribution, networks, and
   region/education/skill draws;
-- builds seven banks and their initial financial-stock DTOs;
+- builds seven banking-sector rows and their initial financial-stock DTOs:
+  six named archetypes plus aggregate `Others`;
 - initializes government, NBP, social funds, insurance, NBFI, quasi-fiscal,
   housing, GVC, expectations, immigration, and demographics state;
 - assembles initial `LedgerFinancialState` as the source of truth for

--- a/src/main/scala/com/boombustgroup/amorfati/Main.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/Main.scala
@@ -28,7 +28,7 @@ object Main extends ZIOAppDefault:
        |
        |  SFC-ABM  |  commit: $commit
        |
-       |  N=${rc.nSeeds} seeds  |  PLN (NBP)  |  HH=${p.household.count}  |  BANK=multi (7)
+       |  N=${rc.nSeeds} seeds  |  PLN (NBP)  |  HH=${p.household.count}  |  BANK=multi (6+Others)
        |  $firms firms x 6 sectors x Poland 2026-04-30 x ${p.topology.label} x ${rc.runDurationMonths}m
        |
        |  Apache 2.0 | Copyright 2026 BoomBustGroup | www.boombustgroup.com

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -85,8 +85,8 @@ object Banking:
   // Aggregate balance sheet (sum over all per-bank BankStates)
   // ---------------------------------------------------------------------------
 
-  /** Aggregate banking-sector balance sheet — sum over all 7 per-bank
-    * BankStates.
+  /** Aggregate banking-sector balance sheet — sum over all seven banking-sector
+    * rows (six named bank archetypes plus aggregate Others).
     *
     * Pure DTO recomputed from bank operational state plus explicit financial
     * stock rows. Read-only snapshot consumed by output columns, SFC identities,
@@ -312,7 +312,8 @@ object Banking:
   )
 
   // ---------------------------------------------------------------------------
-  // Default configs (7 Polish bank archetypes, Poland 2026-04-30 baseline)
+  // Default configs: six named Polish bank archetypes plus aggregate Others,
+  // Poland 2026-04-30 baseline.
   // ---------------------------------------------------------------------------
 
   private def affinity(xs: Share*): Vector[Share] = xs.toVector

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -12,7 +12,7 @@ carry behavioral state, operational diagnostics, and legacy unsupported metrics.
 
 | File | Agent | State | Key SFC identities |
 |------|-------|-------|-------------------|
-| `Banking.scala` | 7 Polish bank archetypes (Poland 2026-04-30 baseline) | Per-bank behavior, capital, NPL/risk buckets, LCR/NSFR inputs; deposits, loans, bonds, reserves, interbank positions are ledger projections | BankCapital, BankDeposits, BondClearing, InterbankNetting |
+| `Banking.scala` | 7 banking-sector rows: 6 named bank archetypes + aggregate `Others` (Poland 2026-04-30 baseline) | Per-row behavior, capital, NPL/risk buckets, LCR/NSFR inputs; deposits, loans, bonds, reserves, interbank positions are ledger projections | BankCapital, BankDeposits, BondClearing, InterbankNetting |
 | `Firm.scala` | Heterogeneous firms (6 sectors) | Technology state (Traditional/Hybrid/Automated), capital stock, inventory, green capital, labor and production state; cash/debt/equity are ledger projections | BankCapital (NPL), FlowOfFunds, CorpBondStock |
 | `Household.scala` | Individual households | Skill, health, MPC, employment status, housing and demographic state; savings, debt, consumer credit, and equity wealth are ledger projections | BankDeposits, ConsumerCredit |
 | `Immigration.scala` | Immigrant workers | Stock, monthly inflow/outflow, remittance outflow | BankDeposits (remittance → deposit outflow), Nfa |

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -5,11 +5,13 @@ import com.boombustgroup.amorfati.types.*
 /** Commercial banking system: balance sheets, credit risk, LCR/NSFR,
   * macroprudential, and KNF/BFG supervision.
   *
-  * Models a multi-bank system (7 banks by default, calibrated to the Poland
-  * 2026-04-30 production baseline) with heterogeneous balance sheets, credit
-  * spreads, NPL dynamics, capital adequacy (Basel III CRR), liquidity coverage
-  * (LCR/NSFR), macroprudential buffers (CCyB, O-SII), KNF BION/SREP P2R
-  * add-ons, BFG resolution levy and bail-in, and interbank market.
+  * Models a multi-bank system with seven banking-sector rows by default: six
+  * named bank archetypes and one aggregate `Others` bucket for the remaining
+  * sector, calibrated to the Poland 2026-04-30 production baseline. Rows have
+  * heterogeneous balance sheets, credit spreads, NPL dynamics, capital adequacy
+  * (Basel III CRR), liquidity coverage (LCR/NSFR), macroprudential buffers
+  * (CCyB, O-SII), KNF BION/SREP P2R add-ons, BFG resolution levy and bail-in,
+  * and interbank market.
   *
   * Stock values (`initCapital`, `initDeposits`, etc.) are in raw PLN — scaled
   * by `gdpRatio` in `SimParams.defaults`.
@@ -54,7 +56,8 @@ import com.boombustgroup.amorfati.types.*
   * @param termDepositFrac
   *   fraction of deposits that are term (stable for NSFR purposes)
   * @param p2rAddons
-  *   per-bank BION/SREP P2R capital add-ons (KNF bridge prior, 7 banks)
+  *   per-row BION/SREP P2R capital add-ons (KNF bridge prior, six named bank
+  *   archetypes plus aggregate Others)
   * @param bfgLevyRate
   *   annual BFG resolution fund levy as fraction of deposits (BFG bridge prior)
   * @param bailInDepositHaircut

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -73,7 +73,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   private def govBonds(stocks: Banking.BankFinancialStocks): PLN =
     Banking.govBondHoldings(stocks)
 
-  "Generators.testBankingSector" should "create 7 banks with explicit financial stocks preserving totals" in {
+  "Generators.testBankingSector" should "create 7 bank rows with explicit financial stocks preserving totals" in {
     val bs = Generators.testBankingSector(totalDeposits = PLN(1000000), totalCapital = PLN(100000), totalLoans = PLN.Zero, configs = configs)
 
     bs.banks.length shouldBe 7


### PR DESCRIPTION
## Summary
- clarify that the model uses seven banking-sector rows: six named bank archetypes plus aggregate Others
- update ODD docs, banking config docs, agent README, runtime banner, and the related test description
- avoid implying that the model contains seven separate commercial-bank case studies

## Tests
- git diff --check
- sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model documentation to clarify banking sector representation as seven banking-sector rows consisting of six named archetypes plus an aggregate "Others" bucket, distinguishing institutional sectors from individual agents.

* **Chores**
  * Modified startup banner to display banking configuration as `BANK=multi (6+Others)` for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->