### PR TITLE
Make bank bail-in event based

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -874,7 +874,8 @@ provision build-up from realized credit losses reported in `BankCreditLoss_*`.
 
 Failure is triggered by negative capital, three consecutive months below
 effective minimum CAR, or an LCR breach below half of the minimum. BFG bail-in
-haircuts uninsured deposits of failed banks. Purchase-and-assumption resolution
+is event-based: it haircuts only the unprocessed uninsured deposit stock of
+banks entering resolution in the current failure event set. P&A resolution then
 transfers deposits, government bonds, performing loans, consumer loans, and
 corporate-bond holdings to the healthiest surviving bank. Firms and households
 routed to failed banks are reassigned to the absorber.

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -250,15 +250,16 @@ object Banking:
 
   /** Ledger-contracted bank financial stocks owned by LedgerFinancialState. */
   case class BankFinancialStocks(
-      totalDeposits: PLN, // total customer deposits (HH + firms)
-      firmLoan: PLN,      // outstanding corporate loan book
-      govBondAfs: PLN,    // Available-for-Sale gov bonds
-      govBondHtm: PLN,    // Held-to-Maturity gov bonds
-      reserve: PLN,       // reserves held at NBP
-      interbankLoan: PLN, // net interbank position (positive = lender)
-      demandDeposit: PLN, // demand deposits
-      termDeposit: PLN,   // term deposits
-      consumerLoan: PLN,  // outstanding unsecured household credit
+      totalDeposits: PLN,              // total customer deposits (HH + firms)
+      firmLoan: PLN,                   // outstanding corporate loan book
+      govBondAfs: PLN,                 // Available-for-Sale gov bonds
+      govBondHtm: PLN,                 // Held-to-Maturity gov bonds
+      reserve: PLN,                    // reserves held at NBP
+      interbankLoan: PLN,              // net interbank position (positive = lender)
+      demandDeposit: PLN,              // demand deposits
+      termDeposit: PLN,                // term deposits
+      consumerLoan: PLN,               // outstanding unsecured household credit
+      bailedInDeposits: PLN = PLN.Zero, // deposits already processed by resolution bail-in
   )
 
   /** Operational state of an individual bank.
@@ -682,10 +683,13 @@ object Banking:
         else stocks.totalDeposits * p.banking.bfgLevyRate.monthly
     PerBankAmounts(perBank, perBank.sumPln)
 
-  /** Bail-in: haircut uninsured deposits on failed banks. Deposits below
-    * bfgDepositGuarantee are protected.
+  /** Bail-in: haircut uninsured deposits only for banks that entered resolution
+    * in the current event set. Deposits below bfgDepositGuarantee are
+    * protected.
     */
