### PR TITLE
Add bank failure reason diagnostics

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -66,7 +66,7 @@ runtime ledger flows and validates SFC identities.
 | Labor, wages, demographics, social funds | `engine/economics/LaborEconomics.scala`, `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` | `MarketWage`, `Unemployment`, `WorkingAgePop`, `NRetirees`, `MonthlyRetirements`, `ZusContributions`, `ZusPensionPayments`, `NfzContributions`, `NfzSpending`, `PpkContributions`, `FpContributions`, `FgspSpending` |
 | Demand allocation and fiscal constraint | `engine/economics/DemandEconomics.scala`, `engine/markets/FiscalRules.scala`, `engine/markets/FiscalBudget.scala` | `GovCurrentSpend`, `GovCapitalSpendDomestic`, `FiscalRuleBinding`, `GovSpendingCutRatio`, `DebtToGdp`, `DeficitToGdp`, `PublicCapitalStock` |
 | Firm production, investment, technology, financing, default, entry | `agents/Firm.scala`, `engine/economics/FirmEconomics.scala`, `engine/mechanisms/FirmEntry.scala` | `TotalAdoption`, `AutoRatio`, `HybridRatio`, `Automation_TechCapex`, `Automation_TechImports`, `Automation_TechLoans`, `Automation_UpgradeFailures`, `Automation_AiDebtTrap`, `Automation_NewFullAi`, `Automation_NewHybrid`, `Adoption_MicroShare`, `Adoption_SmallShare`, `Adoption_MediumShare`, `Adoption_LargeShare`, `Adoption_CashQ1`-`Q4`, `Adoption_DebtQ1`-`Q4`, sector `*_Auto`, sector `*_Sigma`, `GrossInvestment`, `AggCapitalStock`, `AggInventoryStock`, `InventoryChange`, `AggEnergyCost`, `GreenInvestment`, `FirmBirths`, `FirmDeaths`, `NetEntry`, `LivingFirmCount`, `CorpBondIssuance`, `EquityIssuanceTotal` |
-| Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
+| Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `BankFailure_*`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
 | Fiscal, NBP, bond market, external sector | `agents/Nbp.scala`, `engine/markets/OpenEconomy.scala`, `engine/economics/OpenEconEconomics.scala`, `engine/markets/CorporateBondMarket.scala`, `engine/markets/BondAuction.scala` | `RefRate`, `BondYield`, `WeightedCoupon`, `BondsOutstanding`, `NbpBondHoldings`, `ForeignBondHoldings`, `QeActive`, `FxReserves`, `FxInterventionAmt`, `CurrentAccount`, `CapitalAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NFA`, `FDI` |
 | Insurance, NBFI, quasi-fiscal, local government | `agents/Insurance.scala`, `agents/Nbfi.scala`, `agents/QuasiFiscal.scala`, `agents/Jst.scala` | `InsLifeReserves`, `InsNonLifeReserves`, `InsLifePremium`, `InsNonLifePremium`, `InsLifeClaims`, `InsNonLifeClaims`, `NbfiTfiAum`, `NbfiOrigination`, `NbfiDefaults`, `NbfiBankTightness`, `QfBondsOutstanding`, `QfIssuance`, `QfLoanPortfolio`, `Esa2010DebtToGdp`, `JstRevenue`, `JstSpending`, `JstDebt`, `JstDeposits` |
 
@@ -841,6 +841,20 @@ haircuts uninsured deposits of failed banks. Purchase-and-assumption resolution
 transfers deposits, government bonds, performing loans, consumer loans, and
 corporate-bond holdings to the healthiest surviving bank. Firms and households
 routed to failed banks are reassigned to the absorber.
+
+Failure-trigger diagnostics are emitted as `BankFailure_*` seed timeseries
+columns. `BankFailure_NewNegativeCapital`, `BankFailure_NewCarBreach`, and
+`BankFailure_NewLiquidityBreach` count newly failed banks by primary trigger; if
+multiple triggers are true, the priority is negative capital, then CAR breach,
+then LCR/liquidity breach. `BankFailure_FirstNewReasonCode` records the first
+new failure reason in bank-id order using `0 = none`, `1 = negative capital`,
+`2 = CAR breach`, `3 = LCR/liquidity breach`, `4 = all-failed fallback`, and
+`5 = invariant mismatch`. `BankFailure_AllFailedFallback` flags the current
+bridge-bank/resolution fallback where all banks have already failed and the
+absorber is selected from that failed set; this is the path #549 must decide
+whether to recapitalize or fail fast. `BankFailure_InvariantViolation` should
+remain zero and means the failure-event diagnostics do not reconcile to the
+new-failure count.
 
 ## Fiscal, Monetary, Bond-Market, And External Rules
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -220,11 +220,13 @@ as a CSV column; it remains a model-computation boundary. Agent-level prices,
 wages, indexes, rates, shares, and counts remain in their native units.
 
 The seed time-series files also include always-on aggregate diagnostic blocks
