### PR TITLE
Attribute realized bank credit losses

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -66,7 +66,7 @@ runtime ledger flows and validates SFC identities.
 | Labor, wages, demographics, social funds | `engine/economics/LaborEconomics.scala`, `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` | `MarketWage`, `Unemployment`, `WorkingAgePop`, `NRetirees`, `MonthlyRetirements`, `ZusContributions`, `ZusPensionPayments`, `NfzContributions`, `NfzSpending`, `PpkContributions`, `FpContributions`, `FgspSpending` |
 | Demand allocation and fiscal constraint | `engine/economics/DemandEconomics.scala`, `engine/markets/FiscalRules.scala`, `engine/markets/FiscalBudget.scala` | `GovCurrentSpend`, `GovCapitalSpendDomestic`, `FiscalRuleBinding`, `GovSpendingCutRatio`, `DebtToGdp`, `DeficitToGdp`, `PublicCapitalStock` |
 | Firm production, investment, technology, financing, default, entry | `agents/Firm.scala`, `engine/economics/FirmEconomics.scala`, `engine/mechanisms/FirmEntry.scala` | `TotalAdoption`, `AutoRatio`, `HybridRatio`, `Automation_TechCapex`, `Automation_TechImports`, `Automation_TechLoans`, `Automation_UpgradeFailures`, `Automation_AiDebtTrap`, `Automation_NewFullAi`, `Automation_NewHybrid`, `Adoption_MicroShare`, `Adoption_SmallShare`, `Adoption_MediumShare`, `Adoption_LargeShare`, `Adoption_CashQ1`-`Q4`, `Adoption_DebtQ1`-`Q4`, sector `*_Auto`, sector `*_Sigma`, `GrossInvestment`, `AggCapitalStock`, `AggInventoryStock`, `InventoryChange`, `AggEnergyCost`, `GreenInvestment`, `FirmBirths`, `FirmDeaths`, `NetEntry`, `LivingFirmCount`, `CorpBondIssuance`, `EquityIssuanceTotal` |
-| Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `BankFailure_*`, `BankReconciliation_*`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
+| Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `BankFailure_*`, `BankCreditLoss_*`, `BankReconciliation_*`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
 | Fiscal, NBP, bond market, external sector | `agents/Nbp.scala`, `engine/markets/OpenEconomy.scala`, `engine/economics/OpenEconEconomics.scala`, `engine/markets/CorporateBondMarket.scala`, `engine/markets/BondAuction.scala` | `RefRate`, `BondYield`, `WeightedCoupon`, `BondsOutstanding`, `NbpBondHoldings`, `ForeignBondHoldings`, `QeActive`, `FxReserves`, `FxInterventionAmt`, `CurrentAccount`, `CapitalAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NFA`, `FDI` |
 | Insurance, NBFI, quasi-fiscal, local government | `agents/Insurance.scala`, `agents/Nbfi.scala`, `agents/QuasiFiscal.scala`, `agents/Jst.scala` | `InsLifeReserves`, `InsNonLifeReserves`, `InsLifePremium`, `InsNonLifePremium`, `InsLifeClaims`, `InsNonLifeClaims`, `NbfiTfiAum`, `NbfiOrigination`, `NbfiDefaults`, `NbfiBankTightness`, `QfBondsOutstanding`, `QfIssuance`, `QfLoanPortfolio`, `Esa2010DebtToGdp`, `JstRevenue`, `JstSpending`, `JstDebt`, `JstDeposits` |
 
@@ -743,6 +743,13 @@ post-patch reason code uses the same `0..5` reason-code mapping as
 `BankFailure_FirstNewReasonCode`.
 `BankCapital_DepositBailInLoss` is also reported for resolution analysis, but it
 is a depositor haircut rather than an equity-capital P&L term.
+
+Realized credit-loss rates are emitted as `BankCreditLoss_*`. They use closing
+exposure stocks as denominators, so the columns can be joined directly with
+monthly `BankFailure_*` rows. The block separates firm-loan, mortgage,
+consumer-loan, liquidity-bridge charge-off, and bank-held corporate-bond
+channels. `BankCapital_EclProvisionChange` remains a separate accounting
+provision term and is not included in these realized-loss rates.
 
 Liquidity ratios are:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -225,10 +225,13 @@ failure triggers. The bank capital block uses `BankCapital_*` columns to
 reconcile opening capital, retained income, realized credit losses, provisions,
 valuation losses, failure-related capital destruction, reconciliation residuals,
 and closing capital. The `BankFailure_*` block identifies the monthly primary
