### PR TITLE
Prevent household shortfall settlement from bypassing underwriting

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -33,10 +33,10 @@ case class PerBankFlow(
     debtService: PLN,                 // total mortgage/secured debt service
     depositInterest: PLN,             // total deposit interest paid
     consumerDebtService: PLN,         // consumer (unsecured) debt service
-    consumerOrigination: PLN,         // total consumer-loan stock origination
+    consumerOrigination: PLN,         // gross underwritten loan plus same-month bridge origination
     consumerApprovedOrigination: PLN, // underwritten consumer credit originated by the DTI rule
-    liquidityShortfallFinancing: PLN, // residual settlement that prevents negative demand deposits
-    consumerDefault: PLN,             // consumer loan defaults (bankruptcy write-offs)
+    liquidityShortfallFinancing: PLN, // same-month bridge/write-off preventing negative deposits
+    consumerDefault: PLN,             // consumer defaults plus same-month bridge charge-offs
     consumerPrincipal: PLN,           // consumer loan principal repaid
 )
 
@@ -134,14 +134,15 @@ object Household:
   )
 
   /** Diagnostic attribution of residual household liquidity settlement.
-    * Components sum to `HouseholdLiquidity_ShortfallFinancing`.
+    * Components sum to `HouseholdLiquidity_ShortfallFinancing`, which is
+    * charged off in the same month instead of becoming ordinary consumer debt.
     */
   case class LiquidityShortfallComponents(
-      consumptionShortfall: PLN, // residual settlement attributable to modeled consumption outflow
-      rentArrears: PLN,          // residual settlement attributable to rent/housing payment
-      mortgageArrears: PLN,      // residual settlement attributable to secured mortgage debt service
-      consumerDebtArrears: PLN,  // residual settlement attributable to unsecured consumer debt service
-      temporaryOverdraft: PLN,   // residual settlement for other current-month liquidity gaps
+      consumptionShortfall: PLN, // same-month bridge/write-off attributable to modeled consumption outflow
+      rentArrears: PLN,          // same-month bridge/write-off attributable to rent/housing payment
+      mortgageArrears: PLN,      // same-month bridge/write-off attributable to secured mortgage debt service
+      consumerDebtArrears: PLN,  // same-month bridge/write-off attributable to unsecured consumer debt service
+      temporaryOverdraft: PLN,   // same-month bridge/write-off for other current-month liquidity gaps
   ):
     def total: PLN =
       consumptionShortfall + rentArrears + mortgageArrears + consumerDebtArrears + temporaryOverdraft
@@ -197,10 +198,10 @@ object Household:
       totalPit: PLN,                             // aggregate PIT paid
       totalSocialTransfers: PLN,                 // aggregate 800+ social transfers
       totalConsumerDebtService: PLN,             // aggregate consumer debt service
-      totalConsumerOrigination: PLN,             // aggregate consumer-loan stock origination
+      totalConsumerOrigination: PLN,             // aggregate gross consumer-loan and bridge origination
       totalConsumerApprovedOrigination: PLN,     // aggregate underwritten consumer-credit origination
-      totalLiquidityShortfallFinancing: PLN,     // aggregate residual liquidity shortfall financing
-      totalConsumerDefault: PLN,                 // aggregate consumer loan defaults
+      totalLiquidityShortfallFinancing: PLN,     // aggregate same-month bridge/write-off for liquidity gaps
+      totalConsumerDefault: PLN,                 // aggregate consumer defaults plus bridge charge-offs
       totalConsumerPrincipal: PLN,               // aggregate consumer loan principal repaid
       totalConsumptionShortfall: PLN = PLN.Zero, // shortfall component attributed to consumption
       totalRentArrears: PLN = PLN.Zero,          // shortfall component attributed to rent
@@ -269,9 +270,9 @@ object Household:
       rent: PLN,                            // monthly rent paid by the household
       mortgageDebtService: PLN,             // monthly secured mortgage debt service
       consumerApprovedOrigination: PLN,     // underwritten consumer credit originated by the DTI rule
-      liquidityShortfallFinancing: PLN,     // residual settlement that prevents negative closing deposits
+      liquidityShortfallFinancing: PLN,     // same-month bridge/write-off preventing negative closing deposits
       consumerDebtService: PLN,             // monthly unsecured consumer-credit debt service
-      consumerDefault: PLN,                 // gross consumer-loan default this month
+      consumerDefault: PLN,                 // gross consumer default plus bridge charge-off this month
       consumerPrincipal: PLN,               // principal component of consumer debt service
       closingConsumerLoan: PLN,             // closing unsecured consumer-loan principal
       consumptionShortfall: PLN = PLN.Zero, // shortfall attributed to modeled consumption outflow
