### PR TITLE
Add generic firm snapshot export

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -977,7 +977,8 @@ research hypotheses or calibration targets:
   yet.
 - Output columns expose many macro and meso diagnostics, but not every
   household or firm micro trajectory is written to the Monte Carlo time-series
-  output by default.
+  output by default. The Monte Carlo runner can optionally emit selected-month
+  firm micro snapshots for cross-sectional analysis.
 - The SFC ledger and matrix artifacts document accounting structure. They do
   not by themselves validate behavioral realism.
 

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -331,7 +331,8 @@ Observation surfaces include:
 
 - `MonthTrace` for boundary, randomness, validation, and timing diagnostics;
 - Monte Carlo per-seed CSV time series;
-- household and bank terminal summary CSVs;
+- household, bank, and firm terminal summary CSVs;
+- optional selected-month firm micro snapshot CSVs;
 - SFC validation results;
 - ledger-derived symbolic BSM, TFM, and stock-flow reconciliation artifacts;
 - symbolic-row to runtime-ledger mapping.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -196,7 +196,7 @@ branch or opening a PR is optional and outside the assumed operating path.
 The main runtime entrypoint is:
 
 ```bash
-sbt "runMain com.boombustgroup.amorfati.Main <nSeeds> <prefix> [--duration <months>] [--run-id <id>]"
+sbt "runMain com.boombustgroup.amorfati.Main <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>]"
 ```
 
 Example smoke run:
@@ -218,6 +218,14 @@ Per-seed time-series CSV files emit macro PLN aggregates in Poland scale, ready
 for empirical analysis. The internal `gdpRatio` scaling factor is not emitted
 as a CSV column; it remains a model-computation boundary. Agent-level prices,
 wages, indexes, rates, shares, and counts remain in their native units.
+
+Firm-level micro snapshots are optional and off by default. Enable them with
+`--firm-snapshots terminal`, `--firm-snapshots every:12`, or
+`--firm-snapshots months:1,6,12`. When enabled, the runner also writes:
+
+```text
+mc/<prefix>_<run-id>_<months>m_firm_snapshots.csv
+```
 
 `mc/` is ignored by git. Keep committed research-facing artifacts under `docs/`
 only when the command explicitly targets a committed documentation path.

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.agents.HhStatus
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
-import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner, McTimeseriesSchema, RunResult, SimError}
+import com.boombustgroup.amorfati.montecarlo.{McFirmSnapshotSchedule, McRunConfig, McRunner, McTimeseriesSchema, RunResult, SimError}
 import com.boombustgroup.amorfati.types.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -30,6 +30,8 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     "Seed;BankId;Deposits;Loans;Capital;NPL;CAR;GovBonds;InterbankNet;Failed"
   private val ExpectedFirmHeader =
     "Seed;Firm_Living;FirmSize_Micro;FirmSize_Small;FirmSize_Medium;FirmSize_Large;FirmSize_MicroShare;FirmSize_SmallShare;FirmSize_MediumShare;FirmSize_LargeShare"
+  private val ExpectedFirmSnapshotHeader =
+    "RunId;Seed;Month;FirmId;Sector;Region;SizeClass;Workers;TechState;BankruptcyReason;DigitalReadiness;Cash;FirmLoan;Equity;BankId;RiskProfile;InitialSize;CapitalStock;Inventory;GreenCapital;ForeignOwned;StateOwned"
 
   private def rc =
     McRunConfig(
@@ -171,6 +173,51 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
           fields.length.shouldBe(ExpectedFirmHeader.split(';').length)
           fields.head.shouldBe(seed.toString)
         }
