### PR TITLE
Add household credit stress calibration diagnostics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val robustnessReport = inputKey[Unit]("Generate lightweight sensitivity and
 lazy val scenarioRun = inputKey[Unit]("Run named scenario-registry experiments")
 lazy val empiricalValidation = inputKey[Unit]("Generate empirical validation baseline snapshot artifacts")
 lazy val calibrationRegister = inputKey[Unit]("Generate calibration register docs from typed provenance registry")
+lazy val householdCreditStressCalibration = inputKey[Unit]("Generate household liquidity and credit-stress calibration artifacts")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -88,6 +89,13 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<calibration register args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.CalibrationRegisterExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    householdCreditStressCalibration := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<household credit stress args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.HouseholdCreditStressCalibrationExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/household-credit-stress-calibration.md
+++ b/docs/household-credit-stress-calibration.md
@@ -1,0 +1,65 @@
+# Household Credit Stress Calibration
+
+Issue #529 adds a repeatable diagnostic layer for household liquidity and credit
+stress. The diagnostic export itself does not change household behavior. It
+converts existing Monte Carlo outputs and terminal household aggregates into
+Poland-relevant guardrail ratios for the same `2026-04-30` model-start baseline
+used by the production calibration surface.
+
+Run the standard fixture with:
+
+```bash
+sbt "householdCreditStressCalibration --seeds 5 --months 60 --out target/household-credit-stress --run-id household-credit-stress"
+```
+
+The task writes:
+
+- `household-credit-stress-seed-metrics.csv`: one terminal ratio per seed and
+  metric.
+- `household-credit-stress-summary.csv`: mean/min/max across seeds, with status.
+- `household-credit-stress-targets.csv`: documented target bands, vintage, and
+  semantics.
+- `household-credit-stress-report.md`: human-readable summary.
+
+## Guardrail Classes
+
+`HARD_INVARIANT` covers accounting or reporting boundaries that should never
+fail. In this layer, negative demand deposits are treated as invalid because
+demand deposits are non-negative bank liabilities; household stress must appear
+in explicit shortfall/default channels.
+
+`SOFT_CALIBRATION_WARNING` covers Poland-relevant target ranges. A breach is not
+a runtime failure, but it means the baseline should be reviewed before using the
+run as a stylized Poland scenario.
+
+`EXPLORATORY_DIAGNOSTIC` covers useful stress decompositions where the model
+surface exists but the empirical acceptance band is not settled yet. These
+ratios are meant to guide follow-up calibration and source-bridge work. A value
+outside the reference band is still reported as `WARN`, but the warning means
+"investigate this channel", not "empirical validation failed".
+
+## Target Bands
+
+| Metric | Class | Vintage | Band | Unit | Interpretation |
+| --- | --- | --- | --- | --- | --- |
+| `ConsumerLoansToGdp` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.03` to `0.08` | ratio | Consumer credit should be material, but far below mortgage credit as a share of GDP. |
+| `MortgageLoansToGdp` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.09` to `0.16` | ratio | Mortgage stock should sit near the Polish housing-credit scale, not EU high-mortgage economies. |
+| `ConsumerDebtServiceToIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `0.08` | ratio | Consumer instalments should not dominate regular household income in the baseline. |
+| `MortgageDebtServiceToIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `0.12` | ratio | Mortgage payments can be larger than consumer instalments, but should remain a minority of monthly income. |
+| `ConsumerDefaultToConsumerLoans` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.03` | monthly ratio | Flow/stock stress ratio for spotting liquidity bridges leaking into consumer-credit losses. |
+| `MortgageDefaultToMortgageLoans` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.01` | monthly ratio | Flow/stock stress ratio for mortgage stress; this should later be mapped to arrears/default definitions. |
+| `PositiveDepositsToMonthlyIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `1.00` to `8.00` | months of income | Aggregate liquid buffers should be neither exhausted nor implausibly huge relative to household income. |
+| `MedianDepositToMeanMonthlyIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.20` to `6.00` | months of mean income | The median household should have some liquidity, but not years of income in demand deposits. |
+| `NegativeDepositShare` | `HARD_INVARIANT` | `2026-04-30 model-start baseline` | `0.00` to `0.00` | share | Demand deposits are non-negative bank liabilities. |
+| `DebtArrearsToShortfall` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `1.00` | share | Shows whether shortfall pressure comes mainly from debt/rent service or from consumption/liquidity residuals. |
+| `ShortfallToIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `0.05` | ratio | Shortfall financing should be a stress channel, not a large routine substitute for income. |
+| `ShortfallToApprovedOrigination` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `2.00` | ratio | The non-underwritten liquidity bridge should not structurally dominate normal approved consumer credit. |
+
+## Source Status
+
+The current bands are stylized for the `2026-04-30` Poland model-start
+baseline. `MortgageLoansToGdp` is anchored to the existing empirical-validation
+manifest bridge for KNF housing loans relative to model GDP. The consumer-credit,
+household DSR, arrears/default and liquidity-buffer ranges are deliberately
+documented as guardrails, not final empirical pass/fail tests. They should be
+replaced or narrowed when NBP, KNF, GUS or household microdata bridges are added.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -331,7 +331,9 @@ sbt "householdCreditStressCalibration --seeds 5 --months 60 --out target/househo
 ```
 
 This writes terminal household credit-stress ratios, target bands, and a
-summary report under `target/household-credit-stress/`. The semantics and
+summary report under `<out>/<run-id>/`. With the command above, the concrete
+output directory is
+`target/household-credit-stress/household-credit-stress/`. The semantics and
 Poland-relevant guardrail bands are documented in
 [household-credit-stress-calibration.md](household-credit-stress-calibration.md).
 
@@ -398,7 +400,7 @@ Generated local outputs normally belong in ignored paths:
 | `target/sfc-matrices/` | Scratch SFC matrix exports | No |
 | `target/scenarios/` | Scenario registry runs | No |
 | `target/robustness*` | Robustness reports | No |
-| `target/household-credit-stress/` | Household credit-stress calibration | No |
+| `<out>/<run-id>/`, for example `target/household-credit-stress/household-credit-stress/` | Household credit-stress calibration | No |
 | `docs/sfc-matrix-artifacts/` | Intentional committed matrix snapshots | Yes, only when refreshed intentionally |
 | `docs/empirical-validation/` | Empirical-validation snapshot bundle | Yes, only when refreshed intentionally |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -324,6 +324,17 @@ Labor demand probe:
 sbt "runMain com.boombustgroup.amorfati.diagnostics.runLaborDemandProbe 1 2"
 ```
 
+Household liquidity and credit-stress calibration:
+
+```bash
+sbt "householdCreditStressCalibration --seeds 5 --months 60 --out target/household-credit-stress --run-id household-credit-stress"
+```
+
+This writes terminal household credit-stress ratios, target bands, and a
+summary report under `target/household-credit-stress/`. The semantics and
+Poland-relevant guardrail bands are documented in
+[household-credit-stress-calibration.md](household-credit-stress-calibration.md).
+
 For scratch and committed-snapshot SFC matrix exports, see
 [sfc-matrix-evidence.md](sfc-matrix-evidence.md).
 
@@ -387,6 +398,7 @@ Generated local outputs normally belong in ignored paths:
 | `target/sfc-matrices/` | Scratch SFC matrix exports | No |
 | `target/scenarios/` | Scenario registry runs | No |
 | `target/robustness*` | Robustness reports | No |
+| `target/household-credit-stress/` | Household credit-stress calibration | No |
 | `docs/sfc-matrix-artifacts/` | Intentional committed matrix snapshots | Yes, only when refreshed intentionally |
 | `docs/empirical-validation/` | Empirical-validation snapshot bundle | Yes, only when refreshed intentionally |
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
@@ -480,7 +480,7 @@ object HouseholdCreditStressCalibrationExport:
 
   private[diagnostics] def renderReport(config: Config, summary: Vector[SummaryMetric]): String =
     val command     =
-      s"""sbt "householdCreditStressCalibration --seeds ${config.seeds} --months ${config.months} --out ${config.out} --run-id ${config.runId}""""
+      s"""sbt "householdCreditStressCalibration --seed-start ${config.seedStart} --seeds ${config.seeds} --months ${config.months} --out ${config.out} --run-id ${config.runId}""""
     val targetRows  = Targets.map: target =>
       markdownRow(
         Vector(

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
@@ -1,0 +1,592 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.montecarlo.{McRunner, McTimeseriesSchema, MetricValue, RunResult}
+import com.boombustgroup.amorfati.montecarlo.MetricValue.*
+import com.boombustgroup.amorfati.montecarlo.TimeSeries.*
+import com.boombustgroup.amorfati.types.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.math.BigDecimal.RoundingMode
+import scala.util.Try
+
+object HouseholdCreditStressCalibrationExport:
+
+  private val BaselineVintage = "2026-04-30 model-start baseline"
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 5,
+      months: Int = 60,
+      runId: String = "household-credit-stress",
+      out: Path = Path.of("target/household-credit-stress"),
+  ):
+    def seedRange: Vector[Long] = Vector.range(seedStart, seedStart + seeds.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  enum GuardrailClass(val token: String):
+    case HardInvariant          extends GuardrailClass("HARD_INVARIANT")
+    case SoftCalibrationWarning extends GuardrailClass("SOFT_CALIBRATION_WARNING")
+    case ExploratoryDiagnostic  extends GuardrailClass("EXPLORATORY_DIAGNOSTIC")
+
+  enum Status(val token: String):
+    case Pass extends Status("PASS")
+    case Warn extends Status("WARN")
+    case Fail extends Status("FAIL")
+    case Info extends Status("INFO")
+
+  enum ObservedValue:
+    case Finite(value: BigDecimal)
+    case PositiveInfinity
+    case NotAvailable
+
+    def finite: Option[BigDecimal] =
+      this match
+        case Finite(value) => Some(value)
+        case _             => None
+
+  final case class TargetBand(
+      id: String,
+      label: String,
+      unit: String,
+      guardrailClass: GuardrailClass,
+      vintage: String,
+      lower: Option[BigDecimal],
+      upper: Option[BigDecimal],
+      sourceNote: String,
+      interpretation: String,
+  )
+
+  final case class SeedMetric(
+      runId: String,
+      seed: Long,
+      months: Int,
+      target: TargetBand,
+      value: ObservedValue,
+      status: Status,
+  )
+
+  final case class SummaryMetric(
+      runId: String,
+      months: Int,
+      seeds: Int,
+      target: TargetBand,
+      mean: ObservedValue,
+      min: Option[BigDecimal],
+      max: Option[BigDecimal],
+      status: Status,
+  )
+
+  final case class ExportResult(paths: Vector[Path], seedMetrics: Vector[SeedMetric], summary: Vector[SummaryMetric])
+
+  private final case class SeedContext(result: RunResult):
+    val terminalRow: Array[MetricValue] = result.timeSeries.lastMonth
+    val householdCount: Int             = result.terminalState.households.size
+
+    def col(name: String): BigDecimal =
+      decimal(McTimeseriesSchema.colNames.indexOf(name) match
+        case -1      => throw new IllegalArgumentException(s"Missing Monte Carlo column: $name")
+        case ordinal => terminalRow(ordinal).toLong)
+
+    def ratioColumn(numerator: String, denominator: String): ObservedValue =
+      ratio(col(numerator), col(denominator))
+
+    def householdRatio(numerator: PLN, denominator: PLN): ObservedValue =
+      ratioRaw(BigDecimal(numerator.toLong), BigDecimal(denominator.toLong))
+
+    def householdRatio(numerator: PLN, denominatorRaw: BigDecimal): ObservedValue =
+      ratioRaw(BigDecimal(numerator.toLong), denominatorRaw)
+
+  private final case class MetricDef(target: TargetBand, compute: SeedContext => ObservedValue)
+
+  private val RequiredMetricIds: Set[String] = Set(
+    "ConsumerLoansToGdp",
+    "MortgageLoansToGdp",
+    "ConsumerDebtServiceToIncome",
+    "MortgageDebtServiceToIncome",
+    "ConsumerDefaultToConsumerLoans",
+    "MortgageDefaultToMortgageLoans",
+    "PositiveDepositsToMonthlyIncome",
+    "MedianDepositToMeanMonthlyIncome",
+    "NegativeDepositShare",
+    "DebtArrearsToShortfall",
+    "ShortfallToIncome",
+    "ShortfallToApprovedOrigination",
+  )
+
+  private[diagnostics] val Targets: Vector[TargetBand] = Vector(
+    TargetBand(
+      id = "ConsumerLoansToGdp",
+      label = "Consumer loan stock / annual GDP",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.03")),
+      upper = Some(BigDecimal("0.08")),
+      sourceNote = "Stylized-Poland 2026-04-30 household consumer-credit stock band; source extraction should later replace this with NBP/KNF series.",
+      interpretation = "Consumer credit should be material, but far below mortgage credit as a share of GDP.",
+    ),
+    TargetBand(
+      id = "MortgageLoansToGdp",
+      label = "Mortgage stock / annual GDP",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.09")),
+      upper = Some(BigDecimal("0.16")),
+      sourceNote =
+        "Anchored to the 2026-04-30 production baseline and the existing validation manifest bridge: KNF housing loans near 12% of model GDP, with a broad tolerance.",
+      interpretation = "Mortgage stock should sit near the Polish housing-credit scale, not EU high-mortgage economies.",
+    ),
+    TargetBand(
+      id = "ConsumerDebtServiceToIncome",
+      label = "Consumer debt service / monthly household income",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.08")),
+      sourceNote = "Stylized 2026-04-30 household cash-flow guardrail; formal calibration needs DSR microdata or bank loan-payment aggregates.",
+      interpretation = "Consumer instalments should not dominate regular household income in the baseline.",
+    ),
+    TargetBand(
+      id = "MortgageDebtServiceToIncome",
+      label = "Mortgage debt service / monthly household income",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.12")),
+      sourceNote = "Stylized 2026-04-30 household cash-flow guardrail for secured debt service.",
+      interpretation = "Mortgage payments can be larger than consumer instalments, but should remain a minority of monthly income.",
+    ),
+    TargetBand(
+      id = "ConsumerDefaultToConsumerLoans",
+      label = "Consumer defaults and bridge write-offs / consumer-loan stock",
+      unit = "monthly ratio",
+      guardrailClass = GuardrailClass.ExploratoryDiagnostic,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.03")),
+      sourceNote = "Exploratory flow/stock stress ratio; not an official NPL rate.",
+      interpretation = "Useful for spotting whether liquidity bridges are leaking into consumer-credit losses.",
+    ),
+    TargetBand(
+      id = "MortgageDefaultToMortgageLoans",
+      label = "Mortgage arrears/default flow / mortgage stock",
+      unit = "monthly ratio",
+      guardrailClass = GuardrailClass.ExploratoryDiagnostic,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.01")),
+      sourceNote = "Exploratory flow/stock stress ratio; should later be mapped to arrears/default definitions.",
+      interpretation = "Mortgage stress should be rarer than unsecured consumer-credit stress in the baseline.",
+    ),
+    TargetBand(
+      id = "PositiveDepositsToMonthlyIncome",
+      label = "Positive demand deposits / monthly household income",
+      unit = "months of income",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("1.00")),
+      upper = Some(BigDecimal("8.00")),
+      sourceNote = "Stylized 2026-04-30 liquid-buffer band for household deposits relative to one month of income.",
+      interpretation = "Aggregate liquid buffers should be neither exhausted nor implausibly huge relative to household income.",
+    ),
+    TargetBand(
+      id = "MedianDepositToMeanMonthlyIncome",
+      label = "Median demand deposit / mean monthly household income",
+      unit = "months of mean income",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.20")),
+      upper = Some(BigDecimal("6.00")),
+      sourceNote = "Stylized 2026-04-30 distributional liquidity guardrail; later source bridge should use household wealth or deposit microdata.",
+      interpretation = "The median household should have some liquidity, but not years of income in demand deposits.",
+    ),
+    TargetBand(
+      id = "NegativeDepositShare",
+      label = "Share of households with negative demand deposits",
+      unit = "share",
+      guardrailClass = GuardrailClass.HardInvariant,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.00")),
+      sourceNote = "Runtime accounting invariant after liquidity shortfalls are externalized from bank deposits.",
+      interpretation = "Demand deposits are non-negative bank liabilities; stress must appear in explicit shortfall/default channels.",
+    ),
+    TargetBand(
+      id = "DebtArrearsToShortfall",
+      label = "Rent, mortgage, and consumer-debt arrears / liquidity shortfall",
+      unit = "share",
+      guardrailClass = GuardrailClass.ExploratoryDiagnostic,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("1.00")),
+      sourceNote = "Internal attribution check over shortfall components.",
+      interpretation = "Shows whether shortfall pressure comes mainly from debt/rent service or from consumption/liquidity residuals.",
+    ),
+    TargetBand(
+      id = "ShortfallToIncome",
+      label = "Liquidity shortfall financing / monthly household income",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.05")),
+      sourceNote = "Stylized 2026-04-30 red-flag threshold for monthly emergency bridge/write-off flow.",
+      interpretation = "Shortfall financing should be a stress channel, not a large routine substitute for income.",
+    ),
+    TargetBand(
+      id = "ShortfallToApprovedOrigination",
+      label = "Liquidity shortfall financing / approved consumer-credit origination",
+      unit = "ratio",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("2.00")),
+      sourceNote = "Stylized 2026-04-30 guardrail added after the diagnostic run where shortfalls dwarfed approved credit.",
+      interpretation = "The non-underwritten liquidity bridge should not structurally dominate normal approved consumer credit.",
+    ),
+  )
+
+  private val Metrics: Vector[MetricDef] = Vector(
+    metric("ConsumerLoansToGdp")(ctx => ObservedValue.Finite(ctx.col("ConsumerLoansToGdp"))),
+    metric("MortgageLoansToGdp")(ctx => ObservedValue.Finite(ctx.col("MortgageToGdp"))),
+    metric("ConsumerDebtServiceToIncome")(ctx =>
+      ctx.householdRatio(ctx.result.terminalState.householdAggregates.totalConsumerDebtService, ctx.result.terminalState.householdAggregates.totalIncome),
+    ),
+    metric("MortgageDebtServiceToIncome")(ctx =>
+      ctx.householdRatio(ctx.result.terminalState.householdAggregates.totalDebtService, ctx.result.terminalState.householdAggregates.totalIncome),
+    ),
+    metric("ConsumerDefaultToConsumerLoans")(ctx => ctx.ratioColumn("ConsumerDefault", "ConsumerLoans")),
+    metric("MortgageDefaultToMortgageLoans")(ctx => ctx.ratioColumn("MortgageDefault", "MortgageStock")),
+    metric("PositiveDepositsToMonthlyIncome")(ctx =>
+      ctx.householdRatio(
+        ctx.result.terminalState.ledgerFinancialState.households.map(h => h.demandDeposit).sumPln,
+        ctx.result.terminalState.householdAggregates.totalIncome,
+      ),
+    ),
+    metric("MedianDepositToMeanMonthlyIncome")(ctx =>
+      val agg = ctx.result.terminalState.householdAggregates
+      if ctx.householdCount <= 0 then ObservedValue.NotAvailable
+      else ctx.householdRatio(agg.medianSavings, BigDecimal(agg.totalIncome.toLong) / BigDecimal(ctx.householdCount)),
+    ),
+    metric("NegativeDepositShare")(ctx => ObservedValue.Finite(ctx.col("HouseholdLiquidity_NegativeDepositShare"))),
+    metric("DebtArrearsToShortfall")(ctx =>
+      val agg = ctx.result.terminalState.householdAggregates
+      ctx.householdRatio(
+        agg.totalRentArrears + agg.totalMortgageArrears + agg.totalConsumerDebtArrears,
+        agg.totalLiquidityShortfallFinancing,
+      ),
+    ),
+    metric("ShortfallToIncome")(ctx =>
+      val agg = ctx.result.terminalState.householdAggregates
+      ctx.householdRatio(agg.totalLiquidityShortfallFinancing, agg.totalIncome),
+    ),
+    metric("ShortfallToApprovedOrigination")(ctx =>
+      val agg = ctx.result.terminalState.householdAggregates
+      ctx.householdRatio(agg.totalLiquidityShortfallFinancing, agg.totalConsumerApprovedOrigination),
+    ),
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      given SimParams = SimParams.defaults
+
+      val attempts = validConfig.seedRange.map: seed =>
+        Try(McRunner.runSingle(seed, validConfig.months)).toEither.left
+          .map(ex => s"Seed $seed crashed: ${ex.getMessage}")
+          .flatMap:
+            _.left
+              .map(err => s"Seed $seed failed: $err")
+              .map(result => computeSeedMetrics(validConfig, seed, result))
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val seedMetrics = attempts.collect { case Right(rows) => rows }.flatten
+          val summary     = summarize(validConfig, seedMetrics)
+          val paths       = writeArtifacts(validConfig, seedMetrics, summary)
+          Right(ExportResult(paths, seedMetrics, summary))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                       => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")    => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start" =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"      =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"     =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--run-id"     =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"        =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                  => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private[diagnostics] def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+      .flatMap(valid => Either.cond(Metrics.map(_.target.id).toSet == RequiredMetricIds, valid, "Household credit stress metric coverage is incomplete"))
+
+  private[diagnostics] def evaluate(value: ObservedValue, target: TargetBand): Status =
+    value match
+      case ObservedValue.Finite(v)        =>
+        val outside = target.lower.exists(v < _) || target.upper.exists(v > _)
+        target.guardrailClass match
+          case GuardrailClass.HardInvariant if outside          => Status.Fail
+          case GuardrailClass.HardInvariant                     => Status.Pass
+          case GuardrailClass.SoftCalibrationWarning if outside => Status.Warn
+          case GuardrailClass.SoftCalibrationWarning            => Status.Pass
+          case GuardrailClass.ExploratoryDiagnostic if outside  => Status.Warn
+          case GuardrailClass.ExploratoryDiagnostic             => Status.Info
+      case ObservedValue.PositiveInfinity =>
+        target.guardrailClass match
+          case GuardrailClass.HardInvariant          => Status.Fail
+          case GuardrailClass.SoftCalibrationWarning => Status.Warn
+          case GuardrailClass.ExploratoryDiagnostic  => Status.Warn
+      case ObservedValue.NotAvailable     =>
+        target.guardrailClass match
+          case GuardrailClass.HardInvariant          => Status.Fail
+          case GuardrailClass.SoftCalibrationWarning => Status.Warn
+          case GuardrailClass.ExploratoryDiagnostic  => Status.Warn
+
+  private def computeSeedMetrics(config: Config, seed: Long, result: RunResult): Vector[SeedMetric] =
+    val context = SeedContext(result)
+    Metrics.map: metric =>
+      val value = metric.compute(context)
+      SeedMetric(config.runId, seed, config.months, metric.target, value, evaluate(value, metric.target))
+
+  private[diagnostics] def summarize(config: Config, rows: Vector[SeedMetric]): Vector[SummaryMetric] =
+    Targets.map: target =>
+      val metricRows = rows.filter(_.target.id == target.id)
+      val finite     = metricRows.flatMap(_.value.finite)
+      val mean       =
+        if metricRows.exists(_.value == ObservedValue.PositiveInfinity) then ObservedValue.PositiveInfinity
+        else if finite.nonEmpty then ObservedValue.Finite(finite.sum / BigDecimal(finite.size))
+        else ObservedValue.NotAvailable
+      SummaryMetric(
+        runId = config.runId,
+        months = config.months,
+        seeds = config.seeds,
+        target = target,
+        mean = mean,
+        min = if finite.nonEmpty then Some(finite.min) else None,
+        max = if finite.nonEmpty then Some(finite.max) else None,
+        status = evaluate(mean, target),
+      )
+
+  private def writeArtifacts(config: Config, seedMetrics: Vector[SeedMetric], summary: Vector[SummaryMetric]): Vector[Path] =
+    Files.createDirectories(config.runRoot)
+    val seedMetricsPath = config.runRoot.resolve("household-credit-stress-seed-metrics.csv")
+    val summaryPath     = config.runRoot.resolve("household-credit-stress-summary.csv")
+    val targetPath      = config.runRoot.resolve("household-credit-stress-targets.csv")
+    val reportPath      = config.runRoot.resolve("household-credit-stress-report.md")
+    Files.writeString(seedMetricsPath, renderSeedMetricsCsv(seedMetrics), StandardCharsets.UTF_8)
+    Files.writeString(summaryPath, renderSummaryCsv(summary), StandardCharsets.UTF_8)
+    Files.writeString(targetPath, renderTargetsCsv(Targets), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, summary), StandardCharsets.UTF_8)
+    Vector(seedMetricsPath, summaryPath, targetPath, reportPath)
+
+  private[diagnostics] def renderSeedMetricsCsv(rows: Vector[SeedMetric]): String =
+    val header = "RunId;Seed;Months;Metric;Label;Value;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.seed.toString,
+        row.months.toString,
+        row.target.id,
+        row.target.label,
+        renderValue(row.value),
+        row.target.unit,
+        row.target.guardrailClass.token,
+        row.target.vintage,
+        row.target.lower.map(renderDecimal).getOrElse(""),
+        row.target.upper.map(renderDecimal).getOrElse(""),
+        row.status.token,
+        row.target.sourceNote,
+        row.target.interpretation,
+      ).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderSummaryCsv(rows: Vector[SummaryMetric]): String =
+    val header = "RunId;Months;Seeds;Metric;Label;Mean;Min;Max;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.months.toString,
+        row.seeds.toString,
+        row.target.id,
+        row.target.label,
+        renderValue(row.mean),
+        row.min.map(renderDecimal).getOrElse(""),
+        row.max.map(renderDecimal).getOrElse(""),
+        row.target.unit,
+        row.target.guardrailClass.token,
+        row.target.vintage,
+        row.target.lower.map(renderDecimal).getOrElse(""),
+        row.target.upper.map(renderDecimal).getOrElse(""),
+        row.status.token,
+        row.target.sourceNote,
+        row.target.interpretation,
+      ).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderTargetsCsv(targets: Vector[TargetBand]): String =
+    val header = "Metric;Label;Unit;GuardrailClass;Vintage;Lower;Upper;SourceNote;Interpretation"
+    val body   = targets.map: target =>
+      Vector(
+        target.id,
+        target.label,
+        target.unit,
+        target.guardrailClass.token,
+        target.vintage,
+        target.lower.map(renderDecimal).getOrElse(""),
+        target.upper.map(renderDecimal).getOrElse(""),
+        target.sourceNote,
+        target.interpretation,
+      ).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderReport(config: Config, summary: Vector[SummaryMetric]): String =
+    val command     =
+      s"""sbt "householdCreditStressCalibration --seeds ${config.seeds} --months ${config.months} --out ${config.out} --run-id ${config.runId}""""
+    val targetRows  = Targets.map: target =>
+      markdownRow(
+        Vector(
+          target.id,
+          target.guardrailClass.token,
+          target.vintage,
+          bound(target.lower),
+          bound(target.upper),
+          target.unit,
+          target.interpretation,
+        ),
+      )
+    val summaryRows = summary.map: row =>
+      markdownRow(
+        Vector(
+          row.target.id,
+          renderValue(row.mean),
+          row.min.map(renderDecimal).getOrElse("n/a"),
+          row.max.map(renderDecimal).getOrElse("n/a"),
+          row.status.token,
+        ),
+      )
+    val lines       =
+      Vector(
+        "# Household Credit Stress Calibration",
+        "",
+        "Generated by `HouseholdCreditStressCalibrationExport`.",
+        "",
+        s"- Run id: `${config.runId}`",
+        s"- Seeds: `${config.seeds}` from `${config.seedStart}`",
+        s"- Months: `${config.months}`",
+        s"- Repeat command: `$command`",
+        "",
+        "## Guardrail Classes",
+        "",
+        "- `HARD_INVARIANT`: accounting or reporting boundary that should never fail.",
+        "- `SOFT_CALIBRATION_WARNING`: Poland-relevant calibration band; violations are warnings, not runtime failures.",
+        "- `EXPLORATORY_DIAGNOSTIC`: useful stress decomposition without a settled empirical acceptance band.",
+        "",
+        "## Target Bands",
+        "",
+        markdownRow(Vector("Metric", "Class", "Vintage", "Lower", "Upper", "Unit", "Interpretation")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---", "---")),
+      ) ++ targetRows ++ Vector(
+        "",
+        "## Summary",
+        "",
+        markdownRow(Vector("Metric", "Mean", "Min", "Max", "Status")),
+        markdownRow(Vector("---", "---", "---", "---", "---")),
+      ) ++ summaryRows
+    lines.mkString("\n") + "\n"
+
+  private def metric(id: String)(compute: SeedContext => ObservedValue): MetricDef =
+    val target = Targets.find(_.id == id).getOrElse(throw new IllegalArgumentException(s"Missing target band: $id"))
+    MetricDef(target, compute)
+
+  private def ratio(numerator: BigDecimal, denominator: BigDecimal): ObservedValue =
+    ratioRaw(numerator, denominator)
+
+  private def ratioRaw(numerator: BigDecimal, denominator: BigDecimal): ObservedValue =
+    if denominator == BigDecimal(0) then
+      if numerator == BigDecimal(0) then ObservedValue.Finite(BigDecimal(0))
+      else ObservedValue.PositiveInfinity
+    else ObservedValue.Finite(numerator / denominator)
+
+  private def decimal(raw: Long): BigDecimal =
+    BigDecimal(raw) / BigDecimal(com.boombustgroup.amorfati.fp.FixedPointBase.Scale)
+
+  private def renderValue(value: ObservedValue): String =
+    value match
+      case ObservedValue.Finite(v)        => renderDecimal(v)
+      case ObservedValue.PositiveInfinity => "INF"
+      case ObservedValue.NotAvailable     => "NA"
+
+  private def renderDecimal(value: BigDecimal): String =
+    value.setScale(6, RoundingMode.HALF_UP).bigDecimal.stripTrailingZeros.toPlainString
+
+  private def bound(value: Option[BigDecimal]): String =
+    value.map(renderDecimal).getOrElse("n/a")
+
+  private def csv(value: String): String =
+    val escaped = value.replace("\"", "\"\"")
+    if escaped.exists(ch => ch == ';' || ch == '"' || ch == '\n' || ch == '\r') then s""""$escaped""""
+    else escaped
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(_.replace("|", "\\|")).mkString("| ", " | ", " |")
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private def usage: String =
+    """Usage: HouseholdCreditStressCalibrationExport [options]
+      |
+      |Options:
+      |  --seed-start <long>  First Monte Carlo seed, default 1
+      |  --seeds <int>        Number of seeds, default 5
+      |  --months <int>       Number of simulated months, default 60
+      |  --run-id <string>    Output run id, default household-credit-stress
+      |  --out <path>         Output root, default target/household-credit-stress
+      |""".stripMargin
+
+end HouseholdCreditStressCalibrationExport

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -883,10 +883,6 @@ object BankingEconomics:
     val afterResolveStocks           = resolveResult.financialStocks
     val afterResolveCorpBonds        = resolveResult.bankCorpBondHoldings
     val afterResolveCorpBondHoldings = Banking.bankCorpBondHoldingsFromVector(afterResolveCorpBonds)
-    val rawAbsorberId                = resolveResult.absorberId
-    val absorberId                   =
-      if rawAbsorberId.toInt >= 0 then rawAbsorberId
-      else Banking.healthiestBankId(afterResolve, afterResolveStocks, afterResolveCorpBondHoldings)
     val multiCapDest: PLN            =
       if anyFailed then
         tfiSale.banks
@@ -910,18 +906,15 @@ object BankingEconomics:
       configs = bankConfigs,
       interbankCurve = curve,
     )
