### PR TITLE
Add bank capital waterfall diagnostics

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -716,6 +716,11 @@ deltaCapital =
   - eclProvisionChange
   - capitalDestruction
 
+waterfallResidual =
+  observedDeltaCapital
+  - deltaCapital
+  - reconciliationResidual
+
 realizedCreditLoss =
   firmNplLoss
   + mortgageNplLoss
@@ -724,8 +729,9 @@ realizedCreditLoss =
 ```
 
 `BankCapital_ReconciliationResidual` is reported separately as an exactness
-correction to the per-bank allocation; `BankCapital_WaterfallResidual` mirrors
-that patch with positive values meaning capital was added to one per-bank row.
+correction to the per-bank allocation. `BankCapital_WaterfallResidual` is the
+remaining unexplained capital delta after that correction and should remain near
+zero unless a diagnostic term is missing.
 `BankCapital_DepositBailInLoss` is also reported for resolution analysis, but it
 is a depositor haircut rather than an equity-capital P&L term.
 

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -704,6 +704,30 @@ CAR_b = capital_b / RWA_b
 When the denominator is effectively zero, the implementation returns a safe
 ratio floor.
 
+The monthly bank-capital diagnostic waterfall is:
+
+```text
+deltaCapital =
+  retainedIncome
+  - realizedCreditLoss
+  - bfgLevy
+  - unrealizedBondLoss
+  - htmRealizedLoss
+  - eclProvisionChange
+  - capitalDestruction
+
+realizedCreditLoss =
+  firmNplLoss
+  + mortgageNplLoss
+  + consumerNplLoss
+  + bankHeldCorporateBondDefaultLoss
+```
+
+`BankCapital_ReconciliationResidual` is reported separately as an exactness
+correction to the per-bank allocation. `BankCapital_DepositBailInLoss` is also
+reported for resolution analysis, but it is a depositor haircut rather than an
+equity-capital P&L term.
+
 Liquidity ratios are:
 
 ```text

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -724,9 +724,10 @@ realizedCreditLoss =
 ```
 
 `BankCapital_ReconciliationResidual` is reported separately as an exactness
-correction to the per-bank allocation. `BankCapital_DepositBailInLoss` is also
-reported for resolution analysis, but it is a depositor haircut rather than an
-equity-capital P&L term.
+correction to the per-bank allocation; `BankCapital_WaterfallResidual` mirrors
+that patch with positive values meaning capital was added to one per-bank row.
+`BankCapital_DepositBailInLoss` is also reported for resolution analysis, but it
+is a depositor haircut rather than an equity-capital P&L term.
 
 Liquidity ratios are:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -219,6 +219,13 @@ for empirical analysis. The internal `gdpRatio` scaling factor is not emitted
 as a CSV column; it remains a model-computation boundary. Agent-level prices,
 wages, indexes, rates, shares, and counts remain in their native units.
 
+The seed time-series files also include always-on aggregate diagnostic blocks
+for household liquidity, firm automation/adoption, and bank capital. The bank
+capital block uses `BankCapital_*` columns to reconcile opening capital,
+retained income, realized credit losses, provisions, valuation losses,
+failure-related capital destruction, reconciliation residuals, and closing
+capital. No extra flag is needed for these aggregate diagnostics.
+
 Firm-level micro snapshots are optional and off by default. Enable them with
 `--firm-snapshots terminal`, `--firm-snapshots every:12`, or
 `--firm-snapshots months:1,6,12`. When enabled, the runner also writes:

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -86,6 +86,44 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
   private def parseCsvRow(line: String): Vector[BigDecimal] =
     line.split(';').toVector.map(value => BigDecimal(value.replace(',', '.')))
 
+  private def columnIndex(header: Vector[String], name: String): Int =
+    val idx = header.indexOf(name)
+    idx should be >= 0
+    idx
+
+  private def assertBankCapitalWaterfall(header: Vector[String], row: Vector[BigDecimal]): Unit =
+    val openingIdx       = columnIndex(header, "BankCapital_Opening")
+    val closingIdx       = columnIndex(header, "BankCapital_Closing")
+    val deltaIdx         = columnIndex(header, "BankCapital_Delta")
+    val retainedIdx      = columnIndex(header, "BankCapital_RetainedIncome")
+    val realizedIdx      = columnIndex(header, "BankCapital_RealizedCreditLoss")
+    val firmLossIdx      = columnIndex(header, "BankCapital_FirmNplLoss")
+    val mortgageLossIdx  = columnIndex(header, "BankCapital_MortgageNplLoss")
+    val consumerLossIdx  = columnIndex(header, "BankCapital_ConsumerNplLoss")
+    val corpBondLossIdx  = columnIndex(header, "BankCapital_CorpBondDefaultLoss")
+    val bfgLevyIdx       = columnIndex(header, "BankCapital_BfgLevy")
+    val unrealizedIdx    = columnIndex(header, "BankCapital_UnrealizedBondLoss")
+    val htmIdx           = columnIndex(header, "BankCapital_HtmRealizedLoss")
+    val eclIdx           = columnIndex(header, "BankCapital_EclProvisionChange")
+    val destructionIdx   = columnIndex(header, "BankCapital_CapitalDestruction")
+    val residualIdx      = columnIndex(header, "BankCapital_WaterfallResidual")
+    val bailInIdx        = columnIndex(header, "BailInLoss")
+    val bankBailInIdx    = columnIndex(header, "BankCapital_DepositBailInLoss")
+    val newFailuresIdx   = columnIndex(header, "BankCapital_NewFailures")
+    val realizedCredit   =
+      row(firmLossIdx) + row(mortgageLossIdx) + row(consumerLossIdx) + row(corpBondLossIdx)
+    val expectedDelta    =
+      row(retainedIdx) - realizedCredit - row(bfgLevyIdx) - row(unrealizedIdx) -
+        row(htmIdx) - row(eclIdx) - row(destructionIdx)
+    val observedDelta    = row(closingIdx) - row(openingIdx)
+    val expectedResidual = row(deltaIdx) - expectedDelta
+
+    row(deltaIdx) shouldBe observedDelta +- BigDecimal("0.05")
+    row(realizedIdx) shouldBe realizedCredit +- BigDecimal("0.05")
+    row(residualIdx) shouldBe expectedResidual +- BigDecimal("0.05")
+    row(bankBailInIdx) shouldBe row(bailInIdx) +- BigDecimal("0.05")
+    row(newFailuresIdx) should be >= BigDecimal(0)
+
   private def expectedRun(seed: Long): RunResult =
     McRunner.runSingle(seed, DurationMonths).fold(err => fail(err.toString), identity)
 
@@ -179,6 +217,7 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
         val path   = outputDir.resolve(seedFileName(seed, rc))
         val lines  = readLines(path)
         val result = expectedRuns(seed)
+        val header = lines.head.split(';').toVector
 
         lines.head.shouldBe(McTimeseriesSchema.colNames.mkString(";"))
         lines.length.shouldBe(DurationMonths + 1)
@@ -194,6 +233,9 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
             withClue(s"seed=$seed month=${month.toInt} col=$col: ") {
               actual(col).shouldBe(decimal(expected(col)) +- BigDecimal("1e-6"))
             }
+          withClue(s"seed=$seed month=${month.toInt} bank capital waterfall: ") {
+            assertBankCapitalWaterfall(header, actual)
+          }
 
       val hhLines = readLines(outputDir.resolve(s"${filePrefix(rc)}_hh.csv"))
       hhLines.head.shouldBe(ExpectedHhHeader)

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -117,11 +117,11 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
       row(retainedIdx) - realizedCredit - row(bfgLevyIdx) - row(unrealizedIdx) -
         row(htmIdx) - row(eclIdx) - row(destructionIdx)
     val observedDelta    = row(closingIdx) - row(openingIdx)
+    val expectedResidual = row(deltaIdx) - expectedDelta - row(reconcileIdx)
 
     row(deltaIdx) shouldBe observedDelta +- BigDecimal("0.05")
-    row(deltaIdx) shouldBe expectedDelta +- BigDecimal("0.05")
     row(realizedIdx) shouldBe realizedCredit +- BigDecimal("0.05")
-    row(residualIdx) shouldBe row(reconcileIdx) +- BigDecimal("0.05")
+    row(residualIdx) shouldBe expectedResidual +- BigDecimal("0.05")
     row(bankBailInIdx) shouldBe row(bailInIdx) +- BigDecimal("0.05")
     row(newFailuresIdx) should be >= BigDecimal(0)
 

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -106,6 +106,7 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     val htmIdx           = columnIndex(header, "BankCapital_HtmRealizedLoss")
     val eclIdx           = columnIndex(header, "BankCapital_EclProvisionChange")
     val destructionIdx   = columnIndex(header, "BankCapital_CapitalDestruction")
+    val reconcileIdx     = columnIndex(header, "BankCapital_ReconciliationResidual")
     val residualIdx      = columnIndex(header, "BankCapital_WaterfallResidual")
     val bailInIdx        = columnIndex(header, "BailInLoss")
     val bankBailInIdx    = columnIndex(header, "BankCapital_DepositBailInLoss")
@@ -116,11 +117,11 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
       row(retainedIdx) - realizedCredit - row(bfgLevyIdx) - row(unrealizedIdx) -
         row(htmIdx) - row(eclIdx) - row(destructionIdx)
     val observedDelta    = row(closingIdx) - row(openingIdx)
-    val expectedResidual = row(deltaIdx) - expectedDelta
 
     row(deltaIdx) shouldBe observedDelta +- BigDecimal("0.05")
+    row(deltaIdx) shouldBe expectedDelta +- BigDecimal("0.05")
     row(realizedIdx) shouldBe realizedCredit +- BigDecimal("0.05")
-    row(residualIdx) shouldBe expectedResidual +- BigDecimal("0.05")
+    row(residualIdx) shouldBe row(reconcileIdx) +- BigDecimal("0.05")
     row(bankBailInIdx) shouldBe row(bailInIdx) +- BigDecimal("0.05")
     row(newFailuresIdx) should be >= BigDecimal(0)
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -255,36 +255,77 @@ object PipelineState:
 
   def zero(using p: SimParams): PipelineState = zero(p.sectorDefs.length)
 
+/** Monthly banking-sector capital attribution used by Monte Carlo diagnostics.
+  *
+  * Amounts are aggregate sector PLN. Loss components are positive when they
+  * reduce bank capital; retained income is positive when it increases capital.
+  * Deposit bail-in is carried here as a resolution-adjacent diagnostic, but it
+  * is not part of the bank-capital identity because it haircuts deposits rather
+  * than equity capital.
+  */
+case class BankCapitalDiagnostics(
+    openingCapital: PLN = PLN.Zero,         // aggregate bank capital at the start of the month
+    closingCapital: PLN = PLN.Zero,         // aggregate bank capital after monthly banking settlement
+    retainedIncome: PLN = PLN.Zero,         // retained ordinary bank income after profit-retention rule
+    firmNplLoss: PLN = PLN.Zero,            // realized firm-loan credit loss net of recovery
+    mortgageNplLoss: PLN = PLN.Zero,        // realized mortgage credit loss net of recovery
+    consumerNplLoss: PLN = PLN.Zero,        // realized consumer-credit loss net of recovery
+    corpBondDefaultLoss: PLN = PLN.Zero,    // bank-held corporate-bond default loss
+    bfgLevy: PLN = PLN.Zero,                // monthly BFG levy paid by active banks
+    unrealizedBondLoss: PLN = PLN.Zero,     // AFS government-bond mark-to-market capital hit
+    htmRealizedLoss: PLN = PLN.Zero,        // HTM forced-reclassification realized loss
+    eclProvisionChange: PLN = PLN.Zero,     // IFRS 9 provision increase, positive when capital is hit
+    capitalDestruction: PLN = PLN.Zero,     // shareholder capital wiped when banks newly fail
+    reconciliationResidual: PLN = PLN.Zero, // exactness correction applied to per-bank capital rows
+    depositBailInLoss: PLN = PLN.Zero,      // depositor haircut from resolution, not equity-capital P&L
+    newFailures: Int = 0,                   // banks newly marked failed during the month
+):
+  def delta: PLN = closingCapital - openingCapital
+
+  def realizedCreditLoss: PLN =
+    firmNplLoss + mortgageNplLoss + consumerNplLoss + corpBondDefaultLoss
+
+  def expectedDelta: PLN =
+    retainedIncome - realizedCreditLoss - bfgLevy - unrealizedBondLoss -
+      htmRealizedLoss - eclProvisionChange - capitalDestruction
+
+  def waterfallResidual: PLN =
+    delta - expectedDelta
+
+object BankCapitalDiagnostics:
+  val zero: BankCapitalDiagnostics = BankCapitalDiagnostics()
+
 /** Single-step derived flow outputs — recomputed each step, zero at init. Feed
   * into SFC identities and output columns.
   */
 case class FlowState(
-    monthlyGdpProxy: PLN = PLN.Zero,            // cached monthly GDP proxy for diagnostics / output ratios
-    sectorOutputs: Vector[PLN] = Vector.empty,  // nominal monthly output by schema sector
-    ioFlows: PLN = PLN.Zero,                    // I-O intermediate payments between sectors
-    fdiProfitShifting: PLN = PLN.Zero,          // intangible imports booked abroad (profit shifting)
-    fdiRepatriation: PLN = PLN.Zero,            // dividend repatriation by foreign-owned firms
-    fdiCitLoss: PLN = PLN.Zero,                 // CIT lost to profit shifting
-    diasporaRemittanceInflow: PLN = PLN.Zero,   // diaspora remittance inflow
-    tourismExport: PLN = PLN.Zero,              // inbound tourism services export
-    tourismImport: PLN = PLN.Zero,              // outbound tourism services import
-    aggInventoryStock: PLN = PLN.Zero,          // aggregate firm inventory stock
-    aggInventoryChange: PLN = PLN.Zero,         // ΔInventories (enters GDP)
-    aggEnergyCost: PLN = PLN.Zero,              // aggregate energy + CO₂ costs
-    automationTechCapex: PLN = PLN.Zero,        // technology CAPEX for automation/hybrid upgrades
-    automationTechImports: PLN = PLN.Zero,      // import content of technology CAPEX
-    automationTechLoans: PLN = PLN.Zero,        // bank-credit component of technology financing
-    automationUpgradeFailures: Int = 0,         // implementation failures causing firm bankruptcy
-    automationAiDebtTrap: Int = 0,              // AI debt-trap bankruptcies
-    automationNewFullAi: Int = 0,               // new full-AI adopters
-    automationNewHybrid: Int = 0,               // new hybrid adopters
-    firmBirths: Int = 0,                        // new firms (recycled + net new)
-    firmDeaths: Int = 0,                        // firms bankrupt this step
-    netFirmBirths: Int = 0,                     // net new firms appended to vector
-    taxEvasionLoss: PLN = PLN.Zero,             // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
-    realizedTaxShadowShare: Share = Share.Zero, // current-period realized aggregate tax-side shadow share
-    bailInLoss: PLN = PLN.Zero,                 // bail-in capital loss on bank creditors
-    bfgLevyTotal: PLN = PLN.Zero,               // BFG resolution levy from all banks
+    monthlyGdpProxy: PLN = PLN.Zero,                                  // cached monthly GDP proxy for diagnostics / output ratios
+    sectorOutputs: Vector[PLN] = Vector.empty,                        // nominal monthly output by schema sector
+    ioFlows: PLN = PLN.Zero,                                          // I-O intermediate payments between sectors
+    fdiProfitShifting: PLN = PLN.Zero,                                // intangible imports booked abroad (profit shifting)
+    fdiRepatriation: PLN = PLN.Zero,                                  // dividend repatriation by foreign-owned firms
+    fdiCitLoss: PLN = PLN.Zero,                                       // CIT lost to profit shifting
+    diasporaRemittanceInflow: PLN = PLN.Zero,                         // diaspora remittance inflow
+    tourismExport: PLN = PLN.Zero,                                    // inbound tourism services export
+    tourismImport: PLN = PLN.Zero,                                    // outbound tourism services import
+    aggInventoryStock: PLN = PLN.Zero,                                // aggregate firm inventory stock
+    aggInventoryChange: PLN = PLN.Zero,                               // ΔInventories (enters GDP)
+    aggEnergyCost: PLN = PLN.Zero,                                    // aggregate energy + CO₂ costs
+    automationTechCapex: PLN = PLN.Zero,                              // technology CAPEX for automation/hybrid upgrades
+    automationTechImports: PLN = PLN.Zero,                            // import content of technology CAPEX
+    automationTechLoans: PLN = PLN.Zero,                              // bank-credit component of technology financing
+    automationUpgradeFailures: Int = 0,                               // implementation failures causing firm bankruptcy
+    automationAiDebtTrap: Int = 0,                                    // AI debt-trap bankruptcies
+    automationNewFullAi: Int = 0,                                     // new full-AI adopters
+    automationNewHybrid: Int = 0,                                     // new hybrid adopters
+    firmBirths: Int = 0,                                              // new firms (recycled + net new)
+    firmDeaths: Int = 0,                                              // firms bankrupt this step
+    netFirmBirths: Int = 0,                                           // net new firms appended to vector
+    taxEvasionLoss: PLN = PLN.Zero,                                   // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
+    realizedTaxShadowShare: Share = Share.Zero,                       // current-period realized aggregate tax-side shadow share
+    bailInLoss: PLN = PLN.Zero,                                       // bail-in deposit haircut imposed on bank creditors
+    bfgLevyTotal: PLN = PLN.Zero,                                     // BFG resolution levy from all banks
+    bankCapital: BankCapitalDiagnostics = BankCapitalDiagnostics.zero, // monthly bank-capital waterfall diagnostics
 )
 object FlowState:
   val zero: FlowState = FlowState()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -276,7 +276,7 @@ case class BankCapitalDiagnostics(
     htmRealizedLoss: PLN = PLN.Zero,        // HTM forced-reclassification realized loss
     eclProvisionChange: PLN = PLN.Zero,     // IFRS 9 provision increase, positive when capital is hit
     capitalDestruction: PLN = PLN.Zero,     // shareholder capital wiped when banks newly fail
-    reconciliationResidual: PLN = PLN.Zero, // exactness correction applied to per-bank capital rows
+    reconciliationResidual: PLN = PLN.Zero, // per-bank exactness patch; positive values add capital
     depositBailInLoss: PLN = PLN.Zero,      // depositor haircut from resolution, not equity-capital P&L
     newFailures: Int = 0,                   // banks newly marked failed during the month
 ):
@@ -289,11 +289,11 @@ case class BankCapitalDiagnostics(
     retainedIncome - realizedCreditLoss - bfgLevy - unrealizedBondLoss -
       htmRealizedLoss - eclProvisionChange - capitalDestruction
 
-  /** Positive when aggregate exactness adds capital to one per-bank row;
-    * negative when it removes capital.
+  /** Unexplained capital delta after ordinary waterfall terms and the per-bank
+    * exactness patch. Values away from zero indicate a missing diagnostic term.
     */
   def waterfallResidual: PLN =
-    reconciliationResidual
+    delta - expectedDelta - reconciliationResidual
 
 object BankCapitalDiagnostics:
   val zero: BankCapitalDiagnostics = BankCapitalDiagnostics()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -289,8 +289,11 @@ case class BankCapitalDiagnostics(
     retainedIncome - realizedCreditLoss - bfgLevy - unrealizedBondLoss -
       htmRealizedLoss - eclProvisionChange - capitalDestruction
 
+  /** Positive when aggregate exactness adds capital to one per-bank row;
+    * negative when it removes capital.
+    */
   def waterfallResidual: PLN =
-    delta - expectedDelta
+    reconciliationResidual
 
 object BankCapitalDiagnostics:
   val zero: BankCapitalDiagnostics = BankCapitalDiagnostics()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -150,6 +150,7 @@ object BankingEconomics:
       multiCapDestruction: PLN,                          // capital destroyed by bank failures this month
       newFailures: Int,                                  // banks newly marked failed during this month
       capitalReconciliationResidual: PLN,                // exactness correction applied to one per-bank capital row
+      bankCapitalTerms: BankCapitalTerms,                // shared capital-waterfall terms used by reconciliation and diagnostics
       resolvedBank: Banking.Aggregate,                   // aggregate banking sector after resolution
       htmRealizedLoss: PLN,                              // realized loss from HTM forced reclassification
       // Bond waterfall outputs — single source of truth for buyer holdings
@@ -176,8 +177,19 @@ object BankingEconomics:
   private case class AggregateReconciliationResult(
       banks: Vector[Banking.BankState],
       financialStocks: Vector[Banking.BankFinancialStocks],
+      bankCorpBondHoldings: Vector[PLN],
       depositResidual: PLN,
       capitalResidual: PLN,
+      bailInLossDelta: PLN,
+      capitalDestructionDelta: PLN,
+      newFailuresDelta: Int,
+  )
+
+  private case class BankCapitalTerms(
+      unrealizedBondLoss: PLN,
+      eclProvisionChange: PLN,
+      capitalGrossIncome: PLN,
+      retainedIncome: PLN,
   )
 
   private[amorfati] case class ReserveSettlementResult(
@@ -267,37 +279,19 @@ object BankingEconomics:
         LedgerFinancialState.withHouseholdInsuranceReserveAssets(rawLedgerFinancialState),
       )
     val monAgg                  = computeMonetaryAggregates(multi.finalBanks, ledgerFinancialState)
-    val unrealizedBondLoss      =
-      val yieldChange = in.s8.monetary.newBondYield - in.w.gov.bondYield
-      if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * p.banking.govBondDuration else PLN.Zero
-    val eclProvisionChange      = PLN.fromRaw:
-      multi.finalBanks
-        .zip(in.banks)
-        .map: (curr, prev) =>
-          val currProv =
-            curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
-          val prevProv =
-            prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
-          (currProv - prevProv).toLong
-        .sum
-    val capitalGrossIncome      = in.s5.intIncome +
-      prevBankAgg.govBondHoldings * in.s8.monetary.newBondYield.monthly -
-      in.s6.depositInterestPaid + in.s8.banking.totalReserveInterest +
-      in.s8.banking.totalStandingFacilityIncome + in.s8.banking.totalInterbankInterest +
-      housing.mortgageFlows.interest + (in.s6.consumerDebtService - in.s6.consumerPrincipal) +
-      in.s8.corpBonds.corpBondBankCoupon
+    val bankCapitalTerms        = multi.bankCapitalTerms
     val bankCapitalDiagnostics  = BankCapitalDiagnostics(
       openingCapital = prevBankAgg.capital,
       closingCapital = multi.resolvedBank.capital,
-      retainedIncome = capitalGrossIncome * p.banking.profitRetention,
+      retainedIncome = bankCapitalTerms.retainedIncome,
       firmNplLoss = in.s5.nplLoss,
       mortgageNplLoss = housing.mortgageFlows.defaultLoss,
       consumerNplLoss = in.s6.consumerNplLoss,
       corpBondDefaultLoss = in.s8.corpBonds.corpBondBankDefaultLoss,
       bfgLevy = bfgLevy,
-      unrealizedBondLoss = unrealizedBondLoss,
+      unrealizedBondLoss = bankCapitalTerms.unrealizedBondLoss,
       htmRealizedLoss = multi.htmRealizedLoss,
-      eclProvisionChange = eclProvisionChange,
+      eclProvisionChange = bankCapitalTerms.eclProvisionChange,
       capitalDestruction = multi.multiCapDestruction,
       reconciliationResidual = multi.capitalReconciliationResidual,
       depositBailInLoss = multi.bailInLoss,
@@ -340,9 +334,9 @@ object BankingEconomics:
       investNetDepositFlow = investNetDepositFlow,
       actualBondChange = multi.actualBondChange,
       standingFacilityBackstop = multi.standingFacilityBackstop,
-      unrealizedBondLoss = unrealizedBondLoss,
+      unrealizedBondLoss = bankCapitalTerms.unrealizedBondLoss,
       htmRealizedLoss = multi.htmRealizedLoss,
-      eclProvisionChange = eclProvisionChange,
+      eclProvisionChange = bankCapitalTerms.eclProvisionChange,
       newQuasiFiscal = newQuasiFiscal,
       govBondRuntimeMovements = multi.govBondRuntimeMovements,
       ledgerFinancialState = ledgerFinancialState,
@@ -915,26 +909,25 @@ object BankingEconomics:
     val afterFailStocks = tfiSale.financialStocks
     val anyFailed       = failResult.anyFailed || secondaryFail.anyFailed
 
-    val bailInResult                 =
+    val bailInResult          =
       if anyFailed then Banking.applyBailIn(afterFailCheck, afterFailStocks)
       else Banking.BailInResult(afterFailCheck, afterFailStocks, PLN.Zero)
-    val resolveResult                =
+    val resolveResult         =
       if anyFailed then Banking.resolveFailures(bailInResult.banks, bailInResult.financialStocks, settledBankCorpBonds)
       else Banking.ResolutionResult(bailInResult.banks, bailInResult.financialStocks, BankId.NoBank, settledBankCorpBonds)
-    val afterResolve                 = resolveResult.banks
-    val afterResolveStocks           = resolveResult.financialStocks
-    val afterResolveCorpBonds        = resolveResult.bankCorpBondHoldings
-    val afterResolveCorpBondHoldings = Banking.bankCorpBondHoldingsFromVector(afterResolveCorpBonds)
-    val newFailureCount              =
+    val afterResolve          = resolveResult.banks
+    val afterResolveStocks    = resolveResult.financialStocks
+    val afterResolveCorpBonds = resolveResult.bankCorpBondHoldings
+    val newFailureCount       =
       if anyFailed then tfiSale.banks.zip(afterFailCheck).count { case (pre, post) => !pre.failed && post.failed } else 0
-    val multiCapDest: PLN            =
+    val multiCapDest: PLN     =
       if anyFailed then
         tfiSale.banks
           .zip(afterFailCheck)
           .collect { case (pre, post) if !pre.failed && post.failed => pre.capital }
           .sumPln
       else PLN.Zero
-    val curve                        =
+    val curve                 =
       val exp = in.w.mechanisms.expectations
       Some(
         YieldCurve.compute(
@@ -945,31 +938,16 @@ object BankingEconomics:
           targetInflation = p.monetary.targetInfl,
         ),
       )
-    val finalBankingMarket           = Banking.MarketState(
+    val finalBankingMarket    = Banking.MarketState(
       interbankRate = ibRate,
       configs = bankConfigs,
       interbankCurve = curve,
     )
-    // Repair stale failed-bank routing every month; mobility validates survivor bankIds.
-    val reassignedFirms              =
-      in.s5.ioFirms.map: f =>
-        val nextBankId = Banking.reassignBankId(f.bankId, afterResolve, afterResolveStocks, afterResolveCorpBondHoldings)
-        if nextBankId == f.bankId then f else f.copy(bankId = nextBankId)
-    val postFailureHh                =
-      in.s5.households.map: h =>
-        val nextBankId = Banking.reassignBankId(h.bankId, afterResolve, afterResolveStocks, afterResolveCorpBondHoldings)
-        if nextBankId == h.bankId then h else h.copy(bankId = nextBankId)
-
-    // Deposit mobility: HH may switch banks based on health signals and panic
-    val mobilityResult       = DepositMobility(postFailureHh, afterResolve, afterResolveStocks, anyFailed, in.depositRng, afterResolveCorpBondHoldings)
-    val reassignedHouseholds = mobilityResult.households
-
-    // Deposit flows take effect next month when HH income/consumption routes
-    // to new bankId. No immediate balance sheet transfer — consistent with
-    // 1-month account transfer lag and avoids SFC flow mismatch.
-    val reconciled = reconcileAggregateExactness(
+    val bankCapitalTerms      = computeBankCapitalTerms(prevBankAgg, afterResolve, in, mortgageFlows)
+    val reconciled            = reconcileAggregateExactness(
       banks = afterResolve,
       financialStocks = afterResolveStocks,
+      bankCorpBondHoldings = afterResolveCorpBonds,
       prevBankAgg = prevBankAgg,
       in = in,
       jstDepositChange = jstDepositChange,
@@ -979,13 +957,39 @@ object BankingEconomics:
       bailInLoss = bailInResult.totalLoss,
       multiCapDestruction = multiCapDest,
       htmRealizedLoss = htmResult.totalRealizedLoss,
+      bankCapitalTerms = bankCapitalTerms,
     )
+    val finalFailureBanks     = reconciled.banks
+    val finalFailureStocks    = reconciled.financialStocks
+    val finalCorpBondHoldings = reconciled.bankCorpBondHoldings
+    val finalCorpBondLookup   = Banking.bankCorpBondHoldingsFromVector(finalCorpBondHoldings)
+    val totalBailInLoss       = bailInResult.totalLoss + reconciled.bailInLossDelta
+    val totalCapDestruction   = multiCapDest + reconciled.capitalDestructionDelta
+    val totalNewFailures      = newFailureCount + reconciled.newFailuresDelta
+    val anyFailureForMobility = anyFailed || reconciled.newFailuresDelta > 0
 
+    // Repair stale failed-bank routing every month; mobility validates survivor bankIds.
+    val reassignedFirms =
+      in.s5.ioFirms.map: f =>
+        val nextBankId = Banking.reassignBankId(f.bankId, finalFailureBanks, finalFailureStocks, finalCorpBondLookup)
+        if nextBankId == f.bankId then f else f.copy(bankId = nextBankId)
+    val postFailureHh   =
+      in.s5.households.map: h =>
+        val nextBankId = Banking.reassignBankId(h.bankId, finalFailureBanks, finalFailureStocks, finalCorpBondLookup)
+        if nextBankId == h.bankId then h else h.copy(bankId = nextBankId)
+
+    // Deposit mobility: HH may switch banks based on health signals and panic
+    val mobilityResult       = DepositMobility(postFailureHh, finalFailureBanks, finalFailureStocks, anyFailureForMobility, in.depositRng, finalCorpBondLookup)
+    val reassignedHouseholds = mobilityResult.households
+
+    // Deposit flows take effect next month when HH income/consumption routes
+    // to new bankId. No immediate balance sheet transfer — consistent with
+    // 1-month account transfer lag and avoids SFC flow mismatch.
     MultiBankResult(
-      finalBanks = reconciled.banks,
-      finalBankCorpBondHoldings = afterResolveCorpBonds,
-      finalBankLedgerBalances = reconciled.banks
-        .zip(reconciled.financialStocks)
+      finalBanks = finalFailureBanks,
+      finalBankCorpBondHoldings = finalCorpBondHoldings,
+      finalBankLedgerBalances = finalFailureBanks
+        .zip(finalFailureStocks)
         .map { case (bank, stocks) =>
           val bankIndex    = bank.id.toInt
           val mortgageLoan =
@@ -993,18 +997,19 @@ object BankingEconomics:
             else in.ledgerFinancialState.banks.lift(bankIndex).fold(PLN.Zero)(_.mortgageLoan)
           LedgerFinancialState.bankBalances(
             stocks,
-            afterResolveCorpBonds.lift(bankIndex).getOrElse(PLN.Zero),
+            finalCorpBondHoldings.lift(bankIndex).getOrElse(PLN.Zero),
             mortgageLoan = mortgageLoan,
           )
         },
       finalBankingMarket = finalBankingMarket,
       reassignedFirms = reassignedFirms,
       reassignedHouseholds = reassignedHouseholds,
-      bailInLoss = bailInResult.totalLoss,
-      multiCapDestruction = multiCapDest,
-      newFailures = newFailureCount,
+      bailInLoss = totalBailInLoss,
+      multiCapDestruction = totalCapDestruction,
+      newFailures = totalNewFailures,
       capitalReconciliationResidual = reconciled.capitalResidual,
-      resolvedBank = Banking.aggregateFromBankStocks(reconciled.banks, reconciled.financialStocks, afterResolveCorpBondHoldings),
+      bankCapitalTerms = bankCapitalTerms,
+      resolvedBank = Banking.aggregateFromBankStocks(finalFailureBanks, finalFailureStocks, finalCorpBondLookup),
       htmRealizedLoss = htmResult.totalRealizedLoss,
       finalNbp = finalNbp,
       finalNbpFinancialStocks = finalNbpFinancialStocks,
@@ -1021,9 +1026,49 @@ object BankingEconomics:
       govBondRuntimeMovements = govBondRuntimeMovements,
     )
 
+  private def computeBankCapitalTerms(
+      prevBankAgg: Banking.Aggregate,
+      finalBanks: Vector[Banking.BankState],
+      in: StepInput,
+      mortgageFlows: HousingMarket.MortgageFlows,
+  )(using p: SimParams): BankCapitalTerms =
+    require(
+      finalBanks.length == in.banks.length,
+      s"BankingEconomics bank-capital terms require aligned bank rows, got ${finalBanks.length} final banks and ${in.banks.length} opening banks",
+    )
+    val yieldChange        = in.s8.monetary.newBondYield - in.w.gov.bondYield
+    val unrealizedBondLoss =
+      if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * p.banking.govBondDuration
+      else PLN.Zero
+    var eclRaw             = 0L
+    var i                  = 0
+    while i < finalBanks.length do
+      val curr     = finalBanks(i)
+      val prev     = in.banks(i)
+      val currProv =
+        curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
+      val prevProv =
+        prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
+      eclRaw += (currProv - prevProv).toLong
+      i += 1
+    val eclProvisionChange = PLN.fromRaw(eclRaw)
+    val capitalGrossIncome = in.s5.intIncome +
+      prevBankAgg.govBondHoldings * in.s8.monetary.newBondYield.monthly -
+      in.s6.depositInterestPaid + in.s8.banking.totalReserveInterest +
+      in.s8.banking.totalStandingFacilityIncome + in.s8.banking.totalInterbankInterest +
+      mortgageFlows.interest + (in.s6.consumerDebtService - in.s6.consumerPrincipal) +
+      in.s8.corpBonds.corpBondBankCoupon
+    BankCapitalTerms(
+      unrealizedBondLoss = unrealizedBondLoss,
+      eclProvisionChange = eclProvisionChange,
+      capitalGrossIncome = capitalGrossIncome,
+      retainedIncome = capitalGrossIncome * p.banking.profitRetention,
+    )
+
   private def reconcileAggregateExactness(
       banks: Vector[Banking.BankState],
       financialStocks: Vector[Banking.BankFinancialStocks],
+      bankCorpBondHoldings: Vector[PLN],
       prevBankAgg: Banking.Aggregate,
       in: StepInput,
       jstDepositChange: PLN,
@@ -1033,12 +1078,12 @@ object BankingEconomics:
       bailInLoss: PLN,
       multiCapDestruction: PLN,
       htmRealizedLoss: PLN,
+      bankCapitalTerms: BankCapitalTerms,
   )(using p: SimParams): AggregateReconciliationResult =
-    if banks.isEmpty then AggregateReconciliationResult(banks, financialStocks, PLN.Zero, PLN.Zero)
+    if banks.isEmpty then AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0)
     else
       val target         = aggregateReconciliationTarget(
         prevBankAgg = prevBankAgg,
-        finalBanks = banks,
         in = in,
         jstDepositChange = jstDepositChange,
         investNetDepositFlow = investNetDepositFlow,
@@ -1047,27 +1092,46 @@ object BankingEconomics:
         bailInLoss = bailInLoss,
         multiCapDestruction = multiCapDestruction,
         htmRealizedLoss = htmRealizedLoss,
+        bankCapitalTerms = bankCapitalTerms,
       )
       val actualDeposits = financialStocks.iterator.map(_.totalDeposits).sumPln
       val actualCapital  = banks.iterator.map(_.capital).sumPln
       val depResidual    = target.depositsResidual - actualDeposits
       val capResidual    = target.capitalResidual - actualCapital
-      if depResidual == PLN.Zero && capResidual == PLN.Zero then AggregateReconciliationResult(banks, financialStocks, PLN.Zero, PLN.Zero)
+      if depResidual == PLN.Zero && capResidual == PLN.Zero then
+        AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0)
       else
         val targetIdx  = banks.lastIndexWhere(!_.failed) match
           case -1 => banks.indices.last
           case i  => i
         val reconciled = reconcileSingleBank(banks(targetIdx), financialStocks(targetIdx), depResidual, capResidual)
-        AggregateReconciliationResult(
-          banks.updated(targetIdx, reconciled._1),
-          financialStocks.updated(targetIdx, reconciled._2),
-          depResidual,
-          capResidual,
-        )
+        val nextBanks  = banks.updated(targetIdx, reconciled._1)
+        val nextStocks = financialStocks.updated(targetIdx, reconciled._2)
+        if capResidual == PLN.Zero || nextBanks(targetIdx).failed then
+          AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0)
+        else
+          val targetCorpBonds = (bankId: BankId) => bankCorpBondHoldings.lift(bankId.toInt).getOrElse(PLN.Zero)
+          val failCheck       =
+            Banking.checkFailures(Vector(nextBanks(targetIdx)), Vector(nextStocks(targetIdx)), in.s1.m, true, in.s7.newMacropru.ccyb, targetCorpBonds)
+          if !failCheck.anyFailed then
+            AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0)
+          else
+            val failedBank = failCheck.banks.head
+            val bailIn     = Banking.applyBailIn(nextBanks.updated(targetIdx, failedBank), nextStocks)
+            val resolved   = Banking.resolveFailures(bailIn.banks, bailIn.financialStocks, bankCorpBondHoldings)
+            AggregateReconciliationResult(
+              resolved.banks,
+              resolved.financialStocks,
+              resolved.bankCorpBondHoldings,
+              depResidual,
+              capResidual,
+              bailIn.totalLoss,
+              nextBanks(targetIdx).capital,
+              1,
+            )
 
   private def aggregateReconciliationTarget(
       prevBankAgg: Banking.Aggregate,
-      finalBanks: Vector[Banking.BankState],
       in: StepInput,
       jstDepositChange: PLN,
       investNetDepositFlow: PLN,
@@ -1076,32 +1140,14 @@ object BankingEconomics:
       bailInLoss: PLN,
       multiCapDestruction: PLN,
       htmRealizedLoss: PLN,
+      bankCapitalTerms: BankCapitalTerms,
   )(using p: SimParams): AggregateReconciliation =
-    val yieldChange        = in.s8.monetary.newBondYield - in.w.gov.bondYield
-    val unrealizedBondLoss =
-      if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * p.banking.govBondDuration
-      else PLN.Zero
-    val eclProvisionChange = PLN.fromRaw:
-      finalBanks
-        .zip(in.banks)
-        .map: (curr, prev) =>
-          val currProv =
-            curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
-          val prevProv =
-            prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
-          (currProv - prevProv).toLong
-        .sum
-    val capitalLosses      = in.s5.nplLoss + mortgageFlows.defaultLoss + in.s6.consumerNplLoss +
+    val capitalLosses  = in.s5.nplLoss + mortgageFlows.defaultLoss + in.s6.consumerNplLoss +
       in.s8.corpBonds.corpBondBankDefaultLoss +
       Banking.computeBfgLevy(in.banks, in.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)).total +
-      unrealizedBondLoss + htmRealizedLoss + eclProvisionChange + multiCapDestruction
-    val capitalGrossIncome = in.s5.intIncome +
-      prevBankAgg.govBondHoldings * in.s8.monetary.newBondYield.monthly -
-      in.s6.depositInterestPaid + in.s8.banking.totalReserveInterest +
-      in.s8.banking.totalStandingFacilityIncome + in.s8.banking.totalInterbankInterest +
-      mortgageFlows.interest + (in.s6.consumerDebtService - in.s6.consumerPrincipal) + in.s8.corpBonds.corpBondBankCoupon
-    val targetCapital      = prevBankAgg.capital - capitalLosses + capitalGrossIncome * p.banking.profitRetention
-    val targetDeposits     = prevBankAgg.deposits + in.s3.totalIncome - in.s3.consumption +
+      bankCapitalTerms.unrealizedBondLoss + htmRealizedLoss + bankCapitalTerms.eclProvisionChange + multiCapDestruction
+    val targetCapital  = prevBankAgg.capital - capitalLosses + bankCapitalTerms.retainedIncome
+    val targetDeposits = prevBankAgg.deposits + in.s3.totalIncome - in.s3.consumption +
       investNetDepositFlow + jstDepositChange + quasiFiscalDepositChange + in.s7.netDomesticDividends -
       in.s7.foreignDividendOutflow - in.s6.remittanceOutflow + in.s6.diasporaInflow +
       in.s6.tourismExport - in.s6.tourismImport - bailInLoss + in.s5.sumNewLoans -

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -62,6 +62,7 @@ object BankingEconomics:
       bfgLevy: PLN,                                      // BFG resolution fund levy (aggregate)
       bailInLoss: PLN,                                   // bail-in deposit destruction (aggregate)
       multiCapDestruction: PLN,                          // capital wiped when banks fail
+      bankCapitalDiagnostics: BankCapitalDiagnostics,    // aggregate monthly bank-capital waterfall diagnostics
       monAgg: Option[Banking.MonetaryAggregates],        // M0/M1/M2/M3 (when credit diagnostics on)
       finalHhAgg: Household.Aggregates,                  // recomputed HH aggregates
       vat: PLN,                                          // gross VAT revenue
@@ -147,6 +148,8 @@ object BankingEconomics:
       reassignedHouseholds: Vector[Household.State],     // households reassigned from failed banks to absorber bank
       bailInLoss: PLN,                                   // total bail-in losses imposed on depositors
       multiCapDestruction: PLN,                          // capital destroyed by bank failures this month
+      newFailures: Int,                                  // banks newly marked failed during this month
+      capitalReconciliationResidual: PLN,                // exactness correction applied to one per-bank capital row
       resolvedBank: Banking.Aggregate,                   // aggregate banking sector after resolution
       htmRealizedLoss: PLN,                              // realized loss from HTM forced reclassification
       // Bond waterfall outputs — single source of truth for buyer holdings
@@ -167,6 +170,13 @@ object BankingEconomics:
 
   private case class AggregateReconciliation(
       depositsResidual: PLN,
+      capitalResidual: PLN,
+  )
+
+  private case class AggregateReconciliationResult(
+      banks: Vector[Banking.BankState],
+      financialStocks: Vector[Banking.BankFinancialStocks],
+      depositResidual: PLN,
       capitalResidual: PLN,
   )
 
@@ -257,6 +267,42 @@ object BankingEconomics:
         LedgerFinancialState.withHouseholdInsuranceReserveAssets(rawLedgerFinancialState),
       )
     val monAgg                  = computeMonetaryAggregates(multi.finalBanks, ledgerFinancialState)
+    val unrealizedBondLoss      =
+      val yieldChange = in.s8.monetary.newBondYield - in.w.gov.bondYield
+      if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * p.banking.govBondDuration else PLN.Zero
+    val eclProvisionChange      = PLN.fromRaw:
+      multi.finalBanks
+        .zip(in.banks)
+        .map: (curr, prev) =>
+          val currProv =
+            curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
+          val prevProv =
+            prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
+          (currProv - prevProv).toLong
+        .sum
+    val capitalGrossIncome      = in.s5.intIncome +
+      prevBankAgg.govBondHoldings * in.s8.monetary.newBondYield.monthly -
+      in.s6.depositInterestPaid + in.s8.banking.totalReserveInterest +
+      in.s8.banking.totalStandingFacilityIncome + in.s8.banking.totalInterbankInterest +
+      housing.mortgageFlows.interest + (in.s6.consumerDebtService - in.s6.consumerPrincipal) +
+      in.s8.corpBonds.corpBondBankCoupon
+    val bankCapitalDiagnostics  = BankCapitalDiagnostics(
+      openingCapital = prevBankAgg.capital,
+      closingCapital = multi.resolvedBank.capital,
+      retainedIncome = capitalGrossIncome * p.banking.profitRetention,
+      firmNplLoss = in.s5.nplLoss,
+      mortgageNplLoss = housing.mortgageFlows.defaultLoss,
+      consumerNplLoss = in.s6.consumerNplLoss,
+      corpBondDefaultLoss = in.s8.corpBonds.corpBondBankDefaultLoss,
+      bfgLevy = bfgLevy,
+      unrealizedBondLoss = unrealizedBondLoss,
+      htmRealizedLoss = multi.htmRealizedLoss,
+      eclProvisionChange = eclProvisionChange,
+      capitalDestruction = multi.multiCapDestruction,
+      reconciliationResidual = multi.capitalReconciliationResidual,
+      depositBailInLoss = multi.bailInLoss,
+      newFailures = multi.newFailures,
+    )
 
     StepOutput(
       resolvedBank = multi.resolvedBank,
@@ -276,6 +322,7 @@ object BankingEconomics:
       bfgLevy = bfgLevy,
       bailInLoss = multi.bailInLoss,
       multiCapDestruction = multi.multiCapDestruction,
+      bankCapitalDiagnostics = bankCapitalDiagnostics,
       monAgg = monAgg,
       finalHhAgg = finalHhAgg,
       vat = govJst.tax.vat,
@@ -293,22 +340,9 @@ object BankingEconomics:
       investNetDepositFlow = investNetDepositFlow,
       actualBondChange = multi.actualBondChange,
       standingFacilityBackstop = multi.standingFacilityBackstop,
-      unrealizedBondLoss = {
-        val yieldChange = in.s8.monetary.newBondYield - in.w.gov.bondYield
-        if yieldChange > Rate.Zero then prevBankAgg.afsBonds * yieldChange * p.banking.govBondDuration else PLN.Zero
-      },
+      unrealizedBondLoss = unrealizedBondLoss,
       htmRealizedLoss = multi.htmRealizedLoss,
-      eclProvisionChange = PLN.fromRaw:
-        multi.finalBanks
-          .zip(in.banks)
-          .map: (curr, prev) =>
-            val currProv =
-              curr.eclStaging.stage1 * p.banking.eclRate1 + curr.eclStaging.stage2 * p.banking.eclRate2 + curr.eclStaging.stage3 * p.banking.eclRate3
-            val prevProv =
-              prev.eclStaging.stage1 * p.banking.eclRate1 + prev.eclStaging.stage2 * p.banking.eclRate2 + prev.eclStaging.stage3 * p.banking.eclRate3
-            (currProv - prevProv).toLong
-          .sum
-      ,
+      eclProvisionChange = eclProvisionChange,
       newQuasiFiscal = newQuasiFiscal,
       govBondRuntimeMovements = multi.govBondRuntimeMovements,
       ledgerFinancialState = ledgerFinancialState,
@@ -891,6 +925,8 @@ object BankingEconomics:
     val afterResolveStocks           = resolveResult.financialStocks
     val afterResolveCorpBonds        = resolveResult.bankCorpBondHoldings
     val afterResolveCorpBondHoldings = Banking.bankCorpBondHoldingsFromVector(afterResolveCorpBonds)
+    val newFailureCount              =
+      if anyFailed then tfiSale.banks.zip(afterFailCheck).count { case (pre, post) => !pre.failed && post.failed } else 0
     val multiCapDest: PLN            =
       if anyFailed then
         tfiSale.banks
@@ -966,6 +1002,8 @@ object BankingEconomics:
       reassignedHouseholds = reassignedHouseholds,
       bailInLoss = bailInResult.totalLoss,
       multiCapDestruction = multiCapDest,
+      newFailures = newFailureCount,
+      capitalReconciliationResidual = reconciled.capitalResidual,
       resolvedBank = Banking.aggregateFromBankStocks(reconciled.banks, reconciled.financialStocks, afterResolveCorpBondHoldings),
       htmRealizedLoss = htmResult.totalRealizedLoss,
       finalNbp = finalNbp,
@@ -995,8 +1033,8 @@ object BankingEconomics:
       bailInLoss: PLN,
       multiCapDestruction: PLN,
       htmRealizedLoss: PLN,
-  )(using p: SimParams): Banking.BankStockState =
-    if banks.isEmpty then Banking.BankStockState(banks, financialStocks)
+  )(using p: SimParams): AggregateReconciliationResult =
+    if banks.isEmpty then AggregateReconciliationResult(banks, financialStocks, PLN.Zero, PLN.Zero)
     else
       val target         = aggregateReconciliationTarget(
         prevBankAgg = prevBankAgg,
@@ -1014,15 +1052,17 @@ object BankingEconomics:
       val actualCapital  = banks.iterator.map(_.capital).sumPln
       val depResidual    = target.depositsResidual - actualDeposits
       val capResidual    = target.capitalResidual - actualCapital
-      if depResidual == PLN.Zero && capResidual == PLN.Zero then Banking.BankStockState(banks, financialStocks)
+      if depResidual == PLN.Zero && capResidual == PLN.Zero then AggregateReconciliationResult(banks, financialStocks, PLN.Zero, PLN.Zero)
       else
         val targetIdx  = banks.lastIndexWhere(!_.failed) match
           case -1 => banks.indices.last
           case i  => i
         val reconciled = reconcileSingleBank(banks(targetIdx), financialStocks(targetIdx), depResidual, capResidual)
-        Banking.BankStockState(
+        AggregateReconciliationResult(
           banks.updated(targetIdx, reconciled._1),
           financialStocks.updated(targetIdx, reconciled._2),
+          depResidual,
+          capResidual,
         )
 
   private def aggregateReconciliationTarget(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -406,6 +406,7 @@ object WorldAssemblyEconomics:
       realizedTaxShadowShare = informal.realizedTaxShadowShare,
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = in.s9.bfgLevy,
+      bankCapital = in.s9.bankCapitalDiagnostics,
     )
 
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -74,6 +74,7 @@ object McTimeseriesSchema:
       Banking.bankCorpBondHoldingsFromVector(ledgerFinancialState.banks.map(_.corpBond))
     lazy val bankAgg: Banking.Aggregate                                                             =
       Banking.aggregateFromBankStocks(banks, ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks), bankCorpBondHoldings)
+    lazy val bankCapital: BankCapitalDiagnostics                                                    = world.flows.bankCapital
     lazy val ledgerBankStocksById: Map[BankId, Banking.BankFinancialStocks]                         =
       banks.zip(ledgerFinancialState.banks).map((bank, balances) => bank.id -> LedgerFinancialState.projectBankFinancialStocks(balances)).toMap
     lazy val aliveBankRows: Vector[(Banking.BankState, Banking.BankFinancialStocks)]                =
@@ -524,6 +525,25 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("BfgLevyTotal", ctx => ctx.world.flows.bfgLevyTotal),
     ColumnDef.macroPln("BfgFundBalance", ctx => ctx.world.mechanisms.bfgFundBalance),
     ColumnDef.macroPln("BailInLoss", ctx => ctx.world.flows.bailInLoss),
+    // Bank-capital attribution: sector aggregate opening-to-closing waterfall.
+    ColumnDef.macroPln("BankCapital_Opening", ctx => ctx.bankCapital.openingCapital),
+    ColumnDef.macroPln("BankCapital_Closing", ctx => ctx.bankCapital.closingCapital),
+    ColumnDef.macroPln("BankCapital_Delta", ctx => ctx.bankCapital.delta),
+    ColumnDef.macroPln("BankCapital_RetainedIncome", ctx => ctx.bankCapital.retainedIncome),
+    ColumnDef.macroPln("BankCapital_RealizedCreditLoss", ctx => ctx.bankCapital.realizedCreditLoss),
+    ColumnDef.macroPln("BankCapital_FirmNplLoss", ctx => ctx.bankCapital.firmNplLoss),
+    ColumnDef.macroPln("BankCapital_MortgageNplLoss", ctx => ctx.bankCapital.mortgageNplLoss),
+    ColumnDef.macroPln("BankCapital_ConsumerNplLoss", ctx => ctx.bankCapital.consumerNplLoss),
+    ColumnDef.macroPln("BankCapital_CorpBondDefaultLoss", ctx => ctx.bankCapital.corpBondDefaultLoss),
+    ColumnDef.macroPln("BankCapital_BfgLevy", ctx => ctx.bankCapital.bfgLevy),
+    ColumnDef.macroPln("BankCapital_UnrealizedBondLoss", ctx => ctx.bankCapital.unrealizedBondLoss),
+    ColumnDef.macroPln("BankCapital_HtmRealizedLoss", ctx => ctx.bankCapital.htmRealizedLoss),
+    ColumnDef.macroPln("BankCapital_EclProvisionChange", ctx => ctx.bankCapital.eclProvisionChange),
+    ColumnDef.macroPln("BankCapital_CapitalDestruction", ctx => ctx.bankCapital.capitalDestruction),
+    ColumnDef.macroPln("BankCapital_ReconciliationResidual", ctx => ctx.bankCapital.reconciliationResidual),
+    ColumnDef.macroPln("BankCapital_WaterfallResidual", ctx => ctx.bankCapital.waterfallResidual),
+    ColumnDef.macroPln("BankCapital_DepositBailInLoss", ctx => ctx.bankCapital.depositBailInLoss),
+    ColumnDef("BankCapital_NewFailures", ctx => ctx.bankCapital.newFailures),
   )
 
   private def realGroup: Vector[ColumnDef] =
@@ -879,6 +899,24 @@ object McTimeseriesSchema:
     val StandingFacilityNet: Col                      = lookup("StandingFacilityNet")
     val DepositFacilityUsage: Col                     = lookup("DepositFacilityUsage")
     val InterbankInterestNet: Col                     = lookup("InterbankInterestNet")
+    val BankCapitalOpening: Col                       = lookup("BankCapital_Opening")
+    val BankCapitalClosing: Col                       = lookup("BankCapital_Closing")
+    val BankCapitalDelta: Col                         = lookup("BankCapital_Delta")
+    val BankCapitalRetainedIncome: Col                = lookup("BankCapital_RetainedIncome")
+    val BankCapitalRealizedCreditLoss: Col            = lookup("BankCapital_RealizedCreditLoss")
+    val BankCapitalFirmNplLoss: Col                   = lookup("BankCapital_FirmNplLoss")
+    val BankCapitalMortgageNplLoss: Col               = lookup("BankCapital_MortgageNplLoss")
+    val BankCapitalConsumerNplLoss: Col               = lookup("BankCapital_ConsumerNplLoss")
+    val BankCapitalCorpBondDefaultLoss: Col           = lookup("BankCapital_CorpBondDefaultLoss")
+    val BankCapitalBfgLevy: Col                       = lookup("BankCapital_BfgLevy")
+    val BankCapitalUnrealizedBondLoss: Col            = lookup("BankCapital_UnrealizedBondLoss")
+    val BankCapitalHtmRealizedLoss: Col               = lookup("BankCapital_HtmRealizedLoss")
+    val BankCapitalEclProvisionChange: Col            = lookup("BankCapital_EclProvisionChange")
+    val BankCapitalCapitalDestruction: Col            = lookup("BankCapital_CapitalDestruction")
+    val BankCapitalReconciliationResidual: Col        = lookup("BankCapital_ReconciliationResidual")
+    val BankCapitalWaterfallResidual: Col             = lookup("BankCapital_WaterfallResidual")
+    val BankCapitalDepositBailInLoss: Col             = lookup("BankCapital_DepositBailInLoss")
+    val BankCapitalNewFailures: Col                   = lookup("BankCapital_NewFailures")
 
     private val sectorAutoNames   = sectorColumns.map(_.autoColName)
     private val sectorOutputNames = sectorColumns.map(_.outputColName)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -109,6 +109,49 @@ adoption means `Hybrid` or `Automated`. Size cohorts use `McFirmSizeClass`.
 Cash and debt quartiles sort living firms by closing ledger cash or firm-loan
 principal respectively; `Q1` is the lowest cash/debt quartile.
 
+## Bank Capital Diagnostics
+
+The seed timeseries includes aggregate banking-sector capital waterfall columns
+without a separate CLI flag:
+
+```text
+BankCapital_Opening
+BankCapital_Closing
+BankCapital_Delta
+BankCapital_RetainedIncome
+BankCapital_RealizedCreditLoss
+BankCapital_FirmNplLoss
+BankCapital_MortgageNplLoss
+BankCapital_ConsumerNplLoss
+BankCapital_CorpBondDefaultLoss
+BankCapital_BfgLevy
+BankCapital_UnrealizedBondLoss
+BankCapital_HtmRealizedLoss
+BankCapital_EclProvisionChange
+BankCapital_CapitalDestruction
+BankCapital_ReconciliationResidual
+BankCapital_WaterfallResidual
+BankCapital_DepositBailInLoss
+BankCapital_NewFailures
+```
+
+These columns follow the same pattern as household and firm aggregate
+diagnostics: they are cheap monthly sector metrics in each seed CSV, while
+heavier per-agent drilldowns remain separate optional outputs. Loss components
+are positive when they reduce capital. `BankCapital_RetainedIncome` is positive
+when retained bank income raises capital. `BankCapital_RealizedCreditLoss` is
+the sum of firm-loan, mortgage, consumer-credit, and bank-held corporate-bond
+losses. `BankCapital_WaterfallResidual` reconciles
+`BankCapital_Delta` against retained income minus the reported capital-loss
+components.
+
+`BankCapital_ReconciliationResidual` reports the exactness correction applied
+to one per-bank capital row after the normal bank update. It is a diagnostic
+for per-bank allocation artifacts, not a standalone economic loss channel.
+`BankCapital_DepositBailInLoss` mirrors the existing `BailInLoss` column inside
+the bank-capital diagnostic block; it is a resolution-adjacent depositor haircut
+and is not included in the equity-capital waterfall identity.
+
 ## Household Liquidity Diagnostics
 
 The timeseries schema and terminal `_hh.csv` summary include generic household

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -141,9 +141,10 @@ heavier per-agent drilldowns remain separate optional outputs. Loss components
 are positive when they reduce capital. `BankCapital_RetainedIncome` is positive
 when retained bank income raises capital. `BankCapital_RealizedCreditLoss` is
 the sum of firm-loan, mortgage, consumer-credit, and bank-held corporate-bond
-losses. `BankCapital_WaterfallResidual` reconciles
-`BankCapital_Delta` against retained income minus the reported capital-loss
-components.
+losses. `BankCapital_WaterfallResidual` reports
+the post-reconciliation exactness patch rather than a separate economic P&L
+term: positive values mean the patch added capital to one per-bank row, and
+negative values mean it removed capital.
 
 `BankCapital_ReconciliationResidual` reports the exactness correction applied
 to one per-bank capital row after the normal bank update. It is a diagnostic

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -142,13 +142,15 @@ are positive when they reduce capital. `BankCapital_RetainedIncome` is positive
 when retained bank income raises capital. `BankCapital_RealizedCreditLoss` is
 the sum of firm-loan, mortgage, consumer-credit, and bank-held corporate-bond
 losses. `BankCapital_WaterfallResidual` reports
-the post-reconciliation exactness patch rather than a separate economic P&L
-term: positive values mean the patch added capital to one per-bank row, and
-negative values mean it removed capital.
+the remaining unexplained capital delta after the ordinary waterfall terms and
+the exactness patch. It should stay close to zero; non-zero values indicate a
+missing diagnostic term.
 
 `BankCapital_ReconciliationResidual` reports the exactness correction applied
-to one per-bank capital row after the normal bank update. It is a diagnostic
-for per-bank allocation artifacts, not a standalone economic loss channel.
+to one per-bank capital row after the normal bank update. Positive values mean
+the patch added capital, and negative values mean it removed capital. It is a
+diagnostic for per-bank allocation artifacts, not a standalone economic loss
+channel.
 `BankCapital_DepositBailInLoss` mirrors the existing `BailInLoss` column inside
 the bank-capital diagnostic block; it is a resolution-adjacent depositor haircut
 and is not included in the equity-capital waterfall identity.

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -224,6 +224,24 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "BfgLevyTotal",
     "BfgFundBalance",
     "BailInLoss",
+    "BankCapital_Opening",
+    "BankCapital_Closing",
+    "BankCapital_Delta",
+    "BankCapital_RetainedIncome",
+    "BankCapital_RealizedCreditLoss",
+    "BankCapital_FirmNplLoss",
+    "BankCapital_MortgageNplLoss",
+    "BankCapital_ConsumerNplLoss",
+    "BankCapital_CorpBondDefaultLoss",
+    "BankCapital_BfgLevy",
+    "BankCapital_UnrealizedBondLoss",
+    "BankCapital_HtmRealizedLoss",
+    "BankCapital_EclProvisionChange",
+    "BankCapital_CapitalDestruction",
+    "BankCapital_ReconciliationResidual",
+    "BankCapital_WaterfallResidual",
+    "BankCapital_DepositBailInLoss",
+    "BankCapital_NewFailures",
     "HousingPriceIndex",
     "HousingMarketValue",
     "MortgageStock",
@@ -384,7 +402,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 330
+    McTimeseriesSchema.nCols shouldBe 348
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 


### PR DESCRIPTION
Closes #555

## Summary
- add always-on `BankCapital_*` monthly diagnostics for the aggregate bank-capital waterfall
- carry `BankCapitalDiagnostics` through `BankingEconomics` -> `FlowState` -> Monte Carlo time-series CSVs
- document the bank-capital diagnostics next to the existing household and firm diagnostic outputs
- validate CSV arithmetic for capital delta, realized credit losses, waterfall residual, bail-in linkage, and new failures

## Validation
- `sbt scalafmtAll`
- `sbt "integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"`
- `sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"`
- `sbt assembly`
- `java -jar target/scala-3.8.2/amor-fati.jar 10 bank555 --duration 60 --run-id diagnostics`

## 10x60 diagnostic note
Before first bank failures, the average cumulative hits are mainly unrealized bond losses, consumer-credit realized losses, and ECL provision changes. Bail-in remains large terminally, but it is resolution-adjacent and is reported separately from equity-capital P&L.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed bank-capital diagnostics to output timeseries: opening/closing/delta, retained income, breakdown of realized/unrealized credit/bond impacts, deposit bail‑in loss, reconciliation and waterfall residuals, and new-failure counts.

* **Documentation**
  * Added guidance describing the bank-capital diagnostic waterfall, column names, sign conventions, and reconciliation notes.

* **Tests**
  * Added CSV-level validations asserting waterfall reconciliation and related diagnostics for monthly output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->