@@ -589,12 +590,13 @@ object Household:
   private case class CreditResult(
       debtService: PLN,                                 // total consumer debt service (amortization + interest)
       principal: PLN,                                   // principal component of debt service
-      newLoan: PLN,                                     // underwritten new consumer loan, excluding residual settlement
-      liquidityShortfall: LiquidityShortfallComponents, // residual settlement split by diagnostic source
-      defaultAmt: PLN,                                  // amount defaulted on bankruptcy (0 if not bankrupt)
+      newLoan: PLN,                                     // underwritten new consumer loan, excluding same-month liquidity bridge
+      liquidityShortfall: LiquidityShortfallComponents, // same-month bridge/write-off split by diagnostic source
+      defaultAmt: PLN,                                  // same-month bridge charge-off plus bankruptcy default amount
       updatedDebt: PLN,                                 // outstanding consumer debt after this month's flows
   ):
     def liquidityShortfallFinancing: PLN = liquidityShortfall.total
+    // Gross flow preserves the SFC bridge leg; defaultAmt offsets bridge stock in the same month.
     def totalOrigination: PLN            = newLoan + liquidityShortfallFinancing
 
   /** Per-HH monthly result — updated state + all flow variables for
@@ -879,7 +881,7 @@ object Household:
 
   /** Diagnostic-only attribution: outflows consume available cash in a stable
     * audit priority, and any unfunded tail becomes the component split of the
-    * residual settlement.
+    * same-month liquidity bridge/default diagnostic.
     */
   private def attributeLiquidityShortfall(f: MonthlyFlows, rawDemandDeposit: PLN, temporaryOutflow: PLN): LiquidityShortfallComponents =
     if rawDemandDeposit >= PLN.Zero then LiquidityShortfallComponents.Zero
@@ -922,9 +924,10 @@ object Household:
       )
       (
         PLN.Zero,
+        // Residual gaps are explicit same-month bridge defaults, not new ordinary consumer-loan stock.
         credit.copy(
           liquidityShortfall = credit.liquidityShortfall + components,
-          updatedDebt = credit.updatedDebt + shortfall,
+          defaultAmt = credit.defaultAmt + shortfall,
         ),
       )
 
@@ -939,7 +942,7 @@ object Household:
     val _                                   = distressMonths
     val liquidityShortfall                  = attributeLiquidityShortfall(f, f.newSavings, temporaryOutflow = PLN.Zero)
     val (finalDemandDeposit, settledCredit) = settleLiquidityShortfall(f.newSavings, f.credit, liquidityShortfall)
-    val ccDefaultAmt                        = settledCredit.updatedDebt
+    val ccDefaultAmt                        = settledCredit.defaultAmt + settledCredit.updatedDebt
     val creditWithDef                       = settledCredit.copy(defaultAmt = ccDefaultAmt, updatedDebt = PLN.Zero)
     val financial                           = FinancialStocks(
       demandDeposit = finalDemandDeposit,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -48,10 +48,10 @@ object HouseholdFinancialEconomics:
       tourismExport: PLN,               // inbound tourism receipts
       tourismImport: PLN,               // outbound tourism expenditure
       consumerDebtService: PLN,         // total consumer credit debt service
-      consumerOrigination: PLN,         // total consumer-loan stock origination
+      consumerOrigination: PLN,         // gross underwritten loan plus same-month bridge origination
       consumerApprovedOrigination: PLN, // underwritten consumer credit originated by the DTI rule
-      liquidityShortfallFinancing: PLN, // residual settlement that prevents negative demand deposits
-      consumerDefaultAmt: PLN,          // consumer loan default amount
+      liquidityShortfallFinancing: PLN, // same-month bridge/write-off preventing negative demand deposits
+      consumerDefaultAmt: PLN,          // consumer defaults plus same-month bridge charge-offs
       consumerNplLoss: PLN,             // consumer NPL loss net of recovery
       consumerPrincipal: PLN,           // consumer loan principal repayment
   )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -442,6 +442,7 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("ConsumerOrigination", ctx => ctx.hhAgg.totalConsumerOrigination),
     ColumnDef.macroPln("ConsumerApprovedOrigination", ctx => ctx.hhAgg.totalConsumerApprovedOrigination),
     ColumnDef.macroPln("ConsumerDebtService", ctx => ctx.hhAgg.totalConsumerDebtService),