+    // Repair stale failed-bank routing every month; mobility validates survivor bankIds.
     val reassignedFirms              =
-      if anyFailed then
-        in.s5.ioFirms.map: f =>
-          if f.bankId.toInt < afterResolve.length && afterResolve(f.bankId.toInt).failed then f.copy(bankId = absorberId)
-          else f
-      else in.s5.ioFirms
+      in.s5.ioFirms.map: f =>
+        val nextBankId = Banking.reassignBankId(f.bankId, afterResolve, afterResolveStocks, afterResolveCorpBondHoldings)
+        if nextBankId == f.bankId then f else f.copy(bankId = nextBankId)
     val postFailureHh                =
-      if anyFailed then
-        in.s5.households.map: h =>
-          if h.bankId.toInt < afterResolve.length && afterResolve(h.bankId.toInt).failed then h.copy(bankId = absorberId)
-          else h
-      else in.s5.households
+      in.s5.households.map: h =>
+        val nextBankId = Banking.reassignBankId(h.bankId, afterResolve, afterResolveStocks, afterResolveCorpBondHoldings)
+        if nextBankId == h.bankId then h else h.copy(bankId = nextBankId)
 
     // Deposit mobility: HH may switch banks based on health signals and panic
     val mobilityResult       = DepositMobility(postFailureHh, afterResolve, afterResolveStocks, anyFailed, in.depositRng, afterResolveCorpBondHoldings)

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
@@ -57,12 +57,14 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
     val summary = summarize(Config(runId = "stress-spec", seeds = 2, months = 60), rows)
     val seedCsv = renderSeedMetricsCsv(rows)
     val sumCsv  = renderSummaryCsv(summary)
