### PR TITLE
Add bank failure ablation diagnostics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val empiricalValidation = inputKey[Unit]("Generate empirical validation bas
 lazy val calibrationRegister = inputKey[Unit]("Generate calibration register docs from typed provenance registry")
 lazy val householdCreditStressCalibration = inputKey[Unit]("Generate household liquidity and credit-stress calibration artifacts")
 lazy val bankBalanceSheetBenchmark = inputKey[Unit]("Generate initial bank balance-sheet benchmark artifacts")
+lazy val bankFailureAblations = inputKey[Unit]("Run controlled bank-failure ablation diagnostics")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -104,6 +105,13 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<bank balance-sheet benchmark args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    bankFailureAblations := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<bank failure ablation args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.BankFailureAblationExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/bank-failure-ablations.md
+++ b/docs/bank-failure-ablations.md
@@ -1,0 +1,42 @@
+# Bank Failure Ablation Diagnostics
+
+Issue #560 adds a repeatable diagnostic layer for banking-sector failure root
+cause analysis. The export does not change production behavior. It runs the
+baseline and targeted neutralization scenarios, then compares first failure
+timing, terminal failures, cumulative credit losses, ECL provisions, bail-in
+losses, capital destruction, and reconciliation residuals.
+
+Run the standard review fixture with:
+
+```bash
+sbt "bankFailureAblations --seeds 2 --months 24 --out target/bank-failure-ablations --run-id bank-failure-ablations"
+```
+
+The task writes:
+
+- `bank-failure-ablation-seeds.csv`: one row per scenario and seed.
+- `bank-failure-ablation-summary.csv`: mean/min/max style scenario summary.
+- `bank-failure-ablation-scenarios.csv`: scenario definitions and economic
+  interpretation.
+- `bank-failure-ablation-report.md`: human-readable summary.
+
+Use larger `--seeds` and `--months` values for slower research runs. The
+standard review fixture is intentionally smaller because each scenario runs a
+full model simulation.
+
+## Scenario Semantics
+
+- `baseline`: current production configuration after the opening bank
+  calibration fixes.
+- `no-ecl-stress-migration`: keeps realized defaults, but removes
+  macro-driven Stage 1 to Stage 2 ECL migration.
+- `no-realized-credit-loss-capital-hit`: sets firm, mortgage, consumer-credit,
+  and corporate-bond recoveries to 100%, while leaving ECL provisioning active.
+- `no-resolution-feedback`: neutralizes bail-in haircuts, failure-panic
+  switching, CAR-driven deposit flight, and interbank contagion losses.
+- `initial-capital-150pct`: raises opening regulatory capital by 50%.
+
+These scenarios are diagnostics, not candidate policy settings. A scenario that
+materially delays or prevents failures identifies a channel that needs deeper
+economic or accounting work before all-failed bank resolution semantics are
+changed.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -366,6 +366,19 @@ output directory is
 semantics and Poland-relevant guardrail bands are documented in
 [bank-balance-sheet-benchmark.md](bank-balance-sheet-benchmark.md).
 
+Bank failure ablation diagnostics:
+
+```bash
+sbt "bankFailureAblations --seeds 2 --months 24 --out target/bank-failure-ablations --run-id bank-failure-ablations"
+```
+
+This writes baseline-versus-ablation seed rows, scenario definitions, and a
+summary report under `<out>/<run-id>/`. With the command above, the concrete
+output directory is `target/bank-failure-ablations/bank-failure-ablations/`.
+The semantics and scenario set are documented in
+[bank-failure-ablations.md](bank-failure-ablations.md). Use larger
+`--seeds`/`--months` values for heavier research runs.
+
 For scratch and committed-snapshot SFC matrix exports, see
 [sfc-matrix-evidence.md](sfc-matrix-evidence.md).
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankFailureAblationScenarios.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankFailureAblationScenarios.scala
@@ -1,0 +1,72 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Diagnostic-only SimParams variants for bank-failure root-cause ablations.
+  *
+  * The variants live in `config` because `SimParams.copy` is intentionally
+  * package-scoped. They are not production scenarios.
+  */
+object BankFailureAblationScenarios:
+
+  final case class Spec(
+      id: String,
+      label: String,
+      interpretation: String,
+      params: SimParams,
+  )
+
+  private val Baseline = SimParams.defaults
+
+  val all: Vector[Spec] = Vector(
+    Spec(
+      id = "baseline",
+      label = "Baseline",
+      interpretation = "Current production configuration after the opening bank calibration fixes.",
+      params = Baseline,
+    ),
+    Spec(
+      id = "no-ecl-stress-migration",
+      label = "No ECL stress migration",
+      interpretation = "Keeps realized defaults, but removes macro-driven Stage 1 to Stage 2 ECL migration.",
+      params = Baseline.copy(
+        banking = Baseline.banking.copy(
+          eclMigrationSensitivity = Coefficient.Zero,
+          eclGdpSensitivity = Coefficient.Zero,
+          eclMaxMigration = Share.Zero,
+        ),
+      ),
+    ),
+    Spec(
+      id = "no-realized-credit-loss-capital-hit",
+      label = "No realized credit-loss capital hit",
+      interpretation = "Sets firm, mortgage, consumer-credit, and corporate-bond recoveries to 100%, while leaving ECL provisioning active.",
+      params = Baseline.copy(
+        banking = Baseline.banking.copy(loanRecovery = Share.One),
+        household = Baseline.household.copy(ccNplRecovery = Share.One),
+        housing = Baseline.housing.copy(mortgageRecovery = Share.One),
+        corpBond = Baseline.corpBond.copy(recovery = Share.One),
+      ),
+    ),
+    Spec(
+      id = "no-resolution-feedback",
+      label = "No resolution feedback",
+      interpretation = "Neutralizes bail-in haircuts, failure-panic switching, CAR-driven deposit flight, and interbank contagion losses.",
+      params = Baseline.copy(
+        banking = Baseline.banking.copy(
+          bailInDepositHaircut = Share.Zero,
+          depositPanicRate = Share.Zero,
+          depositFlightSensitivity = Coefficient.Zero,
+          interbankRecoveryRate = Share.One,
+        ),
+      ),
+    ),
+    Spec(
+      id = "initial-capital-150pct",
+      label = "Initial bank capital 150%",
+      interpretation = "Raises opening regulatory capital by 50% to test whether failures are mostly a capital-buffer calibration problem.",
+      params = Baseline.copy(
+        banking = Baseline.banking.copy(initCapital = Baseline.banking.initCapital * Multiplier.decimal(150, 2)),
+      ),
+    ),
+  )

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankFailureAblationExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankFailureAblationExport.scala
@@ -1,0 +1,501 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.config.{BankFailureAblationScenarios, SimParams}
+import com.boombustgroup.amorfati.montecarlo.McRunner
+import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema
+import com.boombustgroup.amorfati.montecarlo.MetricValue
+import com.boombustgroup.amorfati.montecarlo.MetricValue.*
+import com.boombustgroup.amorfati.montecarlo.RunResult
+import com.boombustgroup.amorfati.montecarlo.TimeSeries.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.math.BigDecimal.RoundingMode
+import scala.util.Try
+
+/** Controlled diagnostic ablations for #560.
+  *
+  * These scenarios are not production policies. They neutralize one channel at
+  * a time so the resulting failure timing can identify which mechanism is doing
+  * the work.
+  */
+object BankFailureAblationExport:
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 5,
+      months: Int = 60,
+      runId: String = "bank-failure-ablations",
+      out: Path = Path.of("target/bank-failure-ablations"),
+  ):
+    def seedRange: Vector[Long] = Vector.tabulate(seeds)(i => seedStart + i.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  final case class SeedResult(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      seed: Long,
+      months: Int,
+      firstFailureMonth: Option[Int],
+      firstFailureReasonCode: Int,
+      firstFailureBankId: Int,
+      terminalFailures: Int,
+      peakFailures: Int,
+      cumulativeNewFailures: BigDecimal,
+      cumulativeRealizedCreditLoss: BigDecimal,
+      cumulativeEclProvisionChange: BigDecimal,
+      cumulativeBailInLoss: BigDecimal,
+      cumulativeCapitalDestruction: BigDecimal,
+      cumulativeReconciliationResidualAbs: BigDecimal,
+      firstFailureRealizedCreditLoss: BigDecimal,
+      firstFailureEclProvisionChange: BigDecimal,
+      firstFailureConsumerNplLoss: BigDecimal,
+      firstFailureFirmNplLoss: BigDecimal,
+      firstFailureMortgageNplLoss: BigDecimal,
+      firstFailureCorpBondDefaultLoss: BigDecimal,
+      firstFailureReconciliationResidual: BigDecimal,
+      firstFailureDepositBailInLoss: BigDecimal,
+      terminalTotalCreditToGdp: BigDecimal,
+      terminalUnemployment: BigDecimal,
+      terminalInflation: BigDecimal,
+      interpretation: String,
+  )
+
+  final case class SummaryResult(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      seeds: Int,
+      months: Int,
+      failedSeeds: Int,
+      firstFailureMonthMean: Option[BigDecimal],
+      firstFailureMonthMin: Option[Int],
+      firstFailureMonthMax: Option[Int],
+      terminalFailuresMean: BigDecimal,
+      peakFailuresMean: BigDecimal,
+      cumulativeNewFailuresMean: BigDecimal,
+      cumulativeRealizedCreditLossMean: BigDecimal,
+      cumulativeEclProvisionChangeMean: BigDecimal,
+      cumulativeBailInLossMean: BigDecimal,
+      cumulativeCapitalDestructionMean: BigDecimal,
+      cumulativeReconciliationResidualAbsMean: BigDecimal,
+      firstFailureRealizedCreditLossMean: BigDecimal,
+      firstFailureEclProvisionChangeMean: BigDecimal,
+      firstFailureConsumerNplLossMean: BigDecimal,
+      firstFailureFirmNplLossMean: BigDecimal,
+      firstFailureMortgageNplLossMean: BigDecimal,
+      firstFailureCorpBondDefaultLossMean: BigDecimal,
+      terminalTotalCreditToGdpMean: BigDecimal,
+      terminalUnemploymentMean: BigDecimal,
+      terminalInflationMean: BigDecimal,
+      interpretation: String,
+  )
+
+  final case class ExportResult(paths: Vector[Path], seedResults: Vector[SeedResult], summary: Vector[SummaryResult])
+
+  private val RequiredColumns: Set[String] = Set(
+    "Month",
+    "Inflation",
+    "Unemployment",
+    "TotalCreditToGdp",
+    "BankFailures",
+    "BankFailure_FirstNewReasonCode",
+    "BankFailure_FirstNewBankId",
+    "BankCapital_NewFailures",
+    "BankCapital_RealizedCreditLoss",
+    "BankCapital_FirmNplLoss",
+    "BankCapital_MortgageNplLoss",
+    "BankCapital_ConsumerNplLoss",
+    "BankCapital_CorpBondDefaultLoss",
+    "BankCapital_EclProvisionChange",
+    "BankCapital_CapitalDestruction",
+    "BankCapital_ReconciliationResidual",
+    "BankCapital_DepositBailInLoss",
+  )
+
+  private val ColumnIndex: Map[String, Int] =
+    McTimeseriesSchema.colNames.zipWithIndex.toMap
+
+  private[diagnostics] val Scenarios: Vector[BankFailureAblationScenarios.Spec] =
+    BankFailureAblationScenarios.all
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      val attempts =
+        for
+          scenario <- Scenarios
+          seed     <- validConfig.seedRange
+        yield
+          given SimParams = scenario.params
+          Try(McRunner.runSingle(seed, validConfig.months)).toEither.left
+            .map(ex => s"Scenario ${scenario.id} seed $seed crashed: ${ex.getMessage}")
+            .flatMap:
+              _.left
+                .map(err => s"Scenario ${scenario.id} seed $seed failed: $err")
+                .map(result => computeSeedResult(validConfig, scenario, seed, result))
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val seedResults = attempts.collect { case Right(row) => row }
+          val summary     = summarize(validConfig, seedResults)
+          val paths       = writeArtifacts(validConfig, seedResults, summary)
+          Right(ExportResult(paths, seedResults, summary))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                       => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")    => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start" =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"      =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"     =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--run-id"     =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"        =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                  => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private[diagnostics] def validate(config: Config): Either[String, Config] =
+    val missing = RequiredColumns.diff(ColumnIndex.keySet)
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+      .flatMap(valid => Either.cond(missing.isEmpty, valid, s"Missing Monte Carlo columns: ${missing.toVector.sorted.mkString(", ")}"))
+
+  private[diagnostics] def computeSeedResult(config: Config, scenario: BankFailureAblationScenarios.Spec, seed: Long, result: RunResult): SeedResult =
+    val rows            = result.timeSeries.map(identity)
+    val firstFailureRow = rows.find(row => col(row, "BankCapital_NewFailures") > BigDecimal(0))
+    val terminalRow     = rows.lastOption.getOrElse(throw new IllegalArgumentException("Bank-failure ablation run produced no rows"))
+
+    SeedResult(
+      runId = config.runId,
+      scenarioId = scenario.id,
+      scenarioLabel = scenario.label,
+      seed = seed,
+      months = config.months,
+      firstFailureMonth = firstFailureRow.map(row => colInt(row, "Month")),
+      firstFailureReasonCode = firstFailureRow.map(row => colInt(row, "BankFailure_FirstNewReasonCode")).getOrElse(0),
+      firstFailureBankId = firstFailureRow.map(row => colInt(row, "BankFailure_FirstNewBankId")).getOrElse(-1),
+      terminalFailures = colInt(terminalRow, "BankFailures"),
+      peakFailures = rows.map(row => colInt(row, "BankFailures")).maxOption.getOrElse(0),
+      cumulativeNewFailures = cumulative(rows, "BankCapital_NewFailures"),
+      cumulativeRealizedCreditLoss = cumulative(rows, "BankCapital_RealizedCreditLoss"),
+      cumulativeEclProvisionChange = cumulative(rows, "BankCapital_EclProvisionChange"),
+      cumulativeBailInLoss = cumulative(rows, "BankCapital_DepositBailInLoss"),
+      cumulativeCapitalDestruction = cumulative(rows, "BankCapital_CapitalDestruction"),
+      cumulativeReconciliationResidualAbs = rows.map(row => col(row, "BankCapital_ReconciliationResidual").abs).sum,
+      firstFailureRealizedCreditLoss = firstFailureRow.map(row => col(row, "BankCapital_RealizedCreditLoss")).getOrElse(BigDecimal(0)),
+      firstFailureEclProvisionChange = firstFailureRow.map(row => col(row, "BankCapital_EclProvisionChange")).getOrElse(BigDecimal(0)),
+      firstFailureConsumerNplLoss = firstFailureRow.map(row => col(row, "BankCapital_ConsumerNplLoss")).getOrElse(BigDecimal(0)),
+      firstFailureFirmNplLoss = firstFailureRow.map(row => col(row, "BankCapital_FirmNplLoss")).getOrElse(BigDecimal(0)),
+      firstFailureMortgageNplLoss = firstFailureRow.map(row => col(row, "BankCapital_MortgageNplLoss")).getOrElse(BigDecimal(0)),
+      firstFailureCorpBondDefaultLoss = firstFailureRow.map(row => col(row, "BankCapital_CorpBondDefaultLoss")).getOrElse(BigDecimal(0)),
+      firstFailureReconciliationResidual = firstFailureRow.map(row => col(row, "BankCapital_ReconciliationResidual")).getOrElse(BigDecimal(0)),
+      firstFailureDepositBailInLoss = firstFailureRow.map(row => col(row, "BankCapital_DepositBailInLoss")).getOrElse(BigDecimal(0)),
+      terminalTotalCreditToGdp = col(terminalRow, "TotalCreditToGdp"),
+      terminalUnemployment = col(terminalRow, "Unemployment"),
+      terminalInflation = col(terminalRow, "Inflation"),
+      interpretation = scenario.interpretation,
+    )
+
+  private[diagnostics] def summarize(config: Config, rows: Vector[SeedResult]): Vector[SummaryResult] =
+    Scenarios.map: scenario =>
+      val scenarioRows  = rows.filter(_.scenarioId == scenario.id)
+      val failureMonths = scenarioRows.flatMap(_.firstFailureMonth)
+      SummaryResult(
+        runId = config.runId,
+        scenarioId = scenario.id,
+        scenarioLabel = scenario.label,
+        seeds = scenarioRows.length,
+        months = config.months,
+        failedSeeds = failureMonths.length,
+        firstFailureMonthMean = meanOption(failureMonths.map(month => BigDecimal(month))),
+        firstFailureMonthMin = failureMonths.minOption,
+        firstFailureMonthMax = failureMonths.maxOption,
+        terminalFailuresMean = mean(scenarioRows.map(row => BigDecimal(row.terminalFailures))),
+        peakFailuresMean = mean(scenarioRows.map(row => BigDecimal(row.peakFailures))),
+        cumulativeNewFailuresMean = mean(scenarioRows.map(_.cumulativeNewFailures)),
+        cumulativeRealizedCreditLossMean = mean(scenarioRows.map(_.cumulativeRealizedCreditLoss)),
+        cumulativeEclProvisionChangeMean = mean(scenarioRows.map(_.cumulativeEclProvisionChange)),
+        cumulativeBailInLossMean = mean(scenarioRows.map(_.cumulativeBailInLoss)),
+        cumulativeCapitalDestructionMean = mean(scenarioRows.map(_.cumulativeCapitalDestruction)),
+        cumulativeReconciliationResidualAbsMean = mean(scenarioRows.map(_.cumulativeReconciliationResidualAbs)),
+        firstFailureRealizedCreditLossMean = meanFailedOnly(scenarioRows)(_.firstFailureRealizedCreditLoss),
+        firstFailureEclProvisionChangeMean = meanFailedOnly(scenarioRows)(_.firstFailureEclProvisionChange),
+        firstFailureConsumerNplLossMean = meanFailedOnly(scenarioRows)(_.firstFailureConsumerNplLoss),
+        firstFailureFirmNplLossMean = meanFailedOnly(scenarioRows)(_.firstFailureFirmNplLoss),
+        firstFailureMortgageNplLossMean = meanFailedOnly(scenarioRows)(_.firstFailureMortgageNplLoss),
+        firstFailureCorpBondDefaultLossMean = meanFailedOnly(scenarioRows)(_.firstFailureCorpBondDefaultLoss),
+        terminalTotalCreditToGdpMean = mean(scenarioRows.map(_.terminalTotalCreditToGdp)),
+        terminalUnemploymentMean = mean(scenarioRows.map(_.terminalUnemployment)),
+        terminalInflationMean = mean(scenarioRows.map(_.terminalInflation)),
+        interpretation = scenario.interpretation,
+      )
+
+  private def writeArtifacts(config: Config, seedResults: Vector[SeedResult], summary: Vector[SummaryResult]): Vector[Path] =
+    Files.createDirectories(config.runRoot)
+    val seedPath     = config.runRoot.resolve("bank-failure-ablation-seeds.csv")
+    val summaryPath  = config.runRoot.resolve("bank-failure-ablation-summary.csv")
+    val scenarioPath = config.runRoot.resolve("bank-failure-ablation-scenarios.csv")
+    val reportPath   = config.runRoot.resolve("bank-failure-ablation-report.md")
+    Files.writeString(seedPath, renderSeedCsv(seedResults), StandardCharsets.UTF_8)
+    Files.writeString(summaryPath, renderSummaryCsv(summary), StandardCharsets.UTF_8)
+    Files.writeString(scenarioPath, renderScenarioCsv(Scenarios), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, summary), StandardCharsets.UTF_8)
+    Vector(seedPath, summaryPath, scenarioPath, reportPath)
+
+  private[diagnostics] def renderSeedCsv(rows: Vector[SeedResult]): String =
+    val header =
+      "RunId;ScenarioId;ScenarioLabel;Seed;Months;FirstFailureMonth;FirstFailureReasonCode;FirstFailureBankId;TerminalFailures;PeakFailures;CumulativeNewFailures;CumulativeRealizedCreditLoss;CumulativeEclProvisionChange;CumulativeBailInLoss;CumulativeCapitalDestruction;CumulativeReconciliationResidualAbs;FirstFailureRealizedCreditLoss;FirstFailureEclProvisionChange;FirstFailureConsumerNplLoss;FirstFailureFirmNplLoss;FirstFailureMortgageNplLoss;FirstFailureCorpBondDefaultLoss;FirstFailureReconciliationResidual;FirstFailureDepositBailInLoss;TerminalTotalCreditToGdp;TerminalUnemployment;TerminalInflation;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.scenarioId,
+        row.scenarioLabel,
+        row.seed.toString,
+        row.months.toString,
+        row.firstFailureMonth.map(_.toString).getOrElse(""),
+        row.firstFailureReasonCode.toString,
+        row.firstFailureBankId.toString,
+        row.terminalFailures.toString,
+        row.peakFailures.toString,
+        renderDecimal(row.cumulativeNewFailures),
+        renderDecimal(row.cumulativeRealizedCreditLoss),
+        renderDecimal(row.cumulativeEclProvisionChange),
+        renderDecimal(row.cumulativeBailInLoss),
+        renderDecimal(row.cumulativeCapitalDestruction),
+        renderDecimal(row.cumulativeReconciliationResidualAbs),
+        renderDecimal(row.firstFailureRealizedCreditLoss),
+        renderDecimal(row.firstFailureEclProvisionChange),
+        renderDecimal(row.firstFailureConsumerNplLoss),
+        renderDecimal(row.firstFailureFirmNplLoss),
+        renderDecimal(row.firstFailureMortgageNplLoss),
+        renderDecimal(row.firstFailureCorpBondDefaultLoss),
+        renderDecimal(row.firstFailureReconciliationResidual),
+        renderDecimal(row.firstFailureDepositBailInLoss),
+        renderDecimal(row.terminalTotalCreditToGdp),
+        renderDecimal(row.terminalUnemployment),
+        renderDecimal(row.terminalInflation),
+        row.interpretation,
+      ).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderSummaryCsv(rows: Vector[SummaryResult]): String =
+    val header =
+      "RunId;ScenarioId;ScenarioLabel;Seeds;Months;FailedSeeds;FirstFailureMonthMean;FirstFailureMonthMin;FirstFailureMonthMax;TerminalFailuresMean;PeakFailuresMean;CumulativeNewFailuresMean;CumulativeRealizedCreditLossMean;CumulativeEclProvisionChangeMean;CumulativeBailInLossMean;CumulativeCapitalDestructionMean;CumulativeReconciliationResidualAbsMean;FirstFailureRealizedCreditLossMean;FirstFailureEclProvisionChangeMean;FirstFailureConsumerNplLossMean;FirstFailureFirmNplLossMean;FirstFailureMortgageNplLossMean;FirstFailureCorpBondDefaultLossMean;TerminalTotalCreditToGdpMean;TerminalUnemploymentMean;TerminalInflationMean;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.scenarioId,
+        row.scenarioLabel,
+        row.seeds.toString,
+        row.months.toString,
+        row.failedSeeds.toString,
+        row.firstFailureMonthMean.map(renderDecimal).getOrElse(""),
+        row.firstFailureMonthMin.map(_.toString).getOrElse(""),
+        row.firstFailureMonthMax.map(_.toString).getOrElse(""),
+        renderDecimal(row.terminalFailuresMean),
+        renderDecimal(row.peakFailuresMean),
+        renderDecimal(row.cumulativeNewFailuresMean),
+        renderDecimal(row.cumulativeRealizedCreditLossMean),
+        renderDecimal(row.cumulativeEclProvisionChangeMean),
+        renderDecimal(row.cumulativeBailInLossMean),
+        renderDecimal(row.cumulativeCapitalDestructionMean),
+        renderDecimal(row.cumulativeReconciliationResidualAbsMean),
+        renderDecimal(row.firstFailureRealizedCreditLossMean),
+        renderDecimal(row.firstFailureEclProvisionChangeMean),
+        renderDecimal(row.firstFailureConsumerNplLossMean),
+        renderDecimal(row.firstFailureFirmNplLossMean),
+        renderDecimal(row.firstFailureMortgageNplLossMean),
+        renderDecimal(row.firstFailureCorpBondDefaultLossMean),
+        renderDecimal(row.terminalTotalCreditToGdpMean),
+        renderDecimal(row.terminalUnemploymentMean),
+        renderDecimal(row.terminalInflationMean),
+        row.interpretation,
+      ).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderScenarioCsv(scenarios: Vector[BankFailureAblationScenarios.Spec]): String =
+    val header = "ScenarioId;ScenarioLabel;Interpretation"
+    val body   = scenarios.map: scenario =>
+      Vector(scenario.id, scenario.label, scenario.interpretation).map(csv).mkString(";")
+    (header +: body).mkString("\n") + "\n"
+
+  private[diagnostics] def renderReport(config: Config, summary: Vector[SummaryResult]): String =
+    val command        =
+      s"""sbt "bankFailureAblations --seed-start ${config.seedStart} --seeds ${config.seeds} --months ${config.months} --out ${config.out} --run-id ${config.runId}""""
+    val rows           = summary.map: row =>
+      markdownRow(
+        Vector(
+          row.scenarioId,
+          row.failedSeeds.toString,
+          row.firstFailureMonthMean.map(renderDecimal).getOrElse("n/a"),
+          renderDecimal(row.terminalFailuresMean),
+          renderDecimal(row.cumulativeRealizedCreditLossMean),
+          renderDecimal(row.cumulativeEclProvisionChangeMean),
+          renderDecimal(row.cumulativeBailInLossMean),
+          renderDecimal(row.cumulativeReconciliationResidualAbsMean),
+        ),
+      )
+    val comparisonRows = baselineComparisonRows(summary)
+    val lines          = Vector(
+      "# Bank Failure Ablation Diagnostics",
+      "",
+      "Generated by `BankFailureAblationExport` for issue #560.",
+      "",
+      s"- Run id: `${config.runId}`",
+      s"- Seeds: `${config.seeds}` from `${config.seedStart}`",
+      s"- Months: `${config.months}`",
+      s"- Repeat command: `$command`",
+      "",
+      "These scenarios are diagnostic probes, not production policy settings.",
+      "They neutralize one channel at a time so failure timing can be compared with the baseline.",
+      "",
+      "## Scenarios",
+      "",
+    ) ++ Scenarios.flatMap(scenario => Vector(s"- `${scenario.id}`: ${scenario.interpretation}")) ++ Vector(
+      "",
+      "## Summary",
+      "",
+      markdownRow(
+        Vector(
+          "Scenario",
+          "Failed Seeds",
+          "Mean First Failure Month",
+          "Mean Terminal Failures",
+          "Mean Cum Realized Loss",
+          "Mean Cum ECL",
+          "Mean Cum Bail-In",
+          "Mean Abs Reconciliation Residual",
+        ),
+      ),
+      markdownRow(Vector("---", "---", "---", "---", "---", "---", "---", "---")),
+    ) ++ rows ++ Vector(
+      "",
+      "## Baseline Comparison",
+      "",
+      markdownRow(Vector("Scenario", "Failed Seeds Delta", "First Failure Month Delta", "Terminal Failures Delta", "Reading")),
+      markdownRow(Vector("---", "---", "---", "---", "---")),
+    ) ++ comparisonRows
+    lines.mkString("\n") + "\n"
+
+  private def baselineComparisonRows(summary: Vector[SummaryResult]): Vector[String] =
+    summary
+      .find(_.scenarioId == "baseline")
+      .toVector
+      .flatMap: baseline =>
+        summary
+          .filterNot(_.scenarioId == baseline.scenarioId)
+          .map: row =>
+            markdownRow(
+              Vector(
+                row.scenarioId,
+                signed(row.failedSeeds - baseline.failedSeeds),
+                firstFailureDelta(row.firstFailureMonthMean, baseline.firstFailureMonthMean),
+                signedDecimal(row.terminalFailuresMean - baseline.terminalFailuresMean),
+                comparisonReading(row, baseline),
+              ),
+            )
+
+  private def firstFailureDelta(candidate: Option[BigDecimal], baseline: Option[BigDecimal]): String =
+    (candidate, baseline) match
+      case (Some(c), Some(b)) => signedDecimal(c - b)
+      case (None, Some(_))    => "prevented in run"
+      case (Some(_), None)    => "new failures"
+      case (None, None)       => "no failures"
+
+  private def comparisonReading(candidate: SummaryResult, baseline: SummaryResult): String =
+    if candidate.failedSeeds < baseline.failedSeeds then "materially prevents failures in this fixture"
+    else
+      (candidate.firstFailureMonthMean, baseline.firstFailureMonthMean) match
+        case (Some(c), Some(b)) if c > b => "materially delays first failure"
+        case _                           => "does not delay first failure"
+
+  private def col(row: Array[MetricValue], name: String): BigDecimal =
+    decimal(row(ColumnIndex(name)).toLong)
+
+  private def colInt(row: Array[MetricValue], name: String): Int =
+    col(row, name).setScale(0, RoundingMode.HALF_UP).toInt
+
+  private def cumulative(rows: Vector[Array[MetricValue]], name: String): BigDecimal =
+    rows.map(row => col(row, name)).sum
+
+  private def mean(values: Vector[BigDecimal]): BigDecimal =
+    if values.isEmpty then BigDecimal(0) else values.sum / BigDecimal(values.length)
+
+  private def meanOption(values: Vector[BigDecimal]): Option[BigDecimal] =
+    if values.isEmpty then None else Some(mean(values))
+
+  private def meanFailedOnly(rows: Vector[SeedResult])(value: SeedResult => BigDecimal): BigDecimal =
+    mean(rows.filter(_.firstFailureMonth.nonEmpty).map(value))
+
+  private def decimal(raw: Long): BigDecimal =
+    BigDecimal(raw) / BigDecimal(com.boombustgroup.amorfati.fp.FixedPointBase.Scale)
+
+  private def renderDecimal(value: BigDecimal): String =
+    value.setScale(6, RoundingMode.HALF_UP).bigDecimal.stripTrailingZeros.toPlainString
+
+  private def signed(value: Int): String =
+    if value > 0 then s"+$value" else value.toString
+
+  private def signedDecimal(value: BigDecimal): String =
+    val rendered = renderDecimal(value)
+    if value > BigDecimal(0) then s"+$rendered" else rendered
+
+  private def csv(value: String): String =
+    val escaped = value.replace("\"", "\"\"")
+    if escaped.exists(ch => ch == ';' || ch == '"' || ch == '\n' || ch == '\r') then s""""$escaped""""
+    else escaped
+
+  private def markdownRow(values: Vector[String]): String =
+    values.map(_.replace("|", "\\|")).mkString("| ", " | ", " |")
+
+  private def knownFlag(flag: String): Boolean =
+    flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+
+  private def parseLong(value: String, name: String): Either[String, Long] =
+    Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
+
+  private def parseInt(value: String, name: String): Either[String, Int] =
+    Try(value.toInt).toEither.left.map(_ => s"$name must be an integer")
+
+  private val usage: String =
+    """Usage:
+      |  bankFailureAblations [--seed-start N] [--seeds N] [--months N] [--out PATH] [--run-id ID]
+      |
+      |Runs baseline plus controlled bank-failure ablation scenarios and writes:
+      |  bank-failure-ablation-seeds.csv
+      |  bank-failure-ablation-summary.csv
+      |  bank-failure-ablation-scenarios.csv
+      |  bank-failure-ablation-report.md
+      |""".stripMargin

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankFailureAblationExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankFailureAblationExportSpec.scala
@@ -1,0 +1,96 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.EitherValues.*
+
+import java.nio.file.Path
+
+class BankFailureAblationExportSpec extends AnyFlatSpec with Matchers:
+
+  "BankFailureAblationExport" should "parse CLI run controls" in {
+    val parsed = BankFailureAblationExport.parseArgs(
+      Vector("--seed-start", "3", "--seeds", "4", "--months", "24", "--out", "target/x", "--run-id", "probe"),
+    )
+
+    parsed shouldBe Right(
+      BankFailureAblationExport.Config(
+        seedStart = 3L,
+        seeds = 4,
+        months = 24,
+        out = Path.of("target/x"),
+        runId = "probe",
+      ),
+    )
+  }
+
+  it should "cover baseline and targeted banking ablation scenarios" in {
+    BankFailureAblationExport.Scenarios.map(_.id) should contain theSameElementsInOrderAs Vector(
+      "baseline",
+      "no-ecl-stress-migration",
+      "no-realized-credit-loss-capital-hit",
+      "no-resolution-feedback",
+      "initial-capital-150pct",
+    )
+  }
+
+  it should "summarize first failure timing only over failed seeds" in {
+    val config = BankFailureAblationExport.Config(seeds = 2, months = 12, runId = "test")
+    val rows   = Vector(
+      seed("baseline", "Baseline", 1L, Some(3), terminalFailures = 2, peakFailures = 3),
+      seed("baseline", "Baseline", 2L, None, terminalFailures = 0, peakFailures = 0),
+    )
+
+    val summary = BankFailureAblationExport.summarize(config, rows).find(_.scenarioId == "baseline").get
+
+    summary.failedSeeds shouldBe 1
+    summary.firstFailureMonthMean shouldBe Some(BigDecimal(3))
+    summary.terminalFailuresMean shouldBe BigDecimal(1)
+    summary.peakFailuresMean shouldBe BigDecimal("1.5")
+  }
+
+  it should "validate run controls and required schema columns" in {
+    BankFailureAblationExport.validate(BankFailureAblationExport.Config(seeds = 0)).left.value should include("--seeds")
+    BankFailureAblationExport.validate(BankFailureAblationExport.Config(months = 0)).left.value should include("--months")
+    BankFailureAblationExport.validate(BankFailureAblationExport.Config(runId = " ")).left.value should include("--run-id")
+    BankFailureAblationExport.validate(BankFailureAblationExport.Config()).isRight shouldBe true
+  }
+
+  private def seed(
+      scenarioId: String,
+      scenarioLabel: String,
+      seed: Long,
+      firstFailureMonth: Option[Int],
+      terminalFailures: Int,
+      peakFailures: Int,
+  ): BankFailureAblationExport.SeedResult =
+    BankFailureAblationExport.SeedResult(
+      runId = "test",
+      scenarioId = scenarioId,
+      scenarioLabel = scenarioLabel,
+      seed = seed,
+      months = 12,
+      firstFailureMonth = firstFailureMonth,
+      firstFailureReasonCode = firstFailureMonth.fold(0)(_ => 1),
+      firstFailureBankId = firstFailureMonth.fold(-1)(_ => 0),
+      terminalFailures = terminalFailures,
+      peakFailures = peakFailures,
+      cumulativeNewFailures = BigDecimal(terminalFailures),
+      cumulativeRealizedCreditLoss = BigDecimal(10),
+      cumulativeEclProvisionChange = BigDecimal(2),
+      cumulativeBailInLoss = BigDecimal(1),
+      cumulativeCapitalDestruction = BigDecimal(3),
+      cumulativeReconciliationResidualAbs = BigDecimal("0.1"),
+      firstFailureRealizedCreditLoss = firstFailureMonth.fold(BigDecimal(0))(_ => BigDecimal(4)),
+      firstFailureEclProvisionChange = firstFailureMonth.fold(BigDecimal(0))(_ => BigDecimal(1)),
+      firstFailureConsumerNplLoss = BigDecimal(0),
+      firstFailureFirmNplLoss = BigDecimal(0),
+      firstFailureMortgageNplLoss = BigDecimal(0),
+      firstFailureCorpBondDefaultLoss = BigDecimal(0),
+      firstFailureReconciliationResidual = BigDecimal(0),
+      firstFailureDepositBailInLoss = BigDecimal(0),
+      terminalTotalCreditToGdp = BigDecimal("0.2"),
+      terminalUnemployment = BigDecimal("0.05"),
+      terminalInflation = BigDecimal("0.03"),
+      interpretation = "test",
+    )


