### PR TITLE
Add firm decision trace export

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -978,7 +978,9 @@ research hypotheses or calibration targets:
 - Output columns expose many macro and meso diagnostics, but not every
   household or firm micro trajectory is written to the Monte Carlo time-series
   output by default. The Monte Carlo runner can optionally emit selected-month
-  firm micro snapshots for cross-sectional analysis.
+  firm micro snapshots for cross-sectional analysis and selected-firm decision
+  traces for adoption, financing, implementation, and labor/digital-investment
+  gate audits.
 - The SFC ledger and matrix artifacts document accounting structure. They do
   not by themselves validate behavioral realism.
 

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -333,6 +333,8 @@ Observation surfaces include:
 - Monte Carlo per-seed CSV time series;
 - household, bank, and firm terminal summary CSVs;
 - optional selected-month firm micro snapshot CSVs;
+- optional selected-firm decision trace CSVs for adoption, financing,
+  implementation, and labor/digital-investment gate audits;
 - SFC validation results;
 - ledger-derived symbolic BSM, TFM, and stock-flow reconciliation artifacts;
 - symbolic-row to runtime-ledger mapping.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -196,7 +196,7 @@ branch or opening a PR is optional and outside the assumed operating path.
 The main runtime entrypoint is:
 
 ```bash
-sbt "runMain com.boombustgroup.amorfati.Main <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>]"
+sbt "runMain com.boombustgroup.amorfati.Main <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>] [--firm-decision-trace <ids:I1,I2,...|first:N|all|none>]"
 ```
 
 Example smoke run:
@@ -226,6 +226,24 @@ Firm-level micro snapshots are optional and off by default. Enable them with
 ```text
 mc/<prefix>_<run-id>_<months>m_firm_snapshots.csv
 ```
+
+Firm decision traces are optional and off by default. Enable them with an
+explicit firm-id selector such as `--firm-decision-trace ids:0,42,99`, with the
+documented deterministic low-id sample `--firm-decision-trace first:25`, or with
+`--firm-decision-trace all` for tiny/debug runs. The selector is evaluated by
+firm id and does not use the model RNG. When enabled, the runner also writes:
+
+```text
+mc/<prefix>_<run-id>_<months>m_firm_decision_trace.csv
+```
+
+The trace records one selected-firm row per month with opening/closing tech
+state, decision type, bankruptcy reason, cash/debt/readiness/workers before and
+after, capex, new bank loan, down payment where applicable, relationship bank,
+lending rate, available approval/feasibility/probability flags, and separate
+adoption, implementation, upgrade-candidate bank approval, investment-credit
+bank approval, digital-invest, upgrade-efficiency, and labor-adjustment residual
+rolls where those gates were evaluated.
 
 `mc/` is ignored by git. Keep committed research-facing artifacts under `docs/`
 only when the command explicitly targets a committed documentation path.

--- a/src/main/scala/com/boombustgroup/amorfati/Main.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/Main.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.montecarlo.{McFirmSnapshotSchedule, McRunConfig, McRunner}
+import com.boombustgroup.amorfati.montecarlo.{McFirmDecisionTraceSelection, McFirmSnapshotSchedule, McRunConfig, McRunner}
 import com.boombustgroup.amorfati.util.BuildInfo
 import zio.*
 