-  def applyBailIn(banks: Vector[BankState], financialStocks: Vector[BankFinancialStocks])(using p: SimParams): BailInResult =
+  def applyBailIn(banks: Vector[BankState], financialStocks: Vector[BankFinancialStocks], eligibleBankIds: Set[BankId])(using
+      p: SimParams,
+  ): BailInResult =
     require(
       banks.length == financialStocks.length,
       s"Banking.applyBailIn requires aligned banks and financial stocks, got ${banks.length} banks and ${financialStocks.length} stock rows",
@@ -693,11 +697,14 @@ object Banking:
     val withHaircut = banks
       .zip(financialStocks)
       .map: (b, stocks) =>
-        if b.failed && stocks.totalDeposits > PLN.Zero then
-          val guaranteed = stocks.totalDeposits.min(p.banking.bfgDepositGuarantee)
-          val uninsured  = stocks.totalDeposits - guaranteed
-          val haircut    = uninsured * p.banking.bailInDepositHaircut
-          (stocks.copy(totalDeposits = stocks.totalDeposits - haircut), haircut)
+        val unprocessedDeposits = (stocks.totalDeposits - stocks.bailedInDeposits).max(PLN.Zero)
+        if b.failed && eligibleBankIds.contains(b.id) && unprocessedDeposits > PLN.Zero then
+          val guaranteed        = unprocessedDeposits.min(p.banking.bfgDepositGuarantee)
+          val uninsured         = unprocessedDeposits - guaranteed
+          val haircut           = uninsured * p.banking.bailInDepositHaircut
+          val closingDeposits   = stocks.totalDeposits - haircut
+          val processedDeposits = (stocks.bailedInDeposits + unprocessedDeposits - haircut).min(closingDeposits).max(PLN.Zero)
+          (stocks.copy(totalDeposits = closingDeposits, bailedInDeposits = processedDeposits), haircut)
         else (stocks, PLN.Zero)
     BailInResult(banks, withHaircut.map(_._1), withHaircut.map(_._2).sumPln)
 
@@ -728,6 +735,7 @@ object Banking:
       val addCorpB              = toAbsorb.flatMap((bank, _) => holderBalances.lift(bank.id.toInt)).sumPln
       val addCC                 = toAbsorb.map(_._2.consumerLoan).sumPln
       val addIB                 = toAbsorb.map(_._2.interbankLoan).sumPln
+      val addBailedInDep        = toAbsorb.map(_._2.bailedInDeposits).sumPln
       // Weighted yield: Σ(htmBonds × htmBookYield) — PLN × Rate → PLN
       val htmYieldWt            = toAbsorb.map((bank, stocks) => stocks.govBondHtm * bank.htmBookYield).sumPln
 
@@ -748,6 +756,7 @@ object Banking:
                 govBondHtm = combinedHtm,
                 consumerLoan = stocks.consumerLoan + addCC,
                 interbankLoan = stocks.interbankLoan + addIB,
+                bailedInDeposits = (stocks.bailedInDeposits + addBailedInDep).min(stocks.totalDeposits + addDep).max(PLN.Zero),
               ),
             )
           else if b.failed && stocks.totalDeposits > PLN.Zero then
@@ -761,6 +770,7 @@ object Banking:
                 reserve = PLN.Zero,
                 interbankLoan = PLN.Zero,
                 consumerLoan = PLN.Zero,
+                bailedInDeposits = PLN.Zero,
               ),
             )
           else (b, stocks)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -925,9 +925,10 @@ object BankingEconomics:
     val afterFailCheck  = secondaryFail.banks
     val afterFailStocks = tfiSale.financialStocks
     val anyFailed       = failResult.anyFailed || secondaryFail.anyFailed
+    val bailInBankIds   = (failResult.events ++ secondaryFail.events).map(_.bankId).toSet
 
     val bailInResult          =
-      if anyFailed then Banking.applyBailIn(afterFailCheck, afterFailStocks)
+      if bailInBankIds.nonEmpty then Banking.applyBailIn(afterFailCheck, afterFailStocks, bailInBankIds)
       else Banking.BailInResult(afterFailCheck, afterFailStocks, PLN.Zero)
     val resolveResult         =
       if anyFailed then Banking.resolveFailures(bailInResult.banks, bailInResult.financialStocks, settledBankCorpBonds)
@@ -1234,7 +1235,7 @@ object BankingEconomics:
             )
           else
             val failedBank = failCheck.banks.head
