### PR TITLE
Seed opening bank deposit buckets and NBP reserves

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
@@ -48,12 +48,15 @@ object BankInit:
     val rows = Banking.DefaultConfigs
       .zip(bondAlloc)
       .map { case (cfg, bankBondRaw) =>
-        val bId          = cfg.id.toInt
-        val corpLoans    = perBankCorpLoans.getOrElse(bId, PLN.Zero)
-        val consLoans    = perBankConsLoans.getOrElse(bId, PLN.Zero)
-        val firmDeposits = perBankCash.getOrElse(bId, PLN.Zero)
-        val hhDeposits   = perBankHhDeposits.getOrElse(bId, PLN.Zero)
-        val bankBonds    = PLN.fromRaw(bankBondRaw)
+        val bId            = cfg.id.toInt
+        val corpLoans      = perBankCorpLoans.getOrElse(bId, PLN.Zero)
+        val consLoans      = perBankConsLoans.getOrElse(bId, PLN.Zero)
+        val firmDeposits   = perBankCash.getOrElse(bId, PLN.Zero)
+        val hhDeposits     = perBankHhDeposits.getOrElse(bId, PLN.Zero)
+        val bankBonds      = PLN.fromRaw(bankBondRaw)
+        val deposits       = firmDeposits + hhDeposits
+        val termDeposits   = deposits * p.banking.termDepositFrac
+        val demandDeposits = deposits - termDeposits
         (
           Banking.BankState(
             id = cfg.id,
@@ -67,14 +70,14 @@ object BankInit:
             consumerNpl = PLN.Zero,
           ),
           Banking.BankFinancialStocks(
-            totalDeposits = firmDeposits + hhDeposits,
+            totalDeposits = deposits,
             firmLoan = corpLoans,
             govBondAfs = bankBonds * (Share.One - p.banking.htmShare),
             govBondHtm = bankBonds * p.banking.htmShare,
-            reserve = PLN.Zero,
+            reserve = deposits * p.banking.reserveReq,
             interbankLoan = PLN.Zero,
-            demandDeposit = PLN.Zero,
-            termDeposit = PLN.Zero,
+            demandDeposit = demandDeposits,
+            termDeposit = termDeposits,
             consumerLoan = consLoans,
           ),
         )

--- a/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.init
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
+import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.fp.FixedPointBase
@@ -62,4 +63,24 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
     householdMortgage shouldBe p.housing.initMortgage
     bankMortgageBook shouldBe p.housing.initMortgage
     init.world.real.housing.mortgageStock shouldBe p.housing.initMortgage
+  }
+
+  it should "seed bank deposit buckets and NBP reserve liabilities from opening deposits" in {
+    val init         = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val bankBalances = init.ledgerFinancialState.banks
+    val deposits     = bankBalances.map(_.totalDeposits).sumPln
+    val reserves     = bankBalances.map(_.reserve).sumPln
+
+    deposits should be > PLN.Zero
+    bankBalances.foreach { bank =>
+      val expectedTermDeposit = bank.totalDeposits * p.banking.termDepositFrac
+      val expectedReserve     = bank.totalDeposits * p.banking.reserveReq
+      val stocks              = LedgerFinancialState.projectBankFinancialStocks(bank)
+
+      bank.demandDeposit + bank.termDeposit shouldBe bank.totalDeposits
+      bank.termDeposit shouldBe expectedTermDeposit
+      bank.reserve shouldBe expectedReserve
+      Banking.netCashOutflows(stocks) should be > PLN.Zero
+    }
+    init.ledgerFinancialState.nbp.reserveLiability shouldBe reserves
   }


### PR DESCRIPTION
## Summary
- split opening bank totalDeposits into demandDeposit and termDeposit using configured termDepositFrac
- seed opening bank reserves from reserveReq and keep NBP reserve liability aligned through existing WorldInit flow
- add WorldInit regression coverage for deposit-bucket exactness, reserve seeding, and positive LCR outflows

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.init.WorldInitSpec com.boombustgroup.amorfati.accounting.InitCheckSpec com.boombustgroup.amorfati.accounting.matrix.SfcMatrixEvidenceSpec com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec"
- sbt test
- sbt assembly
- sbt "bankBalanceSheetBenchmark --seed-start 1 --seeds 10 --out target/bank-balance-sheet-benchmark --run-id check568"

Benchmark check568:
- DepositSplitCoverage = 1.0 PASS
- DemandDepositShare = 0.6 PASS
- ReserveToDeposits = 0.035 PASS
- per-bank LCR now uses positive demand-deposit outflows instead of zero-denominator safe floor

Closes #568