### PR TITLE
Rebalance opening bank concentration

### DIFF
--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -59,7 +59,7 @@ These ratios guide follow-up calibration and source-bridge work.
 | `EclStagedShareOfCoveredLoans` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.95` to `1.05` | share | The ECL-covered firm and consumer loan book should already be assigned to stages. |
 | `AggregateNplRatio` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.06` | ratio | Opening credit quality should not by itself explain early capital pressure. |
 | `LargestBankCreditShare` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `0.25` | share | No single bank row should dominate the opening credit book. |
-| `BankCreditHhi` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.20` | index | Compact concentration diagnostic for the seven-row banking sector. |
+| `BankCreditHhi` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.20` | index | Compact concentration diagnostic for the default banking-sector rows. |
 
 ## Source Status
 
@@ -78,3 +78,7 @@ deposit liabilities from those holder-side balances. Deposit split, reserves,
 and liquidity ratios are especially important because they determine whether
 LCR, NSFR and monetary aggregates are measuring an economically meaningful
 opening bank balance sheet.
+
+The old aggregate `Others` banking row has been split into BNP Paribas,
+Millennium, Alior, and residual Other banks so that concentration diagnostics do
+not treat the remaining sector as one large failing-or-surviving bank.

--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -78,7 +78,3 @@ deposit liabilities from those holder-side balances. Deposit split, reserves,
 and liquidity ratios are especially important because they determine whether
 LCR, NSFR and monetary aggregates are measuring an economically meaningful
 opening bank balance sheet.
-
-The old aggregate `Others` banking row has been split into BNP Paribas,
-Millennium, Alior, and residual Other banks so that concentration diagnostics do
-not treat the remaining sector as one large failing-or-surviving bank.

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -1154,7 +1154,7 @@ research hypotheses or calibration targets:
   structural life-cycle model.
 - Firm technology adoption and entry include network, risk, and readiness
   effects, but their coefficients still need systematic sensitivity analysis.
-- Banks are seven named agents with rich balance-sheet rules, but deposit
+- Banks are ten banking-sector rows with rich balance-sheet rules, but deposit
   insurance and depositor decisions are not modeled at the individual account
   contract level.
 - Government, NBP, JST, insurance, NBFI, and rest-of-world sectors are

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -356,11 +356,11 @@ a concrete diagnostic artifact path.
 | `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note bridge: NBP bridge prior maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.reserveReq` | `0.035` | share | Code note bridge: NBP bridge prior | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.lcrMin`, `nsfrMin` | `1.0, 1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
-| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.bfgLevyRate` | `0.0024` | annual rate | Code note bridge: BFG bridge prior | Resolution levy | .monthly in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.bfgDepositGuarantee` | `425370` | PLN/depositor | BFG EUR 100,000 guarantee converted at model-start PLN/EUR 4.2537 | Deposit guarantee threshold | Direct | `BankingConfig` | `EMPIRICAL_TRANSFORMED` |
 | `banking.ccybMax` | `0.025` | multiplier | Code note bridge: KNF bridge prior | Max CCyB | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `banking.osiiBuffers` | `[0.020, 0.010, 0.005, 0.010, 0.015, 0.0025, 0.0025]` | multiplier by bank | KNF O-SII decisions announced November 2025 | O-SII buffers for default bank archetypes | Direct | `BankingConfig`, `Macroprudential` | `EMPIRICAL_TRANSFORMED` |
+| `banking.osiiBuffers` | `[0.020, 0.010, 0.005, 0.010, 0.015, 0.0025, 0.005, 0.0025, 0.000, 0.0025]` | multiplier by bank | KNF O-SII decisions announced November 2025 | O-SII buffers for default bank archetypes | Direct | `BankingConfig`, `Macroprudential` | `EMPIRICAL_TRANSFORMED` |
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01, 0.08, 0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -32,11 +32,11 @@ adaptation in households, firms, banks, and policy institutions.
 Amor Fati is designed to support executable counterfactual analysis of a
 monetary production economy under strict stock-flow consistency. The immediate
 domain is the Polish economy with heterogeneous households, heterogeneous firms,
