### PR TITLE
Document bank capital SFC semantics

### DIFF
--- a/docs/adr/0001-bank-capital-sfc-semantics.md
+++ b/docs/adr/0001-bank-capital-sfc-semantics.md
@@ -1,0 +1,110 @@
+# ADR 0001: Bank Capital SFC Semantics
+
+Status: accepted
+
+Date: 2026-05-24
+
+## Context
+
+The engine stores bank capital on each `Banking.BankState` row as
+`BankState.capital`. `LedgerFinancialState.BankBalances` intentionally contains
+ledger-owned financial stocks such as deposits, loans, reserves, government
+bonds, corporate bonds and mortgage assets; it does not contain a bank-capital
+ownership slot.
+
+`AssetOwnershipContract` therefore classifies `AssetType.Capital` as
+`UnsupportedPersistedStock`: the stock exists in engine state and is validated
+by the SFC exactness layer, but it is not part of the supported transferable
+ledger-owned stock slice. The SFC matrix keeps a bank-capital row so monthly
+capital changes remain auditable.
+
+The open design choice is whether bank capital should now become full
+SFC-owned equity with explicit holders, or remain regulatory/accounting state
+with explicit diagnostics.
+
+## Decision
+
+Bank capital remains a regulatory/accounting bank buffer, not a supported
+ledger-owned equity stock.
+
+The authoritative runtime field is `Banking.BankState.capital`. It is persisted
+operational state used by CAR, liquidity/failure logic, resolution diagnostics,
+SFC exactness checks and bank diagnostics. It must not be interpreted as
+holder-resolved household, fund, insurer, government or foreign equity.
+
+Opening bank capital comes from bank calibration and `BankInit`, allocated
+across model bank rows by the configured bank market shares. It does not come
+from household, fund, insurer, government or foreign portfolio allocation.
+
+Monthly bank-capital movements are validated as a P&L and loss-recognition
+waterfall:
+
+- retained bank income increases the buffer;
+- credit losses, corporate-bond losses, bond valuation losses, BFG levy,
+  provision changes and failed-bank capital destruction reduce it;
+- bail-in is a depositor haircut and deposit-resolution channel, reported near
+  bank-capital diagnostics but not treated as bank-equity ownership transfer.
+
+The unretained `(1 - profitRetention)` share of bank gross income has no
+modeled owner-side distribution today. That is consistent with this decision:
+there is no holder-resolved bank equity receiver. The #576 inventory should
+record it as a known unowned income distribution rather than a missing flow to
+route into bank capital.
+
+Resolution ordering is explicit: failure marking first wipes
+`BankState.capital` for newly failed banks, current-event bail-in then haircuts
+eligible depositor claims, and purchase-and-assumption resolution transfers the
+remaining failed-bank balance-sheet rows. Capital destruction and depositor
+bail-in are SFC-validated through separate identities, `BankCapital` and
+`BankDeposits`, not through holder-resolved equity transfer.
+
+The SFC counterpart for those movements is the explicit semantic-flow and
+stock-flow reconciliation evidence, not final-beneficiary equity ownership.
+`AssetType.Equity` remains the supported listed-equity instrument; it must not
+be overloaded to mean bank regulatory capital.
+
+## Consequences
+
+Diagnostics may read `BankState.capital` when they explicitly label it as the
+regulatory/accounting bank-capital buffer. CAR and failure diagnostics remain
+valid uses.
+
+`AssetType.Capital` remains outside `AssetOwnershipContract.supportedPairs`.
+It stays visible as an unsupported persisted diagnostic family so gaps are
+intentional and auditable.
+
+Issues that add holder-resolved bank equity are not needed under this decision:
+#574 (bank-equity ledger contract) and #575 (opening ownership allocation) are
+unnecessary unless the decision is revisited.
+
+#576 reduces to an inventory and guardrail: enumerate every site that writes
+`BankState.capital`, classify each site against the waterfall categories above,
+and add a regression check that fails when a new writer appears without a
+category.
+
+#577 reduces to diagnostic wording: keep `BankBalanceSheetBenchmarkExport`
+reading `BankState.capital`, and keep
+`docs/bank-balance-sheet-benchmark.md` section "Bank Capital Semantics" as the
+reviewer-facing statement of the capital source.
+
+Bank-equity work should only be reopened if the model introduces explicit bank
+share issuance, dividends, public recapitalisation, nationalisation, or other
+ownership-changing bank-equity mechanisms, including a bank acquisition or
+purchase-and-assumption variant that transfers bank equity rather than only
+assets and liabilities.
+
+Any new mechanism that changes `BankState.capital` must update the SFC
+validation projection and the bank-capital diagnostics, even though bank
+capital is not a supported ledger-owned stock.
+
+## Code References
+
+- `Banking.BankState.capital`
+- `Banking.Aggregate.capital`
+- `LedgerFinancialState.BankBalances`
+- `AssetOwnershipContract.publicAsset(AssetType.Capital)`
+- `AssetOwnershipContract.UnsupportedFamilyId.BankCapital`
+- `Sfc.MonthlyFlows.bankCapitalDestruction`
+- `Sfc.SfcIdentity.BankCapital`
+- `BankingEconomics.capitalDestructionDelta`
+- `BankBalanceSheetBenchmarkExport`