-            val bailIn     = Banking.applyBailIn(nextBanks.updated(targetIdx, failedBank), nextStocks)
+            val bailIn     = Banking.applyBailIn(nextBanks.updated(targetIdx, failedBank), nextStocks, failCheck.events.map(_.bankId).toSet)
             val resolved   = Banking.resolveFailures(bailIn.banks, bailIn.financialStocks, bankCorpBondHoldings)
             AggregateReconciliationResult(
               resolved.banks,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala
@@ -326,6 +326,7 @@ object LedgerFinancialState:
       interbankLoan = stocks.interbankLoan,
       corpBond = corpBond,
       mortgageLoan = mortgageLoan,
+      bailedInDeposits = stocks.bailedInDeposits,
     )
 
   /** Project ledger-owned bank balances into the banking execution DTO.
@@ -344,6 +345,7 @@ object LedgerFinancialState:
       govBondHtm = balances.govBondHtm,
       reserve = balances.reserve,
       interbankLoan = balances.interbankLoan,
+      bailedInDeposits = balances.bailedInDeposits,
     )
 
   def insuranceOpeningBalances(ledgerFinancialState: LedgerFinancialState): Insurance.OpeningBalances =
@@ -502,6 +504,8 @@ object LedgerFinancialState:
         * BSM evidence.
         */
       mortgageLoan: PLN = PLN.Zero,
+      /** Deposit liabilities already processed through event-based bail-in. */
+      bailedInDeposits: PLN = PLN.Zero,
   )
 
   /** Ledger-backed financial balances issued by central government. */

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -197,7 +197,8 @@ diagnostic for per-bank allocation artifacts, not a standalone economic loss
 channel.
 `BankCapital_DepositBailInLoss` mirrors the existing `BailInLoss` column inside
 the bank-capital diagnostic block; it is a resolution-adjacent depositor haircut
-and is not included in the equity-capital waterfall identity.
+on newly processed deposits and is not included in the equity-capital waterfall
+identity.
 
 `BankCreditLoss_*` columns normalize realized credit losses and gross
 default/write-off flows by the relevant closing exposure stock, so bank-failure

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -28,6 +28,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
       govBondHoldings: PLN = PLN.Zero,
       interbankNet: PLN = PLN.Zero,
       status: BankStatus = BankStatus.Active(0),
+      bailedInDeposits: PLN = PLN.Zero,
   ): BankRow =
     BankRow(
       Banking.BankState(
@@ -51,6 +52,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         demandDeposit = PLN.Zero,
         termDeposit = PLN.Zero,
         consumerLoan = PLN.Zero,
+        bailedInDeposits = bailedInDeposits,
       ),
     )
 
@@ -97,20 +99,38 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
 
   "Banking.applyBailIn" should "haircut only failed-bank uninsured deposit stocks" in {
     val safe       = Vector(mkBankRow(deposits = PLN(500000), loans = PLN(100000), capital = PLN(50000)))
-    val safeResult = Banking.applyBailIn(banks(safe), stocks(safe))
+    val safeResult = Banking.applyBailIn(banks(safe), stocks(safe), Set(BankId(0)))
     safeResult.financialStocks.head.totalDeposits shouldBe PLN(500000)
     safeResult.totalLoss shouldBe PLN.Zero
 
     val guaranteed       = Vector(mkBankRow(deposits = PLN(300000), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(5))))
-    val guaranteedResult = Banking.applyBailIn(banks(guaranteed), stocks(guaranteed))
+    val guaranteedResult = Banking.applyBailIn(banks(guaranteed), stocks(guaranteed), Set(BankId(0)))
     guaranteedResult.financialStocks.head.totalDeposits shouldBe PLN(300000)
     guaranteedResult.totalLoss shouldBe PLN.Zero
 
     val failed       = Vector(mkBankRow(deposits = PLN(1000000), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(5))))
-    val failedResult = Banking.applyBailIn(banks(failed), stocks(failed))
+    val failedResult = Banking.applyBailIn(banks(failed), stocks(failed), Set(BankId(0)))
     val haircut      = (PLN(1000000) - p.banking.bfgDepositGuarantee) * p.banking.bailInDepositHaircut
     failedResult.financialStocks.head.totalDeposits shouldBe PLN(1000000) - haircut
     failedResult.totalLoss shouldBe haircut