### PR DESCRIPTION
## Summary
- add `bankFailureAblations` sbt task and exporter for controlled bank-failure root-cause probes
- define baseline, no-ECL-stress-migration, no-realized-credit-loss-capital-hit, no-resolution-feedback, and 150% initial-capital scenarios
- write seed, summary, scenario, and markdown report artifacts
- document the workflow in `docs/operations.md` and `docs/bank-failure-ablations.md`

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankFailureAblationExportSpec"`
- `sbt "bankFailureAblations --seed-start 1 --seeds 1 --months 3 --out target/bank-failure-ablations --run-id smoke560-report"`
- `sbt "bankFailureAblations --seed-start 1 --seeds 2 --months 24 --out target/bank-failure-ablations --run-id check560"`
- `sbt assembly`

## check560 result
```text
baseline: failedSeeds=2/2, mean first failure month=5.5, terminal failures=9
no-ecl-stress-migration: failedSeeds=2/2, mean first failure month=7, terminal failures=9
no-realized-credit-loss-capital-hit: failedSeeds=0/2, terminal failures=0
no-resolution-feedback: failedSeeds=2/2, mean first failure month=5.5, terminal failures=9
initial-capital-150pct: failedSeeds=2/2, mean first failure month=16, terminal failures=8
```

Follow-up from the ablation evidence: #582.

Closes #560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `bankFailureAblations` diagnostic command to analyze bank failure root causes through controlled ablation scenarios.
  * Supports configuration of Monte Carlo seeds, simulation months, run identifier, and output directory.
  * Generates seed-level metrics, scenario comparison summaries, and human-readable diagnostic reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->