--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -22,6 +22,19 @@ The task writes:
   liquidity, and concentration rows.
 - `bank-balance-sheet-report.md`: human-readable summary.
 
+## Bank Capital Semantics
+
+Capital columns in this diagnostic use `Banking.BankState.capital`. This is the
+model's persisted regulatory/accounting bank-capital buffer: it is seeded by
+bank calibration and `BankInit`, then updated by the monthly bank P&L, loss,
+provision, valuation and resolution waterfall.
+
+It is SFC-validated diagnostic state, not holder-resolved ledger-owned equity.
+`LedgerFinancialState.BankBalances` owns deposits, loans, reserves and security
+holdings, but not bank-capital ownership. `AssetOwnershipContract` therefore
+keeps `AssetType.Capital` as an unsupported persisted diagnostic family instead
+of adding it to the transferable supported stock slice.
+
 ## Guardrail Classes
 
 `HARD_INVARIANT` covers opening accounting or prudential boundaries that should
@@ -66,7 +79,9 @@ These ratios guide follow-up calibration and source-bridge work.
 The current bands are guardrails for the `2026-04-30` Poland model-start
 baseline, not final empirical validation. `AggregateCar` is anchored to the KNF
 February 2026 total-capital-ratio bridge already recorded in calibration
-provenance. `ConsumerLoansToGdp` and `MortgageLoansToGdp` reuse the household
+provenance, using `BankState.capital` as the capital numerator. This benchmark
+does not assert household, fund, insurer, government or foreign ownership of
+bank capital. `ConsumerLoansToGdp` and `MortgageLoansToGdp` reuse the household
 credit-stress calibration ranges. ECL bands are model-semantics checks: they ask
 whether the opening loan book is already staged and provisioned before monthly
 ECL dynamics begin. The current opening ECL bridge assigns the covered firm and

--- a/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/accounting/Sfc.scala
@@ -92,7 +92,7 @@ object Sfc:
       hhDebt: PLN,                      // Σ household debt (individual mode only, 0 in aggregate)
       firmCash: PLN,                    // Σ firm cash holdings
       firmDebt: PLN,                    // Σ firm bank loan debt
-      bankCapital: PLN,                 // aggregate bank equity capital (retained earnings)
+      bankCapital: PLN,                 // aggregate regulatory/accounting bank-capital buffer
       bankDeposits: PLN,                // aggregate bank deposits (HH + firm + JST)
       bankLoans: PLN,                   // aggregate bank loan book
       govDebt: PLN,                     // fiscal debt metric from deficit accumulation, distinct from holder-tracked bond stock

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -205,7 +205,8 @@ object BankBalanceSheetBenchmarkExport:
       vintage = BaselineVintage,
       lower = Some(BigDecimal("0.06")),
       upper = Some(BigDecimal("0.12")),