-for household liquidity, firm automation/adoption, and bank capital. The bank
-capital block uses `BankCapital_*` columns to reconcile opening capital,
-retained income, realized credit losses, provisions, valuation losses,
-failure-related capital destruction, reconciliation residuals, and closing
-capital. No extra flag is needed for these aggregate diagnostics.
+for household liquidity, firm automation/adoption, bank capital, and bank
+failure triggers. The bank capital block uses `BankCapital_*` columns to
+reconcile opening capital, retained income, realized credit losses, provisions,
+valuation losses, failure-related capital destruction, reconciliation residuals,
+and closing capital. The `BankFailure_*` block identifies the monthly primary
+trigger for newly failed banks. No extra flag is needed for these aggregate
+diagnostics.
 
 Firm-level micro snapshots are optional and off by default. Enable them with
 `--firm-snapshots terminal`, `--firm-snapshots every:12`, or

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -111,6 +111,13 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     val bailInIdx        = columnIndex(header, "BailInLoss")
     val bankBailInIdx    = columnIndex(header, "BankCapital_DepositBailInLoss")
     val newFailuresIdx   = columnIndex(header, "BankCapital_NewFailures")
+    val negCapitalIdx    = columnIndex(header, "BankFailure_NewNegativeCapital")
+    val carBreachIdx     = columnIndex(header, "BankFailure_NewCarBreach")
+    val liquidityIdx     = columnIndex(header, "BankFailure_NewLiquidityBreach")
+    val fallbackIdx      = columnIndex(header, "BankFailure_AllFailedFallback")
+    val invariantIdx     = columnIndex(header, "BankFailure_InvariantViolation")
+    val firstReasonIdx   = columnIndex(header, "BankFailure_FirstNewReasonCode")
+    val firstBankIdx     = columnIndex(header, "BankFailure_FirstNewBankId")
     val realizedCredit   =
       row(firmLossIdx) + row(mortgageLossIdx) + row(consumerLossIdx) + row(corpBondLossIdx)
     val expectedDelta    =
@@ -124,6 +131,13 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     row(residualIdx) shouldBe expectedResidual +- BigDecimal("0.05")
     row(bankBailInIdx) shouldBe row(bailInIdx) +- BigDecimal("0.05")
     row(newFailuresIdx) should be >= BigDecimal(0)
+    row(negCapitalIdx) should be >= BigDecimal(0)
+    row(carBreachIdx) should be >= BigDecimal(0)
+    row(liquidityIdx) should be >= BigDecimal(0)
+    row(fallbackIdx) should (be >= BigDecimal(0) and be <= BigDecimal(1))
+    row(invariantIdx) should be >= BigDecimal(0)
+    row(firstReasonIdx) should (be >= BigDecimal(0) and be <= BigDecimal(5))
+    row(firstBankIdx) should be >= BigDecimal(-1)
 
   private def expectedRun(seed: Long): RunResult =
     McRunner.runSingle(seed, DurationMonths).fold(err => fail(err.toString), identity)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -81,6 +81,17 @@ object Banking:
     case Active(consecutiveLowCar: Int)
     case Failed(month: ExecutionMonth)
 
+  /** Primary reason for a bank newly entering failure/resolution state.
+    *
+    * Codes are stable CSV diagnostics: 0 is reserved for "none".
+    */
+  enum BankFailureReason(val code: Int):
+    case NegativeCapital    extends BankFailureReason(1)
+    case CarBreach          extends BankFailureReason(2)
+    case LiquidityBreach    extends BankFailureReason(3)
+    case AllFailedFallback  extends BankFailureReason(4)
+    case InvariantViolation extends BankFailureReason(5)
+
   // ---------------------------------------------------------------------------
   // Aggregate balance sheet (sum over all per-bank BankStates)
   // ---------------------------------------------------------------------------
@@ -192,8 +203,11 @@ object Banking:
   /** Pair of operational bank state and ledger-owned bank financial stocks. */
   case class BankStockState(banks: Vector[BankState], financialStocks: Vector[BankFinancialStocks])
 
+  /** Single newly failed bank with its primary trigger reason. */
+  case class FailureEvent(bankId: BankId, month: ExecutionMonth, reason: BankFailureReason)
+
   /** Result of monthly failure check. */
-  case class FailureCheckResult(banks: Vector[BankState], anyFailed: Boolean)
+  case class FailureCheckResult(banks: Vector[BankState], anyFailed: Boolean, events: Vector[FailureEvent] = Vector.empty)
 
   /** Result of BRRD bail-in on newly failed banks. */
   case class BailInResult(banks: Vector[BankState], financialStocks: Vector[BankFinancialStocks], totalLoss: PLN)
@@ -204,6 +218,7 @@ object Banking:
       financialStocks: Vector[BankFinancialStocks],
       absorberId: BankId,
       bankCorpBondHoldings: Vector[PLN] = Vector.empty,