+  }
+
+  it should "skip already-failed banks outside the current bail-in event set" in {
+    val rows    = Vector(
+      mkBankRow(id = 0, deposits = PLN(1000000), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(5))),
+      mkBankRow(id = 1, deposits = PLN(1000000), capital = PLN.Zero, status = BankStatus.Failed(ExecutionMonth(6))),
+    )
+    val result  = Banking.applyBailIn(banks(rows), stocks(rows), Set(BankId(1)))
+    val haircut = (PLN(1000000) - p.banking.bfgDepositGuarantee) * p.banking.bailInDepositHaircut
+
+    result.financialStocks(0).totalDeposits shouldBe PLN(1000000)
+    result.financialStocks(1).totalDeposits shouldBe PLN(1000000) - haircut
+    result.financialStocks(1).bailedInDeposits shouldBe PLN(1000000) - haircut
+    result.totalLoss shouldBe haircut
+
+    val repeated = Banking.applyBailIn(result.banks, result.financialStocks, Set(BankId(1)))
+    repeated.financialStocks shouldBe result.financialStocks
+    repeated.totalLoss shouldBe PLN.Zero
   }
 
   "Banking.resolveFailures" should "transfer failed-bank deposits, bonds, and interbank stock to the survivor" in {
@@ -124,6 +144,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         govBondHoldings = PLN(10000000000L),
         interbankNet = PLN(1000),
         status = BankStatus.Failed(ExecutionMonth(3)),
+        bailedInDeposits = PLN(450000),
       ),
       mkBankRow(id = 1, deposits = PLN(2000000), loans = PLN(200000), capital = PLN(200000), govBondHoldings = PLN(5000000000L), interbankNet = PLN(-1000)),
     )
@@ -132,6 +153,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
     result.financialStocks(0).totalDeposits shouldBe PLN.Zero
     result.financialStocks(0).firmLoan shouldBe PLN.Zero
     result.financialStocks(0).interbankLoan shouldBe PLN.Zero
+    result.financialStocks(1).bailedInDeposits shouldBe PLN(450000)
     decimal(Banking.govBondHoldings(result.financialStocks(1))) shouldBe BigDecimal("15e9") +- BigDecimal("1.0")
     decimal(result.financialStocks.map(_.interbankLoan).sumPln) shouldBe BigDecimal("0.0") +- BigDecimal("1e-6")
   }


### PR DESCRIPTION
## Summary
- Make `Banking.applyBailIn` operate on the current failure-event bank set instead of every `failed=true` row.
- Track `bailedInDeposits` on ledger-backed bank stocks so already processed deposits are not haircut again after resolution transfers.
- Update KNF/BFG tests and docs for event-based bail-in semantics.

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.BankingSectorPropertySpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"` — 53/53 passed
- `sbt "testOnly com.boombustgroup.amorfati.engine.ledger.LedgerFinancialStateSpec com.boombustgroup.amorfati.accounting.SfcSpec com.boombustgroup.amorfati.engine.flows.BankingFlowsSpec com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"` — 116/116 passed
- `sbt assembly` — jar hash `9feb7ac2e63db354f6453cd507a46c2b7c41a514`
- `java -jar target/scala-3.8.2/amor-fati.jar 2 issue547-smoke --duration 24 --run-id 20260523-547-smoke` generated seed, HH, bank, and firm CSV files; `BailInLoss` appeared only in months with `BankCapital_NewFailures > 0`.

Note: later bail-in losses can still appear when later failure events happen. The all-failed / absorber behavior remains scoped to #549.

Closes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event-based targeted bail-in: Bail-in now applies selectively to banks in the current resolution event, haircutting only unprocessed uninsured deposits for precise loss allocation.
  * Enhanced deposit tracking with bailed-in state to monitor processed deposits across resolution steps.

* **Documentation**
  * Clarified bail-in mechanics and event-based application during bank resolution.
  * Updated capital diagnostics documentation for deposit loss tracking.

* **Tests**
  * Updated test coverage to verify targeted bail-in behavior and deposit processing accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->