-seven banking-sector rows, public-sector institutions, financial markets,
+ten banking-sector rows, public-sector institutions, financial markets,
 non-bank financial institutions, insurance, and a rest-of-world sector. The
-banking rows are not seven separate commercial-bank case studies: they consist
-of six named bank archetypes plus an aggregate `Others` bucket for the remaining
-banking sector.
+banking rows are not individual commercial-bank case studies: they consist of
+named bank archetypes plus a residual Other banks row for the remaining banking
+sector.
 
 The model is intended to answer questions of the following kind:
 
@@ -83,7 +83,7 @@ Empirical validation of these patterns is structured in
 | --- | --- | --- | --- |
 | Households | Individual agents | employment/activity status, wage, skill, health penalty, MPC, rent, social neighbors, bank assignment, region, education, contract type, household financial stocks projected from the ledger | `agents/Household.scala` |
 | Firms | Individual agents | sector, technology regime, workers, productivity/capacity, capital stock, inventory, cash/debt/equity projections, digital readiness, network position, bankruptcy state | `agents/Firm.scala` |
-| Banks | Seven banking-sector rows: six named bank archetypes plus `Others` | operational status, capital diagnostics, NPLs, risk buckets, regulatory ratios, per-row rates, resolution state; financial stocks projected from ledger rows | `agents/Banking.scala` |
+| Banks | Ten banking-sector rows: named bank archetypes plus residual Other banks | operational status, capital diagnostics, NPLs, risk buckets, regulatory ratios, per-row rates, resolution state; financial stocks projected from ledger rows | `agents/Banking.scala` |
 | Government | Aggregate institution | spending, tax revenue, debt, fiscal rules, bond issuance, benefits, transfers, capital investment | `engine/markets/FiscalBudget.scala`, `engine/flows/GovBudgetFlows.scala` |
 | NBP | Central bank institution | reference rate, QE policy, FX operations, reserve/standing-facility plumbing, government-bond and foreign-asset stocks | `agents/Nbp.scala`, `engine/flows/BankingFlows.scala` |
 | Social funds | Aggregate public-fund agents | ZUS/FUS, NFZ, PPK, FP, PFRON, FGSP balances and monthly contribution/spending flows | `agents/SocialSecurity.scala`, `agents/EarmarkedFunds.scala` |
@@ -127,8 +127,9 @@ The default scale is:
 - firms: 10,000 default firm agents;
 - households: default total population equals `firmsCount * workersPerFirm`,
   currently 100,000 household agents under default parameters;
-- banks: seven banking-sector rows: PKO BP, Pekao, mBank, ING BSK,
-  Santander, BPS/Coop, and aggregate `Others`;
+- banks: ten banking-sector rows: PKO BP, Pekao, mBank, ING BSK,
+  Santander, BPS/Coop, BNP Paribas, Millennium, Alior, and residual Other
+  banks;
 - production sectors: BPO/SSC, Manufacturing, Retail/Services, Healthcare,
   Public, Agriculture;
 - regions: six NUTS-1 macroregions used for regional labor and housing
@@ -317,11 +318,11 @@ and Monte Carlo seeds. Randomness is not hidden in global mutable state.
 ### Collectives
 
 Some entities are true individual agents: households and firms. The banking
-sector is represented by seven bank rows/archetypes, including one aggregate
-`Others` bucket, which behave as bank decision units but should not be read as
-seven individual commercial banks. Other entities are collective or
-institutional sectors represented at aggregate resolution: government, NBP,
-social funds, insurance, NBFI/funds, quasi-fiscal bodies, and rest of world.
+sector is represented by ten bank rows/archetypes, including one residual Other
+banks row, which behave as bank decision units but should not be read as ten
+individual commercial banks. Other entities are collective or institutional
+sectors represented at aggregate resolution: government, NBP, social funds,
+insurance, NBFI/funds, quasi-fiscal bodies, and rest of world.
 This is intentional: the model allocates agent detail where it is expected to
 affect macro dynamics or distributional outcomes.
 
