### PR TITLE
Stop normal updates for failed-bank shells

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -878,6 +878,9 @@ haircuts uninsured deposits of failed banks. Purchase-and-assumption resolution
 transfers deposits, government bonds, performing loans, consumer loans, and
 corporate-bond holdings to the healthiest surviving bank. Firms and households
 routed to failed banks are reassigned to the absorber.
+In later months, a failed-bank row is an inert shell: ordinary lending, P&L,
+ECL migration, NPL write-off, and deposit-flow updates are skipped unless an
+explicit resolution or reconciliation mechanism changes the row.
 
 Failure-trigger diagnostics are emitted as `BankFailure_*` seed timeseries
 columns. `BankFailure_NewNegativeCapital`, `BankFailure_NewCarBreach`, and

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -636,6 +636,10 @@ object BankingEconomics:
       quasiFiscalDepositChange: PLN,
       in: StepInput,
   )(using p: SimParams): SingleBankUpdate =
+    if b.failed then
+      // Failed rows are inert shells; resolution/reconciliation owns any explicit shell changes.
+      return SingleBankUpdate(bank = b, financialStocks = stocks)
+
     val bId           = b.id.toInt
     val bankNplNew    = in.s5.perBankNplDebt(bId)
     val bankNplLoss   = bankNplNew * (Share.One - p.banking.loanRecovery)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MacroprudentialSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MacroprudentialSpec.scala
@@ -36,16 +36,15 @@ class MacroprudentialSpec extends AnyFlatSpec with Matchers:
     decimal(Macroprudential.osiiBufferImpl(1)) shouldBe BigDecimal("0.01") +- BigDecimal("1e-10")
   }
 
-  it should "return current O-SII buffers for the remaining default banks" in {
-    decimal(Macroprudential.osiiBufferImpl(2)) shouldBe BigDecimal("0.005") +- BigDecimal("1e-10")
-    decimal(Macroprudential.osiiBufferImpl(3)) shouldBe BigDecimal("0.01") +- BigDecimal("1e-10")
-    decimal(Macroprudential.osiiBufferImpl(4)) shouldBe BigDecimal("0.015") +- BigDecimal("1e-10")
-    decimal(Macroprudential.osiiBufferImpl(5)) shouldBe BigDecimal("0.0025") +- BigDecimal("1e-10")
-    decimal(Macroprudential.osiiBufferImpl(6)) shouldBe BigDecimal("0.0025") +- BigDecimal("1e-10")
-  }
+  it should "return current O-SII buffers for the remaining default banks" in
+    p.banking.osiiBuffers.zipWithIndex
+      .drop(2)
+      .foreach: (expected, bankId) =>
+        Macroprudential.osiiBufferImpl(bankId) shouldBe expected
 
   it should "return 0% outside the default bank vector" in {
-    Macroprudential.osiiBufferImpl(7) shouldBe Multiplier.Zero
+    Macroprudential.osiiBufferImpl(-1) shouldBe Multiplier.Zero
+    Macroprudential.osiiBufferImpl(p.banking.osiiBuffers.length) shouldBe Multiplier.Zero
   }
 
   // ==========================================================================

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -112,6 +112,51 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     result.reassignedHouseholds.exists(_.bankId == BankId(0)) shouldBe false
   }
 
+  it should "not run ordinary monthly updates for already failed bank shells" in {
+    val prepared             = preparedBankingStep()
+    val failedBank           = prepared.banks.head.copy(
+      status = Banking.BankStatus.Failed(ExecutionMonth.First),
+      capital = PLN(123456789L),
+      nplAmount = PLN(111111L),
+      loansShort = PLN(222222L),
+      loansMedium = PLN(333333L),
+      loansLong = PLN(444444L),
+      consumerNpl = PLN(555555L),
+      eclStaging = EclStaging.State(PLN(666666L), PLN(777777L), PLN(888888L)),
+    )
+    val shellStocks          = LedgerFinancialState
+      .projectBankFinancialStocks(prepared.ledgerFinancialState.banks.head)
+      .copy(
+        totalDeposits = PLN.Zero,
+        demandDeposit = PLN.Zero,
+        termDeposit = PLN.Zero,
+        firmLoan = PLN(900000L),
+        consumerLoan = PLN(800000L),
+        govBondAfs = PLN.Zero,
+        govBondHtm = PLN.Zero,
+        reserve = PLN.Zero,
+        interbankLoan = PLN.Zero,
+      )
+    val shellLedger          = prepared.ledgerFinancialState.copy(
+      banks = prepared.ledgerFinancialState.banks.updated(0, LedgerFinancialState.bankBalances(shellStocks, corpBond = PLN.Zero, mortgageLoan = PLN.Zero)),
+    )
+    val alignedOpeningStocks = BankingEconomics
+      .alignConsumerLoanBookToHouseholdRouting(
+        prepared.s5.households,
+        prepared.s5.ledgerFinancialState.households,
+        shellLedger.banks.map(LedgerFinancialState.projectBankFinancialStocks),
+      )
+      .head
+
+    val result = prepared.run(
+      ledgerFinancialStateOverride = shellLedger,
+      banksOverride = prepared.banks.updated(0, failedBank),
+    )
+
+    result.banks.head shouldBe failedBank
+    LedgerFinancialState.projectBankFinancialStocks(result.ledgerFinancialState.banks.head) shouldBe alignedOpeningStocks
+  }
+
   it should "realign consumer-loan book distribution to household bank routing without changing the aggregate stock" in {
     val households        = Vector(
       TestHouseholdState(id = HhId(0), skill = Share.decimal(7, 1), mpc = Share.decimal(8, 1), status = HhStatus.Unemployed(0), bankId = BankId(0)),


### PR DESCRIPTION
## Summary
- Short-circuit ordinary monthly bank updates for rows already marked failed.
- Keep failed-bank shell changes owned by explicit resolution/reconciliation mechanisms.
- Add a regression test and document the failed-shell semantics.

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.BankingSectorPropertySpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- sbt assembly

Closes #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Failed banks now correctly remain inactive, skipping ordinary monthly updates including lending activities, financial computations, and deposit processing.

* **Tests**
  * Expanded test coverage for failed bank state preservation and buffer calculations.

* **Documentation**
  * Clarified the behavior and lifecycle of inactive banks in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->