-trigger for newly failed banks. The `BankReconciliation_*` block identifies the
-bank row that absorbed the exactness patch, reports capital and CAR before/after
-that patch, and flags material residuals or residual-induced failure-threshold
-crossings. No extra flag is needed for these aggregate diagnostics.
+trigger for newly failed banks. The `BankCreditLoss_*` block reports realized
+loss/default/write-off rates by major exposure class and keeps them separate
+from `BankCapital_EclProvisionChange`. The `BankReconciliation_*` block
+identifies the bank row that absorbed the exactness patch, reports capital and
+CAR before/after that patch, and flags material residuals or residual-induced
+failure-threshold crossings. No extra flag is needed for these aggregate
+diagnostics.
 
 Firm-level micro snapshots are optional and off by default. Enable them with
 `--firm-snapshots terminal`, `--firm-snapshots every:12`, or

--- a/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
+++ b/integration-tests/src/test/scala/com/boombustgroup/amorfati/integration/montecarlo/McRunnerCsvIntegrationSpec.scala
@@ -126,6 +126,16 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     val reconMaterialIdx = columnIndex(header, "BankReconciliation_MaterialResidual")
     val reconCrossedIdx  = columnIndex(header, "BankReconciliation_CrossedFailureThreshold")
     val reconReasonIdx   = columnIndex(header, "BankReconciliation_PostResidualReasonCode")
+    val realizedCapitalIdx = columnIndex(header, "BankCreditLoss_RealizedToOpeningCapital")
+    val firmDefaultRateIdx = columnIndex(header, "BankCreditLoss_FirmDefaultRate")
+    val firmLossRateIdx = columnIndex(header, "BankCreditLoss_FirmLossRate")
+    val mortgageDefaultRateIdx = columnIndex(header, "BankCreditLoss_MortgageDefaultRate")
+    val mortgageLossRateIdx = columnIndex(header, "BankCreditLoss_MortgageLossRate")
+    val consumerDefaultRateIdx = columnIndex(header, "BankCreditLoss_ConsumerLoanDefaultRate")
+    val bridgeChargeOffRateIdx = columnIndex(header, "BankCreditLoss_LiquidityBridgeChargeOffRate")
+    val consumerLossRateIdx = columnIndex(header, "BankCreditLoss_ConsumerLossRate")
+    val corpBondDefaultRateIdx = columnIndex(header, "BankCreditLoss_CorpBondDefaultRate")
+    val corpBondLossRateIdx = columnIndex(header, "BankCreditLoss_CorpBondLossRate")
     val realizedCredit   =
       row(firmLossIdx) + row(mortgageLossIdx) + row(consumerLossIdx) + row(corpBondLossIdx)
     val expectedDelta    =
@@ -153,6 +163,18 @@ class McRunnerCsvIntegrationSpec extends AnyFlatSpec with Matchers:
     row(reconCrossedIdx) should (be >= BigDecimal(0) and be <= BigDecimal(1))
     row(reconReasonIdx) should (be >= BigDecimal(0) and be <= BigDecimal(5))
     if row(reconCrossedIdx) == BigDecimal(1) then row(reconReasonIdx) should be > BigDecimal(0)
+    Vector(
+      realizedCapitalIdx,
+      firmDefaultRateIdx,
+      firmLossRateIdx,
+      mortgageDefaultRateIdx,
+      mortgageLossRateIdx,
+      consumerDefaultRateIdx,
+      bridgeChargeOffRateIdx,
+      consumerLossRateIdx,
+      corpBondDefaultRateIdx,
+      corpBondLossRateIdx,
+    ).foreach(idx => row(idx) should be >= BigDecimal(0))
 
   private def expectedRun(seed: Long): RunResult =
     McRunner.runSingle(seed, DurationMonths).fold(err => fail(err.toString), identity)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -144,6 +144,13 @@ object McTimeseriesSchema:
     def monthlyFlowToGdpRatio(flow: PLN): Scalar =
       if monthlyGdp > PLN.Zero then flow / monthlyGdp else Scalar.Zero
 
+    def flowToStockRate(flow: PLN, stock: PLN): Scalar =
+      if stock > PLN.Zero then flow / stock else Scalar.Zero
+
+    def grossDefaultFromLoss(loss: PLN, recovery: Share): PLN =
+      val lossRate = Share.One - recovery
+      if loss > PLN.Zero && lossRate > Share.Zero then loss / lossRate else PLN.Zero
+
     lazy val meanEmployedWage: PLN =
       var total = PLN.Zero
       var count = 0