+    ColumnDef.macroPln("ConsumerDefault", ctx => ctx.hhAgg.totalConsumerDefault),
     ColumnDef.macroPln("TotalCreditStock", ctx => ctx.totalCreditStock),
     ColumnDef("BankFirmLoansToGdp", ctx => ctx.annualizedGdpRatio(ctx.bankFirmLoans)),
     ColumnDef("ConsumerLoansToGdp", ctx => ctx.annualizedGdpRatio(ctx.consumerLoanStock)),

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -132,8 +132,18 @@ HouseholdLiquidity_DepositP95
 HouseholdLiquidity_DepositP99
 ```
 
-The monthly timeseries additionally includes residual shortfall settlement and
-its component attribution:
+The monthly timeseries consumer-credit block relevant to this reconciliation is:
+
+```text
+ConsumerOrigination
+ConsumerApprovedOrigination
+ConsumerDebtService
+ConsumerDefault
+```
+
+The timeseries also includes residual shortfall settlement and its component
+attribution. `ConsumerDefault` is the matching same-month default/write-off
+diagnostic for the bridge component:
 
 ```text
 HouseholdLiquidity_ShortfallFinancing
@@ -150,17 +160,23 @@ HouseholdLiquidity_TemporaryOverdraft
 therefore indicates legacy or fixture input rows, while the columns remain useful
 as an invariant guard without writing household-level microdata by default.
 
-`HouseholdLiquidity_ShortfallFinancing` is the residual liquidity settlement
-routed into consumer-loan stock after the household budget has closed. It is
-separate from `ConsumerApprovedOrigination`, while `ConsumerOrigination` remains
-the total consumer-loan stock origination used by SFC identities.
+`HouseholdLiquidity_ShortfallFinancing` is the residual liquidity bridge needed
+to keep runtime household demand deposits non-negative after the household
+budget has closed. It is separate from `ConsumerApprovedOrigination` and is
+charged off through `ConsumerDefault` in the same month, so it does not survive
+as ordinary household consumer-loan stock and does not bypass DTI underwriting.
+`ConsumerOrigination` remains the gross SFC bridge plus approved-origination
+flow, while `ConsumerApprovedOrigination` is the underwritten credit channel.
+For the bridge component, the stock effect is zero because
+`HouseholdLiquidity_ShortfallFinancing` is offset by `ConsumerDefault`.
 
 The `HouseholdLiquidity_ConsumptionShortfall`, `RentArrears`,
 `MortgageArrears`, `ConsumerDebtArrears`, and `TemporaryOverdraft` columns split
-that residual settlement by a diagnostic payment-priority attribution. They do
-not yet create persistent arrears/default state; follow-up household distress
-mechanics can replace the residual settlement path while preserving these audit
-columns.
+that bridge amount by a diagnostic payment-priority attribution. They do not yet
+create persistent arrears stock. `TemporaryOverdraft` is not carried as a
+separate household liability; any positive value is part of the same-month
+bridge/default path visible in `HouseholdLiquidity_ShortfallFinancing` and
+`ConsumerDefault`.
 
 Household micro snapshots are disabled by default. When enabled, the runner
 writes two combined files:
@@ -192,8 +208,8 @@ The row selector is separate from the schedule:
 primarily a legacy/invariant guard after non-negative household deposits became
 the runtime contract. `shortfall` selects rows with positive
 `LiquidityShortfallFinancing`, which is the useful mode for diagnosing the
-post-#515 conversion of residual household liquidity gaps into explicit
-consumer-loan stock.
+residual household liquidity gaps that are now bridged and charged off instead
+of being capitalized into ordinary consumer-loan stock.
 
 Snapshot rows are taken at the household-income/liquidity settlement boundary
 for the selected execution month, before later firm-entry, migration, and

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -386,20 +386,39 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
     )
   }
 