+    val report  = renderReport(Config(seedStart = 2L, runId = "stress-spec", seeds = 2, months = 60), summary)
 
     seedCsv.linesIterator.next() shouldBe "RunId;Seed;Months;Metric;Label;Value;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
     seedCsv should include("ShortfallToIncome")
     seedCsv should include("2026-04-30 model-start baseline")
     sumCsv.linesIterator.next() shouldBe "RunId;Months;Seeds;Metric;Label;Mean;Min;Max;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
     sumCsv should include("SOFT_CALIBRATION_WARNING")
+    report should include("--seed-start 2")
   }
 
 end HouseholdCreditStressCalibrationExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
@@ -1,0 +1,68 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Path
+
+class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matchers:
+
+  import HouseholdCreditStressCalibrationExport.*
+
+  "HouseholdCreditStressCalibrationExport" should "parse CLI run controls" in {
+    parseArgs(Vector("--seed-start", "2", "--seeds", "7", "--months", "84", "--run-id", "stress-spec", "--out", "target/stress-spec")) shouldBe
+      Right(Config(seedStart = 2L, seeds = 7, months = 84, runId = "stress-spec", out = Path.of("target/stress-spec")))
+  }
+
+  it should "cover the household credit-stress metric contract" in {
+    Targets.map(_.id).toSet should contain allOf (
+      "ConsumerLoansToGdp",
+      "MortgageLoansToGdp",
+      "ConsumerDebtServiceToIncome",
+      "MortgageDebtServiceToIncome",
+      "ConsumerDefaultToConsumerLoans",
+      "MortgageDefaultToMortgageLoans",
+      "PositiveDepositsToMonthlyIncome",
+      "MedianDepositToMeanMonthlyIncome",
+      "NegativeDepositShare",
+      "DebtArrearsToShortfall",
+      "ShortfallToIncome",
+      "ShortfallToApprovedOrigination",
+    )
+    Targets.map(_.guardrailClass).toSet should contain allOf (
+      GuardrailClass.HardInvariant,
+      GuardrailClass.SoftCalibrationWarning,
+      GuardrailClass.ExploratoryDiagnostic,
+    )
+  }
+
+  it should "map hard failures, soft warnings, and exploratory diagnostics to distinct statuses" in {
+    val hardInvariant = Targets.find(_.id == "NegativeDepositShare").get
+    val softBand      = Targets.find(_.id == "ShortfallToApprovedOrigination").get
+    val exploratory   = Targets.find(_.id == "DebtArrearsToShortfall").get
+
+    evaluate(ObservedValue.Finite(BigDecimal("0.01")), hardInvariant) shouldBe Status.Fail
+    evaluate(ObservedValue.Finite(BigDecimal("1.50")), softBand) shouldBe Status.Pass
+    evaluate(ObservedValue.Finite(BigDecimal("3.00")), softBand) shouldBe Status.Warn
+    evaluate(ObservedValue.Finite(BigDecimal("0.80")), exploratory) shouldBe Status.Info
+    evaluate(ObservedValue.Finite(BigDecimal("1.20")), exploratory) shouldBe Status.Warn
+  }
+
+  it should "render seed and summary CSV artifacts with calibration metadata" in {
+    val target  = Targets.find(_.id == "ShortfallToIncome").get
+    val rows    = Vector(
+      SeedMetric("stress-spec", 1L, 60, target, ObservedValue.Finite(BigDecimal("0.02")), Status.Pass),
+      SeedMetric("stress-spec", 2L, 60, target, ObservedValue.Finite(BigDecimal("0.08")), Status.Warn),
+    )
+    val summary = summarize(Config(runId = "stress-spec", seeds = 2, months = 60), rows)
+    val seedCsv = renderSeedMetricsCsv(rows)
+    val sumCsv  = renderSummaryCsv(summary)
+
+    seedCsv.linesIterator.next() shouldBe "RunId;Seed;Months;Metric;Label;Value;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
+    seedCsv should include("ShortfallToIncome")
+    seedCsv should include("2026-04-30 model-start baseline")
+    sumCsv.linesIterator.next() shouldBe "RunId;Months;Seeds;Metric;Label;Mean;Min;Max;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
+    sumCsv should include("SOFT_CALIBRATION_WARNING")
+  }
+
+end HouseholdCreditStressCalibrationExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/InformalEconomySpec.scala
@@ -313,5 +313,5 @@ class InformalEconomySpec extends AnyFlatSpec with Matchers:
     avgShare should be <= Share.decimal(30, 2)
     avgRatio should be >= Share.decimal(10, 3)
     avgRatio should be <= Share.decimal(20, 3)