@@ -563,6 +570,22 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("BankCapital_WaterfallResidual", ctx => ctx.bankCapital.waterfallResidual),
     ColumnDef.macroPln("BankCapital_DepositBailInLoss", ctx => ctx.bankCapital.depositBailInLoss),
     ColumnDef("BankCapital_NewFailures", ctx => ctx.bankCapital.newFailures),
+    ColumnDef("BankCreditLoss_RealizedToOpeningCapital", ctx => ctx.flowToStockRate(ctx.bankCapital.realizedCreditLoss, ctx.bankCapital.openingCapital)),
+    ColumnDef(
+      "BankCreditLoss_FirmDefaultRate",
+      ctx => ctx.flowToStockRate(ctx.grossDefaultFromLoss(ctx.bankCapital.firmNplLoss, ctx.p.banking.loanRecovery), ctx.bankFirmLoans),
+    ),
+    ColumnDef("BankCreditLoss_FirmLossRate", ctx => ctx.flowToStockRate(ctx.bankCapital.firmNplLoss, ctx.bankFirmLoans)),
+    ColumnDef("BankCreditLoss_MortgageDefaultRate", ctx => ctx.flowToStockRate(ctx.world.real.housing.lastDefault, ctx.ledgerHouseholdMortgageStock)),
+    ColumnDef("BankCreditLoss_MortgageLossRate", ctx => ctx.flowToStockRate(ctx.bankCapital.mortgageNplLoss, ctx.ledgerHouseholdMortgageStock)),
+    ColumnDef("BankCreditLoss_ConsumerLoanDefaultRate", ctx => ctx.flowToStockRate(ctx.hhAgg.totalConsumerLoanDefault, ctx.consumerLoanStock)),
+    ColumnDef("BankCreditLoss_LiquidityBridgeChargeOffRate", ctx => ctx.flowToStockRate(ctx.hhAgg.totalLiquidityBridgeChargeOff, ctx.consumerLoanStock)),
+    ColumnDef("BankCreditLoss_ConsumerLossRate", ctx => ctx.flowToStockRate(ctx.bankCapital.consumerNplLoss, ctx.consumerLoanStock)),
+    ColumnDef(
+      "BankCreditLoss_CorpBondDefaultRate",
+      ctx => ctx.flowToStockRate(ctx.grossDefaultFromLoss(ctx.bankCapital.corpBondDefaultLoss, ctx.p.corpBond.recovery), ctx.bankAgg.corpBondHoldings),
+    ),
+    ColumnDef("BankCreditLoss_CorpBondLossRate", ctx => ctx.flowToStockRate(ctx.bankCapital.corpBondDefaultLoss, ctx.bankAgg.corpBondHoldings)),
   )
 
   private def realGroup: Vector[ColumnDef] =
@@ -953,10 +976,9 @@ object McTimeseriesSchema:
     val BankCapitalWaterfallResidual: Col              = lookup("BankCapital_WaterfallResidual")
     val BankCapitalDepositBailInLoss: Col              = lookup("BankCapital_DepositBailInLoss")
     val BankCapitalNewFailures: Col                    = lookup("BankCapital_NewFailures")
-
-    private val sectorAutoNames   = sectorColumns.map(_.autoColName)
-    private val sectorOutputNames = sectorColumns.map(_.outputColName)
-    private val sectorSigmaNames  = sectorColumns.map(_.sigmaColName)
+    private val sectorAutoNames                        = sectorColumns.map(_.autoColName)
+    private val sectorOutputNames                      = sectorColumns.map(_.outputColName)
+    private val sectorSigmaNames                       = sectorColumns.map(_.sigmaColName)
 
     private def sectorCol(names: Vector[String], sectorIndex: Int, kind: String): Col =
       names

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -133,6 +133,16 @@ BankCapital_ReconciliationResidual
 BankCapital_WaterfallResidual
 BankCapital_DepositBailInLoss
 BankCapital_NewFailures