+      allFailedFallbackUsed: Boolean = false,
   )
 
   /** Auditable result of a firm-credit approval check. `approvalRoll` is
@@ -568,7 +583,9 @@ object Banking:
 
   /** Check for bank failures: negative capital immediately, CAR <
     * effectiveMinCar for 3 consecutive months, or LCR breach at 50% of minimum.
-    * Already-failed banks pass through.
+    * Already-failed banks pass through. If several triggers are true in the
+    * same month, diagnostics report the primary reason in this priority order:
+    * negative capital, CAR breach, liquidity breach.
     */
   def checkFailures(
       banks: Vector[BankState],
@@ -592,10 +609,10 @@ object Banking:
         anyFailed = false,
       )
     else
-      val updated    = banks
+      val checked = banks
         .zip(financialStocks)
         .map: (b, stocks) =>
-          if b.failed then b
+          if b.failed then (b, None)
           else
             val consec    = b.consecutiveLowCar
             val minCar    = Macroprudential.effectiveMinCar(b.id.toInt, ccyb)
@@ -603,10 +620,17 @@ object Banking:
             val lcrBreach = lcr(stocks) < p.banking.lcrMin * Share.decimal(5, 1)
             val newConsec = if lowCar then consec + 1 else 0
             val insolvent = b.capital < PLN.Zero