@@ -35,16 +35,18 @@ object Main extends ZIOAppDefault:
        |""".stripMargin
 
   private[amorfati] def parseArgs(args: Chunk[String]): ZIO[Any, IllegalArgumentException, McRunConfig] =
-    val usage = "Usage: amor-fati <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>]"
+    val usage =
+      "Usage: amor-fati <nSeeds> <prefix> [--duration <months>] [--run-id <id>] [--firm-snapshots <terminal|every:N|months:M1,M2,...>] [--firm-decision-trace <ids:I1,I2,...|first:N|all|none>]"
 
     final case class ParsedFlags(
         runDuration: Int = McRunConfig.DefaultRunDuration,
         runId: Option[String] = None,
         firmSnapshots: McFirmSnapshotSchedule = McFirmSnapshotSchedule.Disabled,
+        firmDecisionTrace: McFirmDecisionTraceSelection = McFirmDecisionTraceSelection.Disabled,
     )
 
     def knownFlag(flag: String): Boolean =
-      flag == "--duration" || flag == "--run-id" || flag == "--firm-snapshots"
+      flag == "--duration" || flag == "--run-id" || flag == "--firm-snapshots" || flag == "--firm-decision-trace"
 
     def missingValue(flag: String): Left[String, ParsedFlags] =
       Left(s"Missing value for $flag")
@@ -70,20 +72,40 @@ object Main extends ZIOAppDefault:
           scala.util.Try(McFirmSnapshotSchedule.ExplicitMonths(months)).toEither.left.map(_.getMessage)
       else Left("--firm-snapshots must be terminal, every:N, months:M1,M2,..., or none")
 
+    def parseFirmDecisionTraceSelection(value: String): Either[String, McFirmDecisionTraceSelection] =
+      val normalized = value.trim.toLowerCase(java.util.Locale.ROOT)
+      if normalized == "none" || normalized == "disabled" then Right(McFirmDecisionTraceSelection.Disabled)
+      else if normalized == "all" then Right(McFirmDecisionTraceSelection.All)
+      else if normalized.startsWith("first:") then
+        parseInt(normalized.stripPrefix("first:"), "--firm-decision-trace first:N").flatMap: count =>
+          scala.util.Try(McFirmDecisionTraceSelection.FirstN(count)).toEither.left.map(_.getMessage)
+      else if normalized.startsWith("ids:") then
+        val rawIds = normalized.stripPrefix("ids:").split(',').toVector.filter(_.nonEmpty)
+        val parsed = rawIds.foldLeft[Either[String, Set[Int]]](Right(Set.empty)): (acc, raw) =>
+          for
+            ids <- acc
+            id  <- parseInt(raw, "--firm-decision-trace ids:I1,I2,...")
+          yield ids + id
+        parsed.flatMap: ids =>
+          scala.util.Try(McFirmDecisionTraceSelection.ExplicitFirmIds(ids)).toEither.left.map(_.getMessage)
+      else Left("--firm-decision-trace must be ids:I1,I2,..., first:N, all, or none")
+
     def parseFlags(rest: Seq[String], flags: ParsedFlags): Either[String, ParsedFlags] =
       rest match
         case Seq()                                  => Right(flags)
         case Seq(flag, tail*) if knownFlag(flag)    =>
           tail match
-            case Seq()                                           => missingValue(flag)
-            case Seq(value, _*) if value.startsWith("--")        => missingValue(flag)
-            case Seq(value, next*) if flag == "--duration"       =>
+            case Seq()                                                => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")             => missingValue(flag)
+            case Seq(value, next*) if flag == "--duration"            =>
               parseInt(value, flag).flatMap(duration => parseFlags(next, flags.copy(runDuration = duration)))
-            case Seq(value, next*) if flag == "--run-id"         =>
+            case Seq(value, next*) if flag == "--run-id"              =>
               parseFlags(next, flags.copy(runId = Some(value)))
-            case Seq(value, next*) if flag == "--firm-snapshots" =>
+            case Seq(value, next*) if flag == "--firm-snapshots"      =>
               parseFirmSnapshotSchedule(value).flatMap(schedule => parseFlags(next, flags.copy(firmSnapshots = schedule)))
-            case Seq(_, _*)                                      => Left(s"Unknown argument: $flag")
+            case Seq(value, next*) if flag == "--firm-decision-trace" =>
+              parseFirmDecisionTraceSelection(value).flatMap(selection => parseFlags(next, flags.copy(firmDecisionTrace = selection)))
+            case Seq(_, _*)                                           => Left(s"Unknown argument: $flag")
         case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
         case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
 
@@ -97,8 +119,15 @@ object Main extends ZIOAppDefault:
         mcRunConfig <- scala.util
           .Try:
             flags.runId match
-              case Some(id) => McRunConfig(nSeeds, prefix, flags.runDuration, id, flags.firmSnapshots)
-              case None     => McRunConfig(nSeeds, prefix, flags.runDuration, firmSnapshotSchedule = flags.firmSnapshots)
+              case Some(id) => McRunConfig(nSeeds, prefix, flags.runDuration, id, flags.firmSnapshots, flags.firmDecisionTrace)
+              case None     =>
+                McRunConfig(
+                  nSeeds,
+                  prefix,
+                  flags.runDuration,
+                  firmSnapshotSchedule = flags.firmSnapshots,
+                  firmDecisionTraceSelection = flags.firmDecisionTrace,
+                )
           .toEither
           .left
           .map(_.getMessage)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -206,6 +206,16 @@ object Banking:
       bankCorpBondHoldings: Vector[PLN] = Vector.empty,
   )
 
+  /** Auditable result of a firm-credit approval check. `approvalRoll` is
+    * defined only when balance-sheet constraints pass and the stochastic
+    * approval gate is actually sampled.
+    */
+  case class CreditApproval(
+      approved: Boolean,
+      approvalProbability: Option[Share],
+      approvalRoll: Option[Share],
+  )
+
   // ---------------------------------------------------------------------------
   // Config
   // ---------------------------------------------------------------------------
@@ -470,7 +480,12 @@ object Banking:
   def canLend(bank: BankState, stocks: BankFinancialStocks, amount: PLN, rng: RandomStream, ccyb: Multiplier, corpBondHoldings: PLN)(using
       p: SimParams,
   ): Boolean =
-    if bank.failed then false
+    creditApproval(bank, stocks, amount, rng, ccyb, corpBondHoldings).approved
+
+  def creditApproval(bank: BankState, stocks: BankFinancialStocks, amount: PLN, rng: RandomStream, ccyb: Multiplier, corpBondHoldings: PLN)(using
+      p: SimParams,
+  ): CreditApproval =
+    if bank.failed then CreditApproval(approved = false, approvalProbability = None, approvalRoll = None)
     else
       val projectedRwa = stocks.firmLoan + stocks.consumerLoan + corpBondHoldings * CorpBondRiskWeight + amount
       val projectedCar = if projectedRwa > MinBalanceThreshold then bank.capital.ratioTo(projectedRwa).toMultiplier else SafeRatioFloor
@@ -482,7 +497,10 @@ object Banking:
       val freeReserves = stocks.totalDeposits * (Share.One - p.banking.reserveReq) - stocks.firmLoan - govBondHoldings(stocks)
       val resPenalty   = if freeReserves > PLN.Zero then Share.Zero else ReserveDeficitPenalty
       val approvalP    = (Share.One - nplPenalty.toShare - resPenalty).max(MinApprovalProb)
-      carOk && lcrOk && nsfrOk && approvalP.sampleBelow(rng)
+      if carOk && lcrOk && nsfrOk then
+        val roll = Share.random(rng)
+        CreditApproval(approved = roll < approvalP, approvalProbability = Some(approvalP), approvalRoll = Some(roll))
+      else CreditApproval(approved = false, approvalProbability = Some(approvalP), approvalRoll = None)
 
   // ---------------------------------------------------------------------------
   // Interbank market

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -191,23 +191,24 @@ object Firm:
     * variables.
     */
   case class Result(
-      firm: State,                      // Updated firm state after this month
-      financialStocks: FinancialStocks, // Closing ledger-contracted financial stocks
-      taxPaid: PLN,                     // CIT actually paid (after informal evasion)
-      realizedPostTaxProfit: PLN,       // realized monthly profit after tax, floored at zero for payout logic
-      capexSpent: PLN,                  // Technology upgrade CAPEX (AI or hybrid)
-      techImports: PLN,                 // Import content of CAPEX (forex demand)
-      newLoan: PLN,                     // New bank loan taken for upgrade
-      equityIssuance: PLN,              // GPW equity raised this month (filled by S4)
-      grossInvestment: PLN,             // Physical capital investment this month
-      bondIssuance: PLN,                // Corporate bond issuance (filled by S4)
-      profitShiftCost: PLN,             // FDI profit shifting outflow
-      fdiRepatriation: PLN,             // FDI dividend repatriation outflow
-      inventoryChange: PLN,             // Net inventory change (+ accumulation, - drawdown)
-      citEvasion: PLN,                  // CIT evaded via informal economy
-      energyCost: PLN,                  // Total energy + ETS cost this month
-      greenInvestment: PLN,             // Green capital investment this month
-      principalRepaid: PLN,             // Monthly firm loan principal repayment
+      firm: State,                                // Updated firm state after this month
+      financialStocks: FinancialStocks,           // Closing ledger-contracted financial stocks
+      taxPaid: PLN,                               // CIT actually paid (after informal evasion)
+      realizedPostTaxProfit: PLN,                 // realized monthly profit after tax, floored at zero for payout logic
+      capexSpent: PLN,                            // Technology upgrade CAPEX (AI or hybrid)
+      techImports: PLN,                           // Import content of CAPEX (forex demand)
+      newLoan: PLN,                               // New bank loan taken for upgrade
+      equityIssuance: PLN,                        // GPW equity raised this month (filled by S4)
+      grossInvestment: PLN,                       // Physical capital investment this month
+      bondIssuance: PLN,                          // Corporate bond issuance (filled by S4)
+      profitShiftCost: PLN,                       // FDI profit shifting outflow
+      fdiRepatriation: PLN,                       // FDI dividend repatriation outflow
+      inventoryChange: PLN,                       // Net inventory change (+ accumulation, - drawdown)
+      citEvasion: PLN,                            // CIT evaded via informal economy
+      energyCost: PLN,                            // Total energy + ETS cost this month
+      greenInvestment: PLN,                       // Green capital investment this month
+      principalRepaid: PLN,                       // Monthly firm loan principal repayment
+      decisionTrace: Option[DecisionTrace] = None, // Auditable decision surface for optional exports
   )
   object Result:
     /** Convenience factory for tests — all flow fields set to `PLN.Zero`. */
@@ -231,6 +232,67 @@ object Firm:
         PLN.Zero,
         PLN.Zero,
       )
+
+  /** Auditable per-firm decision record. It is computed from values already
+    * consumed by the decision path; constructing it must not draw from RNG.
+    */
+  case class DecisionTrace(
+      firmId: FirmId,
+      openingTech: TechState,
+      closingTech: TechState,
+      decisionType: DecisionTrace.DecisionType,
+      bankruptcyReason: Option[BankruptReason],
+      cashBefore: PLN,
+      cashAfter: PLN,
+      firmLoanBefore: PLN,
+      firmLoanAfter: PLN,
+      digitalReadinessBefore: Share,
+      digitalReadinessAfter: Share,
+      workersBefore: Int,
+      workersAfter: Int,
+      capex: PLN,
+      newLoan: PLN,
+      downPayment: Option[PLN],
+      bankId: BankId,
+      lendingRate: Rate,
+      selectedBankApproval: Option[Boolean],
+      selectedBankApprovalProbability: Option[Share],
+      selectedBankApprovalRoll: Option[Share],
+      fullAiFeasible: Option[Boolean],
+      hybridFeasible: Option[Boolean],
+      fullAiAdoptionProbability: Option[Share],
+      hybridAdoptionProbability: Option[Share],
+      adoptionRoll: Option[Share],
+      fullAiBankApproval: Option[Boolean],
+      fullAiBankApprovalProbability: Option[Share],
+      fullAiBankApprovalRoll: Option[Share],
+      hybridBankApproval: Option[Boolean],
+      hybridBankApprovalProbability: Option[Share],
+      hybridBankApprovalRoll: Option[Share],
+      implementationFailureProbability: Option[Share],
+      implementationRoll: Option[Share],
+      upgradeEfficiencyDraw: Option[Scalar],
+      upgradeEfficiencyMultiplier: Option[Multiplier],
+      investmentCreditNeed: Option[PLN],
+      investmentCreditAmount: Option[PLN],
+      investmentBankApproval: Option[Boolean],
+      investmentBankApprovalProbability: Option[Share],
+      investmentBankApprovalRoll: Option[Share],
+      digitalInvestProbability: Option[Share],
+      digitalInvestRoll: Option[Share],
+      laborAdjustmentResidualProbability: Option[Share],
+      laborAdjustmentResidualRoll: Option[Share],
+  )
+  object DecisionTrace:
+    enum DecisionType(val csvValue: String):
+      case Survive       extends DecisionType("survive")
+      case Upsize        extends DecisionType("upsize")
+      case Downsize      extends DecisionType("downsize")
+      case DigiInvest    extends DecisionType("digi-invest")
+      case FullAiUpgrade extends DecisionType("full-AI-upgrade")
+      case HybridUpgrade extends DecisionType("hybrid-upgrade")
+      case UpgradeFailed extends DecisionType("upgrade-failed")
+      case Bankrupt      extends DecisionType("bankrupt")
 
   /** Monthly profit-and-loss breakdown, computed by `computePnL`. */
   case class PnL(
@@ -258,6 +320,94 @@ object Firm:
     case class Downsize(pnl: PnL, newWorkers: Int, adjustedCash: PLN, newTech: TechState, drUpdate: Option[Share] = None)     extends Decision
     case class Upsize(pnl: PnL, newWorkers: Int, newCash: PLN, newTech: TechState, drUpdate: Option[Share] = None)            extends Decision
     case class DigiInvest(pnl: PnL, cost: PLN, newDR: Share)                                                                  extends Decision
+
+  case class CreditDecision(
+      approved: Boolean,
+      approvalProbability: Option[Share] = None,
+      approvalRoll: Option[Share] = None,
+  )
+  object CreditDecision:
+    def fromBoolean(approved: Boolean): CreditDecision =
+      CreditDecision(approved)
+
+  private case class DecisionAudit(
+      selectedBankApproval: Option[Boolean] = None,
+      selectedBankApprovalProbability: Option[Share] = None,
+      selectedBankApprovalRoll: Option[Share] = None,
+      fullAiFeasible: Option[Boolean] = None,
+      hybridFeasible: Option[Boolean] = None,
+      fullAiAdoptionProbability: Option[Share] = None,
+      hybridAdoptionProbability: Option[Share] = None,
+      adoptionRoll: Option[Share] = None,
+      fullAiBankApproval: Option[Boolean] = None,
+      fullAiBankApprovalProbability: Option[Share] = None,
+      fullAiBankApprovalRoll: Option[Share] = None,
+      hybridBankApproval: Option[Boolean] = None,
+      hybridBankApprovalProbability: Option[Share] = None,
+      hybridBankApprovalRoll: Option[Share] = None,
+      implementationFailureProbability: Option[Share] = None,
+      implementationRoll: Option[Share] = None,
+      upgradeEfficiencyDraw: Option[Scalar] = None,
+      upgradeEfficiencyMultiplier: Option[Multiplier] = None,
+      digitalInvestProbability: Option[Share] = None,
+      digitalInvestRoll: Option[Share] = None,
+      laborAdjustmentResidualProbability: Option[Share] = None,
+      laborAdjustmentResidualRoll: Option[Share] = None,
+  ):
+    def merge(next: DecisionAudit): DecisionAudit =
+      DecisionAudit(
+        selectedBankApproval = next.selectedBankApproval.orElse(selectedBankApproval),
+        selectedBankApprovalProbability = next.selectedBankApprovalProbability.orElse(selectedBankApprovalProbability),
+        selectedBankApprovalRoll = next.selectedBankApprovalRoll.orElse(selectedBankApprovalRoll),
+        fullAiFeasible = next.fullAiFeasible.orElse(fullAiFeasible),
+        hybridFeasible = next.hybridFeasible.orElse(hybridFeasible),
+        fullAiAdoptionProbability = next.fullAiAdoptionProbability.orElse(fullAiAdoptionProbability),
+        hybridAdoptionProbability = next.hybridAdoptionProbability.orElse(hybridAdoptionProbability),
+        adoptionRoll = next.adoptionRoll.orElse(adoptionRoll),
+        fullAiBankApproval = next.fullAiBankApproval.orElse(fullAiBankApproval),
+        fullAiBankApprovalProbability = next.fullAiBankApprovalProbability.orElse(fullAiBankApprovalProbability),
+        fullAiBankApprovalRoll = next.fullAiBankApprovalRoll.orElse(fullAiBankApprovalRoll),
+        hybridBankApproval = next.hybridBankApproval.orElse(hybridBankApproval),
+        hybridBankApprovalProbability = next.hybridBankApprovalProbability.orElse(hybridBankApprovalProbability),
+        hybridBankApprovalRoll = next.hybridBankApprovalRoll.orElse(hybridBankApprovalRoll),
+        implementationFailureProbability = next.implementationFailureProbability.orElse(implementationFailureProbability),
+        implementationRoll = next.implementationRoll.orElse(implementationRoll),
+        upgradeEfficiencyDraw = next.upgradeEfficiencyDraw.orElse(upgradeEfficiencyDraw),
+        upgradeEfficiencyMultiplier = next.upgradeEfficiencyMultiplier.orElse(upgradeEfficiencyMultiplier),
+        digitalInvestProbability = next.digitalInvestProbability.orElse(digitalInvestProbability),
+        digitalInvestRoll = next.digitalInvestRoll.orElse(digitalInvestRoll),
+        laborAdjustmentResidualProbability = next.laborAdjustmentResidualProbability.orElse(laborAdjustmentResidualProbability),
+        laborAdjustmentResidualRoll = next.laborAdjustmentResidualRoll.orElse(laborAdjustmentResidualRoll),
+      )
+
+  private case class DecisionWithAudit(decision: Decision, audit: DecisionAudit)
+
+  private case class AdjustmentMagnitude(
+      value: Int,
+      residualProbability: Option[Share],
+      residualRoll: Option[Share],
+  )
+
+  private def selectedBankAudit(credit: CreditDecision): DecisionAudit =
+    DecisionAudit(
+      selectedBankApproval = Some(credit.approved),
+      selectedBankApprovalProbability = credit.approvalProbability,
+      selectedBankApprovalRoll = credit.approvalRoll,
+    )
+
+  private def fullAiBankAudit(credit: CreditDecision): DecisionAudit =
+    DecisionAudit(
+      fullAiBankApproval = Some(credit.approved),
+      fullAiBankApprovalProbability = credit.approvalProbability,
+      fullAiBankApprovalRoll = credit.approvalRoll,
+    )
+
+  private def hybridBankAudit(credit: CreditDecision): DecisionAudit =
+    DecisionAudit(
+      hybridBankApproval = Some(credit.approved),
+      hybridBankApprovalProbability = credit.approvalProbability,
+      hybridBankApprovalRoll = credit.approvalRoll,
+    )
 
   // ---- Queries ----
 
@@ -386,14 +536,16 @@ object Firm:
   private def nextHiringSignalMonths(firm: State, desired: Int, workers: Int): Int =
     if desired > workers then firm.hiringSignalMonths + 1 else 0
 
-  private def stochasticAdjustmentMagnitude(absGap: Int, adjustFrac: Share, rng: RandomStream): Int =
-    if absGap <= 0 then 0
+  private def stochasticAdjustmentMagnitude(absGap: Int, adjustFrac: Share, rng: RandomStream): AdjustmentMagnitude =
+    if absGap <= 0 then AdjustmentMagnitude(0, None, None)
     else
-      val expectedRaw = BigInt(adjustFrac.toLong) * BigInt(absGap)
-      val whole       = (expectedRaw / BigInt(FixedPointBase.Scale)).toInt
-      val residualRaw = (expectedRaw % BigInt(FixedPointBase.Scale)).toLong
-      val residual    = if residualRaw > 0L && Share.fromRaw(residualRaw).sampleBelow(rng) then 1 else 0
-      Math.min(absGap, whole + residual)
+      val expectedRaw  = BigInt(adjustFrac.toLong) * BigInt(absGap)
+      val whole        = (expectedRaw / BigInt(FixedPointBase.Scale)).toInt
+      val residualRaw  = (expectedRaw % BigInt(FixedPointBase.Scale)).toLong
+      val residualP    = if residualRaw > 0L then Some(Share.fromRaw(residualRaw)) else None
+      val residualRoll = residualP.map(_ => Share.random(rng))
+      val residual     = if residualP.exists(p => residualRoll.exists(_ < p)) then 1 else 0
+      AdjustmentMagnitude(Math.min(absGap, whole + residual), residualP, residualRoll)
 
   private def hiringAdjustFrac(using p: SimParams): Share =
     p.firm.laborAdjustSpeed.toShare.clamp(Share.Zero, Share.One)
@@ -528,15 +680,45 @@ object Firm:
       rng: RandomStream,
       corpBondDebt: PLN,
   )(using p: SimParams): Result =
-    val decision = decide(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCanLend, allFirms, rng, corpBondDebt)
-    val r0       = updateHiringSignalState(execute(firm, financialStocks, decision), firm, w, operationalSignals)
+    processWithCreditAudit(
+      firm,
+      financialStocks,
+      w,
+      executionMonth,
+      operationalSignals,
+      lendRate,
+      amount => CreditDecision.fromBoolean(bankCanLend(amount)),
+      allFirms,
+      rng,
+      corpBondDebt,
+      traceDecision = false,
+    )
+
+  private[amorfati] def processWithCreditAudit(
+      firm: State,
+      financialStocks: FinancialStocks,
+      w: World,
+      executionMonth: ExecutionMonth,
+      operationalSignals: OperationalSignals,
+      lendRate: Rate,
+      bankCreditDecision: PLN => CreditDecision,
+      allFirms: Vector[State],
+      rng: RandomStream,
+      corpBondDebt: PLN,
+      traceDecision: Boolean,
+  )(using p: SimParams): Result =
+    val decision = decide(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCreditDecision, allFirms, rng, corpBondDebt)
+    val r0       = updateHiringSignalState(execute(firm, financialStocks, decision.decision), firm, w, operationalSignals)
     val r0a      = applyLoanAmortization(r0)
-    val r1       = applyGreenInvestment(r0a)
-    val r2       = applyInvestment(r1, operationalSignals.sectorDemandPressure(firm.sector.toInt), bankCanLend)
+    val tracedR0 = if traceDecision then r0a.copy(decisionTrace = Some(buildDecisionTrace(firm, financialStocks, lendRate, decision, r0a))) else r0a
+    val r1       = applyGreenInvestment(tracedR0)
+    val r2       = applyInvestment(r1, operationalSignals.sectorDemandPressure(firm.sector.toInt), bankCreditDecision)
     val r3       = applyDigitalDrift(r2)
     val r4       = applyInventory(r3, sectorDemandMult = operationalSignals.sectorDemandMult(firm.sector.toInt))
     val r5       = applyFdiFlows(r4)
-    applyInformalCitEvasion(r5, w.mechanisms.informalCyclicalAdj)
+    val finalR   = applyInformalCitEvasion(r5, w.mechanisms.informalCyclicalAdj)
+    if traceDecision then finalR.copy(decisionTrace = finalR.decisionTrace.map(refreshDecisionTraceClosing(_, finalR)))
+    else finalR
 
   // ---- Decide (all match logic + RandomStream rolls) ----
 
@@ -549,18 +731,18 @@ object Firm:
       executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
-      bankCanLend: PLN => Boolean,
+      bankCreditDecision: PLN => CreditDecision,
       allFirms: Vector[State],
       rng: RandomStream,
       corpBondDebt: PLN,
-  )(using p: SimParams): Decision =
+  )(using p: SimParams): DecisionWithAudit =
     firm.tech match
-      case _: TechState.Bankrupt         => Decision.StayBankrupt
+      case _: TechState.Bankrupt         => DecisionWithAudit(Decision.StayBankrupt, DecisionAudit())
       case _: TechState.Automated        => decideAutomated(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, corpBondDebt)
       case TechState.Hybrid(wkrs, aiEff) =>
-        decideHybrid(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCanLend, wkrs, aiEff, rng, corpBondDebt)
+        decideHybrid(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCreditDecision, wkrs, aiEff, rng, corpBondDebt)
       case TechState.Traditional(wkrs)   =>
-        decideTraditional(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCanLend, allFirms, wkrs, rng, corpBondDebt)
+        decideTraditional(firm, financialStocks, w, executionMonth, operationalSignals, lendRate, bankCreditDecision, allFirms, wkrs, rng, corpBondDebt)
 
   /** Smooth labor adjustment: Δworkers = λ × (target − current), with severance
     * costs. Target = break-even headcount from P&L. If adjustment insufficient
@@ -661,7 +843,7 @@ object Firm:
       operationalSignals: OperationalSignals,
       lendRate: Rate,
       corpBondDebt: PLN,
-  )(using p: SimParams): Decision =
+  )(using p: SimParams): DecisionWithAudit =
     val pnl = computePnL(
       firm,
       financialStocks,
@@ -676,8 +858,8 @@ object Firm:
       w.real.productivityIndex,
     )
     val nc  = financialStocks.cash + pnl.netAfterTax
-    if nc < PLN.Zero then Decision.GoBankrupt(pnl, nc, BankruptReason.AiDebtTrap)
-    else Decision.Survive(pnl, nc)
+    if nc < PLN.Zero then DecisionWithAudit(Decision.GoBankrupt(pnl, nc, BankruptReason.AiDebtTrap), DecisionAudit())
+    else DecisionWithAudit(Decision.Survive(pnl, nc), DecisionAudit())
 
   /** Hybrid firm: attempt full-AI upgrade, else survive/downsize/bankrupt. */
   private def decideHybrid(
@@ -687,12 +869,12 @@ object Firm:
       executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
-      bankCanLend: PLN => Boolean,
+      bankCreditDecision: PLN => CreditDecision,
       workers: Int,
       aiEff: Multiplier,
       rng: RandomStream,
       corpBondDebt: PLN,
-  )(using p: SimParams): Decision =
+  )(using p: SimParams): DecisionWithAudit =
     val pnl    = computePnL(
       firm,
       financialStocks,
@@ -708,7 +890,11 @@ object Firm:
     )
     val ready2 = (firm.digitalReadiness + HybridMonthlyDrDrift).min(Share.One)
 
-    if isInStartup(firm) then return startupFallbackDecision(firm, financialStocks, pnl, workers, w => TechState.Hybrid(w, aiEff), w.householdMarket.marketWage)
+    if isInStartup(firm) then
+      return DecisionWithAudit(
+        startupFallbackDecision(firm, financialStocks, pnl, workers, w => TechState.Hybrid(w, aiEff), w.householdMarket.marketWage),
+        DecisionAudit(),
+      )
 
     val upCapex    = computeAiCapex(firm) * HybridToFullCapexMul
     val upLoan     = upCapex * FullAiLoanShare
@@ -727,18 +913,30 @@ object Firm:
     val profitable = pnl.costs > upCost * FullAiProfitMargin
     val canPay     = financialStocks.cash > upDown
     val ready      = firm.digitalReadiness >= p.firm.fullAiReadinessMin
-    val bankOk     = bankCanLend(upLoan)
+    val bankCredit = bankCreditDecision(upLoan)
+    val bankOk     = bankCredit.approved
 
     val prob: Share =
       if profitable && canPay && ready && bankOk then
         ((firm.riskProfile * RiskWeightHybUpgrade) + (w.real.automationRatio * AutoRatioWeight)) * firm.digitalReadiness
       else Share.Zero
+    val audit       = DecisionAudit(
+      fullAiFeasible = Some(profitable && canPay && ready && bankOk),
+      fullAiAdoptionProbability = Some(prob.min(Share.One)),
+    ).merge(fullAiBankAudit(bankCredit))
+    val roll        = Share.random(rng)
 
-    if prob.sampleBelow(rng) then
-      val eff = Multiplier.One + (Scalar.randomBetween(HybToFullEffMin, HybToFullEffMax, rng) * firm.digitalReadiness.toScalar).toMultiplier
-      Decision.Upgrade(pnl, TechState.Automated(eff), upCapex, upLoan, upDown, drUpdate = Some(ready2))
+    if roll < prob then
+      val effDraw = Scalar.randomBetween(HybToFullEffMin, HybToFullEffMax, rng)
+      val eff     = Multiplier.One + (effDraw * firm.digitalReadiness.toScalar).toMultiplier
+      DecisionWithAudit(
+        Decision.Upgrade(pnl, TechState.Automated(eff), upCapex, upLoan, upDown, drUpdate = Some(ready2)),
+        audit
+          .merge(selectedBankAudit(bankCredit))
+          .copy(adoptionRoll = Some(roll), upgradeEfficiencyDraw = Some(effDraw), upgradeEfficiencyMultiplier = Some(eff)),
+      )
     else
-      fallbackDecision(
+      val fallback = fallbackDecision(
         firm,
         financialStocks,
         pnl,
@@ -750,6 +948,7 @@ object Firm:
         drUpdate = Some(ready2),
         allowDigiInvest = false,
       )
+      DecisionWithAudit(fallback.decision, audit.copy(adoptionRoll = Some(roll)).merge(fallback.audit))
 
   /** Upgrade feasibility for one tech path (full-AI or hybrid). */
   private case class UpgradeCandidate(
@@ -759,8 +958,9 @@ object Firm:
       profitable: Boolean,
       canPay: Boolean,
       ready: Boolean,
-      bankOk: Boolean,
+      credit: CreditDecision,
   ):
+    def bankOk: Boolean   = credit.approved
     def feasible: Boolean = profitable && canPay && ready && bankOk
 
   /** Evaluate full-AI upgrade feasibility for a traditional firm. */
@@ -770,7 +970,7 @@ object Firm:
       pnl: PnL,
       w: World,
       lendRate: Rate,
-      bankCanLend: PLN => Boolean,
+      bankCreditDecision: PLN => CreditDecision,
   )(using p: SimParams): UpgradeCandidate =
     val capex = computeAiCapex(firm)
     val loan  = capex * FullAiLoanShare
@@ -794,7 +994,7 @@ object Firm:
       profitable = pnl.costs > (cost * FullAiProfitMargin) / sigmaThreshold(w.currentSigmas(firm.sector.toInt)),
       canPay = financialStocks.cash > down,
       ready = firm.digitalReadiness >= p.firm.fullAiReadinessMin,
-      bankOk = bankCanLend(loan),
+      credit = bankCreditDecision(loan),
     )
 
   /** Evaluate hybrid upgrade feasibility for a traditional firm. */
@@ -805,7 +1005,7 @@ object Firm:
       workers: Int,
       w: World,
       lendRate: Rate,
-      bankCanLend: PLN => Boolean,
+      bankCreditDecision: PLN => CreditDecision,
   )(using p: SimParams): (UpgradeCandidate, Int) =
     val capex = computeHybridCapex(firm)
     val loan  = capex * HybridLoanShare
@@ -829,7 +1029,7 @@ object Firm:
       profitable = pnl.costs > (cost * HybridProfitMargin) / sigmaThreshold(w.currentSigmas(firm.sector.toInt)),
       canPay = financialStocks.cash > down,
       ready = firm.digitalReadiness >= p.firm.hybridReadinessMin,
-      bankOk = bankCanLend(loan),
+      credit = bankCreditDecision(loan),
     )
     (cand, hWkrs)
 
@@ -878,36 +1078,63 @@ object Firm:
   /** Roll for full-AI upgrade: success (with random efficiency) or
     * implementation failure.
     */
-  private def rollFullAiUpgrade(firm: State, pnl: PnL, ai: UpgradeCandidate, rng: RandomStream): Decision =
+  private def rollFullAiUpgrade(firm: State, pnl: PnL, ai: UpgradeCandidate, rng: RandomStream): DecisionWithAudit =
     val failRate = FullAiBaseFailRate + (Share.One - firm.digitalReadiness) * FullAiFailDrSens
-    if failRate.sampleBelow(rng) then
-      Decision.UpgradeFailed(pnl, BankruptReason.AiImplFailure, ai.capex * FailCapexFrac, ai.loan * FailLoanFrac, ai.down * FailDownFrac)
+    val roll     = Share.random(rng)
+    val audit    = DecisionAudit(
+      implementationFailureProbability = Some(failRate.min(Share.One)),
+      implementationRoll = Some(roll),
+    )
+    if roll < failRate then
+      DecisionWithAudit(
+        Decision.UpgradeFailed(pnl, BankruptReason.AiImplFailure, ai.capex * FailCapexFrac, ai.loan * FailLoanFrac, ai.down * FailDownFrac),
+        audit,
+      )
     else
-      val eff = Multiplier.One + (Scalar.randomBetween(TradToFullEffMin, TradToFullEffMax, rng) * firm.digitalReadiness.toScalar).toMultiplier
-      Decision.Upgrade(pnl, TechState.Automated(eff), ai.capex, ai.loan, ai.down)
+      val effDraw = Scalar.randomBetween(TradToFullEffMin, TradToFullEffMax, rng)
+      val eff     = Multiplier.One + (effDraw * firm.digitalReadiness.toScalar).toMultiplier
+      DecisionWithAudit(
+        Decision.Upgrade(pnl, TechState.Automated(eff), ai.capex, ai.loan, ai.down),
+        audit.copy(upgradeEfficiencyDraw = Some(effDraw), upgradeEfficiencyMultiplier = Some(eff)),
+      )
 
   /** Roll for hybrid upgrade: catastrophic failure, partial failure (bad
     * efficiency), or success (good efficiency).
     */
-  private def rollHybridUpgrade(firm: State, pnl: PnL, hyb: UpgradeCandidate, hWkrs: Int, rng: RandomStream): Decision =
+  private def rollHybridUpgrade(firm: State, pnl: PnL, hyb: UpgradeCandidate, hWkrs: Int, rng: RandomStream): DecisionWithAudit =
     val failRate = HybridBaseFailRate + (Share.One - firm.digitalReadiness) * HybridFailDrSens
     val draw     = Share.random(rng)
+    val audit    = DecisionAudit(
+      implementationFailureProbability = Some(failRate.min(Share.One)),
+      implementationRoll = Some(draw),
+    )
     if draw < failRate * CatastrophicFailFrac then
-      Decision.UpgradeFailed(
-        pnl,
-        BankruptReason.HybridImplFailure,
-        hyb.capex * FailCapexFrac,
-        hyb.loan * FailLoanFrac,
-        hyb.down * FailDownFrac,
+      DecisionWithAudit(
+        Decision.UpgradeFailed(
+          pnl,
+          BankruptReason.HybridImplFailure,
+          hyb.capex * FailCapexFrac,
+          hyb.loan * FailLoanFrac,
+          hyb.down * FailDownFrac,
+        ),
+        audit,
       )
     else if draw < failRate then
-      val badEff = BadHybridEffBase + Scalar.randomBetween(Scalar.Zero, BadHybridEffRange, rng).toMultiplier
-      Decision.Upgrade(pnl, TechState.Hybrid(hWkrs, badEff), hyb.capex, hyb.loan, hyb.down)
+      val effDraw = Scalar.randomBetween(Scalar.Zero, BadHybridEffRange, rng)
+      val badEff  = BadHybridEffBase + effDraw.toMultiplier
+      DecisionWithAudit(
+        Decision.Upgrade(pnl, TechState.Hybrid(hWkrs, badEff), hyb.capex, hyb.loan, hyb.down),
+        audit.copy(upgradeEfficiencyDraw = Some(effDraw), upgradeEfficiencyMultiplier = Some(badEff)),
+      )
     else
+      val effDraw = Scalar.randomBetween(Scalar.Zero, GoodHybridEffRange, rng)
       val goodEff = Multiplier.One +
-        (GoodHybridEffBase + Scalar.randomBetween(Scalar.Zero, GoodHybridEffRange, rng)) *
+        (GoodHybridEffBase + effDraw) *
         (GoodHybridDrBlend + firm.digitalReadiness * GoodHybridDrBlend).toScalar.toMultiplier
-      Decision.Upgrade(pnl, TechState.Hybrid(hWkrs, goodEff), hyb.capex, hyb.loan, hyb.down)
+      DecisionWithAudit(
+        Decision.Upgrade(pnl, TechState.Hybrid(hWkrs, goodEff), hyb.capex, hyb.loan, hyb.down),
+        audit.copy(upgradeEfficiencyDraw = Some(effDraw), upgradeEfficiencyMultiplier = Some(goodEff)),
+      )
 
   /** Try upsize, digital readiness investment, downsize, or survive — fallback
     * when neither full-AI nor hybrid upgrade was chosen.
@@ -923,8 +1150,9 @@ object Firm:
       nextTech: Int => TechState,
       drUpdate: Option[Share] = None,
       allowDigiInvest: Boolean = true,
-  )(using p: SimParams): Decision =
+  )(using p: SimParams): DecisionWithAudit =
     val nc            = financialStocks.cash + pnl.netAfterTax
+    var audit         = DecisionAudit()
     // Firms now distinguish between a one-period desired workforce target,
     // a feasible near-term target, and the actual monthly adjustment.
     val desiredW      = desiredWorkers(firm, w, operationalSignals)
@@ -936,24 +1164,38 @@ object Firm:
     if shouldAdjust then
       val adjustFrac = if gap > 0 then hiringAdjustFrac else firingAdjustFrac(firm)
       val magnitude  = stochasticAdjustmentMagnitude(Math.abs(gap), adjustFrac, rng)
-      if magnitude > 0 then
-        val adj     = magnitude * (if gap > 0 then 1 else -1)
+      audit = audit.copy(
+        laborAdjustmentResidualProbability = magnitude.residualProbability,
+        laborAdjustmentResidualRoll = magnitude.residualRoll,
+      )
+      if magnitude.value > 0 then
+        val adj     = magnitude.value * (if gap > 0 then 1 else -1)
         val newWkrs = (workers + adj).max(p.firm.minWorkersRetained)
         if newWkrs > workers && canFundUpsize(firm, pnl, nc, newWkrs - workers, w.householdMarket.marketWage) then
-          return Decision.Upsize(pnl, newWkrs, nc, nextTech(newWkrs), drUpdate = drUpdate)
-        else if newWkrs < workers then return Decision.Downsize(pnl, newWkrs, nc, nextTech(newWkrs), drUpdate = drUpdate)
+          return DecisionWithAudit(Decision.Upsize(pnl, newWkrs, nc, nextTech(newWkrs), drUpdate = drUpdate), audit)
+        else if newWkrs < workers then return DecisionWithAudit(Decision.Downsize(pnl, newWkrs, nc, nextTech(newWkrs), drUpdate = drUpdate), audit)
     val digiCost: PLN = computeDigiInvestCost(firm)
     val canAfford     = nc > digiCost * DigiInvestCashMult
     val competitive   = w.real.automationRatio + w.real.hybridRatio * Share.decimal(5, 1)
     val diminishing   = Share.One - firm.digitalReadiness
     val digiProb      = (p.firm.digiInvestBaseProb * firm.riskProfile * diminishing * (Share.decimal(5, 1) + competitive)).min(Share.One)
-    if allowDigiInvest && canAfford && digiProb.sampleBelow(rng) then
+    val digiRoll      = if allowDigiInvest && canAfford then Some(Share.random(rng)) else None
+    audit = audit.merge(
+      DecisionAudit(
+        digitalInvestProbability = if allowDigiInvest then Some(digiProb) else None,
+        digitalInvestRoll = digiRoll,
+      ),
+    )
+    if allowDigiInvest && canAfford && digiRoll.exists(_ < digiProb) then
       val boost = p.firm.digiInvestBoost * diminishing
       val newDR = (firm.digitalReadiness + boost).min(Share.One)
-      Decision.DigiInvest(pnl, digiCost, newDR)
+      DecisionWithAudit(Decision.DigiInvest(pnl, digiCost, newDR), audit)
     else if nc < PLN.Zero then
-      attemptDownsize(firm, pnl, nc, workers, nextTech, w.householdMarket.marketWage, BankruptReason.LaborCostInsolvency, drUpdate = drUpdate)
-    else Decision.Survive(pnl, nc, drUpdate = drUpdate)
+      DecisionWithAudit(
+        attemptDownsize(firm, pnl, nc, workers, nextTech, w.householdMarket.marketWage, BankruptReason.LaborCostInsolvency, drUpdate = drUpdate),
+        audit,
+      )
+    else DecisionWithAudit(Decision.Survive(pnl, nc, drUpdate = drUpdate), audit)
 
   private def startupFallbackDecision(
       firm: State,
@@ -996,12 +1238,12 @@ object Firm:
       executionMonth: ExecutionMonth,
       operationalSignals: OperationalSignals,
       lendRate: Rate,
-      bankCanLend: PLN => Boolean,
+      bankCreditDecision: PLN => CreditDecision,
       allFirms: Vector[State],
       workers: Int,
       rng: RandomStream,
       corpBondDebt: PLN,
-  )(using p: SimParams): Decision =
+  )(using p: SimParams): DecisionWithAudit =
     val pnl           = computePnL(
       firm,
       financialStocks,
@@ -1015,15 +1257,131 @@ object Firm:
       corpBondDebt,
       w.real.productivityIndex,
     )
-    if isInStartup(firm) then return startupFallbackDecision(firm, financialStocks, pnl, workers, TechState.Traditional(_), w.householdMarket.marketWage)
-    val ai            = evaluateFullAi(firm, financialStocks, pnl, w, lendRate, bankCanLend)
-    val (hyb, hWkrs)  = evaluateHybrid(firm, financialStocks, pnl, workers, w, lendRate, bankCanLend)
+    if isInStartup(firm) then
+      return DecisionWithAudit(
+        startupFallbackDecision(firm, financialStocks, pnl, workers, TechState.Traditional(_), w.householdMarket.marketWage),
+        DecisionAudit(),
+      )
+    val ai            = evaluateFullAi(firm, financialStocks, pnl, w, lendRate, bankCreditDecision)
+    val (hyb, hWkrs)  = evaluateHybrid(firm, financialStocks, pnl, workers, w, lendRate, bankCreditDecision)
     val (pFull, pHyb) = adoptionProbabilities(firm, pnl, ai, hyb, executionMonth, w, allFirms)
     val roll          = Share.random(rng)
+    val baseAudit     = DecisionAudit(
+      fullAiFeasible = Some(ai.feasible),
+      hybridFeasible = Some(hyb.feasible),
+      fullAiAdoptionProbability = Some(pFull),
+      hybridAdoptionProbability = Some(pHyb),
+      adoptionRoll = Some(roll),
+    ).merge(fullAiBankAudit(ai.credit)).merge(hybridBankAudit(hyb.credit))
 
-    if roll < pFull then rollFullAiUpgrade(firm, pnl, ai, rng)
-    else if roll < pFull + pHyb then rollHybridUpgrade(firm, pnl, hyb, hWkrs, rng)
-    else fallbackDecision(firm, financialStocks, pnl, w, operationalSignals, workers, rng, nextTech = TechState.Traditional(_))
+    if roll < pFull then
+      val upgrade = rollFullAiUpgrade(firm, pnl, ai, rng)
+      DecisionWithAudit(upgrade.decision, baseAudit.merge(selectedBankAudit(ai.credit)).merge(upgrade.audit))
+    else if roll < pFull + pHyb then
+      val upgrade = rollHybridUpgrade(firm, pnl, hyb, hWkrs, rng)
+      DecisionWithAudit(upgrade.decision, baseAudit.merge(selectedBankAudit(hyb.credit)).merge(upgrade.audit))
+    else
+      val fallback = fallbackDecision(firm, financialStocks, pnl, w, operationalSignals, workers, rng, nextTech = TechState.Traditional(_))
+      DecisionWithAudit(fallback.decision, baseAudit.merge(fallback.audit))
+
+  private def buildDecisionTrace(
+      openingFirm: State,
+      openingStocks: FinancialStocks,
+      lendingRate: Rate,
+      decision: DecisionWithAudit,
+      result: Result,
+  )(using p: SimParams): DecisionTrace =
+    val d = decision.decision
+    DecisionTrace(
+      firmId = openingFirm.id,
+      openingTech = openingFirm.tech,
+      closingTech = result.firm.tech,
+      decisionType = decisionType(d),
+      bankruptcyReason = bankruptcyReason(d).orElse(bankruptcyReason(result.firm.tech)),
+      cashBefore = openingStocks.cash,
+      cashAfter = result.financialStocks.cash,
+      firmLoanBefore = openingStocks.firmLoan,
+      firmLoanAfter = result.financialStocks.firmLoan,
+      digitalReadinessBefore = openingFirm.digitalReadiness,
+      digitalReadinessAfter = result.firm.digitalReadiness,
+      workersBefore = workerCount(openingFirm),
+      workersAfter = workerCount(result.firm),
+      capex = result.capexSpent,
+      newLoan = result.newLoan,
+      downPayment = downPayment(d),
+      bankId = openingFirm.bankId,
+      lendingRate = lendingRate,
+      selectedBankApproval = decision.audit.selectedBankApproval,
+      selectedBankApprovalProbability = decision.audit.selectedBankApprovalProbability,
+      selectedBankApprovalRoll = decision.audit.selectedBankApprovalRoll,
+      fullAiFeasible = decision.audit.fullAiFeasible,
+      hybridFeasible = decision.audit.hybridFeasible,
+      fullAiAdoptionProbability = decision.audit.fullAiAdoptionProbability,
+      hybridAdoptionProbability = decision.audit.hybridAdoptionProbability,
+      adoptionRoll = decision.audit.adoptionRoll,
+      fullAiBankApproval = decision.audit.fullAiBankApproval,
+      fullAiBankApprovalProbability = decision.audit.fullAiBankApprovalProbability,
+      fullAiBankApprovalRoll = decision.audit.fullAiBankApprovalRoll,
+      hybridBankApproval = decision.audit.hybridBankApproval,
+      hybridBankApprovalProbability = decision.audit.hybridBankApprovalProbability,
+      hybridBankApprovalRoll = decision.audit.hybridBankApprovalRoll,
+      implementationFailureProbability = decision.audit.implementationFailureProbability,
+      implementationRoll = decision.audit.implementationRoll,
+      upgradeEfficiencyDraw = decision.audit.upgradeEfficiencyDraw,
+      upgradeEfficiencyMultiplier = decision.audit.upgradeEfficiencyMultiplier,
+      investmentCreditNeed = None,
+      investmentCreditAmount = None,
+      investmentBankApproval = None,
+      investmentBankApprovalProbability = None,
+      investmentBankApprovalRoll = None,
+      digitalInvestProbability = decision.audit.digitalInvestProbability,
+      digitalInvestRoll = decision.audit.digitalInvestRoll,
+      laborAdjustmentResidualProbability = decision.audit.laborAdjustmentResidualProbability,
+      laborAdjustmentResidualRoll = decision.audit.laborAdjustmentResidualRoll,
+    )
+
+  private def refreshDecisionTraceClosing(trace: DecisionTrace, result: Result)(using p: SimParams): DecisionTrace =
+    trace.copy(
+      closingTech = result.firm.tech,
+      cashAfter = result.financialStocks.cash,
+      firmLoanAfter = result.financialStocks.firmLoan,
+      digitalReadinessAfter = result.firm.digitalReadiness,
+      workersAfter = workerCount(result.firm),
+      capex = result.capexSpent,
+      newLoan = result.newLoan,
+    )
+
+  private def decisionType(decision: Decision): DecisionTrace.DecisionType =
+    decision match
+      case Decision.StayBankrupt                    => DecisionTrace.DecisionType.Bankrupt
+      case Decision.Survive(_, _, _)                => DecisionTrace.DecisionType.Survive
+      case Decision.GoBankrupt(_, _, _)             => DecisionTrace.DecisionType.Bankrupt
+      case Decision.Upgrade(_, newTech, _, _, _, _) =>
+        newTech match
+          case _: TechState.Automated => DecisionTrace.DecisionType.FullAiUpgrade
+          case _: TechState.Hybrid    => DecisionTrace.DecisionType.HybridUpgrade
+          case _                      => DecisionTrace.DecisionType.Survive
+      case Decision.UpgradeFailed(_, _, _, _, _)    => DecisionTrace.DecisionType.UpgradeFailed
+      case Decision.Downsize(_, _, _, _, _)         => DecisionTrace.DecisionType.Downsize
+      case Decision.Upsize(_, _, _, _, _)           => DecisionTrace.DecisionType.Upsize
+      case Decision.DigiInvest(_, _, _)             => DecisionTrace.DecisionType.DigiInvest
+
+  private def bankruptcyReason(decision: Decision): Option[BankruptReason] =
+    decision match
+      case Decision.GoBankrupt(_, _, reason)          => Some(reason)
+      case Decision.UpgradeFailed(_, reason, _, _, _) => Some(reason)
+      case _                                          => None
+
+  private def bankruptcyReason(tech: TechState): Option[BankruptReason] =
+    tech match
+      case TechState.Bankrupt(reason) => Some(reason)
+      case _                          => None
+
+  private def downPayment(decision: Decision): Option[PLN] =
+    decision match
+      case Decision.Upgrade(_, _, _, _, downPayment, _) => Some(downPayment)
+      case Decision.UpgradeFailed(_, _, _, _, down)     => Some(down)
+      case _                                            => None
 
   // ---- Execute (pure dispatch, zero RandomStream calls) ----
 
@@ -1156,7 +1514,7 @@ object Firm:
   /** Apply physical capital investment after firm decision. Depreciation,
     * replacement + expansion investment, cash-constrained.
     */
-  private def applyInvestment(r: Result, sectorDemandPressure: Multiplier, bankCanLend: PLN => Boolean)(using p: SimParams): Result =
+  private def applyInvestment(r: Result, sectorDemandPressure: Multiplier, bankCreditDecision: PLN => CreditDecision)(using p: SimParams): Result =
     val f                 = r.firm
     if !isAlive(f) then return r.copy(firm = f.copy(capitalStock = PLN.Zero))
     val stocks            = r.financialStocks
@@ -1174,9 +1532,18 @@ object Firm:
     val desiredInv        = depn + (gap * p.capital.adjustSpeed * invMult)
     val cashInv           = desiredInv.min(stocks.cash.max(PLN.Zero))
     val creditNeed        = (desiredInv - cashInv).max(PLN.Zero) * p.capital.investmentCreditShare
-    val creditInv         = if creditNeed > PLN.Zero && bankCanLend(creditNeed) then creditNeed else PLN.Zero
+    val creditDecision    = if creditNeed > PLN.Zero then Some(bankCreditDecision(creditNeed)) else None
+    val creditInv         = if creditDecision.exists(_.approved) then creditNeed else PLN.Zero
     val actualInv         = (cashInv + creditInv).min(desiredInv)
     val newK              = postDepK + actualInv
+    val investmentTrace   = r.decisionTrace.map: trace =>
+      trace.copy(
+        investmentCreditNeed = if creditNeed > PLN.Zero then Some(creditNeed) else None,
+        investmentCreditAmount = if creditNeed > PLN.Zero then Some(creditInv) else None,
+        investmentBankApproval = creditDecision.map(_.approved),
+        investmentBankApprovalProbability = creditDecision.flatMap(_.approvalProbability),
+        investmentBankApprovalRoll = creditDecision.flatMap(_.approvalRoll),
+      )
     r.copy(
       firm = f.copy(capitalStock = newK),
       financialStocks = stocks.copy(
@@ -1185,6 +1552,7 @@ object Firm:
       ),
       newLoan = r.newLoan + creditInv,
       grossInvestment = actualInv,
+      decisionTrace = investmentTrace,
     )
 
   // ---- PnL computation ----

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
@@ -21,8 +21,8 @@ object MonthDriver:
     */
   type RandomnessSchedule = SimState => Option[MonthRandomness.Contract]
 
-  def unfoldSteps(initialState: SimState)(schedule: RandomnessSchedule)(using p: SimParams): Iterator[StepOutput] =
+  def unfoldSteps(initialState: SimState, traceFirmDecisions: Boolean = false)(schedule: RandomnessSchedule)(using p: SimParams): Iterator[StepOutput] =
     Iterator.unfold(initialState): state =>
       schedule(state).map: randomness =>
-        val output = FlowSimulation.step(state, randomness)
+        val output = FlowSimulation.step(state, randomness, traceFirmDecisions = traceFirmDecisions)
         (output, output.nextState)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -82,12 +82,12 @@ object FirmEconomics:
 
   /** Per-bank lending rates and credit approval, shared across phases. */
   private case class LendingConditions(
-      firmWorld: World,                       // world with current-month wages for firm decision-making
-      executionMonth: ExecutionMonth,         // realized month currently being executed
-      operationalSignals: OperationalSignals, // same-month demand / labor surface for incumbent firms
-      rates: Vector[Rate],                    // per-bank lending rates
-      bankCanLend: (Int, PLN) => Boolean,     // credit approval: (bankId, amount) => approved?
-      nBanks: Int,                            // number of banks in multi-bank system
+      firmWorld: World,                                      // world with current-month wages for firm decision-making
+      executionMonth: ExecutionMonth,                        // realized month currently being executed
+      operationalSignals: OperationalSignals,                // same-month demand / labor surface for incumbent firms
+      rates: Vector[Rate],                                   // per-bank lending rates
+      bankCreditDecision: (Int, PLN) => Firm.CreditDecision, // credit approval audit: (bankId, amount) => result
+      nBanks: Int,                                           // number of banks in multi-bank system
   )
 
   /** Per-firm processing outcome — immutable, one per firm. */
@@ -100,13 +100,15 @@ object FirmEconomics:
       finalLoan: PLN,             // bank loan after equity/bond splits
       bondAmt: PLN,               // corporate bond issuance (pre-absorption)
       principalRepaid: PLN,       // scheduled loan principal repaid this month
+      decisionTrace: Option[Firm.DecisionTrace],
   )
 
   /** Result of per-firm processing (phase 2). */
   private case class FirmProcessingResult(
-      outcomes: Vector[FirmOutcome],    // per-firm immutable outcomes
-      flows: FirmFlows,                 // aggregate flows (monoid sum)
+      outcomes: Vector[FirmOutcome],     // per-firm immutable outcomes
+      flows: FirmFlows,                  // aggregate flows (monoid sum)
       firmBondAmounts: Map[FirmId, PLN], // per-firm bond issuance for reversion
+      traceDecisions: Boolean,           // whether per-firm decision traces were requested for this step
   )
 
   /** Result of bond absorption (phase 3). */
@@ -156,43 +158,44 @@ object FirmEconomics:
 
   /** Full step output — all fields previously in FirmProcessingStep.Output. */
   case class StepOutput(
-      ioFirms: Vector[Firm.State],               // firms after I-O intermediate market
-      households: Vector[Household.State],       // households after labor matching + immigration
-      sumTax: PLN,                               // aggregate CIT paid
-      sumCapex: PLN,                             // aggregate technology CAPEX
-      sumTechImp: PLN,                           // aggregate technology imports
-      sumNewLoans: PLN,                          // aggregate new bank loans (incl. bond reversion)
-      sumEquityIssuance: PLN,                    // aggregate GPW equity raised
-      sumGrossInvestment: PLN,                   // aggregate physical capital investment
-      sumBondIssuance: PLN,                      // aggregate bond issuance (pre-absorption)
-      sumProfitShifting: PLN,                    // aggregate FDI profit shifting
-      sumFdiRepatriation: PLN,                   // aggregate FDI repatriation
-      sumInventoryChange: PLN,                   // aggregate net inventory change
-      sumCitEvasion: PLN,                        // aggregate CIT evasion
-      sumEnergyCost: PLN,                        // aggregate energy + ETS cost
-      sumGreenInvestment: PLN,                   // aggregate green capital investment
-      totalIoPaid: PLN,                          // total intermediate goods payments
-      nplNew: PLN,                               // new non-performing loan volume
-      nplLoss: PLN,                              // NPL loss net of recovery
-      totalBondDefault: PLN,                     // bond default from bankrupt firms
-      firmDeaths: Int,                           // number of firms that went bankrupt
-      intIncome: PLN,                            // aggregate bank interest income
-      corpBondAbsorption: Share,                 // Catalyst absorption ratio (0-1)
-      actualBondIssuance: PLN,                   // bond issuance after absorption constraint
-      netMigration: Int,                         // net immigration (inflow - outflow)
-      perBankNewLoans: Vector[PLN],              // new loans by bank index
-      sumFirmPrincipal: PLN,                     // aggregate firm loan principal repaid
-      perBankFirmPrincipal: Vector[PLN],         // firm principal repaid by bank index
-      perBankNplDebt: Vector[PLN],               // NPL debt by bank index
-      perBankIntIncome: Vector[PLN],             // interest income by bank index
-      perBankWorkers: Vector[Int],               // worker count by bank index
-      lendingRates: Vector[Rate],                // per-bank lending rates
-      postFirmCrossSectorHires: Int,             // cross-sector hires in labor matching
-      postFirmHires: Int,                        // total hires consumed by firm-stage matching
-      postFirmHireCapacity: Int,                 // monthly hire capacity available at firm-stage matching
-      markupInflation: Rate,                     // Calvo: annualized revenue-weighted avg markup change
-      sumRealizedPostTaxProfit: PLN,             // aggregate realized post-tax profits from Firm.process
-      sumStateOwnedPostTaxProfit: PLN,           // aggregate realized post-tax profits of SOEs
+      ioFirms: Vector[Firm.State],                // firms after I-O intermediate market
+      households: Vector[Household.State],        // households after labor matching + immigration
+      sumTax: PLN,                                // aggregate CIT paid
+      sumCapex: PLN,                              // aggregate technology CAPEX
+      sumTechImp: PLN,                            // aggregate technology imports
+      sumNewLoans: PLN,                           // aggregate new bank loans (incl. bond reversion)
+      sumEquityIssuance: PLN,                     // aggregate GPW equity raised
+      sumGrossInvestment: PLN,                    // aggregate physical capital investment
+      sumBondIssuance: PLN,                       // aggregate bond issuance (pre-absorption)
+      sumProfitShifting: PLN,                     // aggregate FDI profit shifting
+      sumFdiRepatriation: PLN,                    // aggregate FDI repatriation
+      sumInventoryChange: PLN,                    // aggregate net inventory change
+      sumCitEvasion: PLN,                         // aggregate CIT evasion
+      sumEnergyCost: PLN,                         // aggregate energy + ETS cost
+      sumGreenInvestment: PLN,                    // aggregate green capital investment
+      totalIoPaid: PLN,                           // total intermediate goods payments
+      nplNew: PLN,                                // new non-performing loan volume
+      nplLoss: PLN,                               // NPL loss net of recovery
+      totalBondDefault: PLN,                      // bond default from bankrupt firms
+      firmDeaths: Int,                            // number of firms that went bankrupt
+      intIncome: PLN,                             // aggregate bank interest income
+      corpBondAbsorption: Share,                  // Catalyst absorption ratio (0-1)
+      actualBondIssuance: PLN,                    // bond issuance after absorption constraint
+      netMigration: Int,                          // net immigration (inflow - outflow)
+      perBankNewLoans: Vector[PLN],               // new loans by bank index
+      sumFirmPrincipal: PLN,                      // aggregate firm loan principal repaid
+      perBankFirmPrincipal: Vector[PLN],          // firm principal repaid by bank index
+      perBankNplDebt: Vector[PLN],                // NPL debt by bank index
+      perBankIntIncome: Vector[PLN],              // interest income by bank index
+      perBankWorkers: Vector[Int],                // worker count by bank index
+      lendingRates: Vector[Rate],                 // per-bank lending rates
+      postFirmCrossSectorHires: Int,              // cross-sector hires in labor matching
+      postFirmHires: Int,                         // total hires consumed by firm-stage matching
+      postFirmHireCapacity: Int,                  // monthly hire capacity available at firm-stage matching
+      markupInflation: Rate,                      // Calvo: annualized revenue-weighted avg markup change
+      sumRealizedPostTaxProfit: PLN,              // aggregate realized post-tax profits from Firm.process
+      sumStateOwnedPostTaxProfit: PLN,            // aggregate realized post-tax profits of SOEs
+      decisionTraces: Vector[Firm.DecisionTrace], // per-firm decision trace rows for optional exports
       ledgerFinancialState: LedgerFinancialState, // ledger with firm corporate-bond issuer balances after firm stage
   )
 
@@ -208,15 +211,16 @@ object FirmEconomics:
       s3: HouseholdIncomeEconomics.Output,
       s4: DemandEconomics.Output,
       rng: RandomStream,
+      traceDecisions: Boolean = false,
   )(using p: SimParams): StepOutput =
-    val stepIn = StepInput(w, firms, households, banks, ledgerFinancialState, s1, s2, s3, s4)
+    val stepIn = StepInput(w, firms, households, banks, ledgerFinancialState, s1, s2, s3, s4, traceDecisions)
     runInternal(stepIn, rng)
 
   // ---- Core pipeline ----
 
   private def runInternal(stepIn: StepInput, rng: RandomStream)(using p: SimParams): StepOutput =
     val lending             = prepareLending(stepIn, rng)
-    val fp                  = processFirms(stepIn.firms, stepIn.ledgerFinancialState, lending, rng)
+    val fp                  = processFirms(stepIn.firms, stepIn.ledgerFinancialState, lending, rng, stepIn.traceDecisions)
     val bonded              = applyBondAbsorption(fp, stepIn.w, stepIn.banks, stepIn.ledgerFinancialState, lending.executionMonth)
     val intermediate        = applyIntermediateMarket(bonded.firms, bonded.financialStocks, stepIn)
     // Calvo staggered pricing: per-firm markup update
@@ -277,6 +281,7 @@ object FirmEconomics:
       s2: LaborEconomics.Output,
       s3: HouseholdIncomeEconomics.Output,
       s4: DemandEconomics.Output,
+      traceDecisions: Boolean,
   )
 
   private case class LaborMarketResult(
@@ -301,7 +306,13 @@ object FirmEconomics:
     val rates              = in.banks.zip(bankStocks).zip(bsec.configs).map { case ((b, stocks), cfg) =>
       Banking.lendingRate(b, stocks, cfg, in.s1.lendingBaseRate, in.w.gov.bondYield, bankCorpBonds(b.id))
     }
-    val canLend            = (bankId: Int, amt: PLN) => Banking.canLend(in.banks(bankId), bankStocks(bankId), amt, rng, ccyb, bankCorpBonds(BankId(bankId)))
+    val creditDecision     = (bankId: Int, amt: PLN) =>
+      val approval = Banking.creditApproval(in.banks(bankId), bankStocks(bankId), amt, rng, ccyb, bankCorpBonds(BankId(bankId)))
+      Firm.CreditDecision(
+        approved = approval.approved,
+        approvalProbability = approval.approvalProbability,
+        approvalRoll = approval.approvalRoll,
+      )
     val operationalSignals = OperationalSignals(
       sectorDemandMult = in.s4.sectorMults,
       sectorDemandPressure = in.s4.sectorDemandPressure,
@@ -314,7 +325,7 @@ object FirmEconomics:
         reservationWage = in.s1.resWage,
       ),
     )
-    LendingConditions(world, in.s1.m, operationalSignals, rates, canLend, nBanks)
+    LendingConditions(world, in.s1.m, operationalSignals, rates, creditDecision, nBanks)
 
   // ---- Phase 2: Per-firm processing ----
 
@@ -326,6 +337,7 @@ object FirmEconomics:
       ledgerFinancialState: LedgerFinancialState,
       lending: LendingConditions,
       rng: RandomStream,
+      traceDecisions: Boolean,
   )(using p: SimParams): FirmProcessingResult =
     require(
       firms.length == ledgerFinancialState.firms.length,
@@ -335,21 +347,34 @@ object FirmEconomics:
     val outcomes      = firms
       .zip(openingStocks)
       .map: (f, stocks) =>
-        val rate    = lending.rates(f.bankId.toInt)
-        val canLend = (amt: PLN) => lending.bankCanLend(f.bankId.toInt, amt)
-        val r       = Firm.process(
+        val rate           = lending.rates(f.bankId.toInt)
+        val creditDecision = (amt: PLN) => lending.bankCreditDecision(f.bankId.toInt, amt)
+        val r              = Firm.processWithCreditAudit(
           f,
           stocks,
           lending.firmWorld,
           lending.executionMonth,
           lending.operationalSignals,
           rate,
-          canLend,
+          creditDecision,
           firms,
           rng,
           CorporateBondOwnership.issuerBalanceFor(ledgerFinancialState, f.id),
+          traceDecision = traceDecisions,
         )
-        val fin     = splitFinancing(r)
+        val fin            = splitFinancing(r)
+        val trace          =
+          if traceDecisions then
+            Some(
+              r.decisionTrace
+                .getOrElse:
+                  throw IllegalStateException(s"Firm.process did not return a decision trace for firm ${f.id.toInt}")
+                .copy(
+                  firmLoanAfter = fin.financialStocks.firmLoan,
+                  newLoan = fin.bankLoan,
+                ),
+            )
+          else None
 
         FirmOutcome(
           firm = fin.firm,
@@ -375,12 +400,13 @@ object FirmEconomics:
           finalLoan = fin.bankLoan,
           bondAmt = fin.bonds,
           principalRepaid = r.principalRepaid,
+          decisionTrace = trace,
         )
 
     val aggFlows = outcomes.foldLeft(FirmFlows.zero)((acc, o) => acc + o.flows)
     val bondMap  = outcomes.collect { case o if o.bondAmt > PLN.Zero => o.firm.id -> o.bondAmt }.toMap
 
-    FirmProcessingResult(outcomes, aggFlows, bondMap)
+    FirmProcessingResult(outcomes, aggFlows, bondMap, traceDecisions)
 
   /** Split a firm's new loan into three channels: GPW equity → Catalyst bonds →
     * bank loan remainder.
@@ -711,7 +737,7 @@ object FirmEconomics:
       in: StepInput,
       lending: LendingConditions,
       markupInflation: Rate,
-  ): StepOutput =
+  )(using p: SimParams): StepOutput =
     val flows                 = fp.flows
     val ledgerAfterFirmStocks = in.s3.ledgerFinancialState.copy(
       households = LedgerFinancialState.refreshHouseholdBalances(
@@ -740,6 +766,9 @@ object FirmEconomics:
 
     val perBankFirmPrincipal = fp.outcomes.foldLeft(emptyPln): (acc, o) =>
       acc.updated(o.bankId.toInt, acc(o.bankId.toInt) + o.principalRepaid)
+    val decisionTraces       =
+      if fp.traceDecisions then finalizedDecisionTraces(fp, bonded, ioFirms, firmFinancialStocks)
+      else Vector.empty
 
     StepOutput(
       ioFirms = ioFirms,
@@ -779,5 +808,29 @@ object FirmEconomics:
       markupInflation = markupInflation,
       sumRealizedPostTaxProfit = fp.outcomes.foldLeft(PLN.Zero)(_ + _.realizedPostTaxProfit),
       sumStateOwnedPostTaxProfit = fp.outcomes.filter(_.firm.stateOwned).foldLeft(PLN.Zero)((acc, o) => acc + o.realizedPostTaxProfit),
+      decisionTraces = decisionTraces,
       ledgerFinancialState = ledgerAfterFirmStocks,
     )
+
+  private def finalizedDecisionTraces(
+      fp: FirmProcessingResult,
+      bonded: BondAbsorptionResult,
+      closingFirms: Vector[Firm.State],
+      closingFinancialStocks: Vector[Firm.FinancialStocks],
+  )(using p: SimParams): Vector[Firm.DecisionTrace] =
+    fp.outcomes
+      .zip(closingFirms)
+      .zip(closingFinancialStocks)
+      .map { case ((outcome, closingFirm), closingStocks) =>
+        val revertedLoan = bonded.bondReversionByFirm.getOrElse(outcome.firm.id, PLN.Zero)
+        val trace        = outcome.decisionTrace.getOrElse:
+          throw IllegalStateException(s"FirmEconomics.finalizedDecisionTraces missing decision trace for firm ${outcome.firm.id.toInt}")
+        trace.copy(
+          closingTech = closingFirm.tech,
+          cashAfter = closingStocks.cash,
+          firmLoanAfter = closingStocks.firmLoan,
+          digitalReadinessAfter = closingFirm.digitalReadiness,
+          workersAfter = Firm.workerCount(closingFirm),
+          newLoan = outcome.finalLoan + revertedLoan,
+        )
+      }

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -818,19 +818,33 @@ object FirmEconomics:
       closingFirms: Vector[Firm.State],
       closingFinancialStocks: Vector[Firm.FinancialStocks],
   )(using p: SimParams): Vector[Firm.DecisionTrace] =
-    fp.outcomes
-      .zip(closingFirms)
-      .zip(closingFinancialStocks)
-      .map { case ((outcome, closingFirm), closingStocks) =>
-        val revertedLoan = bonded.bondReversionByFirm.getOrElse(outcome.firm.id, PLN.Zero)
-        val trace        = outcome.decisionTrace.getOrElse:
-          throw IllegalStateException(s"FirmEconomics.finalizedDecisionTraces missing decision trace for firm ${outcome.firm.id.toInt}")
-        trace.copy(
-          closingTech = closingFirm.tech,
-          cashAfter = closingStocks.cash,
-          firmLoanAfter = closingStocks.firmLoan,
-          digitalReadinessAfter = closingFirm.digitalReadiness,
-          workersAfter = Firm.workerCount(closingFirm),
-          newLoan = outcome.finalLoan + revertedLoan,
-        )
-      }
+    if closingFirms.length != closingFinancialStocks.length then
+      throw IllegalStateException(
+        s"FirmEconomics.finalizedDecisionTraces requires aligned closing firms and stocks, got ${closingFirms.length} firms and ${closingFinancialStocks.length} stock rows",
+      )
+
+    val closingFirmById       = closingFirms.map(firm => firm.id -> firm).toMap
+    val closingStocksByFirmId = closingFirms.zip(closingFinancialStocks).map((firm, stocks) => firm.id -> stocks).toMap
+
+    fp.outcomes.map { outcome =>
+      val firmId        = outcome.firm.id
+      val closingFirm   = closingFirmById.getOrElse(
+        firmId,
+        throw IllegalStateException(s"FirmEconomics.finalizedDecisionTraces missing closing firm for firm ${firmId.toInt}"),
+      )
+      val closingStocks = closingStocksByFirmId.getOrElse(
+        firmId,
+        throw IllegalStateException(s"FirmEconomics.finalizedDecisionTraces missing closing stocks for firm ${firmId.toInt}"),
+      )
+      val revertedLoan  = bonded.bondReversionByFirm.getOrElse(firmId, PLN.Zero)
+      val trace         = outcome.decisionTrace.getOrElse:
+        throw IllegalStateException(s"FirmEconomics.finalizedDecisionTraces missing decision trace for firm ${firmId.toInt}")
+      trace.copy(
+        closingTech = closingFirm.tech,
+        cashAfter = closingStocks.cash,
+        firmLoanAfter = closingStocks.firmLoan,
+        digitalReadinessAfter = closingFirm.digitalReadiness,
+        workersAfter = Firm.workerCount(closingFirm),
+        newLoan = outcome.finalLoan + revertedLoan,
+      )
+    }

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -349,6 +349,7 @@ object FlowSimulation:
       seedIn: MonthSemantics.SeedIn,
       randomness: MonthRandomness.Contract,
       boundaryIn: MonthBoundarySnapshot,
+      traceFirmDecisions: Boolean,
   )
 
   /** Same-month signal surface reused by operational, timing, and seed
@@ -422,6 +423,7 @@ object FlowSimulation:
       semanticFlows: Sfc.SemanticFlows,
       sfcResult: Sfc.SfcResult,
       trace: MonthTrace,
+      firmDecisionTraces: Vector[Firm.DecisionTrace],
       nextState: SimState,
   ):
     def transition: (SimState, MonthTrace) = (nextState, trace)
@@ -432,9 +434,9 @@ object FlowSimulation:
     * preferred runtime entrypoint, but `step` remains public as the narrow
     * one-month contract used by tests, replay, and diagnostics.
     */
-  def step(stateIn: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): StepOutput =
+  def step(stateIn: SimState, randomness: MonthRandomness.Contract, traceFirmDecisions: Boolean = false)(using p: SimParams): StepOutput =
     given RuntimeLedgerTopology = RuntimeLedgerTopology.fromState(stateIn)
-    val input                   = stepInput(stateIn, randomness)
+    val input                   = stepInput(stateIn, randomness, traceFirmDecisions)
     val outcome                 = computeMonthOutcome(input)
     val flows                   = emitAllBatches(outcome.flowPlan.calculus)
     val execution               = executeBatches(flows).fold(
@@ -478,17 +480,19 @@ object FlowSimulation:
       semanticFlows = sfcFlows,
       sfcResult,
       trace = monthTrace,
+      firmDecisionTraces = outcome.semanticProjection.firms.decisionTraces,
       nextState = nextState,
     )
 
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
   def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
-    computeStageOutputs(stepInput(state, randomness)).flowPlan
+    computeStageOutputs(stepInput(state, randomness, traceFirmDecisions = false)).flowPlan
 
   private def stepInput(
       stateIn: SimState,
       randomness: MonthRandomness.Contract,
+      traceFirmDecisions: Boolean,
   ): StepInput =
     StepInput(
       stateIn = stateIn,
@@ -496,6 +500,7 @@ object FlowSimulation:
       seedIn = MonthSemantics.seedIn(stateIn.world.seedIn),
       randomness = randomness,
       boundaryIn = MonthBoundarySnapshot.capture(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, stateIn.ledgerFinancialState),
+      traceFirmDecisions = traceFirmDecisions,
     )
 
   /** Compute same-month groups by chaining all Economics. Uses old pipeline
@@ -530,7 +535,19 @@ object FlowSimulation:
       pensionIncome = payrollZus.pensionPayments,
     )
     val s4                = DemandEconomics.compute(w, s2Pre.employed, s2Pre.living, s3.domesticCons)
-    val s5                = FirmEconomics.runStep(w, firms, households, banks, ledger, s1, s2Pre, s3, s4, randomness.firmEconomics.newStream())
+    val s5                = FirmEconomics.runStep(
+      w,
+      firms,
+      households,
+      banks,
+      ledger,
+      s1,
+      s2Pre,
+      s3,
+      s4,
+      randomness.firmEconomics.newStream(),
+      traceDecisions = input.traceFirmDecisions,
+    )
     val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
     val nBankruptFirms    = s5.firmDeaths
     val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.employed / s2Pre.living.length else 0

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceCsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceCsv.scala
@@ -1,0 +1,93 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.Firm
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import zio.stream.ZStream
+import zio.{Scope, ZIO}
+
+import java.io.{BufferedWriter, File}
+import java.nio.file.{Files, StandardCopyOption}
+import scala.util.Using
+
+private[montecarlo] object McFirmDecisionTraceCsv:
+
+  private val operation = "write firm decision trace CSV"
+
+  def tapSeedTraces[A](
+      seed: Long,
+      rc: McRunConfig,
+      outputDir: File,
+      rows: ZStream[Any, SimError, A],
+  )(
+      executionMonth: A => ExecutionMonth,
+      decisionTraces: A => Vector[Firm.DecisionTrace],
+  ): ZStream[Any, SimError, A] =
+    if !rc.firmDecisionTraceSelection.enabled then rows
+    else
+      val partFile = seedPartFile(outputDir, seed, rc)
+      ZStream.unwrapScoped:
+        openWriter(partFile).map: writer =>
+          rows.tap: row =>
+            writeTraceRows(writer, partFile, rc, seed, executionMonth(row), decisionTraces(row))
+
+  def combineSeedFiles(rc: McRunConfig, outputDir: File): ZIO[Any, SimError, Unit] =
+    if !rc.firmDecisionTraceSelection.enabled then ZIO.unit
+    else
+      val outputFile = McOutputFiles.firmDecisionTraceFile(outputDir, rc)
+      val tempFile   = new File(s"${outputFile.getPath}.tmp")
+      ZIO
+        .attemptBlocking:
+          Using.resource(Files.newBufferedWriter(tempFile.toPath)): writer =>
+            writer.write(McFirmDecisionTraceSchema.header)
+            writer.newLine()
+            for seed <- 1L to rc.nSeeds.toLong do
+              val partFile = seedPartFile(outputDir, seed, rc)
+              if Files.exists(partFile.toPath) then
+                Using.resource(Files.lines(partFile.toPath)): lines =>
+                  val it = lines.iterator()
+                  while it.hasNext do
+                    writer.write(it.next())
+                    writer.newLine()
+          Files.move(tempFile.toPath, outputFile.toPath, StandardCopyOption.REPLACE_EXISTING)
+          for seed <- 1L to rc.nSeeds.toLong do Files.deleteIfExists(seedPartFile(outputDir, seed, rc).toPath)
+        .unit
+        .mapError(outputFailure("combine firm decision trace CSV", outputFile))
+        .onError(_ => deleteIfExists(tempFile).ignore)
+
+  private def writeTraceRows(
+      writer: BufferedWriter,
+      outputFile: File,
+      rc: McRunConfig,
+      seed: Long,
+      month: ExecutionMonth,
+      traces: Vector[Firm.DecisionTrace],
+  ): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking:
+        val schema = McFirmDecisionTraceSchema.csvSchema
+        McFirmDecisionTraceSchema
+          .rows(rc.runId, seed, month.toInt, traces, rc.firmDecisionTraceSelection)
+          .foreach: row =>
+            writer.write(schema.render(row))
+            writer.newLine()
+      .unit
+      .mapError(outputFailure(operation, outputFile))
+
+  private def openWriter(outputFile: File): ZIO[Scope, SimError, BufferedWriter] =
+    ZIO.fromAutoCloseable(
+      ZIO
+        .attemptBlocking(Files.newBufferedWriter(outputFile.toPath))
+        .mapError(outputFailure(s"open $operation writer", outputFile)),
+    )
+
+  private def seedPartFile(outputDir: File, seed: Long, rc: McRunConfig): File =
+    new File(outputDir, f".${McOutputFiles.firmDecisionTraceFile(outputDir, rc).getName}.seed${seed}%03d.part")
+
+  private def deleteIfExists(file: File): ZIO[Any, SimError, Unit] =
+    ZIO
+      .attemptBlocking(Files.deleteIfExists(file.toPath))
+      .unit
+      .mapError(outputFailure(s"cleanup $operation temp file", file))
+
+  private def outputFailure(operation: String, path: File)(err: Throwable): SimError =
+    SimError.OutputFailure(operation, path.getPath, Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName))

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSchema.scala
@@ -1,0 +1,102 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.agents.{BankruptReason, Firm, TechState}
+
+private[montecarlo] object McFirmDecisionTraceSchema:
+
+  final case class Row(
+      runId: String,
+      seed: Long,
+      month: Int,
+      trace: Firm.DecisionTrace,
+  )
+
+  private val columns: Vector[(String, Row => String)] = Vector(
+    "RunId"                              -> (row => text(row.runId)),
+    "Seed"                               -> (row => row.seed.toString),
+    "Month"                              -> (row => row.month.toString),
+    "FirmId"                             -> (row => row.trace.firmId.toInt.toString),
+    "OpeningTechState"                   -> (row => techState(row.trace.openingTech)),
+    "ClosingTechState"                   -> (row => techState(row.trace.closingTech)),
+    "DecisionType"                       -> (row => row.trace.decisionType.csvValue),
+    "BankruptcyReason"                   -> (row => row.trace.bankruptcyReason.fold("")(reason => text(bankruptcyReasonName(reason)))),
+    "CashBefore"                         -> (row => row.trace.cashBefore.format(2)),
+    "CashAfter"                          -> (row => row.trace.cashAfter.format(2)),
+    "FirmLoanBefore"                     -> (row => row.trace.firmLoanBefore.format(2)),
+    "FirmLoanAfter"                      -> (row => row.trace.firmLoanAfter.format(2)),
+    "DigitalReadinessBefore"             -> (row => row.trace.digitalReadinessBefore.format(6)),
+    "DigitalReadinessAfter"              -> (row => row.trace.digitalReadinessAfter.format(6)),
+    "WorkersBefore"                      -> (row => row.trace.workersBefore.toString),
+    "WorkersAfter"                       -> (row => row.trace.workersAfter.toString),
+    "Capex"                              -> (row => row.trace.capex.format(2)),
+    "NewLoan"                            -> (row => row.trace.newLoan.format(2)),
+    "DownPayment"                        -> (row => row.trace.downPayment.fold("")(_.format(2))),
+    "BankId"                             -> (row => row.trace.bankId.toInt.toString),
+    "LendingRate"                        -> (row => row.trace.lendingRate.format(6)),
+    "SelectedBankApproval"               -> (row => row.trace.selectedBankApproval.fold("")(_.toString)),
+    "SelectedBankApprovalProbability"    -> (row => row.trace.selectedBankApprovalProbability.fold("")(_.format(6))),
+    "SelectedBankApprovalRoll"           -> (row => row.trace.selectedBankApprovalRoll.fold("")(_.format(6))),
+    "FullAiFeasible"                     -> (row => row.trace.fullAiFeasible.fold("")(_.toString)),
+    "HybridFeasible"                     -> (row => row.trace.hybridFeasible.fold("")(_.toString)),
+    "FullAiAdoptionProbability"          -> (row => row.trace.fullAiAdoptionProbability.fold("")(_.format(6))),
+    "HybridAdoptionProbability"          -> (row => row.trace.hybridAdoptionProbability.fold("")(_.format(6))),
+    "AdoptionRoll"                       -> (row => row.trace.adoptionRoll.fold("")(_.format(6))),
+    "FullAiBankApproval"                 -> (row => row.trace.fullAiBankApproval.fold("")(_.toString)),
+    "FullAiBankApprovalProbability"      -> (row => row.trace.fullAiBankApprovalProbability.fold("")(_.format(6))),
+    "FullAiBankApprovalRoll"             -> (row => row.trace.fullAiBankApprovalRoll.fold("")(_.format(6))),
+    "HybridBankApproval"                 -> (row => row.trace.hybridBankApproval.fold("")(_.toString)),
+    "HybridBankApprovalProbability"      -> (row => row.trace.hybridBankApprovalProbability.fold("")(_.format(6))),
+    "HybridBankApprovalRoll"             -> (row => row.trace.hybridBankApprovalRoll.fold("")(_.format(6))),
+    "ImplementationFailureProbability"   -> (row => row.trace.implementationFailureProbability.fold("")(_.format(6))),
+    "ImplementationRoll"                 -> (row => row.trace.implementationRoll.fold("")(_.format(6))),
+    "UpgradeEfficiencyDraw"              -> (row => row.trace.upgradeEfficiencyDraw.fold("")(_.format(6))),
+    "UpgradeEfficiencyMultiplier"        -> (row => row.trace.upgradeEfficiencyMultiplier.fold("")(_.format(6))),
+    "InvestmentCreditNeed"               -> (row => row.trace.investmentCreditNeed.fold("")(_.format(2))),
+    "InvestmentCreditAmount"             -> (row => row.trace.investmentCreditAmount.fold("")(_.format(2))),
+    "InvestmentBankApproval"             -> (row => row.trace.investmentBankApproval.fold("")(_.toString)),
+    "InvestmentBankApprovalProbability"  -> (row => row.trace.investmentBankApprovalProbability.fold("")(_.format(6))),
+    "InvestmentBankApprovalRoll"         -> (row => row.trace.investmentBankApprovalRoll.fold("")(_.format(6))),
+    "DigitalInvestProbability"           -> (row => row.trace.digitalInvestProbability.fold("")(_.format(6))),
+    "DigitalInvestRoll"                  -> (row => row.trace.digitalInvestRoll.fold("")(_.format(6))),
+    "LaborAdjustmentResidualProbability" -> (row => row.trace.laborAdjustmentResidualProbability.fold("")(_.format(6))),
+    "LaborAdjustmentResidualRoll"        -> (row => row.trace.laborAdjustmentResidualRoll.fold("")(_.format(6))),
+  )
+
+  val header: String =
+    columns.map(_._1).mkString(";")
+
+  val csvSchema: McCsvSchema[Row] =
+    McCsvSchema(
+      header = header,
+      render = row => columns.map(_._2(row)).mkString(";"),
+    )
+
+  def rows(
+      runId: String,
+      seed: Long,
+      month: Int,
+      traces: Vector[Firm.DecisionTrace],
+      selection: McFirmDecisionTraceSelection,
+  ): Vector[Row] =
+    traces
+      .filter(trace => selection.includes(trace.firmId.toInt))
+      .map(trace => Row(runId, seed, month, trace))
+
+  private def techState(tech: TechState): String =
+    tech match
+      case TechState.Traditional(_) => "Traditional"
+      case TechState.Hybrid(_, _)   => "Hybrid"
+      case TechState.Automated(_)   => "Automated"
+      case TechState.Bankrupt(_)    => "Bankrupt"
+
+  private def bankruptcyReasonName(reason: BankruptReason): String =
+    reason match
+      case BankruptReason.AiDebtTrap          => "AiDebtTrap"
+      case BankruptReason.HybridInsolvency    => "HybridInsolvency"
+      case BankruptReason.AiImplFailure       => "AiImplFailure"
+      case BankruptReason.HybridImplFailure   => "HybridImplFailure"
+      case BankruptReason.LaborCostInsolvency => "LaborCostInsolvency"
+      case BankruptReason.Other(msg)          => s"Other(${text(msg)})"
+
+  private def text(value: String): String =
+    value.replace(';', ',').replace('\n', ' ').replace('\r', ' ')

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSelection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSelection.scala
@@ -1,0 +1,31 @@
+package com.boombustgroup.amorfati.montecarlo
+
+/** Optional firm decision trace selector for Monte Carlo runs.
+  *
+  * Selection is by firm id and is evaluated before writing the trace export. It
+  * does not sample through the simulation RNG and therefore cannot change model
+  * decisions.
+  */
+sealed trait McFirmDecisionTraceSelection:
+  def enabled: Boolean
+  def includes(firmId: Int): Boolean
+
+object McFirmDecisionTraceSelection:
+  case object Disabled extends McFirmDecisionTraceSelection:
+    override val enabled: Boolean               = false
+    override def includes(firmId: Int): Boolean = false
+
+  case object All extends McFirmDecisionTraceSelection:
+    override val enabled: Boolean               = true
+    override def includes(firmId: Int): Boolean = true
+
+  final case class ExplicitFirmIds(firmIds: Set[Int]) extends McFirmDecisionTraceSelection:
+    require(firmIds.nonEmpty, "firm decision trace explicit firm id list must be non-empty")
+    require(firmIds.forall(_ >= 0), s"firm decision trace firm ids must be >= 0, got ${firmIds.toVector.sorted.mkString(",")}")
+    override val enabled: Boolean               = true
+    override def includes(firmId: Int): Boolean = firmIds.contains(firmId)
+
+  final case class FirstN(count: Int) extends McFirmDecisionTraceSelection:
+    require(count > 0, s"firm decision trace first:N count must be > 0, got $count")
+    override val enabled: Boolean               = true
+    override def includes(firmId: Int): Boolean = firmId >= 0 && firmId < count

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McOutputFiles.scala
@@ -30,12 +30,18 @@ private[montecarlo] object McOutputFiles:
   def firmSnapshotFile(outputDir: File, rc: McRunConfig): File =
     new File(outputDir, s"${filePrefix(rc)}_firm_snapshots.csv")
 
+  def firmDecisionTraceFile(outputDir: File, rc: McRunConfig): File =
+    new File(outputDir, s"${filePrefix(rc)}_firm_decision_trace.csv")
+
   def savedFiles(outputDir: File, rc: McRunConfig): Vector[File] =
     val baselineFiles =
       (1L to rc.nSeeds.toLong).map(seed => seedFile(outputDir, seed, rc)).toVector ++
         Vector(householdFile(outputDir, rc), bankFile(outputDir, rc), firmFile(outputDir, rc))
-    if rc.firmSnapshotSchedule.enabled then baselineFiles :+ firmSnapshotFile(outputDir, rc)
-    else baselineFiles
+    val withSnapshots =
+      if rc.firmSnapshotSchedule.enabled then baselineFiles :+ firmSnapshotFile(outputDir, rc)
+      else baselineFiles
+    if rc.firmDecisionTraceSelection.enabled then withSnapshots :+ firmDecisionTraceFile(outputDir, rc)
+    else withSnapshots
 
   private def filePrefix(rc: McRunConfig): String =
     s"${rc.outputPrefix}_${rc.runId}_${rc.runDurationMonths}m"

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunConfig.scala
@@ -12,12 +12,14 @@ case class McRunConfig(
     runDurationMonths: Int = McRunConfig.DefaultRunDuration,
     runId: String = McRunConfig.autoRunId(),
     firmSnapshotSchedule: McFirmSnapshotSchedule = McFirmSnapshotSchedule.Disabled,
+    firmDecisionTraceSelection: McFirmDecisionTraceSelection = McFirmDecisionTraceSelection.Disabled,
 ):
   McRunConfig.requirePositiveSeeds(nSeeds)
   McRunConfig.requireNonBlankOutputPrefix(outputPrefix)
   McRunConfig.requirePositiveDuration(runDurationMonths)
   McRunConfig.requireNonBlankRunId(runId)
   McRunConfig.requireFirmSnapshotSchedule(firmSnapshotSchedule)
+  McRunConfig.requireFirmDecisionTraceSelection(firmDecisionTraceSelection)
 
 object McRunConfig:
   val DefaultRunDuration: Int        = 120
@@ -41,3 +43,6 @@ object McRunConfig:
 
   def requireFirmSnapshotSchedule(schedule: McFirmSnapshotSchedule): Unit =
     require(schedule != null, "firmSnapshotSchedule must be non-null")
+
+  def requireFirmDecisionTraceSelection(selection: McFirmDecisionTraceSelection): Unit =
+    require(selection != null, "firmDecisionTraceSelection must be non-null")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.*
 import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
+import com.boombustgroup.amorfati.agents.Firm
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
@@ -19,7 +20,12 @@ import java.util.concurrent.TimeUnit
 object McRunner:
 
   /** Single month snapshot emitted by [[seedStream]]. */
-  private case class MonthSnapshot(executionMonth: ExecutionMonth, state: FlowSimulation.SimState, monthData: Array[MetricValue])
+  private case class MonthSnapshot(
+      executionMonth: ExecutionMonth,
+      state: FlowSimulation.SimState,
+      monthData: Array[MetricValue],
+      firmDecisionTraces: Vector[Firm.DecisionTrace],
+  )
   private case class SeedTerminalSnapshot(executionMonth: ExecutionMonth, lastMonthData: Array[MetricValue], terminalState: FlowSimulation.SimState)
 
   /** Run N seeds in parallel, each streaming months via [[seedStream]]. Writes
@@ -41,6 +47,7 @@ object McRunner:
         .runCollect
       _         <- McTerminalSummaryCsv.writeAll(rc, outputDir, summaries)
       _         <- McFirmSnapshotCsv.combineSeedFiles(rc, outputDir)
+      _         <- McFirmDecisionTraceCsv.combineSeedFiles(rc, outputDir)
       _         <- McRunnerConsole.emit(Event.BlankLine)
       _         <- McRunnerConsole.emitAll(McOutputFiles.savedFiles(outputDir, rc).map(file => Event.SavedFile(file.getPath)))
       t1        <- Clock.currentTime(TimeUnit.MILLISECONDS)
@@ -51,14 +58,14 @@ object McRunner:
   def runSingle(seed: Long, durationMonths: Int = McRunConfig.DefaultRunDuration)(using p: SimParams): Either[SimError, RunResult] =
     McRunConfig.requirePositiveDuration(durationMonths)
     initSeed(seed).flatMap: initState =>
-      materializeRun(initState, runtimeSteps(seed, initState).take(durationMonths))
+      materializeRun(initState, runtimeSteps(seed, initState, traceFirmDecisions = false).take(durationMonths))
 
   /** Streaming simulation — emits one [[MonthSnapshot]] per month. */
-  private def seedStream(seed: Long, durationMonths: Int)(using SimParams) =
-    ZStream.unwrap(ZIO.fromEither(initSeed(seed)).map(simulateMonths(seed, _, durationMonths)))
+  private def seedStream(seed: Long, durationMonths: Int, traceFirmDecisions: Boolean)(using SimParams) =
+    ZStream.unwrap(ZIO.fromEither(initSeed(seed)).map(simulateMonths(seed, _, durationMonths, traceFirmDecisions)))
 
-  private def simulateMonths(seed: Long, initState: FlowSimulation.SimState, durationMonths: Int)(using p: SimParams) =
-    val steps = runtimeSteps(seed, initState).take(durationMonths)
+  private def simulateMonths(seed: Long, initState: FlowSimulation.SimState, durationMonths: Int, traceFirmDecisions: Boolean)(using p: SimParams) =
+    val steps = runtimeSteps(seed, initState, traceFirmDecisions).take(durationMonths)
     ZStream
       .unfold(steps): iterator =>
         if iterator.hasNext then Some((iterator.next(), iterator))
@@ -73,8 +80,10 @@ object McRunner:
     if errors.nonEmpty then Left(SimError.Init(errors))
     else Right(initState)
 
-  private def runtimeSteps(seed: Long, initState: FlowSimulation.SimState)(using p: SimParams): Iterator[FlowSimulation.StepOutput] =
-    MonthDriver.unfoldSteps(initState): state =>
+  private def runtimeSteps(seed: Long, initState: FlowSimulation.SimState, traceFirmDecisions: Boolean)(using
+      p: SimParams,
+  ): Iterator[FlowSimulation.StepOutput] =
+    MonthDriver.unfoldSteps(initState, traceFirmDecisions = traceFirmDecisions): state =>
       Some(MonthRandomness.Contract.fromSeed(runtimeRootSeed(seed, state)))
 
   private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
@@ -95,7 +104,7 @@ object McRunner:
           result.nextState.householdAggregates,
           result.nextState.ledgerFinancialState,
         )
-        Right(MonthSnapshot(result.executionMonth, result.nextState, monthData))
+        Right(MonthSnapshot(result.executionMonth, result.nextState, monthData, result.firmDecisionTraces))
 
   private def materializeRun(
       initState: FlowSimulation.SimState,
@@ -120,19 +129,31 @@ object McRunner:
     */
   private def runSeed(seed: Long, rc: McRunConfig, outputDir: File)(using p: SimParams): ZIO[Any, SimError, McTerminalSummaryRows] =
     for
-      st       <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      snapshots =
+      st        <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      baseRows   =
+        seedStream(seed, rc.runDurationMonths, traceFirmDecisions = rc.firmDecisionTraceSelection.enabled)
+          .tap(snapshot => McRunnerConsole.emit(monthProgressEvent(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths)))
+      tracedRows =
+        McFirmDecisionTraceCsv.tapSeedTraces(
+          seed = seed,
+          rc = rc,
+          outputDir = outputDir,
+          rows = baseRows,
+        )(
+          executionMonth = _.executionMonth,
+          decisionTraces = _.firmDecisionTraces,
+        )
+      snapshots  =
         McFirmSnapshotCsv.tapSeedSnapshots(
           seed = seed,
           rc = rc,
           outputDir = outputDir,
-          rows = seedStream(seed, rc.runDurationMonths)
-            .tap(snapshot => McRunnerConsole.emit(monthProgressEvent(seed, rc.nSeeds, snapshot.executionMonth, rc.runDurationMonths))),
+          rows = tracedRows,
         )(
           executionMonth = _.executionMonth,
           state = _.state,
         )
-      terminal <- McTimeseriesCsv.writeStreaming(
+      terminal  <- McTimeseriesCsv.writeStreaming(
         McOutputFiles.seedFile(outputDir, seed, rc),
         snapshots
           .map(snapshot => SeedTerminalSnapshot(snapshot.executionMonth, snapshot.monthData, snapshot.state)),
@@ -142,8 +163,8 @@ object McRunner:
           s"seed $seed produced no monthly snapshots for duration ${rc.runDurationMonths}",
         ),
       )
-      et       <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _        <- McRunnerConsole.emit(seedDoneEvent(seed, rc.nSeeds, terminal.lastMonthData, et - st))
+      et        <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      _         <- McRunnerConsole.emit(seedDoneEvent(seed, rc.nSeeds, terminal.lastMonthData, et - st))
     yield McTerminalSummarySchema.fromTerminalState(seed, terminal.terminalState)
 
   private def monthProgressEvent(seed: Long, totalSeeds: Int, month: ExecutionMonth, durationMonths: Int): Event =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -9,11 +9,14 @@ pipeline has no dependency on this package.
 
 | File | Object | Role |
 |------|--------|------|
-| `McRunner.scala` | `McRunner` | Orchestrates the Monte Carlo run: initializes seeds, streams monthly snapshots, writes per-seed CSVs, collects terminal summaries and optional firm snapshots |
-| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId`, `firmSnapshotSchedule` |
+| `McRunner.scala` | `McRunner` | Orchestrates the Monte Carlo run: initializes seeds, streams monthly snapshots, writes per-seed CSVs, collects terminal summaries and optional firm micro exports |
+| `McRunConfig.scala` | `McRunConfig` | Runtime config from CLI args: `nSeeds`, `outputPrefix`, `runDurationMonths`, `runId`, `firmSnapshotSchedule`, `firmDecisionTraceSelection` |
 | `McFirmSnapshotSchedule.scala` | `McFirmSnapshotSchedule` | Disabled/terminal/cadence/explicit-month firm microdata export schedule |
 | `McFirmSnapshotSchema.scala` | `McFirmSnapshotSchema` | Generic per-firm snapshot CSV header and row rendering |
 | `McFirmSnapshotCsv.scala` | `McFirmSnapshotCsv` | Optional per-seed firm snapshot chunk writer and combined CSV finalizer |
+| `McFirmDecisionTraceSelection.scala` | `McFirmDecisionTraceSelection` | Disabled/all/explicit-id/first-N firm decision trace selector |
+| `McFirmDecisionTraceSchema.scala` | `McFirmDecisionTraceSchema` | Generic per-firm decision trace CSV header and row rendering |
+| `McFirmDecisionTraceCsv.scala` | `McFirmDecisionTraceCsv` | Optional per-seed firm decision trace chunk writer and combined CSV finalizer |
 | `McFirmSizeClass.scala` | `McFirmSizeClass` | Shared worker-count size-class boundary used by terminal counts and firm snapshots |
 | `McTimeseriesSchema.scala` | `McTimeseriesSchema` | Timeseries schema with typed `Col` definitions, `compute`, and shared `csvSchema` |
 | `McTimeseriesCsv.scala` | `McTimeseriesCsv` | Streaming per-seed timeseries CSV sink with temp-file finalization |
@@ -48,6 +51,7 @@ Main ──→ McRunner.runZIO(rc)
            │
            ├── McTerminalSummaryCsv.writeAll(hh.csv, banks.csv, firms.csv)
            ├── optional McFirmSnapshotCsv.combineSeedFiles(firm_snapshots.csv)
+           ├── optional McFirmDecisionTraceCsv.combineSeedFiles(firm_decision_trace.csv)
            └── McRunnerConsole.emit(...)
 ```
 
@@ -82,3 +86,28 @@ seed, month, firm id, sector, region, size class, workers, tech state,
 bankruptcy reason, digital readiness, cash, firm loan, equity, bank id, risk
 profile, initial size, capital stock, inventory, green capital, and ownership
 flags. The existing terminal `_firms.csv` aggregate remains unchanged.
+
+## Firm Decision Traces
+
+Firm decision traces are disabled by default. When enabled, the runner writes
+one combined file:
+
+```text
+mc/<prefix>_<run-id>_<months>m_firm_decision_trace.csv
+```
+
+The CLI flag is:
+
+```bash
+--firm-decision-trace ids:0,42,99
+--firm-decision-trace first:25
+--firm-decision-trace all
+```
+
+Trace selection is by firm id and does not use model RNG. Rows are one selected
+firm per execution month and include opening/closing tech state, decision type,
+bankruptcy reason, cash, loan, digital readiness, workers, capex, new loan,
+down payment, bank id, lending rate, available approval/feasibility/probability
+flags, plus separate adoption, implementation, upgrade-candidate bank approval,
+investment-credit bank approval, digital-invest, upgrade-efficiency, and
+labor-adjustment residual rolls where those gates were evaluated.

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -102,6 +102,7 @@ The CLI flag is:
 --firm-decision-trace ids:0,42,99
 --firm-decision-trace first:25
 --firm-decision-trace all
+--firm-decision-trace none
 ```
 
 Trace selection is by firm id and does not use model RNG. Rows are one selected

--- a/src/test/scala/com/boombustgroup/amorfati/MainSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/MainSpec.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati
 
-import com.boombustgroup.amorfati.montecarlo.{McFirmSnapshotSchedule, McRunConfig}
+import com.boombustgroup.amorfati.montecarlo.{McFirmDecisionTraceSelection, McFirmSnapshotSchedule, McRunConfig}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import zio.{Chunk, Runtime, Unsafe}
@@ -8,15 +8,29 @@ import zio.{Chunk, Runtime, Unsafe}
 class MainSpec extends AnyFlatSpec with Matchers:
 
   "Main.parseArgs" should "parse optional runtime flags strictly" in {
-    val parsed = parse("3", "smoke", "--duration", "24", "--run-id", "manual", "--firm-snapshots", "months:1,12")
+    val parsed = parse(
+      "3",
+      "smoke",
+      "--duration",
+      "24",
+      "--run-id",
+      "manual",
+      "--firm-snapshots",
+      "months:1,12",
+      "--firm-decision-trace",
+      "ids:0,5",
+    )
       .map: rc =>
-        (rc.nSeeds, rc.outputPrefix, rc.runDurationMonths, rc.runId, rc.firmSnapshotSchedule)
+        (rc.nSeeds, rc.outputPrefix, rc.runDurationMonths, rc.runId, rc.firmSnapshotSchedule, rc.firmDecisionTraceSelection)
 
-    parsed shouldBe Right((3, "smoke", 24, "manual", McFirmSnapshotSchedule.ExplicitMonths(Set(1, 12))))
+    parsed shouldBe Right(
+      (3, "smoke", 24, "manual", McFirmSnapshotSchedule.ExplicitMonths(Set(1, 12)), McFirmDecisionTraceSelection.ExplicitFirmIds(Set(0, 5))),
+    )
   }
 
   it should "report missing values for known flags" in {
     expectError(parse("3", "smoke", "--firm-snapshots"), "Missing value for --firm-snapshots")
+    expectError(parse("3", "smoke", "--firm-decision-trace"), "Missing value for --firm-decision-trace")
     expectError(parse("3", "smoke", "--duration", "--run-id", "manual"), "Missing value for --duration")
     expectError(parse("3", "smoke", "--run-id"), "Missing value for --run-id")
   }

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -121,6 +121,19 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     (0 until 100).forall(_ => !Banking.canLend(weak.bank, weak.stocks, PLN(10000), rng, Multiplier.Zero, PLN.Zero)) shouldBe true
   }
 
+  it should "expose audited approval probability and roll only when the stochastic gate is sampled" in {
+    val weak      = mkBankRow(loans = PLN(100000), capital = PLN(8000))
+    val weakAudit = Banking.creditApproval(weak.bank, weak.stocks, PLN(10000), RandomStream.seeded(42), Multiplier.Zero, PLN.Zero)
+    weakAudit.approved shouldBe false
+    weakAudit.approvalProbability should not be empty
+    weakAudit.approvalRoll shouldBe None
+
+    val healthy      = mkBankRow()
+    val healthyAudit = Banking.creditApproval(healthy.bank, healthy.stocks, PLN(1000), RandomStream.seeded(42), Multiplier.Zero, PLN.Zero)
+    healthyAudit.approvalProbability should not be empty
+    healthyAudit.approvalRoll should not be empty
+  }
+
   "Banking.interbankRate" should "use explicit financial stocks" in {
     val healthy  = Vector(mkBankRow(id = 0), mkBankRow(id = 1))
     val stressed = Vector(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -99,6 +99,26 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
     Interpreter.totalWealth(Interpreter.applyAll(Map.empty[Int, Long], flows)).shouldBe(0L)
   }
 
+  it should "skip firm decision traces unless explicitly requested" in {
+    result.decisionTraces shouldBe empty
+
+    val traced = FirmEconomics.runStep(
+      w,
+      init.firms,
+      init.households,
+      init.banks,
+      init.ledgerFinancialState,
+      s1,
+      s2,
+      s3,
+      s4,
+      RandomStream.seeded(42),
+      traceDecisions = true,
+    )
+
+    traced.decisionTraces should have size init.firms.size
+  }
+
   it should "match current-month immigrant inflows before closing labor matching" in {
     val immigrantInflow    = 12
     val existingUnemployed = init.households.count(_.status.isInstanceOf[HhStatus.Unemployed])

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomicsSpec.scala
@@ -79,6 +79,11 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   private def manufacturingById(step: FirmEconomics.StepOutput): Map[FirmId, Firm.State] =
     manufacturingOutputs(step).map(f => f.id -> f).toMap
 
+  private val CanonicalSocialNeighbors: Array[HhId] = Array.empty
+
+  private def normalizeHouseholdArrayRefs(step: FirmEconomics.StepOutput): FirmEconomics.StepOutput =
+    step.copy(households = step.households.map(hh => hh.copy(socialNeighbors = CanonicalSocialNeighbors)))
+
   "FirmEconomics.runStep" should "produce flows that close at SFC == 0L" in {
     val flows = FirmFlows.emit(
       FirmFlows.Input(
@@ -100,7 +105,19 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "skip firm decision traces unless explicitly requested" in {
-    result.decisionTraces shouldBe empty
+    val untraced = FirmEconomics.runStep(
+      w,
+      init.firms,
+      init.households,
+      init.banks,
+      init.ledgerFinancialState,
+      s1,
+      s2,
+      s3,
+      s4,
+      RandomStream.seeded(42),
+      traceDecisions = false,
+    )
 
     val traced = FirmEconomics.runStep(
       w,
@@ -116,7 +133,21 @@ class FirmEconomicsSpec extends AnyFlatSpec with Matchers:
       traceDecisions = true,
     )
 
+    untraced.decisionTraces shouldBe empty
     traced.decisionTraces should have size init.firms.size
+    traced.households.map(_.socialNeighbors.toVector) shouldBe untraced.households.map(_.socialNeighbors.toVector)
+
+    val normalizedTraced   = normalizeHouseholdArrayRefs(traced.copy(decisionTraces = untraced.decisionTraces))
+    val normalizedUntraced = normalizeHouseholdArrayRefs(untraced)
+    val changedFields      =
+      normalizedTraced.productElementNames
+        .zip(normalizedTraced.productIterator)
+        .zip(normalizedUntraced.productIterator)
+        .collect { case ((name, left), right) if left != right => name }
+        .toVector
+    withClue(s"traceDecisions changed fields outside decisionTraces: ${changedFields.mkString(", ")}") {
+      normalizedTraced shouldBe normalizedUntraced
+    }
   }
 
   it should "match current-month immigrant inflows before closing labor matching" in {

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSchemaSpec.scala
@@ -1,0 +1,11 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class McFirmDecisionTraceSchemaSpec extends AnyFlatSpec with Matchers:
+
+  "McFirmDecisionTraceSchema" should "keep the firm decision trace header stable" in {
+    McFirmDecisionTraceSchema.header shouldBe
+      "RunId;Seed;Month;FirmId;OpeningTechState;ClosingTechState;DecisionType;BankruptcyReason;CashBefore;CashAfter;FirmLoanBefore;FirmLoanAfter;DigitalReadinessBefore;DigitalReadinessAfter;WorkersBefore;WorkersAfter;Capex;NewLoan;DownPayment;BankId;LendingRate;SelectedBankApproval;SelectedBankApprovalProbability;SelectedBankApprovalRoll;FullAiFeasible;HybridFeasible;FullAiAdoptionProbability;HybridAdoptionProbability;AdoptionRoll;FullAiBankApproval;FullAiBankApprovalProbability;FullAiBankApprovalRoll;HybridBankApproval;HybridBankApprovalProbability;HybridBankApprovalRoll;ImplementationFailureProbability;ImplementationRoll;UpgradeEfficiencyDraw;UpgradeEfficiencyMultiplier;InvestmentCreditNeed;InvestmentCreditAmount;InvestmentBankApproval;InvestmentBankApprovalProbability;InvestmentBankApprovalRoll;DigitalInvestProbability;DigitalInvestRoll;LaborAdjustmentResidualProbability;LaborAdjustmentResidualRoll"
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSelectionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McFirmDecisionTraceSelectionSpec.scala
@@ -1,0 +1,32 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class McFirmDecisionTraceSelectionSpec extends AnyFlatSpec with Matchers:
+
+  "McFirmDecisionTraceSelection" should "disable firm decision traces by default in run config" in {
+    McRunConfig(nSeeds = 1, outputPrefix = "baseline").firmDecisionTraceSelection shouldBe McFirmDecisionTraceSelection.Disabled
+  }
+
+  it should "select explicit firm ids" in {
+    val selection = McFirmDecisionTraceSelection.ExplicitFirmIds(Set(2, 5))
+
+    selection.includes(1) shouldBe false
+    selection.includes(2) shouldBe true
+    selection.includes(5) shouldBe true
+  }
+
+  it should "select the first N firm ids deterministically" in {
+    val selection = McFirmDecisionTraceSelection.FirstN(3)
+
+    selection.includes(0) shouldBe true
+    selection.includes(2) shouldBe true
+    selection.includes(3) shouldBe false
+  }
+
+  it should "reject invalid enabled selections" in {
+    an[IllegalArgumentException] should be thrownBy McFirmDecisionTraceSelection.ExplicitFirmIds(Set.empty)
+    an[IllegalArgumentException] should be thrownBy McFirmDecisionTraceSelection.ExplicitFirmIds(Set(0, -1))
+    an[IllegalArgumentException] should be thrownBy McFirmDecisionTraceSelection.FirstN(0)
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McRunnerOutputSpec.scala
@@ -37,6 +37,31 @@ class McRunnerOutputSpec extends AnyFlatSpec with Matchers:
       householdSummary.tail should have size rc.nSeeds
       householdSummary.tail.foreach(_.split(";").length shouldBe householdSummary.head.split(";").length)
 
+  it should "write deterministic selected firm decision traces without changing baseline CSV outputs" in
+    withTempDir: baselineDir =>
+      withTempDir: traceDir =>
+        withTempDir: repeatTraceDir =>
+          val baselineRc = McRunConfig(nSeeds = 1, outputPrefix = "trace-regression", runDurationMonths = 2, runId = "fixed")
+          val traceRc    =
+            baselineRc.copy(firmDecisionTraceSelection = McFirmDecisionTraceSelection.FirstN(1))
+          val traceName  = decisionTraceFileName(traceRc)
+
+          runToDir(baselineRc, baselineDir)
+          runToDir(traceRc, traceDir)
+          runToDir(traceRc, repeatTraceDir)
+
+          listFileNames(traceDir) should contain(traceName)
+          listFileNames(baselineDir).foreach: name =>
+            Files.readAllLines(traceDir.resolve(name), UTF_8).asScala.toVector shouldBe
+              Files.readAllLines(baselineDir.resolve(name), UTF_8).asScala.toVector
+
+          val traceLines       = Files.readAllLines(traceDir.resolve(traceName), UTF_8).asScala.toVector
+          val repeatTraceLines = Files.readAllLines(repeatTraceDir.resolve(traceName), UTF_8).asScala.toVector
+          traceLines shouldBe repeatTraceLines
+          traceLines.head shouldBe McFirmDecisionTraceSchema.header
+          traceLines.tail should have size traceRc.runDurationMonths
+          traceLines.tail.foreach(_.split(";", -1).length shouldBe traceLines.head.split(";", -1).length)
+
   private def runToDir(rc: McRunConfig, outputDir: Path): Unit =
     Unsafe.unsafe: unsafe =>
       given Unsafe = unsafe
@@ -71,6 +96,9 @@ class McRunnerOutputSpec extends AnyFlatSpec with Matchers:
 
   private def seedFileName(seed: Long, rc: McRunConfig): String =
     f"${filePrefix(rc)}_seed${seed}%03d.csv"
+
+  private def decisionTraceFileName(rc: McRunConfig): String =
+    s"${filePrefix(rc)}_firm_decision_trace.csv"
 
   private def listFileNames(outputDir: Path): Set[String] =
     Using.resource(Files.list(outputDir)) { paths =>


### PR DESCRIPTION
Closes #510.

Summary:
- add optional --firm-decision-trace selector for Monte Carlo runs
- export selected-firm decision traces to *_firm_decision_trace.csv
- split stochastic audits into adoption, bank approval, implementation, upgrade, digital investment, labor, and investment-credit rolls
- keep tracing disabled unless explicitly requested
- document the new operational/observation output

Verification:
- sbt scalafmtAll
- targeted sbt test suite: 106 tests passed
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 3 codex-trace-check --duration 24 --run-id review510 --firm-decision-trace first:3 generated expected 24m seed, aggregate, and firm decision trace files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-firm decision-trace export (disabled by default) selectable via CLI (all / first N / explicit IDs); produces a combined CSV with per-month traces across seeds.
  * Traces capture adoption, financing/credit, implementation, digital-investment and labor gate audit fields.

* **Documentation**
  * Docs updated with CLI usage, selection semantics, and CSV schema/fields.

* **Tests**
  * Added tests validating selection logic, CSV header stability, end-to-end CSV generation, and tracing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->