@@ -350,7 +351,7 @@ surfaces. Detailed mathematical rules are documented in
 | --- | --- | --- | --- | --- |
 | Households | consume, save/draw buffers, pay rent/debt, use consumer credit, enter or recover from financial distress, retrain, change sector, enter personal-insolvency write-off | wage, employment status, bank rates, debt service, deposits, financial-distress state, social-neighbor distress, region, education, sector signals | income, deposits, debt, credit terms, distress persistence, unemployment duration, retraining cost and success probability | skill, health, MPC, education, region, contract type, immigrant status, social network |
 | Firms | produce, hire/fire, price/markup, invest, adopt hybrid/AI technology, borrow, issue equity/bonds, enter or exit | demand pressure, capacity, wages, costs, credit rates, cash, debt, sector, network effects, digital readiness | cash, working capital, labor availability, bank lending, profitability thresholds, technology failure risk | sector, size, technology regime, readiness, productivity, bank relation, network position |
-| Banks | price loans/deposits, approve credit, manage liquidity, absorb losses, provision, resolve failures, participate in interbank and bond markets | deposits, loans, reserves, capital, NPLs, bond yields, regulatory buffers, failed-bank state | CAR, LCR/NSFR inputs, reserve requirement, BFG/bail-in rules, failed-bank exclusion | seven bank rows: six named archetypes plus aggregate `Others`, with row-specific buffers, spreads, capital, and balance sheets |
+| Banks | price loans/deposits, approve credit, manage liquidity, absorb losses, provision, resolve failures, participate in interbank and bond markets | deposits, loans, reserves, capital, NPLs, bond yields, regulatory buffers, failed-bank state | CAR, LCR/NSFR inputs, reserve requirement, BFG/bail-in rules, failed-bank exclusion | ten bank rows: named archetypes plus residual Other banks, with row-specific buffers, spreads, capital, and balance sheets |
 | Government | tax, spend, transfer, invest, issue debt, service debt, respond to fiscal rules | fiscal balance, debt, unemployment, tax bases, bond demand, social fund balances | fiscal-rule severity, debt brake, spending cuts, financing needs | aggregate institution with policy parameters |
 | NBP | set rate channel inputs, provide reserve interest and standing facilities, QE/FX operations | inflation, output, forex, reserves, bond market, interbank state | policy corridor, reserves, QE pace, FX reserve stock | aggregate institution |
 | Funds and insurance | collect contributions/premiums, pay claims/benefits, allocate holdings, issue/absorb quasi-fiscal instruments | payroll, unemployment, bankruptcies, AUM, reserves, bond/equity returns | statutory contribution/spending rules, portfolio shares, reserve/liability constraints | aggregate institution by fund family |
@@ -368,8 +369,8 @@ The initialized state is produced by `WorldInit.initialize`, using
 - builds firm and household populations from `PopulationConfig`, `FirmConfig`,
   `HouseholdConfig`, sector definitions, firm-size distribution, networks, and
   region/education/skill draws;
-- builds seven banking-sector rows and their initial financial-stock DTOs:
-  six named archetypes plus aggregate `Others`;
+- builds ten banking-sector rows and their initial financial-stock DTOs:
+  named archetypes plus residual Other banks;
 - initializes government, NBP, social funds, insurance, NBFI, quasi-fiscal,
   housing, GVC, expectations, immigration, and demographics state;
 - assembles initial `LedgerFinancialState` as the source of truth for