-    avgRatio shouldBe Share.decimal(183, 4)
+    avgRatio shouldBe Share.decimal(182, 4)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -99,6 +99,19 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     LedgerFinancialState.bankMortgageStock(result.ledgerFinancialState) shouldBe LedgerFinancialState.householdMortgageStock(result.ledgerFinancialState)
   }
 
+  it should "repair stale household routing away from already failed banks before deposit mobility" in {
+    val prepared    = preparedBankingStep()
+    val failedBanks = prepared.banks.updated(
+      0,
+      prepared.banks.head.copy(status = Banking.BankStatus.Failed(ExecutionMonth.First), capital = PLN.Zero),
+    )
+
+    val result = prepared.run(banksOverride = failedBanks)
+
+    result.banks.head.failed shouldBe true
+    result.reassignedHouseholds.exists(_.bankId == BankId(0)) shouldBe false
+  }
+
   it should "realign consumer-loan book distribution to household bank routing without changing the aggregate stock" in {
     val households        = Vector(
       TestHouseholdState(id = HhId(0), skill = Share.decimal(7, 1), mpc = Share.decimal(8, 1), status = HhStatus.Unemployed(0), bankId = BankId(0)),


### PR DESCRIPTION
## Summary
- add a household credit-stress calibration export and sbt task for the standard `5 seeds / 60 months` fixture
- document 2026-04-30 stylized-Poland guardrails for household liquidity, mortgage, consumer-credit and shortfall ratios
- repair stale failed-bank routing before deposit mobility so long diagnostic runs do not crash on old bank assignments

Closes #529.

## Validation
- `sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.diagnostics.HouseholdCreditStressCalibrationExportSpec"`
- `sbt "householdCreditStressCalibration --seeds 5 --months 60 --out target/household-credit-stress --run-id household-credit-stress"`
- `sbt test`

## Diagnostic results from final 5x60 fixture
- `MortgageLoansToGdp = 0.4595` vs target `0.09-0.16` -> #532
- `MortgageDebtServiceToIncome = 0.37727` vs target `0-0.12` -> #533
- `ConsumerDefaultToConsumerLoans = 1.536876` vs reference `0-0.03` -> #536
- `ShortfallToIncome = 0.298602` vs target `0-0.05` -> #535
- `ShortfallToApprovedOrigination = 41.808307` vs target `0-2` -> #534

The diagnostic output passes the hard negative-deposit invariant: `NegativeDepositShare = 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added household credit stress calibration diagnostic tool that generates seed-level metrics, summary statistics, guardrail assessments, and calibration reports via a new CLI command.

* **Bug Fixes**
  * Fixed bank reassignment logic to properly route households away from failed banks during resolution processing.

* **Documentation**
  * Added comprehensive household credit stress calibration documentation including target bands, diagnostic classes, and usage instructions.
  * Updated operations guide with new calibration workflow and output locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->