-            if insolvent || newConsec >= 3 || lcrBreach then b.copy(status = BankStatus.Failed(month), capital = PLN.Zero)
-            else b.copy(status = BankStatus.Active(newConsec))
-      val prevFailed = banks.filter(_.failed).map(_.id).toSet
-      FailureCheckResult(updated, updated.exists(b => b.failed && !prevFailed.contains(b.id)))
+            val reason    =
+              if insolvent then Some(BankFailureReason.NegativeCapital)
+              else if newConsec >= 3 then Some(BankFailureReason.CarBreach)
+              else if lcrBreach then Some(BankFailureReason.LiquidityBreach)
+              else None
+            reason match
+              case Some(r) => (b.copy(status = BankStatus.Failed(month), capital = PLN.Zero), Some(FailureEvent(b.id, month, r)))
+              case None    => (b.copy(status = BankStatus.Active(newConsec)), None)
+      val updated = checked.map(_._1)
+      val events  = checked.flatMap(_._2)
+      FailureCheckResult(updated, events.nonEmpty, events)
 
   /** Compute monthly BFG levy for all banks.
     *
@@ -659,18 +683,19 @@ object Banking:
     val newlyFailed    = banks.zip(financialStocks).filter((b, stocks) => b.failed && stocks.totalDeposits > PLN.Zero)
     if newlyFailed.isEmpty then ResolutionResult(banks, financialStocks, BankId.NoBank, holderBalances)
     else
-      val absorberId = healthiestBankId(banks, financialStocks, bankCorpBondHoldingsFromVector(holderBalances))
-      val toAbsorb   = newlyFailed.filter((bank, _) => bank.id != absorberId)
+      val allFailedFallbackUsed = banks.forall(_.failed)
+      val absorberId            = healthiestBankId(banks, financialStocks, bankCorpBondHoldingsFromVector(holderBalances))
+      val toAbsorb              = newlyFailed.filter((bank, _) => bank.id != absorberId)
       // Single-pass PLN aggregation of all flows from failed banks (exact Long addition)
-      val addDep     = toAbsorb.map(_._2.totalDeposits).sumPln
-      val addLoans   = toAbsorb.map((bank, stocks) => stocks.firmLoan - bank.nplAmount).sumPln
-      val addAfs     = toAbsorb.map(_._2.govBondAfs).sumPln
-      val addHtm     = toAbsorb.map(_._2.govBondHtm).sumPln
-      val addCorpB   = toAbsorb.flatMap((bank, _) => holderBalances.lift(bank.id.toInt)).sumPln
-      val addCC      = toAbsorb.map(_._2.consumerLoan).sumPln
-      val addIB      = toAbsorb.map(_._2.interbankLoan).sumPln
+      val addDep                = toAbsorb.map(_._2.totalDeposits).sumPln
+      val addLoans              = toAbsorb.map((bank, stocks) => stocks.firmLoan - bank.nplAmount).sumPln
+      val addAfs                = toAbsorb.map(_._2.govBondAfs).sumPln
+      val addHtm                = toAbsorb.map(_._2.govBondHtm).sumPln
+      val addCorpB              = toAbsorb.flatMap((bank, _) => holderBalances.lift(bank.id.toInt)).sumPln
+      val addCC                 = toAbsorb.map(_._2.consumerLoan).sumPln
+      val addIB                 = toAbsorb.map(_._2.interbankLoan).sumPln
       // Weighted yield: Σ(htmBonds × htmBookYield) — PLN × Rate → PLN
-      val htmYieldWt = toAbsorb.map((bank, stocks) => stocks.govBondHtm * bank.htmBookYield).sumPln
+      val htmYieldWt            = toAbsorb.map((bank, stocks) => stocks.govBondHtm * bank.htmBookYield).sumPln
 
       val resolvedRows      = banks
         .zip(financialStocks)
@@ -712,7 +737,7 @@ object Banking:
         else if bank.failed && stocks.totalDeposits == PLN.Zero then PLN.Zero
         else holderBalances(index)
       }
-      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds)
+      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds, allFailedFallbackUsed)
 
   /** Find the healthiest surviving bank.
     *

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -298,37 +298,69 @@ case class BankCapitalDiagnostics(
 object BankCapitalDiagnostics:
   val zero: BankCapitalDiagnostics = BankCapitalDiagnostics()
 
+/** Monthly bank-failure trigger diagnostics.
+  *
+  * Reason-code mapping for `firstNewReasonCode`: 0 = none, 1 = negative
+  * capital, 2 = CAR breach, 3 = LCR/liquidity breach, 4 = all-failed resolution
+  * fallback, 5 = invariant mismatch.
+  */
+case class BankFailureDiagnostics(
+    newNegativeCapital: Int = 0, // newly failed banks whose primary trigger was negative capital
+    newCarBreach: Int = 0,       // newly failed banks whose primary trigger was the consecutive low-CAR rule
+    newLiquidityBreach: Int = 0, // newly failed banks whose primary trigger was the LCR liquidity rule
+    allFailedFallback: Int = 0,  // 1 when resolution had to choose an absorber from an all-failed bank set
+    invariantViolation: Int = 0, // failure-event accounting mismatch, should remain zero
+    firstNewReasonCode: Int = 0, // reason code for first new failure event in bank-id order, or 0 when none
+    firstNewBankId: Int = -1,    // bank id for first new failure event, or -1 when none
+)
+
+object BankFailureDiagnostics:
+  val zero: BankFailureDiagnostics = BankFailureDiagnostics()
+
+  def fromEvents(events: Vector[Banking.FailureEvent], allFailedFallbackUsed: Boolean, invariantViolation: Int): BankFailureDiagnostics =
+    val firstEvent = events.headOption
+    BankFailureDiagnostics(
+      newNegativeCapital = events.count(_.reason == Banking.BankFailureReason.NegativeCapital),
+      newCarBreach = events.count(_.reason == Banking.BankFailureReason.CarBreach),
+      newLiquidityBreach = events.count(_.reason == Banking.BankFailureReason.LiquidityBreach),
+      allFailedFallback = if allFailedFallbackUsed then 1 else 0,
+      invariantViolation = invariantViolation,
+      firstNewReasonCode = firstEvent.map(_.reason.code).getOrElse(if allFailedFallbackUsed then Banking.BankFailureReason.AllFailedFallback.code else 0),
+      firstNewBankId = firstEvent.map(_.bankId.toInt).getOrElse(-1),
+    )
+
 /** Single-step derived flow outputs — recomputed each step, zero at init. Feed
   * into SFC identities and output columns.
   */
 case class FlowState(
-    monthlyGdpProxy: PLN = PLN.Zero,                                  // cached monthly GDP proxy for diagnostics / output ratios
-    sectorOutputs: Vector[PLN] = Vector.empty,                        // nominal monthly output by schema sector
-    ioFlows: PLN = PLN.Zero,                                          // I-O intermediate payments between sectors
-    fdiProfitShifting: PLN = PLN.Zero,                                // intangible imports booked abroad (profit shifting)
-    fdiRepatriation: PLN = PLN.Zero,                                  // dividend repatriation by foreign-owned firms
-    fdiCitLoss: PLN = PLN.Zero,                                       // CIT lost to profit shifting
-    diasporaRemittanceInflow: PLN = PLN.Zero,                         // diaspora remittance inflow
-    tourismExport: PLN = PLN.Zero,                                    // inbound tourism services export
-    tourismImport: PLN = PLN.Zero,                                    // outbound tourism services import
-    aggInventoryStock: PLN = PLN.Zero,                                // aggregate firm inventory stock
-    aggInventoryChange: PLN = PLN.Zero,                               // ΔInventories (enters GDP)
-    aggEnergyCost: PLN = PLN.Zero,                                    // aggregate energy + CO₂ costs
-    automationTechCapex: PLN = PLN.Zero,                              // technology CAPEX for automation/hybrid upgrades
-    automationTechImports: PLN = PLN.Zero,                            // import content of technology CAPEX
-    automationTechLoans: PLN = PLN.Zero,                              // bank-credit component of technology financing
-    automationUpgradeFailures: Int = 0,                               // implementation failures causing firm bankruptcy
-    automationAiDebtTrap: Int = 0,                                    // AI debt-trap bankruptcies
-    automationNewFullAi: Int = 0,                                     // new full-AI adopters
-    automationNewHybrid: Int = 0,                                     // new hybrid adopters
-    firmBirths: Int = 0,                                              // new firms (recycled + net new)
-    firmDeaths: Int = 0,                                              // firms bankrupt this step
-    netFirmBirths: Int = 0,                                           // net new firms appended to vector
-    taxEvasionLoss: PLN = PLN.Zero,                                   // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
-    realizedTaxShadowShare: Share = Share.Zero,                       // current-period realized aggregate tax-side shadow share
-    bailInLoss: PLN = PLN.Zero,                                       // bail-in deposit haircut imposed on bank creditors
-    bfgLevyTotal: PLN = PLN.Zero,                                     // BFG resolution levy from all banks
+    monthlyGdpProxy: PLN = PLN.Zero,                                   // cached monthly GDP proxy for diagnostics / output ratios
+    sectorOutputs: Vector[PLN] = Vector.empty,                         // nominal monthly output by schema sector
+    ioFlows: PLN = PLN.Zero,                                           // I-O intermediate payments between sectors
+    fdiProfitShifting: PLN = PLN.Zero,                                 // intangible imports booked abroad (profit shifting)
+    fdiRepatriation: PLN = PLN.Zero,                                   // dividend repatriation by foreign-owned firms
+    fdiCitLoss: PLN = PLN.Zero,                                        // CIT lost to profit shifting
+    diasporaRemittanceInflow: PLN = PLN.Zero,                          // diaspora remittance inflow
+    tourismExport: PLN = PLN.Zero,                                     // inbound tourism services export
+    tourismImport: PLN = PLN.Zero,                                     // outbound tourism services import
+    aggInventoryStock: PLN = PLN.Zero,                                 // aggregate firm inventory stock
+    aggInventoryChange: PLN = PLN.Zero,                                // ΔInventories (enters GDP)
+    aggEnergyCost: PLN = PLN.Zero,                                     // aggregate energy + CO₂ costs
+    automationTechCapex: PLN = PLN.Zero,                               // technology CAPEX for automation/hybrid upgrades
+    automationTechImports: PLN = PLN.Zero,                             // import content of technology CAPEX
+    automationTechLoans: PLN = PLN.Zero,                               // bank-credit component of technology financing
+    automationUpgradeFailures: Int = 0,                                // implementation failures causing firm bankruptcy
+    automationAiDebtTrap: Int = 0,                                     // AI debt-trap bankruptcies
+    automationNewFullAi: Int = 0,                                      // new full-AI adopters
+    automationNewHybrid: Int = 0,                                      // new hybrid adopters
+    firmBirths: Int = 0,                                               // new firms (recycled + net new)
+    firmDeaths: Int = 0,                                               // firms bankrupt this step
+    netFirmBirths: Int = 0,                                            // net new firms appended to vector
+    taxEvasionLoss: PLN = PLN.Zero,                                    // tax lost to 4-channel evasion (CIT+VAT+PIT+excise)
+    realizedTaxShadowShare: Share = Share.Zero,                        // current-period realized aggregate tax-side shadow share
+    bailInLoss: PLN = PLN.Zero,                                        // bail-in deposit haircut imposed on bank creditors
+    bfgLevyTotal: PLN = PLN.Zero,                                      // BFG resolution levy from all banks
     bankCapital: BankCapitalDiagnostics = BankCapitalDiagnostics.zero, // monthly bank-capital waterfall diagnostics
+    bankFailure: BankFailureDiagnostics = BankFailureDiagnostics.zero, // monthly bank-failure trigger diagnostics
 )
 object FlowState:
   val zero: FlowState = FlowState()

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -63,6 +63,7 @@ object BankingEconomics:
       bailInLoss: PLN,                                   // bail-in deposit destruction (aggregate)
       multiCapDestruction: PLN,                          // capital wiped when banks fail
       bankCapitalDiagnostics: BankCapitalDiagnostics,    // aggregate monthly bank-capital waterfall diagnostics
