### PR TITLE
Classify bank capital write sites

### DIFF
--- a/docs/adr/0001-bank-capital-sfc-semantics.md
+++ b/docs/adr/0001-bank-capital-sfc-semantics.md
@@ -80,7 +80,7 @@ unnecessary unless the decision is revisited.
 #576 reduces to an inventory and guardrail: enumerate every site that writes
 `BankState.capital`, classify each site against the waterfall categories above,
 and add a regression check that fails when a new writer appears without a
-category.
+category. The live inventory is `BankCapitalSemantics.writeSites`.
 
 #577 reduces to diagnostic wording: keep `BankBalanceSheetBenchmarkExport`
 reading `BankState.capital`, and keep
@@ -107,4 +107,5 @@ capital is not a supported ledger-owned stock.
 - `Sfc.MonthlyFlows.bankCapitalDestruction`
 - `Sfc.SfcIdentity.BankCapital`
 - `BankingEconomics.capitalDestructionDelta`
+- `BankCapitalSemantics.writeSites`
 - `BankBalanceSheetBenchmarkExport`

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -756,6 +756,13 @@ post-patch reason code uses the same `0..5` reason-code mapping as
 `BankCapital_DepositBailInLoss` is also reported for resolution analysis, but it
 is a depositor haircut rather than an equity-capital P&L term.
 
+Every production writer of `BankState.capital` is classified in
+`BankCapitalSemantics.writeSites`. The guardrail test fails when a new writer
+appears without an SFC category and absorber statement. `BankCapital_ReconciliationResidual`
+is the only named residual writer; all other capital changes must be assigned
+to an opening calibration, ordinary P&L, provision, valuation, contagion,
+or failure-destruction category.
+
 Realized credit-loss rates are emitted as `BankCreditLoss_*`. They use closing
 exposure stocks as denominators, so the columns can be joined directly with
 monthly `BankFailure_*` rows. The block separates firm-loan, mortgage,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankCapitalSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankCapitalSemantics.scala
