### PR TITLE
Seed opening IFRS 9 ECL allowance

### DIFF
--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -69,6 +69,9 @@ February 2026 total-capital-ratio bridge already recorded in calibration
 provenance. `ConsumerLoansToGdp` and `MortgageLoansToGdp` reuse the household
 credit-stress calibration ranges. ECL bands are model-semantics checks: they ask
 whether the opening loan book is already staged and provisioned before monthly
-ECL dynamics begin. Deposit split, reserves, and liquidity ratios are especially
-important because they determine whether LCR, NSFR and monetary aggregates are
-measuring an economically meaningful opening bank balance sheet.
+ECL dynamics begin. The current opening ECL bridge assigns the covered firm and
+consumer loan book to Stage 1; calibrated opening Stage 2/3 shares remain a
+separate banking-risk calibration step. Deposit split, reserves, and liquidity
+ratios are especially important because they determine whether LCR, NSFR and
+monetary aggregates are measuring an economically meaningful opening bank
+balance sheet.

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -704,6 +704,11 @@ CAR_b = capital_b / RWA_b
 When the denominator is effectively zero, the implementation returns a safe
 ratio floor.
 
+Opening IFRS 9 ECL staging is seeded from the bank-owned firm and consumer loan
+book as all-performing Stage 1 exposure. The opening allowance is therefore a
+pre-existing baseline allowance, while `BankCapital_EclProvisionChange` measures
+monthly movement in that allowance.
+
 The monthly bank-capital diagnostic waterfall is:
 
 ```text

--- a/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
@@ -36,6 +36,13 @@ object EclStaging:
   object State:
     val zero: State = State(PLN.Zero, PLN.Zero, PLN.Zero)
 
+    /** Opening all-performing book used until a calibrated Stage 2/3 split is
+      * introduced.
+      */
+    def allStage1(coveredLoans: PLN): State =
+      require(coveredLoans >= PLN.Zero, s"ECL opening covered loans must be non-negative, got $coveredLoans")
+      State(coveredLoans, PLN.Zero, PLN.Zero)
+
   /** ECL staging result: updated stages + total provision change. */
   case class StepResult(
       newStaging: State,

--- a/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
@@ -48,15 +48,16 @@ object BankInit:
     val rows = Banking.DefaultConfigs
       .zip(bondAlloc)
       .map { case (cfg, bankBondRaw) =>
-        val bId            = cfg.id.toInt
-        val corpLoans      = perBankCorpLoans.getOrElse(bId, PLN.Zero)
-        val consLoans      = perBankConsLoans.getOrElse(bId, PLN.Zero)
-        val firmDeposits   = perBankCash.getOrElse(bId, PLN.Zero)
-        val hhDeposits     = perBankHhDeposits.getOrElse(bId, PLN.Zero)
-        val bankBonds      = PLN.fromRaw(bankBondRaw)
-        val deposits       = firmDeposits + hhDeposits
-        val termDeposits   = deposits * p.banking.termDepositFrac
-        val demandDeposits = deposits - termDeposits
+        val bId             = cfg.id.toInt
+        val corpLoans       = perBankCorpLoans.getOrElse(bId, PLN.Zero)
+        val consLoans       = perBankConsLoans.getOrElse(bId, PLN.Zero)
+        val firmDeposits    = perBankCash.getOrElse(bId, PLN.Zero)
+        val hhDeposits      = perBankHhDeposits.getOrElse(bId, PLN.Zero)
+        val bankBonds       = PLN.fromRaw(bankBondRaw)
+        val deposits        = firmDeposits + hhDeposits
+        val termDeposits    = deposits * p.banking.termDepositFrac
+        val demandDeposits  = deposits - termDeposits
+        val eclCoveredLoans = corpLoans + consLoans
         (
           Banking.BankState(
             id = cfg.id,
@@ -68,6 +69,7 @@ object BankInit:
             loansMedium = PLN.Zero,
             loansLong = PLN.Zero,
             consumerNpl = PLN.Zero,
+            eclStaging = EclStaging.State.allStage1(eclCoveredLoans),
           ),
           Banking.BankFinancialStocks(
             totalDeposits = deposits,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -131,6 +131,8 @@ BankEcl_GdpGrowthMonthly
 ```
 
 `EclStage1`, `EclStage2`, and `EclStage3` are aggregate staged exposure stocks.
+At model start the ECL-covered firm and consumer loan book is seeded as
+all-performing Stage 1; calibrated opening Stage 2/3 shares are not modeled yet.
 `BankEcl_OpeningAllowance` and `BankEcl_ClosingAllowance` are the accounting
 allowances implied by those staged stocks and configured ECL rates.
 `BankEcl_BaselineStage1Allowance` asks what the closing allowance would have

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
@@ -50,34 +50,46 @@ class EclStagingSpec extends AnyFlatSpec with Matchers:
     EclStaging.allowance(state) shouldBe expected
   }
 
-  it should "migrate S1->S2 when unemployment rises" in {
+  "EclStaging.step" should "migrate S1->S2 when unemployment rises" in {
     val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Coefficient.Zero)
     decimal(result.newStaging.stage2) should be > BigDecimal("0.0")
     decimal(result.newStaging.stage1) should be < decimal(loans)
   }
 