+      bankFailureDiagnostics: BankFailureDiagnostics,    // monthly bank-failure trigger diagnostics
       monAgg: Option[Banking.MonetaryAggregates],        // M0/M1/M2/M3 (when credit diagnostics on)
       finalHhAgg: Household.Aggregates,                  // recomputed HH aggregates
       vat: PLN,                                          // gross VAT revenue
@@ -151,6 +152,7 @@ object BankingEconomics:
       newFailures: Int,                                  // banks newly marked failed during this month
       capitalReconciliationResidual: PLN,                // exactness correction applied to one per-bank capital row
       bankCapitalTerms: BankCapitalTerms,                // shared capital-waterfall terms used by reconciliation and diagnostics
+      bankFailureDiagnostics: BankFailureDiagnostics,    // failure trigger reason diagnostics for this month
       resolvedBank: Banking.Aggregate,                   // aggregate banking sector after resolution
       htmRealizedLoss: PLN,                              // realized loss from HTM forced reclassification
       // Bond waterfall outputs — single source of truth for buyer holdings
@@ -183,6 +185,8 @@ object BankingEconomics:
       bailInLossDelta: PLN,
       capitalDestructionDelta: PLN,
       newFailuresDelta: Int,
+      failureEvents: Vector[Banking.FailureEvent],
+      allFailedFallbackUsed: Boolean,
   )
 
   private case class BankCapitalTerms(
@@ -317,6 +321,7 @@ object BankingEconomics:
       bailInLoss = multi.bailInLoss,
       multiCapDestruction = multi.multiCapDestruction,
       bankCapitalDiagnostics = bankCapitalDiagnostics,
+      bankFailureDiagnostics = multi.bankFailureDiagnostics,
       monAgg = monAgg,
       finalHhAgg = finalHhAgg,
       vat = govJst.tax.vat,
@@ -966,6 +971,10 @@ object BankingEconomics:
     val totalBailInLoss       = bailInResult.totalLoss + reconciled.bailInLossDelta
     val totalCapDestruction   = multiCapDest + reconciled.capitalDestructionDelta
     val totalNewFailures      = newFailureCount + reconciled.newFailuresDelta
+    val failureEvents         = failResult.events ++ secondaryFail.events ++ reconciled.failureEvents
+    val invariantMismatches   = math.abs(totalNewFailures - failureEvents.length)
+    val failureDiagnostics    =
+      BankFailureDiagnostics.fromEvents(failureEvents, resolveResult.allFailedFallbackUsed || reconciled.allFailedFallbackUsed, invariantMismatches)
     val anyFailureForMobility = anyFailed || reconciled.newFailuresDelta > 0
 
     // Repair stale failed-bank routing every month; mobility validates survivor bankIds.
@@ -1009,6 +1018,7 @@ object BankingEconomics:
       newFailures = totalNewFailures,
       capitalReconciliationResidual = reconciled.capitalResidual,
       bankCapitalTerms = bankCapitalTerms,
+      bankFailureDiagnostics = failureDiagnostics,
       resolvedBank = Banking.aggregateFromBankStocks(finalFailureBanks, finalFailureStocks, finalCorpBondLookup),
       htmRealizedLoss = htmResult.totalRealizedLoss,
       finalNbp = finalNbp,
@@ -1080,7 +1090,8 @@ object BankingEconomics:
       htmRealizedLoss: PLN,
       bankCapitalTerms: BankCapitalTerms,
   )(using p: SimParams): AggregateReconciliationResult =