@@ -1,0 +1,138 @@
+package com.boombustgroup.amorfati.engine.economics
+
+/** Contract for every production path that writes or computes
+  * `Banking.BankState.capital`.
+  *
+  * ADR 0001 keeps bank capital as a regulatory/accounting buffer rather than a
+  * holder-resolved equity asset. This registry is the guardrail for that
+  * decision: every production write site must have a named economic category,
+  * an SFC treatment, and an explicit loss absorber.
+  */
+object BankCapitalSemantics:
+
+  enum Category(val token: String):
+    /** Opening stock seeded by bank calibration, not a monthly SFC delta. */
+    case OpeningCalibration extends Category("opening-calibration")
+
+    /** Retained ordinary income and realized banking losses inside the monthly
+      * P&L waterfall.
+      */
+    case OrdinaryPnlWaterfall extends Category("ordinary-pnl-waterfall")
+
+    /** IFRS 9 provision movement, positive when additional allowance hits
+      * capital.
+      */
+    case EclProvisionChange extends Category("ecl-provision-change")
+
+    /** Hidden HTM mark-to-market loss realized on forced reclassification. */
+    case HtmRealizedLoss extends Category("htm-realized-loss")
+
+    /** Counterparty loss from failed-bank interbank exposure. */
+    case InterbankContagionLoss extends Category("interbank-contagion-loss")
+
+    /** Regulatory buffer wiped when a bank newly enters failure/resolution. */
+    case FailureCapitalDestruction extends Category("failure-capital-destruction")
+
+    /** Exactness patch that keeps aggregate SFC identities closed after
+      * per-bank allocation.
+      */
+    case ExactnessReconciliation extends Category("exactness-reconciliation")
+
+  final case class SourceAnchor(
+      path: String,
+      fragment: String,
+  )
+
+  final case class WriteSite(
+      id: String,
+      categories: Set[Category],
+      source: SourceAnchor,
+      sfcTreatment: String,
+      absorber: String,
+      diagnostics: String,
+  )
+
+  val writeSites: Vector[WriteSite] = Vector(
+    WriteSite(
+      id = "opening-bank-capital-calibration",
+      categories = Set(Category.OpeningCalibration),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala",
+        "capital = totalCapital * cfg.initMarketShare",
+      ),
+      sfcTreatment = "Opening regulatory/accounting stock. It seeds BankState.capital and is not a monthly SFC delta.",
+      absorber = "No monthly absorber; source is model-start bank calibration.",
+      diagnostics = "Opening value appears in BankBalanceSheetBenchmarkExport and BankCapital_Opening.",
+    ),
+    WriteSite(
+      id = "ordinary-bank-pnl-formula",
+      categories = Set(Category.OrdinaryPnlWaterfall),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala",
+        "CapitalPnlOutput(newCapital = in.prevCapital - losses + retainedIncome)",
+      ),
+      sfcTreatment = "Monthly BankCapital identity: retained income increases capital; realized banking losses reduce it.",
+      absorber = "Bank regulatory/accounting capital buffer absorbs losses; unretained income has no holder-resolved bank-equity receiver under ADR 0001.",
+      diagnostics = "BankCapital_RetainedIncome, BankCapital_RealizedCreditLoss, BankCapital_BfgLevy, BankCapital_UnrealizedBondLoss.",
+    ),
+    WriteSite(
+      id = "monthly-bank-capital-and-ecl-write",
+      categories = Set(Category.OrdinaryPnlWaterfall, Category.EclProvisionChange),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala",
+        "capital = capitalPnl.newCapital - eclResult.provisionChange",
+      ),
+      sfcTreatment = "Applies the ordinary P&L formula and the IFRS 9 provision-change hit before failure checks.",
+      absorber = "Bank regulatory/accounting capital buffer.",
+      diagnostics = "BankCapital_EclProvisionChange plus the ordinary BankCapital_* waterfall columns.",
+    ),
+    WriteSite(
+      id = "htm-forced-sale-capital-loss",
+      categories = Set(Category.HtmRealizedLoss),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala",
+        "b.copy(capital = b.capital - loss)",
+      ),
+      sfcTreatment = "Non-batch monthly BankCapital identity term htmRealizedLoss.",
+      absorber = "Bank regulatory/accounting capital buffer absorbs realized HTM valuation loss.",
+      diagnostics = "BankCapital_HtmRealizedLoss.",
+    ),
+    WriteSite(
+      id = "interbank-contagion-counterparty-loss",
+      categories = Set(Category.InterbankContagionLoss),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala",
+        "b.copy(capital = b.capital - loss)",
+      ),
+      sfcTreatment =
+        "Same-month per-bank counterparty loss. Closing aggregate exactness must classify its effect through failure capital destruction or the documented reconciliation residual until a dedicated interbank-loss SFC term is introduced.",
+      absorber = "Initially the exposed bank capital buffer; if resolution is triggered, remaining loss is handled by the failure/bail-in path.",
+      diagnostics = "Failure-trigger evidence plus BankCapital_CapitalDestruction and BankCapital_ReconciliationResidual at aggregate close.",
+    ),
+    WriteSite(
+      id = "failure-check-capital-wipe",
+      categories = Set(Category.FailureCapitalDestruction),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala",
+        "b.copy(status = BankStatus.Failed(month), capital = PLN.Zero)",
+      ),
+      sfcTreatment = "Monthly BankCapital identity term bankCapitalDestruction.",
+      absorber = "Shareholder/regulatory capital buffer is wiped; depositor loss is separate BankDeposits bail-in, not an equity transfer.",
+      diagnostics = "BankCapital_CapitalDestruction and BankFailure_* reason columns.",
+    ),
+    WriteSite(
+      id = "aggregate-exactness-capital-reconciliation",
+      categories = Set(Category.ExactnessReconciliation),
+      source = SourceAnchor(
+        "src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala",
+        "bank.copy(capital = bank.capital + capitalResidual)",
+      ),
+      sfcTreatment = "Documented exactness patch after per-bank allocation; this is the only named residual capital writer.",
+      absorber = "One selected survivor bank row absorbs the aggregate exactness patch; diagnostics expose bank id, size and CAR impact.",
+      diagnostics = "BankCapital_ReconciliationResidual and BankReconciliation_*.",
+    ),
+  )
+
+  val writeSiteIds: Set[String] = writeSites.map(_.id).toSet
+
+end BankCapitalSemantics

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankCapitalSemanticsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankCapitalSemanticsSpec.scala
@@ -1,0 +1,103 @@
+package com.boombustgroup.amorfati.engine.economics
+
+import com.boombustgroup.amorfati.engine.economics.BankCapitalSemantics.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+
+class BankCapitalSemanticsSpec extends AnyFlatSpec with Matchers:
+
+  private final case class SourceLine(path: String, text: String)
+
+  private val SourceRoot = Path.of("src/main/scala/com/boombustgroup/amorfati")
+
+  private val KnownNonBankCapitalCandidates: Set[SourceLine] = Set(
+    SourceLine(
+      "src/main/scala/com/boombustgroup/amorfati/config/RobustnessScenarios.scala",
+      "params = baseline.copy(capital = baseline.capital.copy(adjustSpeed = Coefficient.decimal(16, 2))),",
+    ),
+  )
+
+  "BankCapitalSemantics" should "classify every known production bank-capital writer" in {
+    val ids = writeSites.map(_.id)
+
+    ids.distinct shouldBe ids
+    writeSites.foreach: site =>
+      site.categories should not be empty
+      site.sfcTreatment.trim should not be empty
+      site.absorber.trim should not be empty
+      site.diagnostics.trim should not be empty
+
+    writeSites.flatMap(_.categories).toSet should contain allOf (
+      Category.OpeningCalibration,
+      Category.OrdinaryPnlWaterfall,
+      Category.EclProvisionChange,
+      Category.HtmRealizedLoss,
+      Category.InterbankContagionLoss,
+      Category.FailureCapitalDestruction,
+      Category.ExactnessReconciliation,
+    )
+  }
+
+  it should "keep source anchors aligned with the current code" in
+    writeSites.foreach: site =>
+      matchingLines(site.source) should have size 1
+
+  it should "fail when a new production bank-capital writer lacks a semantic category" in {
+    val classifiedAnchors = writeSites.map(_.source)
+    val unclassified      = candidateCapitalWriters.filterNot(line =>
+      KnownNonBankCapitalCandidates.contains(line) ||
+        classifiedAnchors.exists(anchor => line.path == anchor.path && line.text.contains(anchor.fragment)),
+    )
+
+    unclassified shouldBe Vector.empty
+  }
+
+  it should "keep exactness reconciliation as the only residual capital writer" in {
+    val residualSites = writeSites.filter(_.categories.contains(Category.ExactnessReconciliation)).map(_.id)
+
+    residualSites shouldBe Vector("aggregate-exactness-capital-reconciliation")
+  }
+
+  private def matchingLines(anchor: SourceAnchor): Vector[String] =
+    Files
+      .readAllLines(Path.of(anchor.path), StandardCharsets.UTF_8)
+      .asScala
+      .toVector
+      .map(_.trim)
+      .filter(_.contains(anchor.fragment))
+
+  private def candidateCapitalWriters: Vector[SourceLine] =
+    scalaFiles.flatMap: path =>
+      val relativePath = path.toString.replace(java.io.File.separatorChar, '/')
+      Files
+        .readAllLines(path, StandardCharsets.UTF_8)
+        .asScala
+        .toVector
+        .map(_.trim)
+        .filter(isCandidateCapitalWriter)
+        .map(SourceLine(relativePath, _))
+
+  private def scalaFiles: Vector[Path] =
+    val stream = Files.walk(SourceRoot)
+    try
+      stream
+        .iterator()
+        .asScala
+        .filter(path => Files.isRegularFile(path) && path.toString.endsWith(".scala"))
+        .filterNot(_.toString.endsWith("BankCapitalSemantics.scala"))
+        .toVector
+        .sortBy(_.toString)
+    finally stream.close()
+
+  private def isCandidateCapitalWriter(line: String): Boolean =
+    line.contains("copy(capital =") ||
+      line.contains("capital = totalCapital * cfg.initMarketShare") ||
+      line.contains("capital = capitalPnl.newCapital") ||
+      line.contains("capital = PLN.Zero") ||
+      line.contains("CapitalPnlOutput(newCapital =")
+
+end BankCapitalSemanticsSpec


### PR DESCRIPTION
## Summary
- add BankCapitalSemantics.writeSites as the live inventory for BankState.capital writers
- classify each writer by economic category, SFC treatment, absorber, and diagnostics surface
- add a guardrail test that scans production Scala sources and fails on unclassified bank-capital writers
- link ADR/docs to the live inventory

Closes #576.

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankCapitalSemanticsSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.agents.InterbankContagionSpec"
- git diff --cached --check