### PR TITLE
Add HH-bank lead-lag diagnostics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val calibrationRegister = inputKey[Unit]("Generate calibration register doc
 lazy val householdCreditStressCalibration = inputKey[Unit]("Generate household liquidity and credit-stress calibration artifacts")
 lazy val bankBalanceSheetBenchmark = inputKey[Unit]("Generate initial bank balance-sheet benchmark artifacts")
 lazy val bankFailureAblations = inputKey[Unit]("Run controlled bank-failure ablation diagnostics")
+lazy val hhBankLeadLagDiagnostics = inputKey[Unit]("Run HH-to-bank lead-lag and causal attribution diagnostics")
 
 lazy val baseScalacOptions = Seq(
   "-Werror",
@@ -112,6 +113,13 @@ lazy val root = project
         val parsedArgs = spaceDelimited("<bank failure ablation args>").parsed
         (Compile / runMain)
           .toTask(" com.boombustgroup.amorfati.diagnostics.BankFailureAblationExport " + parsedArgs.mkString(" "))
+      }
+      .evaluated,
+    hhBankLeadLagDiagnostics := Def
+      .inputTaskDyn {
+        val parsedArgs = spaceDelimited("<HH-bank lead-lag args>").parsed
+        (Compile / runMain)
+          .toTask(" com.boombustgroup.amorfati.diagnostics.HhBankLeadLagDiagnosticsExport " + parsedArgs.mkString(" "))
       }
       .evaluated,
     Test / testOptions ++= {

--- a/docs/hh-bank-lead-lag-diagnostics.md
+++ b/docs/hh-bank-lead-lag-diagnostics.md
@@ -1,0 +1,70 @@
+# HH-to-Bank Lead-Lag Diagnostics
+
+This diagnostic export supports issue #584. It connects household stress flows
+to bank outcomes by `BankId` and month, then separates descriptive lead-lag
+correlation from controlled counterfactual evidence.
+
+Run:
+
+```bash
+sbt "hhBankLeadLagDiagnostics --seeds 2 --months 24 --lag-max 6 --out target/hh-bank-lead-lag --run-id hh-bank-lead-lag"
+```
+
+The task writes:
+
+```text
+<out>/<run-id>/hh-bank-lead-lag-bank-months.csv
+<out>/<run-id>/hh-bank-lead-lag-correlations.csv
+<out>/<run-id>/hh-bank-lead-lag-counterfactuals.csv
+<out>/<run-id>/hh-bank-lead-lag-report.md
+```
+
+## Bank-Month Rows
+
+`hh-bank-lead-lag-bank-months.csv` is the join surface. Each row is one
+`RunId` / scenario / seed / month / bank. Household flows are assigned to the
+bank referenced by the household during the household stage of that month.
+
+Key household-side columns:
+
+- `HhConsumerLoanDefault`: ordinary unsecured consumer-loan default.
+- `HhLiquidityBridgeChargeOff`: same-month liquidity bridge/write-off,
+  separate from ordinary consumer-loan default.
+- `HhLiquidityShortfallFinancing`: residual monthly liquidity gap closed by the
+  bridge mechanism.
+- `HhConsumerDebtArrears` and `HhMortgageArrears`: shortfall components.
+
+Key bank-side columns:
+
+- `BankConsumerNplLoss`: realized ordinary consumer-loan capital loss net of
+  recovery, aligned with #582 semantics.
+- `BankConsumerNplStock`: closing consumer NPL stock.
+- `BankCapital`, `BankCapitalDelta`, `BankCar`, `BankLcr`: closing bank stress
+  state.
+- `BankNewFailure`: 1 when the bank moves from not failed to failed in that
+  month.
+- `BankFailureReasonCode`: populated for the first new failure event when the
+  aggregate failure diagnostic identifies that bank.
+
+## Correlation Versus Causality
+
+`hh-bank-lead-lag-correlations.csv` computes Pearson correlations over lag
+windows `0..--lag-max`. For lag `k`, household metric values at `t-k` are
+paired with bank outcomes at `t` for the same scenario, seed, and bank.
+
+These correlations answer: "does HH stress tend to move before this bank
+outcome?" They do not prove causality because a common macro shock can move
+households and banks together.
+
+`hh-bank-lead-lag-counterfactuals.csv` is the controlled intervention check. It
+compares:
+
+- `baseline`: production configuration.
+- `no-consumer-npl-capital-hit`: household consumer defaults remain visible,
+  but unsecured consumer-credit recovery is set to 100%, removing the direct
+  consumer NPL capital hit.
+
+If failures materially fall in the counterfactual while household default flows
+remain visible, the direct consumer NPL capital-hit channel is necessary for
+failure timing in that fixture. This is model-internal intervention evidence,
+not full macro-causal identification.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -379,6 +379,18 @@ The semantics and scenario set are documented in
 [bank-failure-ablations.md](bank-failure-ablations.md). Use larger
 `--seeds`/`--months` values for heavier research runs.
 
+HH-to-bank lead-lag diagnostics:
+
+```bash
+sbt "hhBankLeadLagDiagnostics --seeds 2 --months 24 --lag-max 6 --out target/hh-bank-lead-lag --run-id hh-bank-lead-lag"
+```
+
+This writes per-bank/month household-stress routing rows, lead-lag correlation
+tables, consumer-credit counterfactual rows, and a summary report under
+`<out>/<run-id>/`. With the command above, the concrete output directory is
+`target/hh-bank-lead-lag/hh-bank-lead-lag/`. The export is documented in
+[hh-bank-lead-lag-diagnostics.md](hh-bank-lead-lag-diagnostics.md).
+
 For scratch and committed-snapshot SFC matrix exports, see
 [sfc-matrix-evidence.md](sfc-matrix-evidence.md).
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/HhBankLeadLagScenarios.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/HhBankLeadLagScenarios.scala
@@ -1,0 +1,34 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.types.*
+
+/** Diagnostic-only scenarios for HH-to-bank causal attribution.
+  *
+  * They keep household distress/default flows visible but selectively
+  * neutralize the bank-capital consumer-credit loss channel.
+  */
+object HhBankLeadLagScenarios:
+
+  final case class Spec(
+      id: String,
+      label: String,
+      interpretation: String,
+      params: SimParams,
+  )
+
+  private val Baseline = SimParams.defaults
+
+  val all: Vector[Spec] = Vector(
+    Spec(
+      id = "baseline",
+      label = "Baseline",
+      interpretation = "Current production configuration.",
+      params = Baseline,
+    ),
+    Spec(
+      id = "no-consumer-npl-capital-hit",
+      label = "No consumer NPL capital hit",
+      interpretation = "Sets unsecured consumer-credit recovery to 100%, leaving household default and bridge diagnostics visible.",
+      params = Baseline.copy(household = Baseline.household.copy(ccNplRecovery = Share.One)),
+    ),
+  )

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
@@ -1,0 +1,599 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
+import com.boombustgroup.amorfati.agents.Banking
+import com.boombustgroup.amorfati.config.{HhBankLeadLagScenarios, SimParams}
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation
+import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, LedgerFinancialState}
+import com.boombustgroup.amorfati.engine.{MonthDriver, MonthRandomness}
+import com.boombustgroup.amorfati.fp.FixedPointBase
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.types.*
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.math.BigDecimal.RoundingMode
+
+/** HH-to-bank lead-lag diagnostics for #584.
+  *
+  * The export is intentionally separate from the standard Monte Carlo schema:
+  * it is a heavier per-bank/month drilldown used to connect household stress to
+  * bank capital, CAR, and failure outcomes.
+  */
+object HhBankLeadLagDiagnosticsExport:
+
+  final case class Config(
+      seedStart: Long = 1L,
+      seeds: Int = 5,
+      months: Int = 60,
+      lagMax: Int = 6,
+      runId: String = "hh-bank-lead-lag",
+      out: Path = Path.of("target/hh-bank-lead-lag"),
+  ):
+    def seedRange: Vector[Long] = Vector.tabulate(seeds)(i => seedStart + i.toLong)
+    def runRoot: Path           = out.resolve(runId)
+
+  final case class BankMonthRow(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      seed: Long,
+      month: Int,
+      bankId: Int,
+      bankName: String,
+      householdCount: Int,
+      hhMonthlyIncome: BigDecimal,
+      hhConsumerLoanDefault: BigDecimal,
+      hhLiquidityBridgeChargeOff: BigDecimal,
+      hhLiquidityShortfallFinancing: BigDecimal,
+      hhConsumerDefault: BigDecimal,
+      hhConsumerDebtService: BigDecimal,
+      hhConsumerApprovedOrigination: BigDecimal,
+      hhConsumerRejectedOrigination: BigDecimal,
+      hhConsumerDebtArrears: BigDecimal,
+      hhMortgageArrears: BigDecimal,
+      bankConsumerLoanStock: BigDecimal,
+      bankConsumerNplStock: BigDecimal,
+      bankConsumerNplLoss: BigDecimal,
+      bankCapital: BigDecimal,
+      bankCapitalDelta: BigDecimal,
+      bankCar: BigDecimal,
+      bankLcr: BigDecimal,
+      bankFailed: Int,
+      bankNewFailure: Int,
+      bankFailureReasonCode: Int,
+      unemployment: BigDecimal,
+      inflation: BigDecimal,
+      monthlyGdpProxy: BigDecimal,
+  )
+
+  final case class CorrelationResult(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      lagMonths: Int,
+      hhMetric: String,
+      bankMetric: String,
+      observations: Int,
+      correlation: Option[BigDecimal],
+      interpretation: String,
+  )
+
+  final case class CounterfactualResult(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      seeds: Int,
+      months: Int,
+      failedSeeds: Int,
+      firstFailureMonthMean: Option[BigDecimal],
+      terminalFailuresMean: BigDecimal,
+      cumulativeNewFailuresMean: BigDecimal,
+      cumulativeConsumerNplLossMean: BigDecimal,
+      cumulativeHhConsumerLoanDefaultMean: BigDecimal,
+      cumulativeLiquidityBridgeChargeOffMean: BigDecimal,
+      interpretation: String,
+  )
+
+  final case class ExportResult(
+      paths: Vector[Path],
+      bankMonthRows: Vector[BankMonthRow],
+      correlations: Vector[CorrelationResult],
+      counterfactuals: Vector[CounterfactualResult],
+  )
+
+  private final class HhBankTotals:
+    var householdCount: Int              = 0
+    var monthlyIncome: PLN               = PLN.Zero
+    var consumerLoanDefault: PLN         = PLN.Zero
+    var liquidityBridgeChargeOff: PLN    = PLN.Zero
+    var liquidityShortfallFinancing: PLN = PLN.Zero
+    var consumerDefault: PLN             = PLN.Zero
+    var consumerDebtService: PLN         = PLN.Zero
+    var consumerApprovedOrigination: PLN = PLN.Zero
+    var consumerRejectedOrigination: PLN = PLN.Zero
+    var consumerDebtArrears: PLN         = PLN.Zero
+    var mortgageArrears: PLN             = PLN.Zero
+
+    def add(flow: com.boombustgroup.amorfati.agents.Household.MonthlyFlow): Unit =
+      householdCount += 1
+      monthlyIncome = monthlyIncome + flow.monthlyIncome
+      consumerLoanDefault = consumerLoanDefault + flow.consumerLoanDefault
+      liquidityBridgeChargeOff = liquidityBridgeChargeOff + flow.liquidityBridgeChargeOff
+      liquidityShortfallFinancing = liquidityShortfallFinancing + flow.liquidityShortfallFinancing
+      consumerDefault = consumerDefault + flow.consumerDefault
+      consumerDebtService = consumerDebtService + flow.consumerDebtService
+      consumerApprovedOrigination = consumerApprovedOrigination + flow.consumerApprovedOrigination
+      consumerRejectedOrigination = consumerRejectedOrigination + flow.consumerRejectedOrigination
+      consumerDebtArrears = consumerDebtArrears + flow.consumerDebtArrears
+      mortgageArrears = mortgageArrears + flow.mortgageArrears
+
+  private[diagnostics] val Scenarios: Vector[HhBankLeadLagScenarios.Spec] =
+    HhBankLeadLagScenarios.all
+
+  private val HhMetricAccessors: Vector[(String, BankMonthRow => BigDecimal)] = Vector(
+    "HhConsumerLoanDefault"         -> (_.hhConsumerLoanDefault),
+    "HhLiquidityBridgeChargeOff"    -> (_.hhLiquidityBridgeChargeOff),
+    "HhLiquidityShortfallFinancing" -> (_.hhLiquidityShortfallFinancing),
+    "HhConsumerDebtArrears"         -> (_.hhConsumerDebtArrears),
+    "HhMortgageArrears"             -> (_.hhMortgageArrears),
+    "HhConsumerDebtService"         -> (_.hhConsumerDebtService),
+  )
+
+  private val BankMetricAccessors: Vector[(String, BankMonthRow => BigDecimal)] = Vector(
+    "BankConsumerNplLoss" -> (_.bankConsumerNplLoss),
+    "BankCapitalDelta"    -> (_.bankCapitalDelta),
+    "BankCar"             -> (_.bankCar),
+    "BankLcr"             -> (_.bankLcr),
+    "BankNewFailure"      -> (row => BigDecimal(row.bankNewFailure)),
+  )
+
+  def main(args: Array[String]): Unit =
+    parseArgs(args.toVector) match
+      case Left(err)     =>
+        Console.err.println(err)
+        Console.err.println(usage)
+        sys.exit(2)
+      case Right(config) =>
+        run(config) match
+          case Left(err)     =>
+            Console.err.println(err)
+            sys.exit(1)
+          case Right(result) =>
+            result.paths.foreach(path => println(path.toString))
+
+  def run(config: Config): Either[String, ExportResult] =
+    validate(config).flatMap: validConfig =>
+      val attempts =
+        for
+          scenario <- Scenarios
+          seed     <- validConfig.seedRange
+        yield runScenarioSeed(validConfig, scenario, seed)
+
+      attempts.collectFirst { case Left(err) => err } match
+        case Some(err) => Left(err)
+        case None      =>
+          val bankRows        = attempts.collect { case Right(rows) => rows }.flatten
+          val correlations    = computeCorrelations(validConfig, bankRows)
+          val counterfactuals = summarizeCounterfactuals(validConfig, bankRows)
+          val paths           = writeArtifacts(validConfig, bankRows, correlations, counterfactuals)
+          Right(ExportResult(paths, bankRows, correlations, counterfactuals))
+
+  def parseArgs(args: Vector[String]): Either[String, Config] =
+    def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
+
+    def loop(rest: Seq[String], config: Config): Either[String, Config] =
+      rest match
+        case Seq()                                  => Right(config)
+        case Seq("--help", _*)                      => Left(usage)
+        case Seq(flag, tail*) if knownFlag(flag)    =>
+          tail match
+            case Seq()                                       => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")    => missingValue(flag)
+            case Seq(value, next*) if flag == "--seed-start" =>
+              parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
+            case Seq(value, next*) if flag == "--seeds"      =>
+              parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
+            case Seq(value, next*) if flag == "--months"     =>
+              parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
+            case Seq(value, next*) if flag == "--lag-max"    =>
+              parseInt(value, flag).flatMap(lagMax => loop(next, config.copy(lagMax = lagMax)))
+            case Seq(value, next*) if flag == "--run-id"     =>
+              loop(next, config.copy(runId = value))
+            case Seq(value, next*) if flag == "--out"        =>
+              loop(next, config.copy(out = Path.of(value)))
+            case Seq(_, _*)                                  => Left(s"Unknown argument: $flag")
+        case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
+        case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
+
+    loop(args, Config())
+
+  private[diagnostics] def validate(config: Config): Either[String, Config] =
+    Either
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
+      .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
+      .flatMap(valid => Either.cond(valid.lagMax >= 0, valid, "--lag-max must be >= 0"))
+      .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
+
+  private def runScenarioSeed(config: Config, scenario: HhBankLeadLagScenarios.Spec, seed: Long): Either[String, Vector[BankMonthRow]] =
+    given SimParams = scenario.params
+    val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
+    val initState   = FlowSimulation.SimState.fromInit(init)
+    val runtime     = Sfc.RuntimeState(initState.world, initState.firms, initState.households, initState.banks, initState.ledgerFinancialState)
+    val initErrors  = InitCheck.validate(runtime)
+    if initErrors.nonEmpty then Left(s"Scenario ${scenario.id} seed $seed failed init checks: ${initErrors.mkString("; ")}")
+    else
+      val rows                    = Vector.newBuilder[BankMonthRow]
+      val steps                   = MonthDriver
+        .unfoldSteps(initState): state =>
+          Some(MonthRandomness.Contract.fromSeed(runtimeRootSeed(seed, state)))
+        .take(config.months)
+      var previousFailedByBank    = initState.banks.map(_.failed)
+      var failure: Option[String] = None
+      while steps.hasNext && failure.isEmpty do
+        val output = steps.next()
+        output.sfcResult match
+          case Left(errors) =>
+            failure = Some(s"Scenario ${scenario.id} seed $seed failed SFC at month ${output.executionMonth.toInt}: ${errors.mkString("; ")}")
+          case Right(())    =>
+            rows ++= bankMonthRows(config, scenario, seed, output, previousFailedByBank)
+            previousFailedByBank = output.nextState.banks.map(_.failed)
+      failure match
+        case Some(err) => Left(err)
+        case None      => Right(rows.result())
+
+  private def bankMonthRows(
+      config: Config,
+      scenario: HhBankLeadLagScenarios.Spec,
+      seed: Long,
+      output: FlowSimulation.StepOutput,
+      previousFailedByBank: Vector[Boolean],
+  )(using p: SimParams): Vector[BankMonthRow] =
+    val nBanks = output.nextState.banks.length
+    require(
+      output.householdSnapshotState.households.length == output.householdMonthlyFlows.length,
+      s"HH-bank diagnostics require aligned household rows and flow rows, got ${output.householdSnapshotState.households.length} households and ${output.householdMonthlyFlows.length} flows",
+    )
+    require(
+      output.nextState.ledgerFinancialState.banks.length == nBanks,
+      s"HH-bank diagnostics require aligned bank rows and ledger rows, got $nBanks banks and ${output.nextState.ledgerFinancialState.banks.length} ledger rows",
+    )
+    require(
+      previousFailedByBank.length == nBanks,
+      s"HH-bank diagnostics require aligned previous failure flags and bank rows, got ${previousFailedByBank.length} flags and $nBanks banks",
+    )
+
+    val hhTotals = Array.tabulate(nBanks)(_ => HhBankTotals())
+    output.householdSnapshotState.households
+      .zip(output.householdMonthlyFlows)
+      .foreach: (household, flow) =>
+        require(
+          household.id == flow.householdId,
+          s"HH-bank diagnostics require positional household-flow alignment, got household ${household.id.toInt} and flow ${flow.householdId.toInt}",
+        )
+        val bankId = household.bankId.toInt
+        require(bankId >= 0 && bankId < nBanks, s"Household ${household.id.toInt} references invalid bank id $bankId for $nBanks banks")
+        hhTotals(bankId).add(flow)
+
+    val bankStocks        = output.nextState.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
+    val failureDiagnostic = output.nextState.world.flows.bankFailure
+    val unemployment      = fixed(output.nextState.world.unemploymentRate(output.nextState.householdAggregates.employed).toLong)
+    val inflation         = fixed(output.nextState.world.inflation.toLong)
+    val monthlyGdp        = pln(output.nextState.world.cachedMonthlyGdpProxy)
+
+    output.nextState.banks.zipWithIndex.map: (bank, idx) =>
+      val stocks            = bankStocks(idx)
+      val openingCapital    = output.stateIn.banks(idx).capital
+      val corpBondHoldings  = CorporateBondOwnership.bankHolderFor(output.nextState.ledgerFinancialState, bank.id)
+      val totals            = hhTotals(idx)
+      val consumerNplLoss   = totals.consumerLoanDefault * (Share.One - p.household.ccNplRecovery)
+      val newFailure        = if !previousFailedByBank(idx) && bank.failed then 1 else 0
+      val failureReasonCode =
+        if newFailure == 1 && failureDiagnostic.firstNewBankId == bank.id.toInt then failureDiagnostic.firstNewReasonCode
+        else 0
+      BankMonthRow(
+        runId = config.runId,
+        scenarioId = scenario.id,
+        scenarioLabel = scenario.label,
+        seed = seed,
+        month = output.executionMonth.toInt,
+        bankId = bank.id.toInt,
+        bankName = bankName(idx),
+        householdCount = totals.householdCount,
+        hhMonthlyIncome = pln(totals.monthlyIncome),
+        hhConsumerLoanDefault = pln(totals.consumerLoanDefault),
+        hhLiquidityBridgeChargeOff = pln(totals.liquidityBridgeChargeOff),
+        hhLiquidityShortfallFinancing = pln(totals.liquidityShortfallFinancing),
+        hhConsumerDefault = pln(totals.consumerDefault),
+        hhConsumerDebtService = pln(totals.consumerDebtService),
+        hhConsumerApprovedOrigination = pln(totals.consumerApprovedOrigination),
+        hhConsumerRejectedOrigination = pln(totals.consumerRejectedOrigination),
+        hhConsumerDebtArrears = pln(totals.consumerDebtArrears),
+        hhMortgageArrears = pln(totals.mortgageArrears),
+        bankConsumerLoanStock = pln(stocks.consumerLoan),
+        bankConsumerNplStock = pln(bank.consumerNpl),
+        bankConsumerNplLoss = pln(consumerNplLoss),
+        bankCapital = pln(bank.capital),
+        bankCapitalDelta = pln(bank.capital - openingCapital),
+        bankCar = fixed(Banking.car(bank, stocks, corpBondHoldings).toLong),
+        bankLcr = fixed(Banking.lcr(stocks).toLong),
+        bankFailed = if bank.failed then 1 else 0,
+        bankNewFailure = newFailure,
+        bankFailureReasonCode = failureReasonCode,
+        unemployment = unemployment,
+        inflation = inflation,
+        monthlyGdpProxy = monthlyGdp,
+      )
+
+  private[diagnostics] def computeCorrelations(config: Config, rows: Vector[BankMonthRow]): Vector[CorrelationResult] =
+    Scenarios.flatMap: scenario =>
+      val scenarioRows = rows.filter(_.scenarioId == scenario.id)
+      val bySeedBank   = scenarioRows.groupBy(row => (row.seed, row.bankId)).view.mapValues(_.sortBy(_.month).map(row => row.month -> row).toMap).toMap
+      for
+        lag                  <- (0 to config.lagMax).toVector
+        (hhMetric, hhValue)  <- HhMetricAccessors
+        (bankMetric, target) <- BankMetricAccessors
+      yield
+        val pairs       = bySeedBank.valuesIterator.flatMap: byMonth =>
+          byMonth.valuesIterator.flatMap: current =>
+            byMonth.get(current.month - lag).map(previous => hhValue(previous) -> target(current))
+        val vectorPairs = pairs.toVector
+        CorrelationResult(
+          runId = config.runId,
+          scenarioId = scenario.id,
+          scenarioLabel = scenario.label,
+          lagMonths = lag,
+          hhMetric = hhMetric,
+          bankMetric = bankMetric,
+          observations = vectorPairs.length,
+          correlation = pearson(vectorPairs),
+          interpretation = s"$hhMetric at t-$lag versus $bankMetric at t; correlation is descriptive, causal evidence comes from counterfactual rows.",
+        )
+
+  private[diagnostics] def summarizeCounterfactuals(config: Config, rows: Vector[BankMonthRow]): Vector[CounterfactualResult] =
+    Scenarios.map: scenario =>
+      val scenarioRows  = rows.filter(_.scenarioId == scenario.id)
+      val bySeed        = scenarioRows.groupBy(_.seed)
+      val seedSummaries = config.seedRange.map: seed =>
+        val seedRows       = bySeed.getOrElse(seed, Vector.empty)
+        val firstFailure   = seedRows.filter(_.bankNewFailure > 0).map(_.month).minOption
+        val terminalMonth  = seedRows.map(_.month).maxOption.getOrElse(0)
+        val terminalFailed = seedRows.filter(_.month == terminalMonth).map(_.bankFailed).sum
+        (
+          firstFailure,
+          terminalFailed,
+          seedRows.map(_.bankNewFailure).sum,
+          seedRows.map(_.bankConsumerNplLoss).sum,
+          seedRows.map(_.hhConsumerLoanDefault).sum,
+          seedRows.map(_.hhLiquidityBridgeChargeOff).sum,
+        )
+      val failureMonths = seedSummaries.flatMap(_._1)
+      CounterfactualResult(
+        runId = config.runId,
+        scenarioId = scenario.id,
+        scenarioLabel = scenario.label,
+        seeds = seedSummaries.length,
+        months = config.months,
+        failedSeeds = seedSummaries.count(_._1.isDefined),
+        firstFailureMonthMean = mean(failureMonths.map(BigDecimal(_))),
+        terminalFailuresMean = meanOrZero(seedSummaries.map(row => BigDecimal(row._2))),
+        cumulativeNewFailuresMean = meanOrZero(seedSummaries.map(row => BigDecimal(row._3))),
+        cumulativeConsumerNplLossMean = meanOrZero(seedSummaries.map(_._4)),
+        cumulativeHhConsumerLoanDefaultMean = meanOrZero(seedSummaries.map(_._5)),
+        cumulativeLiquidityBridgeChargeOffMean = meanOrZero(seedSummaries.map(_._6)),
+        interpretation = scenario.interpretation,
+      )
+
+  private[diagnostics] def pearson(pairs: Vector[(BigDecimal, BigDecimal)]): Option[BigDecimal] =
+    if pairs.length < 2 then None
+    else
+      val xs    = pairs.map(_._1.toDouble)
+      val ys    = pairs.map(_._2.toDouble)
+      val meanX = xs.sum / xs.length
+      val meanY = ys.sum / ys.length
+      val dx    = xs.map(_ - meanX)
+      val dy    = ys.map(_ - meanY)
+      val sx    = math.sqrt(dx.map(v => v * v).sum)
+      val sy    = math.sqrt(dy.map(v => v * v).sum)
+      if sx == 0.0 || sy == 0.0 then None
+      else Some(BigDecimal((dx zip dy).map((x, y) => x * y).sum / (sx * sy)).setScale(6, RoundingMode.HALF_UP))
+
+  private def writeArtifacts(
+      config: Config,
+      bankRows: Vector[BankMonthRow],
+      correlations: Vector[CorrelationResult],
+      counterfactuals: Vector[CounterfactualResult],
+  ): Vector[Path] =
+    Files.createDirectories(config.runRoot)
+    val bankRowsPath        = config.runRoot.resolve("hh-bank-lead-lag-bank-months.csv")
+    val correlationsPath    = config.runRoot.resolve("hh-bank-lead-lag-correlations.csv")
+    val counterfactualsPath = config.runRoot.resolve("hh-bank-lead-lag-counterfactuals.csv")
+    val reportPath          = config.runRoot.resolve("hh-bank-lead-lag-report.md")
+    Files.writeString(bankRowsPath, renderBankRows(bankRows), StandardCharsets.UTF_8)
+    Files.writeString(correlationsPath, renderCorrelations(correlations), StandardCharsets.UTF_8)
+    Files.writeString(counterfactualsPath, renderCounterfactuals(counterfactuals), StandardCharsets.UTF_8)
+    Files.writeString(reportPath, renderReport(config, correlations, counterfactuals), StandardCharsets.UTF_8)
+    Vector(bankRowsPath, correlationsPath, counterfactualsPath, reportPath)
+
+  private def renderBankRows(rows: Vector[BankMonthRow]): String =
+    val header =
+      "RunId;ScenarioId;ScenarioLabel;Seed;Month;BankId;BankName;HouseholdCount;HhMonthlyIncome;HhConsumerLoanDefault;HhLiquidityBridgeChargeOff;HhLiquidityShortfallFinancing;HhConsumerDefault;HhConsumerDebtService;HhConsumerApprovedOrigination;HhConsumerRejectedOrigination;HhConsumerDebtArrears;HhMortgageArrears;BankConsumerLoanStock;BankConsumerNplStock;BankConsumerNplLoss;BankCapital;BankCapitalDelta;BankCar;BankLcr;BankFailed;BankNewFailure;BankFailureReasonCode;Unemployment;Inflation;MonthlyGdpProxy"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.scenarioId,
+        row.scenarioLabel,
+        row.seed.toString,
+        row.month.toString,
+        row.bankId.toString,
+        row.bankName,
+        row.householdCount.toString,
+        renderDecimal(row.hhMonthlyIncome),
+        renderDecimal(row.hhConsumerLoanDefault),
+        renderDecimal(row.hhLiquidityBridgeChargeOff),
+        renderDecimal(row.hhLiquidityShortfallFinancing),
+        renderDecimal(row.hhConsumerDefault),
+        renderDecimal(row.hhConsumerDebtService),
+        renderDecimal(row.hhConsumerApprovedOrigination),
+        renderDecimal(row.hhConsumerRejectedOrigination),
+        renderDecimal(row.hhConsumerDebtArrears),
+        renderDecimal(row.hhMortgageArrears),
+        renderDecimal(row.bankConsumerLoanStock),
+        renderDecimal(row.bankConsumerNplStock),
+        renderDecimal(row.bankConsumerNplLoss),
+        renderDecimal(row.bankCapital),
+        renderDecimal(row.bankCapitalDelta),
+        renderDecimal(row.bankCar),
+        renderDecimal(row.bankLcr),
+        row.bankFailed.toString,
+        row.bankNewFailure.toString,
+        row.bankFailureReasonCode.toString,
+        renderDecimal(row.unemployment),
+        renderDecimal(row.inflation),
+        renderDecimal(row.monthlyGdpProxy),
+      ).mkString(";")
+    (header +: body).mkString("", "\n", "\n")
+
+  private def renderCorrelations(rows: Vector[CorrelationResult]): String =
+    val header = "RunId;ScenarioId;ScenarioLabel;LagMonths;HhMetric;BankMetric;Observations;Correlation;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.scenarioId,
+        row.scenarioLabel,
+        row.lagMonths.toString,
+        row.hhMetric,
+        row.bankMetric,
+        row.observations.toString,
+        row.correlation.map(renderDecimal).getOrElse("NA"),
+        row.interpretation,
+      ).mkString(";")
+    (header +: body).mkString("", "\n", "\n")
+
+  private def renderCounterfactuals(rows: Vector[CounterfactualResult]): String =
+    val header =
+      "RunId;ScenarioId;ScenarioLabel;Seeds;Months;FailedSeeds;FirstFailureMonthMean;TerminalFailuresMean;CumulativeNewFailuresMean;CumulativeConsumerNplLossMean;CumulativeHhConsumerLoanDefaultMean;CumulativeLiquidityBridgeChargeOffMean;Interpretation"
+    val body   = rows.map: row =>
+      Vector(
+        row.runId,
+        row.scenarioId,
+        row.scenarioLabel,
+        row.seeds.toString,
+        row.months.toString,
+        row.failedSeeds.toString,
+        row.firstFailureMonthMean.map(renderDecimal).getOrElse("NA"),
+        renderDecimal(row.terminalFailuresMean),
+        renderDecimal(row.cumulativeNewFailuresMean),
+        renderDecimal(row.cumulativeConsumerNplLossMean),
+        renderDecimal(row.cumulativeHhConsumerLoanDefaultMean),
+        renderDecimal(row.cumulativeLiquidityBridgeChargeOffMean),
+        row.interpretation,
+      ).mkString(";")
+    (header +: body).mkString("", "\n", "\n")
+
+  private def renderReport(config: Config, correlations: Vector[CorrelationResult], counterfactuals: Vector[CounterfactualResult]): String =
+    val baseline = counterfactuals.find(_.scenarioId == "baseline")
+    val noHit    = counterfactuals.find(_.scenarioId == "no-consumer-npl-capital-hit")
+    val topCorr  = correlations
+      .filter(row => row.scenarioId == "baseline" && row.lagMonths > 0 && row.correlation.isDefined)
+      .sortBy(row => -row.correlation.get.abs)
+      .take(10)
+    val command  =
+      s"""sbt "hhBankLeadLagDiagnostics --seed-start ${config.seedStart} --seeds ${config.seeds} --months ${config.months} --lag-max ${config.lagMax} --out ${config.out} --run-id ${config.runId}""""
+    Vector(
+      "# HH-to-Bank Lead-Lag Diagnostics",
+      "",
+      "Generated for issue #584.",
+      "",
+      s"- Run id: `${config.runId}`",
+      s"- Seeds: `${config.seeds}` from `${config.seedStart}`",
+      s"- Months: `${config.months}`",
+      s"- Lag window: `0..${config.lagMax}` months",
+      s"- Repeat command: `$command`",
+      "",
+      "The bank-month export joins household stress flows by routed `BankId` to",
+      "bank consumer-credit loss, capital, CAR, LCR, and failure outcomes. The",
+      "correlation table is descriptive lead-lag evidence; the counterfactual table",
+      "tests whether the direct consumer NPL capital-hit channel is necessary in this fixture.",
+      "",
+      "## Counterfactual Summary",
+      "",
+      counterfactualTable(counterfactuals),
+      "",
+      "## Counterfactual Reading",
+      "",
+      causalReading(baseline, noHit),
+      "",
+      "## Strongest Positive-Lag Baseline Correlations",
+      "",
+      correlationTable(topCorr),
+      "",
+    ).mkString("\n")
+
+  private def counterfactualTable(rows: Vector[CounterfactualResult]): String =
+    val header = "| Scenario | Failed Seeds | Mean First Failure Month | Mean Terminal Failures | Mean Cum Consumer NPL Loss |"
+    val sep    = "| --- | --- | --- | --- | --- |"
+    val body   = rows.map: row =>
+      s"| ${row.scenarioId} | ${row.failedSeeds}/${row.seeds} | ${row.firstFailureMonthMean.map(renderDecimal).getOrElse("n/a")} | ${renderDecimal(row.terminalFailuresMean)} | ${renderDecimal(row.cumulativeConsumerNplLossMean)} |"
+    (header +: sep +: body).mkString("\n")
+
+  private def correlationTable(rows: Vector[CorrelationResult]): String =
+    if rows.isEmpty then "No finite baseline correlations."
+    else
+      val header = "| Lag | HH Metric | Bank Metric | Observations | Correlation |"
+      val sep    = "| --- | --- | --- | --- | --- |"
+      val body   = rows.map: row =>
+        s"| ${row.lagMonths} | ${row.hhMetric} | ${row.bankMetric} | ${row.observations} | ${row.correlation.map(renderDecimal).getOrElse("NA")} |"
+      (header +: sep +: body).mkString("\n")
+
+  private def causalReading(baseline: Option[CounterfactualResult], noHit: Option[CounterfactualResult]): String =
+    (baseline, noHit) match
+      case (Some(base), Some(counter)) =>
+        val failureDelta  = counter.failedSeeds - base.failedSeeds
+        val terminalDelta = counter.terminalFailuresMean - base.terminalFailuresMean
+        s"Neutralizing the consumer NPL capital hit changes failed seed count by $failureDelta and mean terminal failures by ${renderDecimal(terminalDelta)} versus baseline. If failures fall materially while HH default flows remain visible, the direct consumer NPL capital-hit channel is necessary for bank failure timing in this fixture. This is a controlled model intervention, not full macro-causal identification."
+      case _                           =>
+        "Counterfactual rows are incomplete; counterfactual reading unavailable."
+
+  private def pln(value: PLN)(using p: SimParams): BigDecimal =
+    fixed(polandScale(value).toLong)
+
+  private def polandScale(value: PLN)(using p: SimParams): PLN =
+    if p.gdpRatio > Scalar.Zero then value / p.gdpRatio.toMultiplier else value
+
+  private def fixed(raw: Long): BigDecimal =
+    BigDecimal(raw) / BigDecimal(FixedPointBase.Scale)
+
+  private def renderDecimal(value: BigDecimal): String =
+    value.setScale(6, RoundingMode.HALF_UP).bigDecimal.stripTrailingZeros.toPlainString
+
+  private def mean(values: Vector[BigDecimal]): Option[BigDecimal] =
+    if values.isEmpty then None else Some(values.sum / BigDecimal(values.length))
+
+  private def meanOrZero(values: Vector[BigDecimal]): BigDecimal =
+    mean(values).getOrElse(BigDecimal(0))
+
+  private def bankName(index: Int): String =
+    Banking.DefaultConfigs.lift(index).map(_.name).getOrElse(s"Bank-$index")
+
+  private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
+    seed * 10000L + state.completedMonth.toLong
+
+  private def knownFlag(flag: String): Boolean =
+    Set("--seed-start", "--seeds", "--months", "--lag-max", "--run-id", "--out").contains(flag)
+
+  private def parseLong(value: String, flag: String): Either[String, Long] =
+    value.toLongOption.toRight(s"Invalid long for $flag: $value")
+
+  private def parseInt(value: String, flag: String): Either[String, Int] =
+    value.toIntOption.toRight(s"Invalid integer for $flag: $value")
+
+  private val usage: String =
+    """Usage: hhBankLeadLagDiagnostics [--seed-start N] [--seeds N] [--months N] [--lag-max N] [--out DIR] [--run-id ID]
+      |
+      |Writes:
+      |- hh-bank-lead-lag-bank-months.csv
+      |- hh-bank-lead-lag-correlations.csv
+      |- hh-bank-lead-lag-counterfactuals.csv
+      |- hh-bank-lead-lag-report.md
+      |""".stripMargin

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
@@ -1,0 +1,107 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with OptionValues:
+
+  "HhBankLeadLagDiagnosticsExport.parseArgs" should "parse run controls" in {
+    val parsed = HhBankLeadLagDiagnosticsExport.parseArgs(
+      Vector("--seed-start", "3", "--seeds", "4", "--months", "24", "--lag-max", "3", "--out", "target/x", "--run-id", "review"),
+    )
+
+    parsed.map(config => (config.seedStart, config.seeds, config.months, config.lagMax, config.out.toString, config.runId)) shouldBe
+      Right((3L, 4, 24, 3, "target/x", "review"))
+  }
+
+  it should "reject negative lag windows" in {
+    HhBankLeadLagDiagnosticsExport.validate(HhBankLeadLagDiagnosticsExport.Config(lagMax = -1)).left.toOption.value should include("--lag-max")
+  }
+
+  "HhBankLeadLagDiagnosticsExport.pearson" should "return a finite correlation when both sides vary" in {
+    HhBankLeadLagDiagnosticsExport.pearson(Vector(BigDecimal(1) -> BigDecimal(2), BigDecimal(2) -> BigDecimal(4), BigDecimal(3) -> BigDecimal(6))) shouldBe
+      Some(BigDecimal("1.000000"))
+  }
+
+  it should "return None when a side is constant" in {
+    HhBankLeadLagDiagnosticsExport.pearson(Vector(BigDecimal(1) -> BigDecimal(2), BigDecimal(1) -> BigDecimal(4))) shouldBe None
+  }
+
+  "HhBankLeadLagDiagnosticsExport.computeCorrelations" should "join household metrics at t-lag to bank outcomes at t" in {
+    val rows = Vector(
+      row(month = 1, hhConsumerLoanDefault = BigDecimal(10), bankConsumerNplLoss = BigDecimal(0)),
+      row(month = 2, hhConsumerLoanDefault = BigDecimal(20), bankConsumerNplLoss = BigDecimal(10)),
+      row(month = 3, hhConsumerLoanDefault = BigDecimal(30), bankConsumerNplLoss = BigDecimal(20)),
+    )
+
+    val correlations = HhBankLeadLagDiagnosticsExport.computeCorrelations(HhBankLeadLagDiagnosticsExport.Config(lagMax = 1), rows)
+    val lagOne       = correlations
+      .find(row =>
+        row.scenarioId == "baseline" && row.lagMonths == 1 &&
+          row.hhMetric == "HhConsumerLoanDefault" && row.bankMetric == "BankConsumerNplLoss",
+      )
+      .value
+
+    lagOne.observations shouldBe 2
+    lagOne.correlation shouldBe Some(BigDecimal("1.000000"))
+  }
+
+  "HhBankLeadLagDiagnosticsExport.summarizeCounterfactuals" should "separate baseline failures from consumer-loss counterfactual failures" in {
+    val rows = Vector(
+      row(month = 1, hhConsumerLoanDefault = BigDecimal(10), bankConsumerNplLoss = BigDecimal(8)),
+      row(month = 2, hhConsumerLoanDefault = BigDecimal(20), bankConsumerNplLoss = BigDecimal(16), bankNewFailure = 1, bankFailed = 1),
+      row("no-consumer-npl-capital-hit", "No consumer NPL capital hit", month = 1, hhConsumerLoanDefault = BigDecimal(10), bankConsumerNplLoss = BigDecimal(0)),
+      row("no-consumer-npl-capital-hit", "No consumer NPL capital hit", month = 2, hhConsumerLoanDefault = BigDecimal(20), bankConsumerNplLoss = BigDecimal(0)),
+    )
+
+    val summary = HhBankLeadLagDiagnosticsExport.summarizeCounterfactuals(HhBankLeadLagDiagnosticsExport.Config(seeds = 1, months = 2), rows)
+
+    summary.find(_.scenarioId == "baseline").value.failedSeeds shouldBe 1
+    summary.find(_.scenarioId == "no-consumer-npl-capital-hit").value.failedSeeds shouldBe 0
+  }
+
+  private def row(
+      scenarioId: String = "baseline",
+      scenarioLabel: String = "Baseline",
+      seed: Long = 1L,
+      month: Int,
+      bankId: Int = 0,
+      hhConsumerLoanDefault: BigDecimal,
+      bankConsumerNplLoss: BigDecimal,
+      bankNewFailure: Int = 0,
+      bankFailed: Int = 0,
+  ): HhBankLeadLagDiagnosticsExport.BankMonthRow =
+    HhBankLeadLagDiagnosticsExport.BankMonthRow(
+      runId = "test",
+      scenarioId = scenarioId,
+      scenarioLabel = scenarioLabel,
+      seed = seed,
+      month = month,
+      bankId = bankId,
+      bankName = s"Bank-$bankId",
+      householdCount = 1,
+      hhMonthlyIncome = BigDecimal(100),
+      hhConsumerLoanDefault = hhConsumerLoanDefault,
+      hhLiquidityBridgeChargeOff = BigDecimal(0),
+      hhLiquidityShortfallFinancing = BigDecimal(0),
+      hhConsumerDefault = hhConsumerLoanDefault,
+      hhConsumerDebtService = BigDecimal(0),
+      hhConsumerApprovedOrigination = BigDecimal(0),
+      hhConsumerRejectedOrigination = BigDecimal(0),
+      hhConsumerDebtArrears = BigDecimal(0),
+      hhMortgageArrears = BigDecimal(0),
+      bankConsumerLoanStock = BigDecimal(1000),
+      bankConsumerNplStock = BigDecimal(0),
+      bankConsumerNplLoss = bankConsumerNplLoss,
+      bankCapital = BigDecimal(100),
+      bankCapitalDelta = -bankConsumerNplLoss,
+      bankCar = BigDecimal("0.1"),
+      bankLcr = BigDecimal("1.0"),
+      bankFailed = bankFailed,
+      bankNewFailure = bankNewFailure,
+      bankFailureReasonCode = if bankNewFailure == 1 then 2 else 0,
+      unemployment = BigDecimal("0.05"),
+      inflation = BigDecimal("0.02"),
+      monthlyGdpProxy = BigDecimal(10000),
+    )


### PR DESCRIPTION
Closes #584

Summary:
- Add the hhBankLeadLagDiagnostics sbt export for bank-month HH stress routing, lead-lag correlations, and counterfactual summaries.
- Add baseline vs no-consumer-npl-capital-hit scenarios to test whether direct consumer NPL capital hits are necessary for bank failure timing.
- Document output files and interpretation, including that the counterfactual is model-internal evidence, not full macro-causal identification.

Key check:
- seeds=2, months=24: baseline has 2/2 failed seeds, mean first failure month 6.5, mean terminal failures 9.
- no-consumer-npl-capital-hit has 0/2 failed seeds and 0 terminal failures while HH default flows remain visible.

Validation:
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.diagnostics.HhBankLeadLagDiagnosticsExportSpec"
- sbt "hhBankLeadLagDiagnostics --seed-start 1 --seeds 2 --months 24 --lag-max 6 --out target/hh-bank-lead-lag --run-id check584-s2-final"
- sbt assembly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HH-to-bank lead-lag diagnostics tool with sbt command for analyzing household-to-bank causal relationships, correlations, and counterfactual scenarios.

* **Documentation**
  * Added comprehensive documentation for the new diagnostics tool including command parameters, output artifacts, and metric definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->