-    if banks.isEmpty then AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0)
+    if banks.isEmpty then
+      AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0, Vector.empty, false)
     else
       val target         = aggregateReconciliationTarget(
         prevBankAgg = prevBankAgg,
@@ -1099,7 +1110,7 @@ object BankingEconomics:
       val depResidual    = target.depositsResidual - actualDeposits
       val capResidual    = target.capitalResidual - actualCapital
       if depResidual == PLN.Zero && capResidual == PLN.Zero then
-        AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0)
+        AggregateReconciliationResult(banks, financialStocks, bankCorpBondHoldings, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, 0, Vector.empty, false)
       else
         val targetIdx  = banks.lastIndexWhere(!_.failed) match
           case -1 => banks.indices.last
@@ -1108,13 +1119,13 @@ object BankingEconomics:
         val nextBanks  = banks.updated(targetIdx, reconciled._1)
         val nextStocks = financialStocks.updated(targetIdx, reconciled._2)
         if capResidual == PLN.Zero || nextBanks(targetIdx).failed then
-          AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0)
+          AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0, Vector.empty, false)
         else
           val targetCorpBonds = (bankId: BankId) => bankCorpBondHoldings.lift(bankId.toInt).getOrElse(PLN.Zero)
           val failCheck       =
             Banking.checkFailures(Vector(nextBanks(targetIdx)), Vector(nextStocks(targetIdx)), in.s1.m, true, in.s7.newMacropru.ccyb, targetCorpBonds)
           if !failCheck.anyFailed then
-            AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0)
+            AggregateReconciliationResult(nextBanks, nextStocks, bankCorpBondHoldings, depResidual, capResidual, PLN.Zero, PLN.Zero, 0, Vector.empty, false)
           else
             val failedBank = failCheck.banks.head
             val bailIn     = Banking.applyBailIn(nextBanks.updated(targetIdx, failedBank), nextStocks)
@@ -1128,6 +1139,8 @@ object BankingEconomics:
               bailIn.totalLoss,
               nextBanks(targetIdx).capital,
               1,
