### PR TITLE
Fix consumer NPL loss attribution

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -753,8 +753,12 @@ Realized credit-loss rates are emitted as `BankCreditLoss_*`. They use closing
 exposure stocks as denominators, so the columns can be joined directly with
 monthly `BankFailure_*` rows. The block separates firm-loan, mortgage,
 consumer-loan, liquidity-bridge charge-off, and bank-held corporate-bond
-channels. `BankCapital_EclProvisionChange` remains a separate accounting
-provision term and is not included in these realized-loss rates.
+channels. `BankCapital_ConsumerNplLoss` is the capital loss on ordinary
+consumer-loan defaults only; same-month liquidity bridge charge-offs stay
+visible as a separate gross stress/write-off diagnostic instead of being folded
+into ordinary consumer-credit NPL loss. `BankCapital_EclProvisionChange` remains
+a separate accounting provision term and is not included in these realized-loss
+rates.
 
 Liquidity ratios are:
 
@@ -834,7 +838,7 @@ Bank capital changes by losses plus retained income:
 losses_b =
   corporateNplLoss_b
   + mortgageNplLoss_b
-  + consumerNplLoss_b
+  + ordinaryConsumerLoanNplLoss_b
   + corporateBondDefaultLoss_b
   + BFGLevy_b
   + unrealizedAfsBondLoss_b

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -167,7 +167,7 @@ object Sfc:
       remittanceOutflow: PLN,                   // immigrant remittances → deposit outflow
       fofResidual: PLN,                         // flow-of-funds residual (Σ firmRevenue - Σ sectorDemand)
       consumerDebtService: PLN,                 // consumer credit: monthly instalment burden (principal + interest)
-      consumerNplLoss: PLN,                     // consumer credit: NPL loss (after recovery)
+      consumerNplLoss: PLN,                     // ordinary consumer-loan NPL loss (after recovery)
       consumerOrigination: PLN,                 // consumer credit: total new loan origination
       consumerLiquidityShortfallFinancing: PLN, // consumer credit: residual shortfall settlement
       consumerPrincipalRepaid: PLN,             // consumer credit: principal portion of debt service

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -993,7 +993,7 @@ object Banking:
       prevCapital: PLN,            // previous period capital
       nplLoss: PLN,                // corporate NPL loss (after recovery)
       mortgageNplLoss: PLN,        // mortgage default loss (bank share)
-      consumerNplLoss: PLN,        // consumer credit NPL loss (after recovery)
+      consumerNplLoss: PLN,        // ordinary consumer-loan NPL loss (after recovery)
       corpBondDefaultLoss: PLN,    // corporate bond default loss (bank share)
       bfgLevy: PLN,                // BFG resolution fund levy
       unrealizedBondLoss: PLN,     // mark-to-market loss on gov bond portfolio (interest rate risk channel)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala
@@ -47,11 +47,13 @@ case class PerBankFlow(
     consumerApprovedOrigination: PLN, // underwritten consumer credit originated by the DTI rule
     liquidityShortfallFinancing: PLN, // same-month bridge/write-off preventing negative deposits
     consumerDefault: PLN,             // consumer defaults plus same-month bridge charge-offs
+    consumerLoanDefault: PLN,         // default of ordinary outstanding consumer-loan principal
     consumerPrincipal: PLN,           // consumer loan principal repaid
 )
 
 object PerBankFlow:
-  val zero: PerBankFlow = PerBankFlow(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
+  val zero: PerBankFlow =
+    PerBankFlow(PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero, PLN.Zero)
 
 object Household:
   def isEmployed(hh: State): Boolean =
@@ -700,6 +702,7 @@ object Household:
         consumerApprovedOrigination = cur.consumerApprovedOrigination + r.credit.newLoan,
         liquidityShortfallFinancing = cur.liquidityShortfallFinancing + r.credit.liquidityShortfallFinancing,
         consumerDefault = cur.consumerDefault + r.credit.defaultAmt,
+        consumerLoanDefault = cur.consumerLoanDefault + r.credit.consumerLoanDefault,
         consumerPrincipal = cur.consumerPrincipal + r.credit.principal,
       )
     acc.toVector

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -269,7 +269,7 @@ case class BankCapitalDiagnostics(
     retainedIncome: PLN = PLN.Zero,         // retained ordinary bank income after profit-retention rule
     firmNplLoss: PLN = PLN.Zero,            // realized firm-loan credit loss net of recovery
     mortgageNplLoss: PLN = PLN.Zero,        // realized mortgage credit loss net of recovery
-    consumerNplLoss: PLN = PLN.Zero,        // realized consumer-credit loss net of recovery
+    consumerNplLoss: PLN = PLN.Zero,        // realized ordinary consumer-loan loss net of recovery
     corpBondDefaultLoss: PLN = PLN.Zero,    // bank-held corporate-bond default loss
     bfgLevy: PLN = PLN.Zero,                // monthly BFG levy paid by active banks
     unrealizedBondLoss: PLN = PLN.Zero,     // AFS government-bond mark-to-market capital hit

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -135,6 +135,7 @@ object BankingEconomics:
       ccPrincipal: PLN,      // consumer credit principal repaid to this bank
       ccOrigination: PLN,    // total consumer-loan stock origination at this bank
       ccDefault: PLN,        // consumer credit defaults at this bank
+      ccLoanDefault: PLN,    // ordinary consumer-loan defaults at this bank, excluding bridge charge-offs
   )
 
   private case class SingleBankUpdate(
@@ -572,6 +573,7 @@ object BankingEconomics:
           ccPrincipal = f.consumerPrincipal,
           ccOrigination = f.consumerOrigination,
           ccDefault = f.consumerDefault,
+          ccLoanDefault = f.consumerLoanDefault,
         )
       case None      =>
         val ws = if totalWorkers > 0 then Share.fraction(perBankWorkers(bId), totalWorkers) else Share.Zero