-  it should "convert closing liquidity shortfalls into consumer credit instead of negative deposits" in {
+  it should "charge off closing liquidity shortfalls instead of rolling them into consumer-loan stock" in {
     val rng    = RandomStream.seeded(42)
     val hh     = mkHousehold(0, HhStatus.Unemployed(10), savings = PLN.Zero, rent = PLN(10000), mpc = BigDecimal("0.50"))
     val result = step(Vector(hh), mkWorld(), PLN(8000), PLN(4666), Share.decimal(4, 1), rng)
     val stocks = result.financialStocks.head
 
     stocks.demandDeposit shouldBe PLN.Zero
-    stocks.consumerLoan should be > PLN.Zero
-    result.aggregates.totalConsumerOrigination shouldBe stocks.consumerLoan
+    stocks.consumerLoan shouldBe PLN.Zero
+    result.aggregates.totalConsumerOrigination shouldBe result.aggregates.totalLiquidityShortfallFinancing
     result.aggregates.totalConsumerApprovedOrigination shouldBe PLN.Zero
-    result.aggregates.totalLiquidityShortfallFinancing shouldBe stocks.consumerLoan
+    result.aggregates.totalConsumerDefault shouldBe result.aggregates.totalLiquidityShortfallFinancing
     result.aggregates.totalLiquidityShortfallComponents shouldBe result.aggregates.totalLiquidityShortfallFinancing
     result.monthlyFlows.head.rentArrears + result.monthlyFlows.head.temporaryOverdraft should be > PLN.Zero
     result.aggregates.meanSavings shouldBe PLN.Zero
+  }
+
+  it should "route residual consumer-debt-service financing through same-month default" in {
+    val rng         = RandomStream.seeded(42)
+    val openingLoan = PLN(12000)
+    val hh          = mkHousehold(0, HhStatus.Unemployed(10), savings = PLN.Zero, rent = PLN.Zero, mpc = BigDecimal("0.50"))
+    financialById.update(
+      hh.id.toInt,
+      TestHouseholdState.financial(savings = PLN.Zero, debt = PLN.Zero, consumerDebt = openingLoan, equityWealth = PLN.Zero),
+    )
+
+    val result = step(Vector(hh), mkWorld(), PLN(8000), PLN(4666), Share.decimal(4, 1), rng)
+    val flow   = result.monthlyFlows.head
+
+    flow.consumerDebtArrears shouldBe flow.consumerDebtService
+    flow.consumerDefault shouldBe flow.consumerDebtArrears
+    flow.closingConsumerLoan shouldBe (openingLoan - flow.consumerDebtService).max(PLN.Zero)
+    result.financialStocks.head.consumerLoan shouldBe flow.closingConsumerLoan
+    result.aggregates.totalConsumerApprovedOrigination shouldBe PLN.Zero
   }
 
   it should "reconcile shortfall components when wealth effects make consumption negative" in {

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
-import com.boombustgroup.amorfati.agents.{Firm, TechState}
+import com.boombustgroup.amorfati.agents.{Firm, Household, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
@@ -169,6 +169,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "ConsumerOrigination",
     "ConsumerApprovedOrigination",
     "ConsumerDebtService",
+    "ConsumerDefault",
     "TotalCreditStock",
     "BankFirmLoansToGdp",
     "ConsumerLoansToGdp",
@@ -336,6 +337,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
       world: World,
       ledgerFinancialState: LedgerFinancialState = initState.ledgerFinancialState,
       firms: Vector[Firm.State] = init.firms,
+      householdAggregates: Household.Aggregates = init.householdAggregates,
       preserveSectorOutputs: Boolean = false,
   ): Array[MetricValue] =
     val effectiveWorld =
@@ -347,7 +349,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
       firms = firms,
       households = init.households,
       banks = init.banks,
-      householdAggregates = init.householdAggregates,
+      householdAggregates = householdAggregates,
       ledgerFinancialState = ledgerFinancialState,
     )
 
@@ -363,7 +365,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 310
+    McTimeseriesSchema.nCols shouldBe 311
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -549,10 +551,12 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
         sectorOutputs = Vector.fill(summon[SimParams].sectorDefs.length)(PLN.Zero),
       ),
     )
-    val row           = computeRow(world, ledger)
+    val hhAgg         = init.householdAggregates.copy(totalConsumerDefault = PLN(7))
+    val row           = computeRow(world, ledger, householdAggregates = hhAgg)
 
     valueAt(row, "BankFirmLoans") shouldBe polandScale(bankFirmLoans)
     valueAt(row, "ConsumerLoans") shouldBe polandScale(consumerLoans)
+    valueAt(row, "ConsumerDefault") shouldBe polandScale(PLN(7))
     valueAt(row, "NbfiLoanStock") shouldBe polandScale(nbfiLoans)
     valueAt(row, "TotalCreditStock") shouldBe polandScale(totalCredit)
     valueAt(row, "BankFirmLoansToGdp") shouldBe MetricValue.fromRaw((bankFirmLoans / annualGdp).toLong)


### PR DESCRIPTION
Closes #526.

Summary:
- route residual household liquidity shortfalls through same-month bridge/default diagnostics instead of increasing ordinary consumer-loan stock
- expose ConsumerDefault in the monthly MC timeseries next to approved credit, debt service, and shortfall diagnostics
- document the new bridge/default semantics and add regression coverage for consumer-debt-service shortfalls

Validation:
- sbt scalafmtAll
- sbt testOnly com.boombustgroup.amorfati.agents.HouseholdSpec
- sbt testOnly com.boombustgroup.amorfati.engine.flows.HouseholdFlowsSpec
- sbt testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec
- sbt testOnly com.boombustgroup.amorfati.montecarlo.McHouseholdSnapshotSchemaSpec
- sbt integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 1 issue526 --duration 6 --run-id 20260519-526-credit-constraints-check --household-snapshots terminal --household-snapshot-selector shortfall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer-default metric to household financial diagnostics timeseries output for improved visibility into charge-off activity.

* **Improvements**
  * Refined household liquidity-shortfall accounting: temporary deposit gaps are now recognized as explicit same-month charge-offs rather than being converted into consumer-loan obligations, improving diagnostic clarity.

* **Documentation**
  * Updated financial-diagnostics documentation with more precise explanations of consumer-credit and liquidity-bridge accounting treatment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->