+    }
+  }
+
+  it.should("write terminal firm snapshots aligned with terminal firm-size counts when enabled").in {
+    withTempDir { outputDir =>
+      val snapshotRc = McRunConfig(
+        nSeeds = 1,
+        outputPrefix = "mc-it-snap",
+        runDurationMonths = DurationMonths,
+        runId = "snap",
+        firmSnapshotSchedule = McFirmSnapshotSchedule.TerminalOnly,
+      )
+
+      unsafeRun(McRunner.runZIO(snapshotRc, outputDir.toFile))
+
+      val expectedRun = McRunner.runSingle(1L, DurationMonths).fold(err => fail(err.toString), identity)
+      val snapshotLines = readLines(outputDir.resolve(s"${filePrefix(snapshotRc)}_firm_snapshots.csv"))
+      val snapshotHeader = snapshotLines.head.split(';').toVector
+      snapshotLines.head.shouldBe(ExpectedFirmSnapshotHeader)
+      snapshotLines.tail.size.shouldBe(expectedRun.terminalState.firms.length)
+
+      val monthIdx = snapshotHeader.indexOf("Month")
+      monthIdx should be >= 0
+      snapshotLines.tail.map(_.split(';')(monthIdx)).toSet.shouldBe(Set(DurationMonths.toString))
+
+      val sizeClassIdx = snapshotHeader.indexOf("SizeClass")
+      val techStateIdx = snapshotHeader.indexOf("TechState")
+      sizeClassIdx should be >= 0
+      techStateIdx should be >= 0
+      val snapshotCounts = snapshotLines.tail
+        .map(_.split(';').toVector)
+        .filter(row => row(techStateIdx) != "Bankrupt")
+        .groupBy(row => row(sizeClassIdx))
+        .view
+        .mapValues(_.size)
+        .toMap
+
+      val firmSummaryLine = readLines(outputDir.resolve(s"${filePrefix(snapshotRc)}_firms.csv"))(1)
+      val summaryFields   = ExpectedFirmHeader.split(';').toVector.zip(firmSummaryLine.split(';').toVector).toMap
+
+      snapshotCounts.getOrElse("Micro", 0).shouldBe(summaryFields("FirmSize_Micro").toInt)
+      snapshotCounts.getOrElse("Small", 0).shouldBe(summaryFields("FirmSize_Small").toInt)
+      snapshotCounts.getOrElse("Medium", 0).shouldBe(summaryFields("FirmSize_Medium").toInt)
+      snapshotCounts.getOrElse("Large", 0).shouldBe(summaryFields("FirmSize_Large").toInt)
+      snapshotCounts.values.sum.shouldBe(summaryFields("Firm_Living").toInt)
     }
   }
 

--- a/src/main/scala/com/boombustgroup/amorfati/Main.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/Main.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner}
+import com.boombustgroup.amorfati.montecarlo.{McFirmSnapshotSchedule, McRunConfig, McRunner}
 import com.boombustgroup.amorfati.util.BuildInfo
 import zio.*
 