+BankCreditLoss_RealizedToOpeningCapital
+BankCreditLoss_FirmDefaultRate
+BankCreditLoss_FirmLossRate
+BankCreditLoss_MortgageDefaultRate
+BankCreditLoss_MortgageLossRate
+BankCreditLoss_ConsumerLoanDefaultRate
+BankCreditLoss_LiquidityBridgeChargeOffRate
+BankCreditLoss_ConsumerLossRate
+BankCreditLoss_CorpBondDefaultRate
+BankCreditLoss_CorpBondLossRate
 ```
 
 These columns follow the same pattern as household and firm aggregate
@@ -154,6 +164,15 @@ channel.
 `BankCapital_DepositBailInLoss` mirrors the existing `BailInLoss` column inside
 the bank-capital diagnostic block; it is a resolution-adjacent depositor haircut
 and is not included in the equity-capital waterfall identity.
+
+`BankCreditLoss_*` columns normalize realized credit losses and gross
+default/write-off flows by the relevant closing exposure stock, so bank-failure
+months can be read without post-processing. `RealizedToOpeningCapital` measures
+the total realized credit-loss hit against opening bank capital. Firm and
+corporate-bond default rates reverse the configured recovery rate to estimate
+gross default flow from net loss. Consumer diagnostics separate ordinary
+consumer-loan default from liquidity-bridge charge-off; `ConsumerLossRate`
+keeps the combined capital-loss view used by the bank waterfall.
 
 ## Bank Failure Diagnostics
 

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -4,7 +4,7 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.agents.{Firm, Household, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.{BankFailureDiagnostics, BankReconciliationDiagnostics, World}
+import com.boombustgroup.amorfati.engine.{BankCapitalDiagnostics, BankFailureDiagnostics, BankReconciliationDiagnostics, World}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -259,6 +259,16 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "BankCapital_WaterfallResidual",
     "BankCapital_DepositBailInLoss",
     "BankCapital_NewFailures",
+    "BankCreditLoss_RealizedToOpeningCapital",
+    "BankCreditLoss_FirmDefaultRate",
+    "BankCreditLoss_FirmLossRate",
+    "BankCreditLoss_MortgageDefaultRate",
+    "BankCreditLoss_MortgageLossRate",
+    "BankCreditLoss_ConsumerLoanDefaultRate",
+    "BankCreditLoss_LiquidityBridgeChargeOffRate",
+    "BankCreditLoss_ConsumerLossRate",
+    "BankCreditLoss_CorpBondDefaultRate",
+    "BankCreditLoss_CorpBondLossRate",
     "HousingPriceIndex",
     "HousingMarketValue",
     "MortgageStock",
@@ -419,7 +429,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 365
+    McTimeseriesSchema.nCols shouldBe 375
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -591,20 +601,33 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
   it should "emit validation-ready credit stock splits and GDP ratios" in {
     val bankFirmLoans = PLN(10) * initState.ledgerFinancialState.banks.length
     val consumerLoans = PLN(2) * initState.ledgerFinancialState.banks.length
+    val bankCorpBonds = PLN(25) * initState.ledgerFinancialState.banks.length
+    val mortgageStock = PLN(20)
     val nbfiLoans     = PLN(6)
-    val totalCredit   = bankFirmLoans + consumerLoans + nbfiLoans
+    val totalCredit   = bankFirmLoans + consumerLoans + mortgageStock + nbfiLoans
     val annualGdp     = PLN(10) * 12
+    val householdRows = initState.ledgerFinancialState.households.zipWithIndex.map: (household, idx) =>
+      household.copy(mortgageLoan = if idx == 0 then mortgageStock else PLN.Zero)
     val ledger        = initState.ledgerFinancialState.copy(
-      households = initState.ledgerFinancialState.households.map(_.copy(mortgageLoan = PLN.Zero)),
-      banks = initState.ledgerFinancialState.banks.map(_.copy(firmLoan = PLN(10), consumerLoan = PLN(2))),
+      households = householdRows,
+      banks = initState.ledgerFinancialState.banks.map(_.copy(firmLoan = PLN(10), consumerLoan = PLN(2), corpBond = PLN(25))),
       funds = initState.ledgerFinancialState.funds.copy(
         nbfi = initState.ledgerFinancialState.funds.nbfi.copy(nbfiLoanStock = nbfiLoans),
       ),
     )
+    val bankCapital   = BankCapitalDiagnostics(
+      openingCapital = PLN(1000),
+      firmNplLoss = PLN(2),
+      mortgageNplLoss = PLN(2),
+      consumerNplLoss = PLN(5),
+      corpBondDefaultLoss = PLN(3),
+    )
     val world         = init.world.copy(
+      real = init.world.real.copy(housing = init.world.real.housing.copy(lastDefault = PLN(6))),
       flows = init.world.flows.copy(
         monthlyGdpProxy = PLN(10),
         sectorOutputs = Vector.fill(summon[SimParams].sectorDefs.length)(PLN.Zero),
+        bankCapital = bankCapital,
       ),
     )
     val hhAgg         = init.householdAggregates.copy(
@@ -625,6 +648,24 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "ConsumerLoansToGdp") shouldBe MetricValue.fromRaw((consumerLoans / annualGdp).toLong)
     valueAt(row, "NbfiLoansToGdp") shouldBe MetricValue.fromRaw((nbfiLoans / annualGdp).toLong)
     valueAt(row, "TotalCreditToGdp") shouldBe MetricValue.fromRaw((totalCredit / annualGdp).toLong)
+
+    val firmGrossDefault     =
+      val lossRate = Share.One - summon[SimParams].banking.loanRecovery
+      if lossRate > Share.Zero then bankCapital.firmNplLoss / lossRate else PLN.Zero
+    val corpBondGrossDefault =
+      val lossRate = Share.One - summon[SimParams].corpBond.recovery
+      if lossRate > Share.Zero then bankCapital.corpBondDefaultLoss / lossRate else PLN.Zero
+
+    valueAt(row, "BankCreditLoss_RealizedToOpeningCapital") shouldBe MetricValue.fromRaw((bankCapital.realizedCreditLoss / bankCapital.openingCapital).toLong)
+    valueAt(row, "BankCreditLoss_FirmDefaultRate") shouldBe MetricValue.fromRaw((firmGrossDefault / bankFirmLoans).toLong)
+    valueAt(row, "BankCreditLoss_FirmLossRate") shouldBe MetricValue.fromRaw((bankCapital.firmNplLoss / bankFirmLoans).toLong)
+    valueAt(row, "BankCreditLoss_MortgageDefaultRate") shouldBe MetricValue.fromRaw((PLN(6) / mortgageStock).toLong)
+    valueAt(row, "BankCreditLoss_MortgageLossRate") shouldBe MetricValue.fromRaw((bankCapital.mortgageNplLoss / mortgageStock).toLong)
+    valueAt(row, "BankCreditLoss_ConsumerLoanDefaultRate") shouldBe MetricValue.fromRaw((PLN(3) / consumerLoans).toLong)
+    valueAt(row, "BankCreditLoss_LiquidityBridgeChargeOffRate") shouldBe MetricValue.fromRaw((PLN(4) / consumerLoans).toLong)
+    valueAt(row, "BankCreditLoss_ConsumerLossRate") shouldBe MetricValue.fromRaw((bankCapital.consumerNplLoss / consumerLoans).toLong)
+    valueAt(row, "BankCreditLoss_CorpBondDefaultRate") shouldBe MetricValue.fromRaw((corpBondGrossDefault / bankCorpBonds).toLong)
+    valueAt(row, "BankCreditLoss_CorpBondLossRate") shouldBe MetricValue.fromRaw((bankCapital.corpBondDefaultLoss / bankCorpBonds).toLong)
   }
 
   it should "emit household bankruptcy validation fields alongside firm and bank failures" in {


### PR DESCRIPTION
## Summary
- add always-on BankCreditLoss_* seed-timeseries diagnostics for realized loss/default/write-off rates by major bank exposure class
- keep realized credit-loss attribution separate from BankCapital_EclProvisionChange so #557 can investigate provisions independently
- update CSV schema contract, integration checks, and documentation

## Current 10x60 evidence
Run command:

```bash
java -jar target/scala-3.8.2/amor-fati.jar 10 bank561 --duration 60 --run-id check561
```

First failure months across 10 seeds:
- avg realized credit loss: ~10.56bn
- avg ECL provision change: ~1.17bn
- realized / ECL: ~9.0x
- realized-loss mix: firm ~0.3%, mortgage ~2.1%, consumer ~97.6%, corp bonds ~0.0%
- avg consumer-loan default rate: ~5.12% monthly
- avg liquidity-bridge charge-off rate: ~1.48% monthly

Interpretation: early bank failures in the current run are driven primarily by realized consumer-credit losses, not by firm/mortgage/corp-bond losses and not by ECL/provisioning.

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- sbt "integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 10 bank561 --duration 60 --run-id check561

Closes #561