--- a/src/main/scala/com/boombustgroup/amorfati/Main.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/Main.scala
@@ -35,7 +35,7 @@ object Main extends ZIOAppDefault:
        |
        |  SFC-ABM  |  commit: $commit
        |
-       |  N=${rc.nSeeds} seeds  |  PLN (NBP)  |  HH=${p.household.count}  |  BANK=multi (6+Others)
+       |  N=${rc.nSeeds} seeds  |  PLN (NBP)  |  HH=${p.household.count}  |  BANK=multi (10 rows)
        |  $firms firms x 6 sectors x Poland 2026-04-30 x ${p.topology.label} x ${rc.runDurationMonths}m
        |
        |  Apache 2.0 | Copyright 2026 BoomBustGroup | www.boombustgroup.com

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -96,8 +96,7 @@ object Banking:
   // Aggregate balance sheet (sum over all per-bank BankStates)
   // ---------------------------------------------------------------------------
 
-  /** Aggregate banking-sector balance sheet — sum over all seven banking-sector
-    * rows (six named bank archetypes plus aggregate Others).
+  /** Aggregate banking-sector balance sheet — sum over all banking-sector rows.
     *
     * Pure DTO recomputed from bank operational state plus explicit financial
     * stock rows. Read-only snapshot consumed by output columns, SFC identities,
@@ -237,7 +236,7 @@ object Banking:
 
   /** Configuration for a single bank in the multi-bank system. */
   case class Config(
-      id: BankId,                   // unique bank identifier (0–6)
+      id: BankId,                   // unique bank identifier (index into DefaultConfigs)
       name: String,                 // human-readable label (KNF registry)
       initMarketShare: Share,       // deposit-weighted share at t = 0
       initCet1: Share,              // archetype CET1 prior
@@ -337,7 +336,7 @@ object Banking:
   )
 
   // ---------------------------------------------------------------------------
-  // Default configs: six named Polish bank archetypes plus aggregate Others,
+  // Default configs: Poland-facing bank archetypes plus residual Other banks,
   // Poland 2026-04-30 baseline.
   // ---------------------------------------------------------------------------
 
