### PR TITLE
Fix mortgage amortization schedule

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -137,11 +137,20 @@ mortgageRate_h =
   lendingRate_b                         if bank-specific lendingRate_b exists
   nbp.referenceRate + housing.mortgageSpread
                                         otherwise
-mortgagePrincipal_h = mortgageLoan_h / housing.mortgageMaturity
+remainingMortgageMonths_h =
+  remainingMortgageMonths_h             if mortgageLoan_h > 0 and remainingMortgageMonths_h > 0
+  housing.mortgageMaturity              if mortgageLoan_h > 0 and no contract state exists
+  0                                     otherwise
+mortgagePrincipal_h =
+  mortgageLoan_h / remainingMortgageMonths_h if mortgageLoan_h > 0
+  0                                          otherwise
 mortgageInterest_h = mortgageLoan_h * mortgageRate_h.monthly
 scheduledMortgagePayment_h =
   mortgagePrincipal_h + mortgageInterest_h
 mortgageLoan'_h = max(mortgageLoan_h - mortgagePrincipal_h, 0)
+remainingMortgageMonths'_h =
+  max(remainingMortgageMonths_h - 1, 1)  if mortgageLoan'_h > 0
+  0                                     otherwise
 ```
 
 `scheduledMortgagePayment_h` is a household budget burden. It is not a single

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -144,11 +144,13 @@ object Household:
     * execution.
     */
   case class FinancialStocks(
-      demandDeposit: PLN, // non-negative bank demand deposits owned by the household
-      mortgageLoan: PLN,  // outstanding secured mortgage principal
-      consumerLoan: PLN,  // outstanding unsecured consumer-loan principal
-      equity: PLN,        // listed equity owned by the household
-  )
+      demandDeposit: PLN,              // non-negative bank demand deposits owned by the household
+      mortgageLoan: PLN,               // outstanding secured mortgage principal
+      consumerLoan: PLN,               // outstanding unsecured consumer-loan principal
+      equity: PLN,                     // listed equity owned by the household
+      mortgageRemainingMonths: Int = 0, // remaining contractual mortgage-payment months; 0 means no active mortgage
+  ):
+    require(mortgageRemainingMonths >= 0, s"mortgageRemainingMonths must be non-negative: $mortgageRemainingMonths")
 
   /** Diagnostic attribution of residual household liquidity settlement.
     * Components sum to `HouseholdLiquidity_ShortfallFinancing`, which is
@@ -176,6 +178,20 @@ object Household:
   object LiquidityShortfallComponents:
     val Zero: LiquidityShortfallComponents =
       LiquidityShortfallComponents(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+
+  private[amorfati] def activeMortgageRemainingMonths(stocks: FinancialStocks)(using p: SimParams): Int =
+    if stocks.mortgageLoan <= PLN.Zero then 0
+    else if stocks.mortgageRemainingMonths > 0 then stocks.mortgageRemainingMonths
+    else p.housing.mortgageMaturity
+
+  private[amorfati] def scheduledMortgagePrincipal(stocks: FinancialStocks)(using p: SimParams): PLN =
+    val remainingMonths = activeMortgageRemainingMonths(stocks)
+    if remainingMonths <= 0 then PLN.Zero
+    else stocks.mortgageLoan / remainingMonths
+
+  private[amorfati] def remainingMortgageMonthsAfterPayment(stocks: FinancialStocks, closingMortgageLoan: PLN)(using p: SimParams): Int =
+    if closingMortgageLoan <= PLN.Zero then 0
+    else (activeMortgageRemainingMonths(stocks).max(1) - 1).max(1)
 
   /** Aggregate statistics computed from individual households (Paper-06). */
   case class Aggregates(
@@ -471,7 +487,7 @@ object Household:
       if stocks.isEmpty then stocks
       else
         val target = p.housing.initMortgage
-        if target <= PLN.Zero then stocks.map(_.copy(mortgageLoan = PLN.Zero))
+        if target <= PLN.Zero then stocks.map(_.copy(mortgageLoan = PLN.Zero, mortgageRemainingMonths = 0))
         else
           val current   = stocks.iterator.map(_.mortgageLoan).sumPln
           val weights   =
@@ -479,7 +495,12 @@ object Household:
             else Array.fill(stocks.length)(1L)
           val allocated = com.boombustgroup.ledger.Distribute.distribute(target.toLong, weights)
           stocks.zip(allocated).map { case (stock, rawMortgageLoan) =>
-            stock.copy(mortgageLoan = PLN.fromRaw(rawMortgageLoan))
+            val mortgageLoan = PLN.fromRaw(rawMortgageLoan)
+            val remaining    =
+              if mortgageLoan <= PLN.Zero then 0
+              else if stock.mortgageRemainingMonths > 0 then stock.mortgageRemainingMonths
+              else p.housing.mortgageMaturity
+            stock.copy(mortgageLoan = mortgageLoan, mortgageRemainingMonths = remaining)
           }
 
     private case class SampledHousehold(
@@ -533,6 +554,7 @@ object Household:
           mortgageLoan = debt,
           consumerLoan = consDebt,
           equity = eqWealth,
+          mortgageRemainingMonths = if debt > PLN.Zero then p.housing.mortgageMaturity else 0,
         ),
       )
 
@@ -965,6 +987,7 @@ object Household:
       newEquityWealth: PLN,
       newSavings: PLN, // raw closing liquid balance before non-negative deposit settlement
       newDebt: PLN,
+      newMortgageRemainingMonths: Int,
       neighborDistress: Share,
   )
 
@@ -1033,7 +1056,7 @@ object Household:
   )(using p: SimParams): MonthlyFlows =
     val (baseIncome, benefit, newStatus) = computeIncome(hh)
 
-    // Mortgage service uses housing maturity for principal and bank rates for interest.
+    // Mortgage service uses the contract's remaining maturity for principal and bank rates for interest.
     val mortgageRate: Rate = bankRates match
       case Some(br) => br.lendingRates(hh.bankId.toInt)
       case None     => world.nbp.referenceRate + p.housing.mortgageSpread
@@ -1047,9 +1070,10 @@ object Household:
     val pitTax            = computeMonthlyPit(grossIncome)
     val socialTransfer    = computeSocialTransfer(hh.numDependentChildren)
     val income            = grossIncome - pitTax + socialTransfer
-    val mortgagePrincipal = financialStocks.mortgageLoan / p.housing.mortgageMaturity
+    val mortgagePrincipal = scheduledMortgagePrincipal(financialStocks)
     val mortgageInterest  = financialStocks.mortgageLoan * mortgageRate.max(Rate.Zero).monthly
     val thisDebtService   = mortgagePrincipal + mortgageInterest
+    val newMortgageLoan   = (financialStocks.mortgageLoan - mortgagePrincipal).max(PLN.Zero)
 
     val remittance =
       if hh.isImmigrant then income * p.immigration.remitRate
@@ -1101,7 +1125,8 @@ object Household:
       discretionaryConsumptionCompression = consumptionWaterfall.discretionaryConsumptionCompression,
       newEquityWealth = newEquityWealth,
       newSavings = financialStocks.demandDeposit + income - fullObligations + credit.newLoan - consumptionWaterfall.actualConsumption,
-      newDebt = (financialStocks.mortgageLoan - mortgagePrincipal).max(PLN.Zero),
+      newDebt = newMortgageLoan,
+      newMortgageRemainingMonths = remainingMortgageMonthsAfterPayment(financialStocks, newMortgageLoan),
       neighborDistress = neighborDistress,
     )
     underwriteResidualShortfall(initialFlows)
@@ -1194,6 +1219,7 @@ object Household:
       mortgageLoan = f.newDebt,
       consumerLoan = PLN.Zero,
       equity = PLN.Zero,
+      mortgageRemainingMonths = f.newMortgageRemainingMonths,
     )
     HhMonthlyResult(
       newState = f.hh.copy(
@@ -1257,6 +1283,7 @@ object Household:
       mortgageLoan = f.newDebt,
       consumerLoan = settledCredit.updatedDebt,
       equity = f.newEquityWealth,
+      mortgageRemainingMonths = f.newMortgageRemainingMonths,
     )
 
     HhMonthlyResult(
@@ -1584,7 +1611,7 @@ object Household:
 
       val rentRaw       = hh.monthlyRent.toLong
       val mortgageRate  = p.monetary.initialRate + p.housing.mortgageSpread
-      val debtSvcRaw    = ((stocks.mortgageLoan / p.housing.mortgageMaturity) + (stocks.mortgageLoan * mortgageRate.monthly)).toLong
+      val debtSvcRaw    = (scheduledMortgagePrincipal(stocks) + (stocks.mortgageLoan * mortgageRate.monthly)).toLong
       val disposableRaw = math.max(0L, incomes(i) - rentRaw - debtSvcRaw)
       consumptions(i) = FixedPointBase.multiplyRaw(disposableRaw, hh.mpc.toLong)
       savingsArr(i) = stocks.demandDeposit.toLong

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala
@@ -114,6 +114,7 @@ object Immigration:
         mortgageLoan = PLN.Zero,
         consumerLoan = PLN.Zero,
         equity = PLN.Zero,
+        mortgageRemainingMonths = 0,
       )
       (household, stocks)
     }.toVector

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -222,7 +222,11 @@ object BankingEconomics:
 
     val rawLedgerFinancialState =
       in.s5.ledgerFinancialState.copy(
-        households = LedgerFinancialState.settleHouseholdMortgageStock(in.s5.ledgerFinancialState.households, housing.housingAfterFlows.mortgageStock),
+        households = LedgerFinancialState.settleHouseholdMortgageStock(
+          in.s5.ledgerFinancialState.households,
+          housing.housingAfterFlows.mortgageStock,
+          housing.housingAfterFlows.lastOrigination,
+        ),
         firms = issuerSettledFirmBalances,
         banks = multi.finalBankLedgerBalances,
         government = LedgerFinancialState.GovernmentBalances(govBondOutstanding = govJst.newGovBondOutstanding),
@@ -416,7 +420,8 @@ object BankingEconomics:
     )
     val housingAfterOrig       =
       HousingMarket.processOrigination(housingAfterPrice, in.s3.totalIncome, mortgageRate, true)
-    val mortgageFlows          = HousingMarket.processMortgageFlows(housingAfterOrig, mortgageRate, unempRate)
+    val scheduledPrincipal     = Some(in.s3.hhAgg.totalMortgagePrincipal)
+    val mortgageFlows          = HousingMarket.processMortgageFlows(housingAfterOrig, mortgageRate, unempRate, scheduledPrincipal)
     val housingAfterFlows      = HousingMarket.applyFlows(housingAfterOrig, mortgageFlows)
 
     HousingResult(housingAfterFlows = housingAfterFlows, mortgageFlows = mortgageFlows)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.ledger
 
 import com.boombustgroup.amorfati.agents.{Banking, Firm, Household, Insurance, Nbfi, Nbp, QuasiFiscal}
+import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.markets.CorporateBondMarket
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.Distribute
@@ -47,6 +48,7 @@ object LedgerFinancialState:
       mortgageLoan = stocks.mortgageLoan,
       consumerLoan = stocks.consumerLoan,
       equity = stocks.equity,
+      mortgageRemainingMonths = stocks.mortgageRemainingMonths,
     )
 
   /** Project ledger-owned household balances into the household execution DTO.
@@ -61,6 +63,7 @@ object LedgerFinancialState:
       mortgageLoan = balances.mortgageLoan,
       consumerLoan = balances.consumerLoan,
       equity = balances.equity,
+      mortgageRemainingMonths = balances.mortgageRemainingMonths,
     )
 
   def householdMortgageStock(ledgerFinancialState: LedgerFinancialState): PLN =
@@ -102,10 +105,14 @@ object LedgerFinancialState:
   /** Writes the aggregate mortgage model's closing principal back into
     * household ledger rows. Until origination/defaults are modeled per
     * household, the aggregate stock is distributed proportionally across the
-    * existing household mortgage book.
+    * existing household mortgage book, and new origination extends remaining
+    * maturity by weighted average.
     */
-  def settleHouseholdMortgageStock(households: Vector[HouseholdBalances], closingStock: PLN): Vector[HouseholdBalances] =
+  def settleHouseholdMortgageStock(households: Vector[HouseholdBalances], closingStock: PLN, newOrigination: PLN = PLN.Zero)(using
+      p: SimParams,
+  ): Vector[HouseholdBalances] =
     require(closingStock >= PLN.Zero, s"LedgerFinancialState.settleHouseholdMortgageStock requires non-negative closing stock, got $closingStock")
+    require(newOrigination >= PLN.Zero, s"LedgerFinancialState.settleHouseholdMortgageStock requires non-negative newOrigination, got $newOrigination")
     if households.isEmpty then
       require(
         closingStock == PLN.Zero,
@@ -114,17 +121,40 @@ object LedgerFinancialState:
       households
     else
       val currentStock = householdMortgageStock(households)
-      if currentStock == closingStock then households
+      if currentStock == closingStock && newOrigination <= PLN.Zero then
+        households.map(balances => balances.copy(mortgageRemainingMonths = mortgageRemainingMonthsFor(balances, balances.mortgageLoan, 0L)))
       else
         val mortgageWeights = households.map(_.mortgageLoan.distributeRaw.max(0L)).toArray
         val weights         =
           if mortgageWeights.exists(_ > 0L) then mortgageWeights
           else Array.fill(households.length)(1L)
+        val originationRows = Distribute.distribute(newOrigination.distributeRaw, weights)
         Distribute
           .distribute(closingStock.distributeRaw, weights)
+          .zip(originationRows)
           .zip(households)
-          .map((rawStock, balances) => balances.copy(mortgageLoan = PLN.fromRaw(rawStock)))
+          .map { case ((rawStock, rawOrigination), balances) =>
+            val mortgageLoan = PLN.fromRaw(rawStock)
+            balances.copy(
+              mortgageLoan = mortgageLoan,
+              mortgageRemainingMonths = mortgageRemainingMonthsFor(balances, mortgageLoan, rawOrigination),
+            )
+          }
           .toVector
+
+  private def mortgageRemainingMonthsFor(balances: HouseholdBalances, closingMortgageLoan: PLN, allocatedOriginationRaw: Long)(using p: SimParams): Int =
+    if closingMortgageLoan <= PLN.Zero then 0
+    else
+      val previousMonths = if balances.mortgageRemainingMonths > 0 then balances.mortgageRemainingMonths else p.housing.mortgageMaturity
+      val previousRaw    = balances.mortgageLoan.distributeRaw.max(0L)
+      val closingRaw     = closingMortgageLoan.distributeRaw.max(0L)
+      val originatedRaw  = allocatedOriginationRaw.max(0L).min(closingRaw)
+      if previousRaw <= 0L then p.housing.mortgageMaturity
+      else if originatedRaw <= 0L then previousMonths
+      else
+        val previousComponentRaw = closingRaw - originatedRaw
+        val weightedMonths       = BigInt(previousComponentRaw) * previousMonths + BigInt(originatedRaw) * p.housing.mortgageMaturity
+        ((weightedMonths + BigInt(closingRaw) - 1) / BigInt(closingRaw)).toInt.max(1)
 
   /** Writes the aggregate mortgage book into bank-side ledger asset rows.
     *
@@ -425,7 +455,12 @@ object LedgerFinancialState:
       lifeReserveAsset: PLN = PLN.Zero,
       /** Non-life insurance technical reserve asset owned by the household. */
       nonLifeReserveAsset: PLN = PLN.Zero,
-  )
+      /** Remaining contractual mortgage-payment months; 0 means no active
+        * mortgage.
+        */
+      mortgageRemainingMonths: Int = 0,
+  ):
+    require(mortgageRemainingMonths >= 0, s"mortgageRemainingMonths must be non-negative: $mortgageRemainingMonths")
 
   /** Ledger-backed financial balances owned or issued by a single firm.
     */

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala
@@ -310,17 +310,19 @@ object HousingMarket:
       regions = Some(updatedRegions),
     )
 
-  def processMortgageFlows(prev: State, mortgageRate: Rate, unemploymentRate: Share)(using p: SimParams): MortgageFlows =
+  def processMortgageFlows(prev: State, mortgageRate: Rate, unemploymentRate: Share, scheduledPrincipal: Option[PLN] = None)(using
+      p: SimParams,
+  ): MortgageFlows =
     if prev.mortgageStock <= PLN.Zero
     then MortgageFlows(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
     else
       val stock         = prev.mortgageStock
       val interest      = stock * mortgageRate.max(Rate.Zero).monthly
-      val principal     = stock / p.housing.mortgageMaturity
+      val principal     = scheduledPrincipal.getOrElse(stock / p.housing.mortgageMaturity).max(PLN.Zero).min(stock)
       val unempExcess   = (unemploymentRate - Share.decimal(5, 2)).max(Share.Zero)
       val stressAdj     = (p.housing.defaultUnempSens * unempExcess).toMultiplier
       val defaultRate   = p.housing.defaultBase + stressAdj.toShare
-      val defaultAmount = stock * defaultRate
+      val defaultAmount = (stock * defaultRate).min((stock - principal).max(PLN.Zero))
       val defaultLoss   = defaultAmount * (Share.One - p.housing.mortgageRecovery)
       MortgageFlows(interest, principal, defaultAmount, defaultLoss)
 

--- a/src/test/scala/com/boombustgroup/amorfati/TestHouseholdState.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/TestHouseholdState.scala
@@ -15,12 +15,14 @@ object TestHouseholdState:
       debt: PLN = PLN.Zero,
       consumerDebt: PLN = PLN.Zero,
       equityWealth: PLN = PLN.Zero,
+      mortgageRemainingMonths: Int = 0,
   ): Household.FinancialStocks =
     Household.FinancialStocks(
       demandDeposit = savings,
       mortgageLoan = debt,
       consumerLoan = consumerDebt,
       equity = equityWealth,
+      mortgageRemainingMonths = mortgageRemainingMonths,
     )
 
   def fixture(
@@ -46,6 +48,7 @@ object TestHouseholdState:
       contractType: ContractType = ContractType.Permanent,
       region: Region = Region.Central,
       financialDistressState: HhFinancialDistressState = HhFinancialDistressState.Current,
+      mortgageRemainingMonths: Int = 0,
   ): Fixture =
     Fixture(
       state = apply(
@@ -68,7 +71,13 @@ object TestHouseholdState:
         region = region,
         financialDistressState = financialDistressState,
       ),
-      financialStocks = financial(savings = savings, debt = debt, consumerDebt = consumerDebt, equityWealth = equityWealth),
+      financialStocks = financial(
+        savings = savings,
+        debt = debt,
+        consumerDebt = consumerDebt,
+        equityWealth = equityWealth,
+        mortgageRemainingMonths = mortgageRemainingMonths,
+      ),
     )
 
   def apply(

--- a/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/HouseholdSpec.scala
@@ -669,6 +669,38 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
     result.aggregates.totalDebtService shouldBe principal + interest
   }
 
+  it should "close a mortgage to zero at its remaining contractual maturity" in {
+    val debt = PLN(3000)
+    val hh   = mkHousehold(
+      22,
+      HhStatus.Employed(FirmId(0), SectorIdx(0), PLN(9000)),
+      savings = PLN(100000),
+      debt = debt,
+      rent = PLN.Zero,
+      bankId = 0,
+      mortgageRemainingMonths = 3,
+    )
+    val br   = BankRates(
+      lendingRates = Vector(Rate.Zero),
+      depositRates = Vector(Rate.Zero),
+    )
+
+    val month1 = step(Vector(hh), mkWorld(), PLN(8000), PLN(4666), Share.decimal(4, 1), RandomStream.seeded(101), bankRates = Some(br))
+    month1.financialStocks.head.mortgageLoan shouldBe PLN(2000)
+    month1.financialStocks.head.mortgageRemainingMonths shouldBe 2
+    month1.aggregates.totalMortgagePrincipal shouldBe PLN(1000)
+
+    val month2 = step(month1.households, mkWorld(), PLN(8000), PLN(4666), Share.decimal(4, 1), RandomStream.seeded(102), bankRates = Some(br))
+    month2.financialStocks.head.mortgageLoan shouldBe PLN(1000)
+    month2.financialStocks.head.mortgageRemainingMonths shouldBe 1
+    month2.aggregates.totalMortgagePrincipal shouldBe PLN(1000)
+
+    val month3 = step(month2.households, mkWorld(), PLN(8000), PLN(4666), Share.decimal(4, 1), RandomStream.seeded(103), bankRates = Some(br))
+    month3.financialStocks.head.mortgageLoan shouldBe PLN.Zero
+    month3.financialStocks.head.mortgageRemainingMonths shouldBe 0
+    month3.aggregates.totalMortgagePrincipal shouldBe PLN(1000)
+  }
+
   it should "use the live policy rate for mortgage interest when bankRates are absent" in {
     val rng          = RandomStream.seeded(42)
     val debt         = PLN(120000)
@@ -892,6 +924,7 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
       healthPenalty: BigDecimal = BigDecimal("0.0"),
       mpc: BigDecimal = BigDecimal("0.82"),
       bankId: Int = 0,
+      mortgageRemainingMonths: Int = 0,
   ): Household.State =
     val hh = TestHouseholdState(
       HhId(id),
@@ -913,7 +946,16 @@ class HouseholdSpec extends AnyFlatSpec with Matchers:
       taskRoutineness = Share.decimal(5, 1),
       wageScar = Share.Zero,
     )
-    financialById.update(id, TestHouseholdState.financial(savings = savings, debt = debt, consumerDebt = PLN.Zero, equityWealth = PLN.Zero))
+    financialById.update(
+      id,
+      TestHouseholdState.financial(
+        savings = savings,
+        debt = debt,
+        consumerDebt = PLN.Zero,
+        equityWealth = PLN.Zero,
+        mortgageRemainingMonths = mortgageRemainingMonths,
+      ),
+    )
     hh
 
   private def mkWorld(): World =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialStateSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialStateSpec.scala
@@ -25,7 +25,7 @@ class LedgerFinancialStateSpec extends AnyFlatSpec with Matchers:
     val existingHousehold = existing
     val newHousehold      = init.households.last.copy(id = HhId(previous.length))
     val newStocks         =
-      Household.FinancialStocks(demandDeposit = PLN(777), mortgageLoan = PLN(55), consumerLoan = PLN(11), equity = PLN(22))
+      Household.FinancialStocks(demandDeposit = PLN(777), mortgageLoan = PLN(55), consumerLoan = PLN(11), equity = PLN(22), mortgageRemainingMonths = 120)
 
     val refreshed =
       LedgerFinancialState.refreshHouseholdBalances(Vector(existingHousehold, newHousehold), init.households, previous, Map(newHousehold.id -> newStocks))
@@ -45,6 +45,15 @@ class LedgerFinancialStateSpec extends AnyFlatSpec with Matchers:
       LedgerFinancialState.HouseholdBalances(demandDeposit = PLN(-1), mortgageLoan = PLN.Zero, consumerLoan = PLN.Zero, equity = PLN.Zero)
 
     an[IllegalArgumentException] should be thrownBy LedgerFinancialState.projectHouseholdFinancialStocks(balances)
+  }
+
+  it should "preserve mortgage remaining maturity through household projection" in {
+    val stocks   =
+      Household.FinancialStocks(demandDeposit = PLN(10), mortgageLoan = PLN(20), consumerLoan = PLN(30), equity = PLN(40), mortgageRemainingMonths = 180)
+    val balances = LedgerFinancialState.householdBalances(stocks)
+
+    balances.mortgageRemainingMonths shouldBe 180
+    LedgerFinancialState.projectHouseholdFinancialStocks(balances) shouldBe stocks
   }
 
   "LedgerFinancialState.settleHouseholdMortgageStock" should "write an aggregate closing mortgage stock into household rows" in {
@@ -71,6 +80,47 @@ class LedgerFinancialStateSpec extends AnyFlatSpec with Matchers:
     settled.map(_.equity) shouldBe households.map(_.equity)
   }
 
+  it should "preserve active household mortgage maturities when aggregate stock is reallocated" in {
+    val households = Vector(
+      LedgerFinancialState.HouseholdBalances(
+        demandDeposit = PLN.Zero,
+        mortgageLoan = PLN(10),
+        consumerLoan = PLN.Zero,
+        equity = PLN.Zero,
+        mortgageRemainingMonths = 12,
+      ),
+      LedgerFinancialState.HouseholdBalances(
+        demandDeposit = PLN.Zero,
+        mortgageLoan = PLN(30),
+        consumerLoan = PLN.Zero,
+        equity = PLN.Zero,
+        mortgageRemainingMonths = 24,
+      ),
+    )
+
+    val settled = LedgerFinancialState.settleHouseholdMortgageStock(households, PLN(20))
+
+    LedgerFinancialState.householdMortgageStock(settled) shouldBe PLN(20)
+    settled.map(_.mortgageRemainingMonths) shouldBe Vector(12, 24)
+  }
+
+  it should "blend aggregate mortgage origination into remaining maturity even when net stock is unchanged" in {
+    val households = Vector(
+      LedgerFinancialState.HouseholdBalances(
+        demandDeposit = PLN.Zero,
+        mortgageLoan = PLN(100),
+        consumerLoan = PLN.Zero,
+        equity = PLN.Zero,
+        mortgageRemainingMonths = 12,
+      ),
+    )
+
+    val settled = LedgerFinancialState.settleHouseholdMortgageStock(households, closingStock = PLN(100), newOrigination = PLN(50))
+
+    LedgerFinancialState.householdMortgageStock(settled) shouldBe PLN(100)
+    settled.head.mortgageRemainingMonths shouldBe 156
+  }
+
   it should "allocate a positive closing mortgage stock across zero-debt household rows" in {
     val households = Vector.fill(2)(
       LedgerFinancialState.HouseholdBalances(
@@ -84,6 +134,7 @@ class LedgerFinancialStateSpec extends AnyFlatSpec with Matchers:
     val settled = LedgerFinancialState.settleHouseholdMortgageStock(households, PLN(30))
 
     LedgerFinancialState.householdMortgageStock(settled) shouldBe PLN(30)
+    settled.map(_.mortgageRemainingMonths) shouldBe Vector.fill(2)(summon[SimParams].housing.mortgageMaturity)
   }
 
   "LedgerFinancialState.settleHouseholdInsuranceReserveAssets" should "mirror aggregate insurance reserves into household asset rows" in {


### PR DESCRIPTION
## Summary
- add per-household mortgage remaining maturity state and carry it through household/ledger projections
- compute scheduled mortgage principal from remaining maturity so loans retire at contractual maturity
- align aggregate mortgage flows and ledger settlement with household principal, origination, and maturity weighting
- update behavioral equations docs and tests for closing amortization

Closes #540

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.HouseholdSpec com.boombustgroup.amorfati.engine.ledger.LedgerFinancialStateSpec com.boombustgroup.amorfati.engine.HousingMarketSpec com.boombustgroup.amorfati.engine.HousingMarketPropertySpec"
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationRuntimeProjectionSpec"
- sbt assembly
- sbt integrationTests/test