@@ -34,15 +34,58 @@ object Main extends ZIOAppDefault:
        |  Apache 2.0 | Copyright 2026 BoomBustGroup | www.boombustgroup.com
        |""".stripMargin
 
-  private def parseArgs(args: Chunk[String]): ZIO[Any, IllegalArgumentException, McRunConfig] =
-    val usage = "Usage: amor-fati <nSeeds> <prefix> [--duration <months>] [--run-id <id>]"
+  private[amorfati] def parseArgs(args: Chunk[String]): ZIO[Any, IllegalArgumentException, McRunConfig] =
+    val usage = "Usage: amor-fati <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>]"
 
-    def findFlag(name: String): Option[String] =
-      val idx = args.indexOf(name)
-      if idx >= 0 && idx + 1 < args.length then Some(args(idx + 1)) else None
+    final case class ParsedFlags(
+        runDuration: Int = McRunConfig.DefaultRunDuration,
+        runId: Option[String] = None,
+        firmSnapshots: McFirmSnapshotSchedule = McFirmSnapshotSchedule.Disabled,
+    )
+
+    def knownFlag(flag: String): Boolean =
+      flag == "--duration" || flag == "--run-id" || flag == "--firm-snapshots"
+
+    def missingValue(flag: String): Left[String, ParsedFlags] =
+      Left(s"Missing value for $flag")
 
     def parseInt(value: String, label: String): Either[String, Int] =
       scala.util.Try(value.toInt).toOption.toRight(s"$label must be an integer")
+
+    def parseFirmSnapshotSchedule(value: String): Either[String, McFirmSnapshotSchedule] =
+      val normalized = value.trim.toLowerCase(java.util.Locale.ROOT)
+      if normalized == "none" || normalized == "disabled" then Right(McFirmSnapshotSchedule.Disabled)
+      else if normalized == "terminal" || normalized == "terminal-only" then Right(McFirmSnapshotSchedule.TerminalOnly)
+      else if normalized.startsWith("every:") then
+        parseInt(normalized.stripPrefix("every:"), "--firm-snapshots every:N").flatMap: months =>
+          scala.util.Try(McFirmSnapshotSchedule.EveryNMonths(months)).toEither.left.map(_.getMessage)
+      else if normalized.startsWith("months:") then
+        val rawMonths = normalized.stripPrefix("months:").split(',').toVector.filter(_.nonEmpty)
+        val parsed    = rawMonths.foldLeft[Either[String, Set[Int]]](Right(Set.empty)): (acc, raw) =>
+          for
+            months <- acc
+            month  <- parseInt(raw, "--firm-snapshots months:M1,M2,...")
+          yield months + month
+        parsed.flatMap: months =>
+          scala.util.Try(McFirmSnapshotSchedule.ExplicitMonths(months)).toEither.left.map(_.getMessage)
+      else Left("--firm-snapshots must be terminal, every:N, months:M1,M2,..., or none")
+
+    def parseFlags(rest: Seq[String], flags: ParsedFlags): Either[String, ParsedFlags] =
+      rest match
+        case Seq()                                  => Right(flags)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                           => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")        => missingValue(flag)
+            case Seq(value, next*) if flag == "--duration"       =>
+              parseInt(value, flag).flatMap(duration => parseFlags(next, flags.copy(runDuration = duration)))
+            case Seq(value, next*) if flag == "--run-id"         =>
+              parseFlags(next, flags.copy(runId = Some(value)))
+            case Seq(value, next*) if flag == "--firm-snapshots" =>
+              parseFirmSnapshotSchedule(value).flatMap(schedule => parseFlags(next, flags.copy(firmSnapshots = schedule)))
+            case Seq(_, _*)                                      => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
 
     ZIO
       .fromEither(for
@@ -50,14 +93,12 @@ object Main extends ZIOAppDefault:
         nSeedsValue <- args.headOption.toRight(usage)
         nSeeds      <- parseInt(nSeedsValue, "<nSeeds>")
         prefix      <- args.lift(1).toRight(usage)
-        runDuration <- findFlag("--duration") match
-          case Some(value) => parseInt(value, "--duration")
-          case None        => Right(McRunConfig.DefaultRunDuration)
+        flags       <- parseFlags(args.drop(2), ParsedFlags())
         mcRunConfig <- scala.util
           .Try:
-            findFlag("--run-id") match
-              case Some(id) => McRunConfig(nSeeds, prefix, runDuration, id)
-              case None     => McRunConfig(nSeeds, prefix, runDuration)
+            flags.runId match
+              case Some(id) => McRunConfig(nSeeds, prefix, flags.runDuration, id, flags.firmSnapshots)
+              case None     => McRunConfig(nSeeds, prefix, flags.runDuration, firmSnapshotSchedule = flags.firmSnapshots)
           .toEither
           .left
           .map(_.getMessage)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSizeClass.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSizeClass.scala
@@ -1,0 +1,16 @@
+package com.boombustgroup.amorfati.montecarlo
+
+private[montecarlo] enum McFirmSizeClass(val csvValue: String):
+  case Micro  extends McFirmSizeClass("Micro")
+  case Small  extends McFirmSizeClass("Small")
+  case Medium extends McFirmSizeClass("Medium")
+  case Large  extends McFirmSizeClass("Large")
+
+private[montecarlo] object McFirmSizeClass:
+  def fromWorkerCount(workers: Int): McFirmSizeClass =
+    require(workers >= 0, s"firm worker count must be >= 0, got $workers")
+    workers match
+      case size if size <= 9   => Micro
+      case size if size <= 49  => Small
+      case size if size <= 249 => Medium
+      case _                   => Large

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotCsv.scala
@@ -1,0 +1,96 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import zio.stream.ZStream
+import zio.{Scope, ZIO}
+
+import java.io.{BufferedWriter, File}
+import java.nio.file.{Files, StandardCopyOption}
+import scala.util.Using
+
+private[montecarlo] object McFirmSnapshotCsv:
+
+  private val operation = "write firm snapshot CSV"
+
+  def tapSeedSnapshots[A](
+      seed: Long,
+      rc: McRunConfig,
+      outputDir: File,
+      rows: ZStream[Any, SimError, A],
+  )(
+      executionMonth: A => ExecutionMonth,
+      state: A => FlowSimulation.SimState,
+  )(using SimParams): ZStream[Any, SimError, A] =
+    if !rc.firmSnapshotSchedule.enabled then rows
+    else
+      val partFile = seedPartFile(outputDir, seed, rc)
+      ZStream.unwrapScoped:
+        openWriter(partFile).map: writer =>
+          rows.tap: row =>
+            writeSnapshotRows(writer, partFile, rc, seed, executionMonth(row), state(row))
+
+  def combineSeedFiles(rc: McRunConfig, outputDir: File): ZIO[Any, SimError, Unit] =
+    if !rc.firmSnapshotSchedule.enabled then ZIO.unit
+    else
+      val outputFile = McOutputFiles.firmSnapshotFile(outputDir, rc)
+      val tempFile   = new File(s"${outputFile.getPath}.tmp")
+      ZIO
+        .attemptBlocking:
+          Using.resource(Files.newBufferedWriter(tempFile.toPath)): writer =>
+            writer.write(McFirmSnapshotSchema.header)
+            writer.newLine()
+            for seed <- 1L to rc.nSeeds.toLong do
+              val partFile = seedPartFile(outputDir, seed, rc)
+              if Files.exists(partFile.toPath) then
+                Using.resource(Files.lines(partFile.toPath)): lines =>
+                  val it = lines.iterator()
+                  while it.hasNext do
+                    writer.write(it.next())
+                    writer.newLine()
+          Files.move(tempFile.toPath, outputFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+          for seed <- 1L to rc.nSeeds.toLong do Files.deleteIfExists(seedPartFile(outputDir, seed, rc).toPath)
+        .unit
+        .mapError(outputFailure("combine firm snapshot CSV", outputFile))
+        .onError(_ => deleteIfExists(tempFile).ignore)
+
+  private def writeSnapshotRows(
+      writer: BufferedWriter,
+      outputFile: File,
+      rc: McRunConfig,
+      seed: Long,
+      month: ExecutionMonth,
+      state: FlowSimulation.SimState,
+  )(using SimParams): ZIO[Any, SimError, Unit] =
+    if !rc.firmSnapshotSchedule.includes(month, ExecutionMonth(rc.runDurationMonths)) then ZIO.unit
+    else
+      ZIO
+        .attemptBlocking:
+          val schema = McFirmSnapshotSchema.csvSchema
+          McFirmSnapshotSchema
+            .rows(rc.runId, seed, month, state)
+            .foreach: row =>
+              writer.write(schema.render(row))
+              writer.newLine()
+        .unit
+        .mapError(outputFailure(operation, outputFile))
+
+  private def openWriter(outputFile: File): ZIO[Scope, SimError, BufferedWriter] =
+    ZIO.fromAutoCloseable(
+      ZIO
+        .attemptBlocking(Files.newBufferedWriter(outputFile.toPath))
+        .mapError(outputFailure(s"open $operation writer", outputFile)),
+    )
+
+  private def seedPartFile(outputDir: File, seed: Long, rc: McRunConfig): File =
+    new File(outputDir, f".${McOutputFiles.firmSnapshotFile(outputDir, rc).getName}.seed${seed}%03d.part")
+
+  private def deleteIfExists(file: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking(Files.deleteIfExists(file.toPath))
+      .unit
+      .mapError(outputFailure(s"cleanup $operation temp file", file))
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchedule.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchedule.scala
@@ -1,0 +1,31 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+
+/** Optional firm-level microdata export schedule for Monte Carlo runs. */
+sealed trait McFirmSnapshotSchedule:
+  def enabled: Boolean
+  def includes(month: ExecutionMonth, terminalMonth: ExecutionMonth): Boolean
+
+object McFirmSnapshotSchedule:
+  case object Disabled extends McFirmSnapshotSchedule:
+    override val enabled: Boolean                                                        = false
+    override def includes(month: ExecutionMonth, terminalMonth: ExecutionMonth): Boolean = false
+
+  case object TerminalOnly extends McFirmSnapshotSchedule:
+    override val enabled: Boolean                                                        = true
+    override def includes(month: ExecutionMonth, terminalMonth: ExecutionMonth): Boolean =
+      month == terminalMonth
+
+  final case class EveryNMonths(months: Int) extends McFirmSnapshotSchedule:
+    require(months > 0, s"firm snapshot cadence must be > 0 months, got $months")
+    override val enabled: Boolean                                                        = true
+    override def includes(month: ExecutionMonth, terminalMonth: ExecutionMonth): Boolean =
+      month.toInt % months == 0
+
+  final case class ExplicitMonths(months: Set[Int]) extends McFirmSnapshotSchedule:
+    require(months.nonEmpty, "firm snapshot explicit month list must be non-empty")
+    require(months.forall(_ >= 1), s"firm snapshot months must be >= 1, got ${months.toVector.sorted.mkString(",")}")
+    override val enabled: Boolean                                                        = true
+    override def includes(month: ExecutionMonth, terminalMonth: ExecutionMonth): Boolean =
+      months.contains(month.toInt)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchema.scala
@@ -1,0 +1,98 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+
+private[montecarlo] object McFirmSnapshotSchema:
+
+  final case class Row(
+      runId: String,
+      seed: Long,
+      month: ExecutionMonth,
+      firm: Firm.State,
+      sectorName: String,
+      workers: Int,
+      sizeClass: McFirmSizeClass,
+      balances: LedgerFinancialState.FirmBalances,
+  )
+
+  private val columns: Vector[(String, Row => String)] = Vector(
+    "RunId"            -> (row => text(row.runId)),
+    "Seed"             -> (row => row.seed.toString),
+    "Month"            -> (row => row.month.toInt.toString),
+    "FirmId"           -> (row => row.firm.id.toInt.toString),
+    "Sector"           -> (row => text(row.sectorName)),
+    "Region"           -> (row => text(row.firm.region.toString)),
+    "SizeClass"        -> (row => row.sizeClass.csvValue),
+    "Workers"          -> (row => row.workers.toString),
+    "TechState"        -> (row => techState(row.firm.tech)),
+    "BankruptcyReason" -> (row => bankruptcyReason(row.firm.tech)),
+    "DigitalReadiness" -> (row => row.firm.digitalReadiness.format(6)),
+    "Cash"             -> (row => row.balances.cash.format(2)),
+    "FirmLoan"         -> (row => row.balances.firmLoan.format(2)),
+    "Equity"           -> (row => row.balances.equity.format(2)),
+    "BankId"           -> (row => row.firm.bankId.toInt.toString),
+    "RiskProfile"      -> (row => row.firm.riskProfile.format(6)),
+    "InitialSize"      -> (row => row.firm.initialSize.toString),
+    "CapitalStock"     -> (row => row.firm.capitalStock.format(2)),
+    "Inventory"        -> (row => row.firm.inventory.format(2)),
+    "GreenCapital"     -> (row => row.firm.greenCapital.format(2)),
+    "ForeignOwned"     -> (row => row.firm.foreignOwned.toString),
+    "StateOwned"       -> (row => row.firm.stateOwned.toString),
+  )
+
+  val header: String =
+    columns.map(_._1).mkString(";")
+
+  val csvSchema: McCsvSchema[Row] =
+    McCsvSchema(
+      header = header,
+      render = row => columns.map(_._2(row)).mkString(";"),
+    )
+
+  def rows(runId: String, seed: Long, month: ExecutionMonth, state: FlowSimulation.SimState)(using SimParams): Vector[Row] =
+    state.firms.map: firm =>
+      val workers = Firm.workerCount(firm)
+      Row(
+        runId = runId,
+        seed = seed,
+        month = month,
+        firm = firm,
+        sectorName = sectorName(firm),
+        workers = workers,
+        sizeClass = McFirmSizeClass.fromWorkerCount(workers),
+        balances = state.ledgerFinancialState.firms
+          .lift(firm.id.toInt)
+          .getOrElse:
+            throw IllegalStateException(s"Missing ledger financial balances for firm ${firm.id.toInt}"),
+      )
+
+  private def sectorName(firm: Firm.State)(using p: SimParams): String =
+    p.sectorDefs.lift(firm.sector.toInt).fold(s"sector-${firm.sector.toInt}")(_.name)
+
+  private def techState(tech: TechState): String =
+    tech match
+      case TechState.Traditional(_) => "Traditional"
+      case TechState.Hybrid(_, _)   => "Hybrid"
+      case TechState.Automated(_)   => "Automated"
+      case TechState.Bankrupt(_)    => "Bankrupt"
+
+  private def bankruptcyReason(tech: TechState): String =
+    tech match
+      case TechState.Bankrupt(reason) => text(bankruptcyReasonName(reason))
+      case _                          => ""
+
+  private def bankruptcyReasonName(reason: BankruptReason): String =
+    reason match
+      case BankruptReason.AiDebtTrap          => "AiDebtTrap"
+      case BankruptReason.HybridInsolvency    => "HybridInsolvency"
+      case BankruptReason.AiImplFailure       => "AiImplFailure"
+      case BankruptReason.HybridImplFailure   => "HybridImplFailure"
+      case BankruptReason.LaborCostInsolvency => "LaborCostInsolvency"
+      case BankruptReason.Other(msg)          => s"Other(${text(msg)})"
+
+  private def text(value: String): String =
+    value.replace(';', ',').replace('\n', ' ').replace('\r', ' ')

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
@@ -27,9 +27,15 @@ private[montecarlo] object McOutputFiles:
   def firmFile(outputDir: File, rc: McRunConfig): File =
     new File(outputDir, s"${filePrefix(rc)}_firms.csv")
 
+  def firmSnapshotFile(outputDir: File, rc: McRunConfig): File =
+    new File(outputDir, s"${filePrefix(rc)}_firm_snapshots.csv")
+
   def savedFiles(outputDir: File, rc: McRunConfig): Vector[File] =
-    (1L to rc.nSeeds.toLong).map(seed => seedFile(outputDir, seed, rc)).toVector ++
-      Vector(householdFile(outputDir, rc), bankFile(outputDir, rc), firmFile(outputDir, rc))
+    val baselineFiles =
+      (1L to rc.nSeeds.toLong).map(seed => seedFile(outputDir, seed, rc)).toVector ++
+        Vector(householdFile(outputDir, rc), bankFile(outputDir, rc), firmFile(outputDir, rc))
+    if rc.firmSnapshotSchedule.enabled then baselineFiles :+ firmSnapshotFile(outputDir, rc)
+    else baselineFiles
 
   private def filePrefix(rc: McRunConfig): String =
     s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
@@ -11,11 +11,13 @@ case class McRunConfig(
     outputPrefix: String,
     runDurationMonths: Int = McRunConfig.DefaultRunDuration,
     runId: String = McRunConfig.autoRunId(),
+    firmSnapshotSchedule: McFirmSnapshotSchedule = McFirmSnapshotSchedule.Disabled,
 ):
   McRunConfig.requirePositiveSeeds(nSeeds)
   McRunConfig.requireNonBlankOutputPrefix(outputPrefix)
   McRunConfig.requirePositiveDuration(runDurationMonths)
   McRunConfig.requireNonBlankRunId(runId)
+  McRunConfig.requireFirmSnapshotSchedule(firmSnapshotSchedule)
 
 object McRunConfig:
   val DefaultRunDuration: Int        = 120
@@ -36,3 +38,6 @@ object McRunConfig:
 
   def requireNonBlankRunId(runId: String): Unit =
     require(runId != null && runId.trim.nonEmpty, "runId must be non-blank")
+
+  def requireFirmSnapshotSchedule(schedule: McFirmSnapshotSchedule): Unit =
+    require(schedule != null, "firmSnapshotSchedule must be non-null")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -40,6 +40,7 @@ object McRunner:
           runSeed(seed, rc, outputDir)
         .runCollect
       _         <- McTerminalSummaryCsv.writeAll(rc, outputDir, summaries)
+      _         <- McFirmSnapshotCsv.combineSeedFiles(rc, outputDir)
       _         <- McRunnerConsole.emit(Event.BlankLine)
       _         <- McRunnerConsole.emitAll(McOutputFiles.savedFiles(outputDir, rc).map(file => Event.SavedFile(file.getPath)))
       t1        <- Clock.currentTime(TimeUnit.MILLISECONDS)
@@ -120,10 +121,20 @@ object McRunner:
   private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, McTerminalSummaryRows] =
     for
       st       <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      snapshots =
+        McFirmSnapshotCsv.tapSeedSnapshots(
+          seed = seed,
+          rc = rc,
+          outputDir = outputDir,
+          rows = seedStream(seed, rc.runDurationMonths)
+            .tap(snapshot => McRunnerConsole.emit(monthProgressEvent(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))),
+        )(
+          executionMonth = _.executionMonth,
+          state = _.state,
+        )
       terminal <- McTimeseriesCsv.writeStreaming(
         McOutputFiles.seedFile(outputDir, seed, rc),
-        seedStream(seed, rc.runDurationMonths)
-          .tap(snapshot => McRunnerConsole.emit(monthProgressEvent(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths)))
+        snapshots
           .map(snapshot => SeedTerminalSnapshot(snapshot.executionMonth, snapshot.monthData, snapshot.state)),
         McTimeseriesSchema.csvSchema.contramap(snapshot => (snapshot.executionMonth, snapshot.lastMonthData)),
         SimError.RuntimeFailure(

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTerminalSummarySchema.scala
@@ -167,11 +167,11 @@ private[montecarlo] object McTerminalSummarySchema:
   private def firmSizeCounts(firms: Vector[Firm.State])(using SimParams): FirmSizeCounts =
     val living = firms.filter(Firm.isAlive)
     val counts = living.foldLeft(FirmSizeCounts(living = living.length, micro = 0, small = 0, medium = 0, large = 0)): (acc, firm) =>
-      Firm.workerCount(firm) match
-        case size if size <= 9   => acc.copy(micro = acc.micro + 1)
-        case size if size <= 49  => acc.copy(small = acc.small + 1)
-        case size if size <= 249 => acc.copy(medium = acc.medium + 1)
-        case _                   => acc.copy(large = acc.large + 1)
+      McFirmSizeClass.fromWorkerCount(Firm.workerCount(firm)) match
+        case McFirmSizeClass.Micro  => acc.copy(micro = acc.micro + 1)
+        case McFirmSizeClass.Small  => acc.copy(small = acc.small + 1)
+        case McFirmSizeClass.Medium => acc.copy(medium = acc.medium + 1)
+        case McFirmSizeClass.Large  => acc.copy(large = acc.large + 1)
     counts
 
   private def percentile(values: Vector[PLN], p: Share): PLN =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -9,8 +9,12 @@ pipeline has no dependency on this package.
 
 | File | Object | Role |
 |------|--------|------|
-| `McRunner.scala` | `McRunner` | Orchestrates the Monte Carlo run: initializes seeds, streams monthly snapshots, writes per-seed CSVs, collects terminal summaries |
-| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId` |
+| `McRunner.scala` | `McRunner` | Orchestrates the Monte Carlo run: initializes seeds, streams monthly snapshots, writes per-seed CSVs, collects terminal summaries and optional firm snapshots |
+| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId`, `firmSnapshotSchedule` |
+| `McFirmSnapshotSchedule.scala` | `McFirmSnapshotSchedule` | Disabled/terminal/cadence/explicit-month firm microdata export schedule |
+| `McFirmSnapshotSchema.scala` | `McFirmSnapshotSchema` | Generic per-firm snapshot CSV header and row rendering |
+| `McFirmSnapshotCsv.scala` | `McFirmSnapshotCsv` | Optional per-seed firm snapshot chunk writer and combined CSV finalizer |
+| `McFirmSizeClass.scala` | `McFirmSizeClass` | Shared worker-count size-class boundary used by terminal counts and firm snapshots |
 | `McTimeseriesSchema.scala` | `McTimeseriesSchema` | Timeseries schema with typed `Col` definitions, `compute`, and shared `csvSchema` |
 | `McTimeseriesCsv.scala` | `McTimeseriesCsv` | Streaming per-seed timeseries CSV sink with temp-file finalization |
 | `McTerminalSummarySchema.scala` | `McTerminalSummarySchema` | Household/bank/firm terminal summary schemas and terminal-state row extraction; bank stock columns read `LedgerFinancialState` |
@@ -39,9 +43,11 @@ Main ──→ McRunner.runZIO(rc)
            │       └── McTimeseriesSchema.compute -> Array[MetricValue]
            │
            │     McTimeseriesCsv.writeStreaming(seed.csv)
+           │       └── optional McFirmSnapshotCsv.tapSeedSnapshots(...)
            │     McTerminalSummarySchema.fromTerminalState
            │
            ├── McTerminalSummaryCsv.writeAll(hh.csv, banks.csv, firms.csv)
+           ├── optional McFirmSnapshotCsv.combineSeedFiles(firm_snapshots.csv)
            └── McRunnerConsole.emit(...)
 ```
 
@@ -53,3 +59,26 @@ tests and local callers.
 `runDurationMonths` is a Monte Carlo/runtime concern. It controls how
 many monthly snapshots the runner materializes, but it is not part of
 `SimParams` and should not leak into economic decision rules.
+
+## Firm Snapshots
+
+Firm microdata is disabled by default. When enabled, the runner writes one
+combined file:
+
+```text
+mc/<prefix>_<run-id>_<months>m_firm_snapshots.csv
+```
+
+The CLI flag is:
+
+```bash
+--firm-snapshots terminal
+--firm-snapshots every:12
+--firm-snapshots months:1,6,12
+```
+
+Snapshot rows are one firm per selected execution month and include run id,
+seed, month, firm id, sector, region, size class, workers, tech state,
+bankruptcy reason, digital readiness, cash, firm loan, equity, bank id, risk
+profile, initial size, capital stock, inventory, green capital, and ownership
+flags. The existing terminal `_firms.csv` aggregate remains unchanged.

--- a/src/test/scala/com/boombustgroup/amorfati/MainSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/MainSpec.scala
@@ -1,0 +1,46 @@
+package com.boombustgroup.amorfati
+
+import com.boombustgroup.amorfati.montecarlo.{McFirmSnapshotSchedule, McRunConfig}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.{Chunk, Runtime, Unsafe}
+
+class MainSpec extends AnyFlatSpec with Matchers:
+
+  "Main.parseArgs" should "parse optional runtime flags strictly" in {
+    val parsed = parse("3", "smoke", "--duration", "24", "--run-id", "manual", "--firm-snapshots", "months:1,12")
+      .map: rc =>
+        (rc.nSeeds, rc.outputPrefix, rc.runDurationMonths, rc.runId, rc.firmSnapshotSchedule)
+
+    parsed shouldBe Right((3, "smoke", 24, "manual", McFirmSnapshotSchedule.ExplicitMonths(Set(1, 12))))
+  }
+
+  it should "report missing values for known flags" in {
+    expectError(parse("3", "smoke", "--firm-snapshots"), "Missing value for --firm-snapshots")
+    expectError(parse("3", "smoke", "--duration", "--run-id", "manual"), "Missing value for --duration")
+    expectError(parse("3", "smoke", "--run-id"), "Missing value for --run-id")
+  }
+
+  it should "reject unknown flags and unexpected positional arguments" in {
+    expectError(parse("3", "smoke", "--unknown", "value"), "Unknown argument: --unknown")
+    expectError(parse("3", "smoke", "extra"), "Unexpected positional argument: extra")
+  }
+
+  private def parse(args: String*): Either[String, McRunConfig] =
+    Unsafe.unsafe:
+      implicit unsafe =>
+        Runtime.default.unsafe
+          .run(Main.parseArgs(Chunk.fromIterable(args)).either)
+          .getOrThrowFiberFailure()
+          .left
+          .map(_.getMessage)
+
+  private def expectError(result: Either[String, McRunConfig], expected: String): Unit =
+    result match
+      case Left(message) =>
+        message should include(expected)
+        message should include("Usage: amor-fati")
+      case Right(value)  =>
+        fail(s"Expected parse error, got $value")
+
+end MainSpec

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotScheduleSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotScheduleSpec.scala
@@ -1,0 +1,38 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class McFirmSnapshotScheduleSpec extends AnyFlatSpec with Matchers:
+
+  "McFirmSnapshotSchedule" should "disable firm snapshots by default in run config" in {
+    McRunConfig(nSeeds = 1, outputPrefix = "baseline").firmSnapshotSchedule shouldBe McFirmSnapshotSchedule.Disabled
+  }
+
+  it should "select only the terminal execution month for terminal-only exports" in {
+    val schedule = McFirmSnapshotSchedule.TerminalOnly
+    schedule.includes(ExecutionMonth(2), ExecutionMonth(3)) shouldBe false
+    schedule.includes(ExecutionMonth(3), ExecutionMonth(3)) shouldBe true
+  }
+
+  it should "select cadence months for every-N-month exports" in {
+    val schedule = McFirmSnapshotSchedule.EveryNMonths(2)
+    schedule.includes(ExecutionMonth(1), ExecutionMonth(5)) shouldBe false
+    schedule.includes(ExecutionMonth(2), ExecutionMonth(5)) shouldBe true
+    schedule.includes(ExecutionMonth(4), ExecutionMonth(5)) shouldBe true
+    schedule.includes(ExecutionMonth(5), ExecutionMonth(5)) shouldBe false
+  }
+
+  it should "select explicit month lists" in {
+    val schedule = McFirmSnapshotSchedule.ExplicitMonths(Set(1, 3))
+    schedule.includes(ExecutionMonth(1), ExecutionMonth(4)) shouldBe true
+    schedule.includes(ExecutionMonth(2), ExecutionMonth(4)) shouldBe false
+    schedule.includes(ExecutionMonth(3), ExecutionMonth(4)) shouldBe true
+  }
+
+  it should "reject invalid enabled schedules" in {
+    an[IllegalArgumentException] should be thrownBy McFirmSnapshotSchedule.EveryNMonths(0)
+    an[IllegalArgumentException] should be thrownBy McFirmSnapshotSchedule.ExplicitMonths(Set.empty)
+    an[IllegalArgumentException] should be thrownBy McFirmSnapshotSchedule.ExplicitMonths(Set(0, 1))
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchemaSpec.scala
@@ -1,0 +1,11 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class McFirmSnapshotSchemaSpec extends AnyFlatSpec with Matchers:
+
+  "McFirmSnapshotSchema" should "keep the firm snapshot header stable" in {
+    McFirmSnapshotSchema.header shouldBe
+      "RunId;Seed;Month;FirmId;Sector;Region;SizeClass;Workers;TechState;BankruptcyReason;DigitalReadiness;Cash;FirmLoan;Equity;BankId;RiskProfile;InitialSize;CapitalStock;Inventory;GreenCapital;ForeignOwned;StateOwned"
+  }


### PR DESCRIPTION
## Summary
- Adds opt-in firm snapshot export with terminal, every-N, and explicit-month schedules.
- Streams selected-month firm rows through per-seed part files and combines them without changing default Monte Carlo outputs.
- Documents the new CLI/output surface and tightens Main CLI flag parsing for missing values.

## Tests
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.MainSpec com.boombustgroup.amorfati.montecarlo.McFirmSnapshotScheduleSpec com.boombustgroup.amorfati.montecarlo.McFirmSnapshotSchemaSpec"`
- `sbt "integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"`
- `sbt assembly`
- `java -jar target/scala-3.8.2/amor-fati.jar 3 issue-509-smoke --duration 24 --run-id issue509-24m --firm-snapshots every:12`

Closes #509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional firm-level snapshot exports during Monte Carlo simulations via a new `--firm-snapshots` CLI argument supporting multiple export schedules: terminal-only, every N months, or specific months.
  * Generates detailed firm microdata CSVs with size classification based on worker counts.

* **Documentation**
  * Updated command documentation with `--firm-snapshots` usage and output file paths.
  * Clarified simulation output artifacts to include firm snapshot options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->