@@ -584,6 +586,7 @@ object BankingEconomics:
           ccPrincipal = in.s6.consumerPrincipal * ws,
           ccOrigination = in.s6.consumerOrigination * ws,
           ccDefault = in.s6.consumerDefaultAmt * ws,
+          ccLoanDefault = in.s6.consumerLoanDefaultAmt * ws,
         )
 
   private def allocateBankCorpBondIssuance(issuance: PLN, perBankWorkers: Vector[Int]): Vector[PLN] =
@@ -663,7 +666,7 @@ object BankingEconomics:
 
     val bankMortgageIntIncome     = hhFlows.mortgageInterest
     val bankMortgageNplLoss       = mortgageFlows.defaultLoss * workerShare
-    val bankCcNplLoss             = hhFlows.ccDefault * (Share.One - p.household.ccNplRecovery)
+    val bankCcNplLoss             = hhFlows.ccLoanDefault * (Share.One - p.household.ccNplRecovery)
     val bankCcStockReduction: PLN = in.s3.perBankHhFlowsOpt match
       case Some(pbf) => pbf(bId).consumerPrincipal
       case _         => hhFlows.ccPrincipal
@@ -712,7 +715,7 @@ object BankingEconomics:
         loansShort = newLoansTotal * ShortLoanFrac,
         loansMedium = newLoansTotal * MediumLoanFrac,
         loansLong = newLoansTotal * LongLoanFrac,
-        consumerNpl = (b.consumerNpl + hhFlows.ccDefault - b.consumerNpl * NplMonthlyWriteOff).max(PLN.Zero),
+        consumerNpl = (b.consumerNpl + hhFlows.ccLoanDefault - b.consumerNpl * NplMonthlyWriteOff).max(PLN.Zero),
       ),
       financialStocks = stocks.copy(
         firmLoan = newLoansTotal,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -50,7 +50,8 @@ object HouseholdFinancialEconomics:
       consumerApprovedOrigination: PLN, // underwritten consumer credit originated by the DTI rule
       liquidityShortfallFinancing: PLN, // same-month bridge/write-off preventing negative demand deposits
       consumerDefaultAmt: PLN,          // combined SFC default: loan defaults plus bridge charge-offs
-      consumerNplLoss: PLN,             // combined consumer-credit loss net of recovery
+      consumerLoanDefaultAmt: PLN,      // ordinary consumer-loan default, excluding same-month bridge charge-offs
+      consumerNplLoss: PLN,             // ordinary consumer-loan NPL loss net of recovery
       consumerPrincipal: PLN,           // consumer loan principal repayment
   )
 
@@ -100,7 +101,8 @@ object HouseholdFinancialEconomics:
     val consumerApprovedOrigination = hhAgg.totalConsumerApprovedOrigination
     val liquidityShortfallFinancing = hhAgg.totalLiquidityShortfallFinancing
     val consumerDefaultAmt          = hhAgg.totalConsumerDefault