@@ -394,8 +393,32 @@ object Banking:
     ),
     Config(
       BankId(6),
-      "Others",
-      Share.decimal(425, 3),
+      "BNP Paribas",
+      Share.decimal(85, 3),
+      Share.decimal(165, 3),
+      Rate(0),
+      affinity(Share.decimal(15, 2), Share.decimal(20, 2), Share.decimal(20, 2), Share.decimal(15, 2), Share.decimal(15, 2), Share.decimal(15, 2)),
+    ),
+    Config(
+      BankId(7),
+      "Millennium",
+      Share.decimal(70, 3),
+      Share.decimal(160, 3),
+      Rate.decimal(1, 3),
+      affinity(Share.decimal(15, 2), Share.decimal(10, 2), Share.decimal(25, 2), Share.decimal(15, 2), Share.decimal(15, 2), Share.decimal(20, 2)),
+    ),
+    Config(
+      BankId(8),
+      "Alior",
+      Share.decimal(55, 3),
+      Share.decimal(150, 3),
+      Rate.decimal(2, 3),
+      affinity(Share.decimal(15, 2), Share.decimal(15, 2), Share.decimal(25, 2), Share.decimal(10, 2), Share.decimal(10, 2), Share.decimal(25, 2)),
+    ),
+    Config(
+      BankId(9),
+      "Other banks",
+      Share.decimal(215, 3),
       Share.decimal(165, 3),
       Rate.decimal(1, 3),
       affinity(Share.decimal(15, 2), Share.decimal(17, 2), Share.decimal(17, 2), Share.decimal(17, 2), Share.decimal(17, 2), Share.decimal(17, 2)),

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -12,7 +12,7 @@ carry behavioral state, operational diagnostics, and legacy unsupported metrics.
 
 | File | Agent | State | Key SFC identities |
 |------|-------|-------|-------------------|
-| `Banking.scala` | 7 banking-sector rows: 6 named bank archetypes + aggregate `Others` (Poland 2026-04-30 baseline) | Per-row behavior, capital, NPL/risk buckets, LCR/NSFR inputs; deposits, loans, bonds, reserves, interbank positions are ledger projections | BankCapital, BankDeposits, BondClearing, InterbankNetting |
+| `Banking.scala` | 10 banking-sector rows: named bank archetypes plus residual Other banks (Poland 2026-04-30 baseline) | Per-row behavior, capital, NPL/risk buckets, LCR/NSFR inputs; deposits, loans, bonds, reserves, interbank positions are ledger projections | BankCapital, BankDeposits, BondClearing, InterbankNetting |
 | `Firm.scala` | Heterogeneous firms (6 sectors) | Technology state (Traditional/Hybrid/Automated), capital stock, inventory, green capital, labor and production state; cash/debt/equity are ledger projections | BankCapital (NPL), FlowOfFunds, CorpBondStock |
 | `Household.scala` | Individual households | Skill, health, MPC, employment status, housing and demographic state; savings, debt, consumer credit, and equity wealth are ledger projections | BankDeposits, ConsumerCredit |
 | `Immigration.scala` | Immigrant workers | Stock, monthly inflow/outflow, remittance outflow | BankDeposits (remittance → deposit outflow), Nfa |

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -5,13 +5,13 @@ import com.boombustgroup.amorfati.types.*
 /** Commercial banking system: balance sheets, credit risk, LCR/NSFR,
   * macroprudential, and KNF/BFG supervision.
   *
-  * Models a multi-bank system with seven banking-sector rows by default: six
-  * named bank archetypes and one aggregate `Others` bucket for the remaining
-  * sector, calibrated to the Poland 2026-04-30 production baseline. Rows have
-  * heterogeneous balance sheets, credit spreads, NPL dynamics, capital adequacy
-  * (Basel III CRR), liquidity coverage (LCR/NSFR), macroprudential buffers
-  * (CCyB, O-SII), KNF BION/SREP P2R add-ons, BFG resolution levy and bail-in,
-  * and interbank market.
+  * Models a multi-bank system with ten banking-sector rows by default: named
+  * bank archetypes plus a residual `Other banks` bucket, calibrated to the
+  * Poland 2026-04-30 production baseline. Rows have heterogeneous balance
+  * sheets, credit spreads, NPL dynamics, capital adequacy (Basel III CRR),
+  * liquidity coverage (LCR/NSFR), macroprudential buffers (CCyB, O-SII), KNF
+  * BION/SREP P2R add-ons, BFG resolution levy and bail-in, and interbank
+  * market.
   *
   * Stock values (`initCapital`, `initDeposits`, etc.) are in raw PLN — scaled
   * by `gdpRatio` in `SimParams.defaults`.
@@ -56,8 +56,8 @@ import com.boombustgroup.amorfati.types.*
   * @param termDepositFrac
   *   fraction of deposits that are term (stable for NSFR purposes)
   * @param p2rAddons
-  *   per-row BION/SREP P2R capital add-ons (KNF bridge prior, six named bank
-  *   archetypes plus aggregate Others)
+  *   per-row BION/SREP P2R capital add-ons (KNF bridge prior, named bank
+  *   archetypes plus residual Other banks)
   * @param bfgLevyRate
   *   annual BFG resolution fund levy as fraction of deposits (BFG bridge prior)
   * @param bailInDepositHaircut
@@ -153,6 +153,9 @@ case class BankingConfig(
       Multiplier.decimal(20, 3),
       Multiplier.decimal(25, 3),
       Multiplier.decimal(20, 3),
+      Multiplier.decimal(20, 3),
+      Multiplier.decimal(25, 3),
+      Multiplier.decimal(20, 3),
     ),
     bfgLevyRate: Rate = Rate.decimal(24, 4),
     bailInDepositHaircut: Share = Share.decimal(8, 2),
@@ -168,7 +171,10 @@ case class BankingConfig(
       Multiplier.decimal(1, 2),  // ING BSK: 1.00%
       Multiplier.decimal(15, 3), // Santander: 1.50%
       Multiplier.decimal(25, 4), // BPS/Coop: 0.25%
-      Multiplier.decimal(25, 4), // Other O-SII banks aggregated into Others: 0.25%
+      Multiplier.decimal(5, 3),  // BNP Paribas: 0.50%
+      Multiplier.decimal(25, 4), // Millennium: 0.25%
+      Multiplier.Zero,           // Alior: no O-SII buffer in this bridge
+      Multiplier.decimal(25, 4), // residual Other banks: 0.25%
     ),
     concentrationLimit: Share = Share.decimal(25, 2),
     // AFS/HTM bond portfolio split (interest rate risk channel)

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -627,11 +627,11 @@ object CalibrationProvenance:
 | `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note bridge: NBP bridge prior maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.reserveReq` | `0.035` | share | Code note bridge: NBP bridge prior | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.lcrMin`, `nsfrMin` | `1.0`, `1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
-| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.bfgLevyRate` | `0.0024` | annual rate | Code note bridge: BFG bridge prior | Resolution levy | `.monthly` in use | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.bfgDepositGuarantee` | `425370` | PLN/depositor | BFG EUR 100,000 guarantee converted at model-start PLN/EUR 4.2537 | Deposit guarantee threshold | Direct | `BankingConfig` | `EMPIRICAL_TRANSFORMED` |
 | `banking.ccybMax` | `0.025` | multiplier | Code note bridge: KNF bridge prior | Max CCyB | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `banking.osiiBuffers` | `[0.020, 0.010, 0.005, 0.010, 0.015, 0.0025, 0.0025]` | multiplier by bank | KNF O-SII decisions announced November 2025 | O-SII buffers for default bank archetypes | Direct | `BankingConfig`, `Macroprudential` | `EMPIRICAL_TRANSFORMED` |
+| `banking.osiiBuffers` | `[0.020, 0.010, 0.005, 0.010, 0.015, 0.0025, 0.005, 0.0025, 0.000, 0.0025]` | multiplier by bank | KNF O-SII decisions announced November 2025 | O-SII buffers for default bank archetypes | Direct | `BankingConfig`, `Macroprudential` | `EMPIRICAL_TRANSFORMED` |
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -404,7 +404,7 @@ object BankBalanceSheetBenchmarkExport:
       lower = Some(BigDecimal("0.00")),
       upper = Some(BigDecimal("0.20")),
       sourceNote = "Herfindahl-Hirschman index over opening bank credit shares.",
-      interpretation = "A compact concentration diagnostic for the seven-row banking sector.",
+      interpretation = "A compact concentration diagnostic for the default banking-sector rows.",
     ),
   )
 

--- a/src/test/scala/com/boombustgroup/amorfati/Generators.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/Generators.scala
@@ -11,8 +11,9 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 
 object Generators:
 
-  given SimParams          = SimParams.defaults
-  private val p: SimParams = summon[SimParams]
+  given SimParams              = SimParams.defaults
+  private val p: SimParams     = summon[SimParams]
+  private val DefaultBankIdMax = Banking.DefaultConfigs.length - 1
 
   /** Test helper: create banking sector by splitting aggregates across banks by
     * market share.
@@ -221,7 +222,7 @@ object Generators:
     innov  <- genDecimal("0.5", "2.0")
     digiR  <- genDecimal("0.02", "0.98")
     sector <- Gen.choose(0, 5)
-    bankId <- Gen.choose(0, 6)
+    bankId <- Gen.choose(0, DefaultBankIdMax)
     eqR    <- genDecimal("0.0", "1000000.0")
     iSize  <- Gen.choose(1, 500)
   yield TestFirmState(
@@ -253,7 +254,7 @@ object Generators:
     innov  <- genDecimal("0.5", "2.0")
     digiR  <- genDecimal("0.02", "0.98")
     sector <- Gen.choose(0, 5)
-    bankId <- Gen.choose(0, 6)
+    bankId <- Gen.choose(0, DefaultBankIdMax)
     eqR    <- genDecimal("0.0", "1000000.0")
     iSize  <- Gen.choose(1, 500)
   yield TestFirmState(
@@ -382,7 +383,7 @@ object Generators:
     health  <- genDecimal("0.0", "0.5")
     mpc     <- genDecimal("0.5", "0.98")
     status  <- genHhStatus
-    bankId  <- Gen.choose(0, 6)
+    bankId  <- Gen.choose(0, DefaultBankIdMax)
     eqW     <- genDecimal("0.0", "100000.0")
     lastSec <- Gen.choose(-1, 5)
   yield TestHouseholdState(
@@ -703,7 +704,7 @@ object Generators:
     )
 
     val Config: Gen[Banking.Config] = for
-      id     <- Gen.choose(0, 6)
+      id     <- Gen.choose(0, DefaultBankIdMax)
       share  <- genDecimal("0.01", "0.50")
       cet1   <- genDecimal("0.10", "0.25")
       spread <- genDecimal("-0.005", "0.005")
@@ -711,7 +712,7 @@ object Generators:
     yield Banking.Config(BankId(id), s"Bank$id", shareBD(share), shareBD(cet1), rateBD(spread), aff.map(shareBD(_)))
 
     val BankRow: Gen[(Banking.BankState, Banking.BankFinancialStocks)] = for
-      id       <- Gen.choose(0, 6)
+      id       <- Gen.choose(0, DefaultBankIdMax)
       deposits <- genDecimal("1000000.0", "10000000000.0")
       loans    <- genDecimal("0.0", "10000000000.0")
       capital  <- genDecimal("100000.0", "1000000000.0")

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -73,10 +73,16 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
   private def govBonds(stocks: Banking.BankFinancialStocks): PLN =
     Banking.govBondHoldings(stocks)
 
-  "Generators.testBankingSector" should "create 7 bank rows with explicit financial stocks preserving totals" in {
+  "Banking.DefaultConfigs" should "split opening credit concentration across default rows" in {
+    configs.map(_.id.toInt) shouldBe configs.indices.toVector
+    configs.map(_.initMarketShare).sumShare shouldBe Share.One
+    configs.map(_.initMarketShare).max should be <= summon[SimParams].banking.concentrationLimit
+  }
+
+  "Generators.testBankingSector" should "create default bank rows with explicit financial stocks preserving totals" in {
     val bs = Generators.testBankingSector(totalDeposits = PLN(1000000), totalCapital = PLN(100000), totalLoans = PLN.Zero, configs = configs)
 
-    bs.banks.length shouldBe 7
+    bs.banks.length shouldBe configs.length
     bs.financialStocks.map(s => decimal(s.totalDeposits)).sum shouldBe BigDecimal("1000000.0") +- BigDecimal("0.01")
     bs.banks.map(b => decimal(b.capital)).sum shouldBe BigDecimal("100000.0") +- BigDecimal("0.01")
     decimal(bs.financialStocks(0).totalDeposits) shouldBe (BigDecimal("1000000.0") * BigDecimal("0.175")) +- BigDecimal("0.01")
@@ -89,7 +95,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     for _ <- 0 until 100 do
       val bId = Banking.assignBank(SectorIdx(0), configs, rng)
       bId.toInt should be >= 0
-      bId.toInt should be < 7
+      bId.toInt should be < configs.length
   }
 
   it should "favor BPS/Coop for agriculture firms" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -61,7 +61,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
     rows.map(_.stocks)
 
   "KNF banking params" should "expose calibrated P2R, BFG levy, bail-in, and guarantee defaults" in {
-    p.banking.p2rAddons.length shouldBe 7
+    p.banking.p2rAddons.length shouldBe Banking.DefaultConfigs.length
     p.banking.p2rAddons(0) shouldBe Multiplier.decimal(15, 3)
     p.banking.p2rAddons(2) shouldBe Multiplier.decimal(30, 3)
     p.banking.bfgLevyRate shouldBe Rate.decimal(24, 4)
@@ -72,7 +72,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
   "Macroprudential P2R" should "return per-bank add-ons and affect effective minimum CAR" in {
     Macroprudential.p2rAddon(0) shouldBe Multiplier.decimal(15, 3)
     Macroprudential.p2rAddon(2) shouldBe Multiplier.decimal(30, 3)
-    Macroprudential.p2rAddon(7) shouldBe p.banking.p2rAddons.last
+    Macroprudential.p2rAddon(p.banking.p2rAddons.length) shouldBe p.banking.p2rAddons.last
 
     val ccyb        = Multiplier.decimal(1, 2)
     val expectedPko = decimal(p.banking.minCar) + decimal(ccyb) + decimal(p.banking.osiiBuffers(0)) + decimal(p.banking.p2rAddons(0))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MacroprudentialPropertySpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MacroprudentialPropertySpec.scala
@@ -13,6 +13,7 @@ class MacroprudentialPropertySpec extends AnyFlatSpec with Matchers with ScalaCh
   import com.boombustgroup.amorfati.config.SimParams
   given SimParams                                                         = SimParams.defaults
   private val p: SimParams                                                = summon[SimParams]
+  private val maxBankIndex                                                = p.banking.p2rAddons.length - 1
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 200)
 
@@ -31,13 +32,13 @@ class MacroprudentialPropertySpec extends AnyFlatSpec with Matchers with ScalaCh
     }
 
   "effectiveMinCarImpl" should "be >= base MinCar for all banks" in
-    forAll(Gen.choose(0, 6), genDecimal("0.0", "0.025")) { (bankId, ccyb) =>
+    forAll(Gen.choose(0, maxBankIndex), genDecimal("0.0", "0.025")) { (bankId, ccyb) =>
       val eff = Macroprudential.effectiveMinCarImpl(bankId, multiplierBD(ccyb))
       eff should be >= p.banking.minCar
     }
 
   it should "be monotonically increasing in CCyB" in
-    forAll(Gen.choose(0, 6), genDecimal("0.0", "0.01"), genDecimal("0.005", "0.025")) { (bankId, ccyb1, delta) =>
+    forAll(Gen.choose(0, maxBankIndex), genDecimal("0.0", "0.01"), genDecimal("0.005", "0.025")) { (bankId, ccyb1, delta) =>
       val ccyb2 = ccyb1 + delta
       val eff1  = Macroprudential.effectiveMinCarImpl(bankId, multiplierBD(ccyb1))
       val eff2  = Macroprudential.effectiveMinCarImpl(bankId, multiplierBD(ccyb2))


### PR DESCRIPTION
## Summary
- split the old aggregate Others banking row into BNP Paribas, Millennium, Alior, and residual Other banks
- align P2R/O-SII arrays, generators, tests, and docs with the 10-row banking-sector representation
- keep aggregate banking totals unchanged while reducing opening single-row credit concentration

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.engine.MacroprudentialPropertySpec com.boombustgroup.amorfati.config.CalibrationRegisterRendererSpec com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec"
- sbt "bankBalanceSheetBenchmark --seed-start 1 --seeds 10 --out target/bank-balance-sheet-benchmark --run-id check570"
- sbt assembly

Benchmark check570:
- LargestBankCreditShare mean=0.206831, min=0.184872, max=0.232562, PASS
- BankCreditHhi mean=0.127864, min=0.119599, max=0.138066, INFO

Closes #570