-  it should "move defaults to S3" in {
+  "EclStaging.step" should "move defaults to S3" in {
     val nplNew = PLN(100000000)
     val s2Init = EclStaging.State(loans - nplNew, nplNew, PLN.Zero)
     val result = EclStaging.step(s2Init, loans, nplNew, Share.decimal(4, 2), Coefficient.decimal(1, 2))
     decimal(result.newStaging.stage3) should be > BigDecimal("0.0")
   }
 
-  it should "increase provisions when loans migrate S1->S2" in {
+  "EclStaging.step" should "increase provisions when loans migrate S1->S2" in {
     val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Coefficient.decimal(-2, 2))
     // S1->S2 migration -> higher provisions -> positive provisionChange
     decimal(result.provisionChange) should be > BigDecimal("0.0")
   }
 
-  it should "preserve total loans across stages" in {
+  "EclStaging.step" should "preserve total loans across stages" in {
     val result = EclStaging.step(init, loans, PLN(50000000), Share.decimal(8, 2), Coefficient.decimal(-1, 2))
     val total  = result.newStaging.stage1 + result.newStaging.stage2 + result.newStaging.stage3
     decimal(total) shouldBe decimal(loans) +- BigDecimal("1.0")
   }
 
-  it should "cure some S3 loans back to S2" in {
+  "EclStaging.step" should "cure some S3 loans back to S2" in {
     val s3Init = EclStaging.State(PLN.Zero, PLN.Zero, loans)
     val result = EclStaging.step(s3Init, loans, PLN.Zero, Share.decimal(4, 2), Coefficient.decimal(1, 2))
     decimal(result.newStaging.stage2) should be > BigDecimal("0.0")
     decimal(result.newStaging.stage3) should be < decimal(loans)
+  }
+
+  "EclStaging.State.allStage1" should "seed an all-performing opening book" in {
+    val state = EclStaging.State.allStage1(loans)
+
+    state.stage1 shouldBe loans
+    state.stage2 shouldBe PLN.Zero
+    state.stage3 shouldBe PLN.Zero
+  }
+
+  it should "reject negative opening covered loans" in {
+    an[IllegalArgumentException] should be thrownBy EclStaging.State.allStage1(PLN(-1))
   }

--- a/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.init
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
-import com.boombustgroup.amorfati.agents.Banking
+import com.boombustgroup.amorfati.agents.{Banking, EclStaging}
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.fp.FixedPointBase
@@ -53,6 +53,26 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
 
     householdLoans shouldBe p.banking.initConsumerLoans
     bankConsumerBook shouldBe p.banking.initConsumerLoans
+  }
+
+  it should "seed bank ECL staging from the opening covered loan book" in {
+    val init         = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val bankBalances = init.ledgerFinancialState.banks
+    val allowance    = init.banks.map(bank => EclStaging.allowance(bank.eclStaging)).sumPln
+
+    allowance should be > PLN.Zero
+    init.banks.size shouldBe bankBalances.size
+    init.banks.map(_.id.toInt).distinct.size shouldBe init.banks.size
+    val balancesByBankId = bankBalances.zipWithIndex.map { case (balances, bankId) => bankId -> balances }.toMap
+    init.banks.foreach { bank =>
+      val balances     = balancesByBankId(bank.id.toInt)
+      val coveredLoans = balances.firmLoan + balances.consumerLoan
+
+      bank.eclStaging.stage1 shouldBe coveredLoans
+      bank.eclStaging.stage2 shouldBe PLN.Zero
+      bank.eclStaging.stage3 shouldBe PLN.Zero
+      EclStaging.allowance(bank.eclStaging) shouldBe coveredLoans * p.banking.eclRate1
+    }
   }
 
   it should "honor the housing mortgage opening stock" in {


### PR DESCRIPTION
## Summary
- seed the opening ECL-covered firm and consumer loan book as all-performing Stage 1 exposure
- keep opening bank capital semantics unchanged: initial capital is treated as already net of baseline allowances
- document the current all-Stage-1 opening bridge and leave calibrated Stage 2/3 shares to the follow-up ECL calibration work
- add regression coverage for ECL staging initialization and the allStage1 helper

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.EclStagingSpec com.boombustgroup.amorfati.init.WorldInitSpec com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- sbt "bankBalanceSheetBenchmark --seed-start 1 --seeds 10 --out target/bank-balance-sheet-benchmark --run-id check566"
- sbt assembly
- java -jar target/scala-3.8.2/amor-fati.jar 10 bank566 --duration 60 --run-id check566
- sbt test
- sbt "integrationTests/testOnly com.boombustgroup.amorfati.integration.montecarlo.McRunnerCsvIntegrationSpec"

Benchmark check566:
- InitialEclAllowanceToLoans = 0.01 PASS
- EclStagedShareOfCoveredLoans = 1.0 PASS

10x60 check566:
- month 1 avg BankEcl_OpeningAllowance ~= 7.72bn PLN
- month 1 avg BankEcl_ClosingAllowance ~= 12.33bn PLN
- month 1 avg BankCapital_EclProvisionChange ~= 4.61bn PLN
- month 1 provision change now reflects monthly Stage 1 -> Stage 2 movement, not a catch-up from zero opening allowance

Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ECL staging initialization for bank opening balances; all covered loans seeded as Stage 1 (all-performing).

* **Documentation**
  * Clarified IFRS 9 ECL staging initialization process and bank balance sheet setup.

* **Tests**
  * Added test coverage for ECL staging initialization and bank opening balance validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->