+              failCheck.events,
+              resolved.allFailedFallbackUsed,
             )
 
   private def aggregateReconciliationTarget(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -407,6 +407,7 @@ object WorldAssemblyEconomics:
       bailInLoss = in.s9.bailInLoss,
       bfgLevyTotal = in.s9.bfgLevy,
       bankCapital = in.s9.bankCapitalDiagnostics,
+      bankFailure = in.s9.bankFailureDiagnostics,
     )
 
   /** FDI M&A: monthly stochastic conversion of domestic firms to foreign

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -75,6 +75,7 @@ object McTimeseriesSchema:
     lazy val bankAgg: Banking.Aggregate                                                             =
       Banking.aggregateFromBankStocks(banks, ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks), bankCorpBondHoldings)
     lazy val bankCapital: BankCapitalDiagnostics                                                    = world.flows.bankCapital
+    lazy val bankFailure: BankFailureDiagnostics                                                    = world.flows.bankFailure
     lazy val ledgerBankStocksById: Map[BankId, Banking.BankFinancialStocks]                         =
       banks.zip(ledgerFinancialState.banks).map((bank, balances) => bank.id -> LedgerFinancialState.projectBankFinancialStocks(balances)).toMap
     lazy val aliveBankRows: Vector[(Banking.BankState, Banking.BankFinancialStocks)]                =
@@ -405,6 +406,13 @@ object McTimeseriesSchema:
       ctx => if ctx.aliveBankRows.isEmpty then Share.Zero else ctx.aliveBankRows.map((bank, stocks) => Banking.nplRatio(bank, stocks)).max,
     ),
     ColumnDef("BankFailures", ctx => ctx.banks.count(_.failed)),
+    ColumnDef("BankFailure_NewNegativeCapital", ctx => ctx.bankFailure.newNegativeCapital),
+    ColumnDef("BankFailure_NewCarBreach", ctx => ctx.bankFailure.newCarBreach),
+    ColumnDef("BankFailure_NewLiquidityBreach", ctx => ctx.bankFailure.newLiquidityBreach),
+    ColumnDef("BankFailure_AllFailedFallback", ctx => ctx.bankFailure.allFailedFallback),
+    ColumnDef("BankFailure_InvariantViolation", ctx => ctx.bankFailure.invariantViolation),
+    ColumnDef("BankFailure_FirstNewReasonCode", ctx => ctx.bankFailure.firstNewReasonCode),
+    ColumnDef("BankFailure_FirstNewBankId", ctx => ctx.bankFailure.firstNewBankId),
     // LCR/NSFR
     ColumnDef(
       "MinBankLCR",
@@ -892,6 +900,13 @@ object McTimeseriesSchema:
     val MinBankCAR: Col                               = lookup("MinBankCAR")
     val MaxBankNPL: Col                               = lookup("MaxBankNPL")
     val BankFailures: Col                             = lookup("BankFailures")
+    val BankFailureNewNegativeCapital: Col            = lookup("BankFailure_NewNegativeCapital")
+    val BankFailureNewCarBreach: Col                  = lookup("BankFailure_NewCarBreach")
+    val BankFailureNewLiquidityBreach: Col            = lookup("BankFailure_NewLiquidityBreach")
+    val BankFailureAllFailedFallback: Col             = lookup("BankFailure_AllFailedFallback")
+    val BankFailureInvariantViolation: Col            = lookup("BankFailure_InvariantViolation")
+    val BankFailureFirstNewReasonCode: Col            = lookup("BankFailure_FirstNewReasonCode")
+    val BankFailureFirstNewBankId: Col                = lookup("BankFailure_FirstNewBankId")
     val BankFirmLoans: Col                            = lookup("BankFirmLoans")
     val TotalCreditStock: Col                         = lookup("TotalCreditStock")
     val TotalCreditToGdp: Col                         = lookup("TotalCreditToGdp")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -155,6 +155,33 @@ channel.
 the bank-capital diagnostic block; it is a resolution-adjacent depositor haircut
 and is not included in the equity-capital waterfall identity.
 
+## Bank Failure Diagnostics
+
+The seed timeseries also includes monthly failure-trigger diagnostics:
+
+```text
+BankFailure_NewNegativeCapital
+BankFailure_NewCarBreach
+BankFailure_NewLiquidityBreach
+BankFailure_AllFailedFallback
+BankFailure_InvariantViolation
+BankFailure_FirstNewReasonCode
+BankFailure_FirstNewBankId
+```
+
+`BankFailure_NewNegativeCapital`, `BankFailure_NewCarBreach`, and
+`BankFailure_NewLiquidityBreach` count newly failed banks by primary trigger.
+If several triggers are true in the same month, the primary reason priority is
+negative capital, then CAR breach, then LCR/liquidity breach.
+`BankFailure_AllFailedFallback` is `1` when purchase-and-assumption resolution
+had to choose an absorber from an all-failed bank set. This is a bridge-bank /
+resolution-semantics warning, not an ordinary failure trigger.
+`BankFailure_InvariantViolation` should stay zero; a non-zero value means the
+failure-event diagnostics no longer reconcile to the new-failure count and the
+run should be treated as an invalid model state. `BankFailure_FirstNewReasonCode`
+uses stable codes: `0` none, `1` negative capital, `2` CAR breach,
+`3` LCR/liquidity breach, `4` all-failed fallback, `5` invariant mismatch.
+
 ## Household Liquidity Diagnostics
 
 The timeseries schema and terminal `_hh.csv` summary include generic household

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import com.boombustgroup.amorfati.Generators
-import com.boombustgroup.amorfati.agents.Banking.BankStatus
+import com.boombustgroup.amorfati.agents.Banking.{BankFailureReason, BankStatus}
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.types.*
@@ -180,6 +180,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     failed.anyFailed shouldBe true
     failed.banks.head.failed shouldBe true
     failed.banks.head.capital shouldBe PLN.Zero
+    failed.events.map(_.reason) shouldBe Vector(BankFailureReason.CarBreach)
 
     val recovered = mkBankRow(status = BankStatus.Active(2))
     Banking
@@ -196,6 +197,15 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     result.anyFailed shouldBe true
     result.banks.head.failed shouldBe true
     result.banks.head.capital shouldBe PLN.Zero
+    result.events.map(_.reason) shouldBe Vector(BankFailureReason.NegativeCapital)
+  }
+
+  it should "report LCR breaches as liquidity failure reasons" in {
+    val illiquid = mkBankRow(capital = PLN(500000), demandDeposits = PLN(1000000), reservesAtNbp = PLN.Zero, govBondHoldings = PLN.Zero)
+    val result   = Banking.checkFailures(Vector(illiquid.bank), Vector(illiquid.stocks), ExecutionMonth(30), enabled = true, Multiplier.Zero)
+
+    result.anyFailed shouldBe true
+    result.events.map(_.reason) shouldBe Vector(BankFailureReason.LiquidityBreach)
   }
 
   "Banking.resolveFailures" should "move failed-bank stocks to the healthiest survivor" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -172,6 +172,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
     after shouldBe before +- BigDecimal("1.0")
     result.banks.exists(!_.failed) shouldBe true
+    result.allFailedFallbackUsed shouldBe true
   }
 
   "Banking.healthiestBankId" should "return bank with highest capital when all fail" in {

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.agents.{Firm, Household, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.{BankFailureDiagnostics, World}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -157,6 +157,13 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "MinBankCAR",
     "MaxBankNPL",
     "BankFailures",
+    "BankFailure_NewNegativeCapital",
+    "BankFailure_NewCarBreach",
+    "BankFailure_NewLiquidityBreach",
+    "BankFailure_AllFailedFallback",
+    "BankFailure_InvariantViolation",
+    "BankFailure_FirstNewReasonCode",
+    "BankFailure_FirstNewBankId",
     "MinBankLCR",
     "MinBankNSFR",
     "AvgTermDepositFrac",
@@ -402,7 +409,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 348
+    McTimeseriesSchema.nCols shouldBe 355
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -619,6 +626,33 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "HouseholdDistress_Current") shouldBe MetricValue.fromInt(init.householdAggregates.distressCurrent)
     valueAt(row, "HouseholdDistress_ActiveShare") shouldBe MetricValue.fromRaw(init.householdAggregates.distressActiveShare(init.households.length).toLong)
     valueAt(row, "BankFailures") shouldBe MetricValue.fromInt(init.banks.count(_.failed))
+  }
+
+  it should "emit bank failure trigger diagnostics" in {
+    val diagnostics = BankFailureDiagnostics(
+      newNegativeCapital = 1,
+      newCarBreach = 2,
+      newLiquidityBreach = 3,
+      allFailedFallback = 1,
+      invariantViolation = 0,
+      firstNewReasonCode = 3,
+      firstNewBankId = 4,
+    )
+    val world       = init.world.copy(
+      flows = init.world.flows.copy(
+        sectorOutputs = Vector.fill(summon[SimParams].sectorDefs.length)(PLN.Zero),
+        bankFailure = diagnostics,
+      ),
+    )
+    val row         = computeRow(world)
+
+    valueAt(row, "BankFailure_NewNegativeCapital") shouldBe MetricValue.fromInt(1)
+    valueAt(row, "BankFailure_NewCarBreach") shouldBe MetricValue.fromInt(2)
+    valueAt(row, "BankFailure_NewLiquidityBreach") shouldBe MetricValue.fromInt(3)
+    valueAt(row, "BankFailure_AllFailedFallback") shouldBe MetricValue.fromInt(1)
+    valueAt(row, "BankFailure_InvariantViolation") shouldBe MetricValue.Zero
+    valueAt(row, "BankFailure_FirstNewReasonCode") shouldBe MetricValue.fromInt(3)
+    valueAt(row, "BankFailure_FirstNewBankId") shouldBe MetricValue.fromInt(4)
   }
 
   it should "emit annualized deficit-to-GDP consistently with fiscal rules" in {


### PR DESCRIPTION
Closes #556

## Summary
- add explicit bank failure reason diagnostics for negative capital, CAR breach, LCR/liquidity breach, all-failed fallback, and invariant mismatch
- expose `BankFailure_*` columns in the standard seed time-series CSVs
- carry failure events through `Banking.checkFailures` and `BankingEconomics` without changing the existing `BankStatus` persistence shape
- document reason-code semantics and the all-failed fallback boundary for #549

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"`
- `sbt "integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"`
- `sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"`
- `sbt assembly`
- `java -jar target/scala-3.8.2/amor-fati.jar 3 bank556 --duration 24 --run-id check`
- `git diff --check`

## 3x24 diagnostic note
- seed001 first new failure: month 6, `new=2`, `car=2`, `firstReason=2`, `firstBank=0`
- seed002 first new failure: month 5, `new=2`, `car=2`, `firstReason=2`, `firstBank=3`
- seed003 first new failure: month 5, `new=1`, `car=1`, `firstReason=2`, `firstBank=4`

In this smoke run, first failures are explained by CAR breach, not negative capital or LCR. `BankFailure_InvariantViolation=0` and `BankFailure_AllFailedFallback=0`.