-      sourceNote = "Stylized Poland 2026 opening balance-sheet guardrail: capital should be material relative to simplified banking-sector assets.",
+      sourceNote =
+        "Stylized Poland 2026 opening balance-sheet guardrail using BankState.capital, the regulatory/accounting bank-capital buffer, relative to simplified banking-sector assets.",
       interpretation = "Checks whether the opening balance sheet is thinly capitalised before any macro shock.",
     ),
     TargetBand(
@@ -216,7 +217,8 @@ object BankBalanceSheetBenchmarkExport:
       vintage = BaselineVintage,
       lower = Some(BigDecimal("0.191")),
       upper = Some(BigDecimal("0.231")),
-      sourceNote = "KNF February 2026 total-capital ratio anchor near 21.1%, mapped to the model's simplified RWA perimeter with +/-2pp tolerance.",
+      sourceNote =
+        "KNF February 2026 total-capital ratio anchor near 21.1%, mapped from BankState.capital to the model's simplified RWA perimeter with +/-2pp tolerance.",
       interpretation = "The sector should not start close to regulatory capital failure.",
     ),
     TargetBand(
@@ -227,7 +229,7 @@ object BankBalanceSheetBenchmarkExport:
       vintage = BaselineVintage,
       lower = Some(BigDecimal("0.08")),
       upper = None,
-      sourceNote = "Basel III CRR floor: model banks should not start below the base 8% capital requirement.",
+      sourceNote = "Basel III CRR floor applied to BankState.capital; model banks should not start below the base 8% capital requirement.",
       interpretation = "A bank below the base capital floor at t=0 means the failure process begins from an invalid initial state.",
     ),
     TargetBand(
@@ -238,7 +240,7 @@ object BankBalanceSheetBenchmarkExport:
       vintage = BaselineVintage,
       lower = Some(BigDecimal("0.00")),
       upper = None,
-      sourceNote = "Effective minimum CAR includes base requirement, O-SII buffer and P2R add-ons with CCyB at zero at model start.",
+      sourceNote = "Effective minimum CAR compares BankState.capital with base requirement, O-SII buffer and P2R add-ons with CCyB at zero at model start.",
       interpretation = "Negative opening buffer means at least one bank starts already in supervisory breach.",
     ),
     TargetBand(
@@ -249,7 +251,7 @@ object BankBalanceSheetBenchmarkExport:
       vintage = BaselineVintage,
       lower = Some(BigDecimal("0")),
       upper = Some(BigDecimal("0")),
-      sourceNote = "Direct count of opening bank rows whose CAR is below their effective minimum.",
+      sourceNote = "Direct count of opening bank rows whose BankState.capital-based CAR is below their effective minimum.",
       interpretation = "No bank should require resolution before the first simulated month.",
     ),
     TargetBand(
@@ -708,6 +710,10 @@ object BankBalanceSheetBenchmarkExport:
         "- `HARD_INVARIANT`: opening accounting or prudential boundary that should not fail.",
         "- `SOFT_CALIBRATION_WARNING`: Poland-relevant opening balance-sheet band; violations are warnings, not runtime failures.",
         "- `EXPLORATORY_DIAGNOSTIC`: useful bank-sector diagnostic without a settled empirical acceptance band.",
+        "",
+        "## Bank Capital Semantics",
+        "",
+        "Capital columns use `BankState.capital`: a persisted regulatory/accounting bank-capital buffer seeded by bank calibration and updated by the bank P&L/loss waterfall. It is SFC-validated diagnostic state, not holder-resolved ledger-owned equity.",
         "",
         "## Target Bands",
         "",

--- a/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala
@@ -321,7 +321,7 @@ object AssetOwnershipContract:
       AssetType.Capital,
       PublicAssetStatus.UnsupportedPersistedStock,
       Set(dynamic(EntitySector.Banks)),
-      "Used for persisted bank capital diagnostics, but not part of the supported transferable ledger-owned stock slice.",
+      "BankState.capital is a persisted regulatory/accounting bank-capital buffer for CAR, failure and SFC diagnostics; it is not holder-resolved equity and is outside the supported transferable ledger-owned stock slice.",
     ),
     PublicAssetContract(
       AssetType.ForeignAsset,
@@ -415,7 +415,7 @@ object AssetOwnershipContract:
     UnsupportedFamily(
       UnsupportedFamilyId.BankCapital,
       UnsupportedCategory.UnsupportedPersistedStock,
-      "Bank capital is persisted and SFC-validated as a diagnostic stock, but not modeled as a supported transferable asset family.",
+      "Bank capital is persisted as BankState.capital and SFC-validated as a regulatory/accounting diagnostic stock, but not modeled as holder-resolved equity or a supported transferable asset family.",
     ),
     UnsupportedFamily(
       UnsupportedFamilyId.BankCreditRiskState,

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
@@ -111,6 +111,8 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
     bankCsv should include("PKO BP")
     report should include("--seed-start 2")
     report should include("ReserveToDeposits")
+    report should include("regulatory/accounting bank-capital buffer")
+    report should include("not holder-resolved ledger-owned equity")
   }
 
 end BankBalanceSheetBenchmarkExportSpec

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContractSpec.scala
@@ -81,8 +81,12 @@ class AssetOwnershipContractSpec extends AnyFlatSpec with Matchers:
     publicAsset(AssetType.StandingFacility).status shouldBe PublicAssetStatus.PublicAssetWithoutEngineContract
     publicAsset(AssetType.Capital).status shouldBe PublicAssetStatus.UnsupportedPersistedStock
     publicAsset(AssetType.Capital).supportedSlots shouldBe Set(SectorId.Dynamic(EntitySector.Banks))
+    publicAsset(AssetType.Capital).note should include("regulatory/accounting bank-capital buffer")
+    publicAsset(AssetType.Capital).note should include("not holder-resolved equity")
     supportedPairs should not contain SupportedPair(SectorId.Dynamic(EntitySector.Banks), AssetType.Capital)
-    unsupportedFamilies.find(_.id == UnsupportedFamilyId.BankCapital).map(_.category) shouldBe Some(UnsupportedCategory.UnsupportedPersistedStock)
+    val bankCapitalFamily = unsupportedFamilies.find(_.id == UnsupportedFamilyId.BankCapital).get
+    bankCapitalFamily.category shouldBe UnsupportedCategory.UnsupportedPersistedStock
+    bankCapitalFamily.note should include("not modeled as holder-resolved equity")
   }
 
   it should "expose non-persisted runtime shells separately from supported stock owners" in {


### PR DESCRIPTION
## Summary
- add ADR 0001 for bank capital SFC semantics
- keep BankState.capital as regulatory/accounting state, not holder-resolved ledger-owned equity
- update AssetOwnershipContract and bank balance-sheet benchmark wording/tests to expose the authoritative capital source

Closes #573.

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec com.boombustgroup.amorfati.engine.ledger.AssetOwnershipContractSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record documenting bank capital semantics and regulatory treatment.
  * Updated bank balance sheet benchmark documentation with explicit Bank Capital Semantics section clarifying that bank capital represents a regulatory/accounting buffer, not holder-resolved equity.
  * Expanded guardrail documentation to explicitly detail capital ratio validation semantics.

* **Tests**
  * Updated tests to verify new bank capital documentation appears in exported reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->