-    val consumerNplLoss             = consumerDefaultAmt * (Share.One - p.household.ccNplRecovery)
+    val consumerLoanDefaultAmt      = hhAgg.totalConsumerLoanDefault
+    val consumerNplLoss             = consumerLoanDefaultAmt * (Share.One - p.household.ccNplRecovery)
     val consumerPrincipal           = hhAgg.totalConsumerPrincipal
 
     Output(
@@ -114,6 +116,7 @@ object HouseholdFinancialEconomics:
       consumerApprovedOrigination,
       liquidityShortfallFinancing,
       consumerDefaultAmt,
+      consumerLoanDefaultAmt,
       consumerNplLoss,
       consumerPrincipal,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -324,7 +324,7 @@ object FlowSimulation:
           firmInterestIncome = c.firmInterestIncome,
           firmNplLoss = c.firmNplLoss,
           mortgageNplLoss = c.mortgageDefault * (Share.One - p.housing.mortgageRecovery),
-          consumerNplLoss = c.totalCcDefault * (Share.One - p.household.ccNplRecovery),
+          consumerNplLoss = (c.totalCcDefault - c.liquidityShortfallFinancing).max(PLN.Zero) * (Share.One - p.household.ccNplRecovery),
           govBondIncome = c.bankGovBondIncome,
           reserveInterest = c.bankReserveInterest,
           standingFacilityIncome = c.bankStandingFacility,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -206,7 +206,7 @@ the total realized credit-loss hit against opening bank capital. Firm and
 corporate-bond default rates reverse the configured recovery rate to estimate
 gross default flow from net loss. Consumer diagnostics separate ordinary
 consumer-loan default from liquidity-bridge charge-off; `ConsumerLossRate`
-keeps the combined capital-loss view used by the bank waterfall.
+tracks the ordinary consumer-loan capital loss used by the bank waterfall.
 
 ## Bank Failure Diagnostics
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomicsSpec.scala
@@ -1,0 +1,60 @@
+package com.boombustgroup.amorfati.engine.economics
+
+import com.boombustgroup.amorfati.Generators
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+import com.boombustgroup.amorfati.random.RandomStream
+import com.boombustgroup.amorfati.types.*
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HouseholdFinancialEconomicsSpec extends AnyFlatSpec with Matchers:
+
+  private given SimParams = SimParams.defaults
+
+  "HouseholdFinancialEconomics.compute" should "exclude liquidity-bridge charge-offs from ordinary consumer NPL loss" in {
+    val hhAgg = Generators
+      .testHouseholdAggregates()
+      .copy(
+        totalLiquidityShortfallFinancing = PLN(1000),
+        totalConsumerDefault = PLN(1000),
+        totalConsumerLoanDefault = PLN.Zero,
+        totalLiquidityBridgeChargeOff = PLN(1000),
+      )
+
+    val result = HouseholdFinancialEconomics.compute(
+      Generators.testWorld(),
+      ExecutionMonth.First,
+      employed = 100,
+      hhAgg = hhAgg,
+      rng = RandomStream.seeded(42),
+    )
+
+    result.consumerDefaultAmt shouldBe PLN(1000)
+    result.consumerLoanDefaultAmt shouldBe PLN.Zero
+    result.consumerNplLoss shouldBe PLN.Zero
+  }
+
+  it should "apply recovery only to ordinary consumer-loan defaults" in {
+    val hhAgg = Generators
+      .testHouseholdAggregates()
+      .copy(
+        totalLiquidityShortfallFinancing = PLN(800),
+        totalConsumerDefault = PLN(1000),
+        totalConsumerLoanDefault = PLN(200),
+        totalLiquidityBridgeChargeOff = PLN(800),
+      )
+
+    val result = HouseholdFinancialEconomics.compute(
+      Generators.testWorld(),
+      ExecutionMonth.First,
+      employed = 100,
+      hhAgg = hhAgg,
+      rng = RandomStream.seeded(42),
+    )
+
+    result.consumerDefaultAmt shouldBe PLN(1000)
+    result.consumerLoanDefaultAmt shouldBe PLN(200)
+    result.consumerNplLoss shouldBe PLN(170)
+  }


### PR DESCRIPTION
## Summary

- exclude same-month liquidity bridge charge-offs from ordinary consumer NPL capital loss
- route per-bank consumer NPL stock and capital PnL through ordinary consumer-loan defaults only
- keep combined ConsumerDefault available for SFC/write-off diagnostics and update docs to describe the split
- add regression coverage for bridge-only defaults and mixed ordinary/default bridge cases

## Economic interpretation

BankCapital_ConsumerNplLoss now measures realized ordinary consumer-loan loss net of recovery. LiquidityBridgeChargeOff remains a separate gross household liquidity stress/write-off diagnostic and is no longer folded into ordinary consumer-credit NPL loss.

## Validation

- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.HouseholdFinancialEconomicsSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.CompositeFlowsSpec com.boombustgroup.amorfati.accounting.SfcSpec com.boombustgroup.amorfati.accounting.SfcPropertySpec"
- sbt assembly
- sbt "bankFailureAblations --seed-start 1 --seeds 2 --months 24 --out target/bank-failure-ablations --run-id check582"

## Ablation evidence

After the semantic split (check582, seeds=2, months=24):

- baseline: failedSeeds=2/2, mean first failure month=6.5, terminal failures=9
- no-ecl-stress-migration: failedSeeds=2/2, mean first failure month=14, terminal failures=6
- no-realized-credit-loss-capital-hit: failedSeeds=0/2, terminal failures=0
- no-resolution-feedback: failedSeeds=2/2, mean first failure month=6.5, terminal failures=9
- initial-capital-150pct: failedSeeds=0/2, terminal failures=0

The remaining first-failure realized loss is still dominated by ordinary consumer-loan NPL loss, not the liquidity bridge channel.

Closes #582

Follow-up: #584
