### PR TITLE
Expose bank capital diagnostic source

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -14,7 +14,9 @@ import scala.util.Try
 
 object BankBalanceSheetBenchmarkExport:
 
-  private val BaselineVintage = "2026-04-30 model-start baseline"
+  private val BaselineVintage                         = "2026-04-30 model-start baseline"
+  private[diagnostics] val BankCapitalSourceStatement =
+    "Capital source: `BankState.capital`. It is a persisted regulatory/accounting bank-capital buffer seeded by bank calibration and updated by the bank P&L/loss waterfall. `LedgerFinancialState.BankBalances` intentionally has no capital field; this diagnostic must not infer holder-resolved ledger-owned bank equity."
 
   final case class Config(
       seedStart: Long = 1L,
@@ -539,7 +541,7 @@ object BankBalanceSheetBenchmarkExport:
         status = status,
       )
 
-  private def computeSeed(config: Config, seed: Long, init: WorldInit.InitResult)(using SimParams): (Vector[SeedMetric], Vector[BankRow]) =
+  private[diagnostics] def computeSeed(config: Config, seed: Long, init: WorldInit.InitResult)(using SimParams): (Vector[SeedMetric], Vector[BankRow]) =
     val context = SeedContext(seed, init)
     val metrics = Metrics.map: metric =>
       val value = metric.compute(context)
@@ -713,7 +715,9 @@ object BankBalanceSheetBenchmarkExport:
         "",
         "## Bank Capital Semantics",
         "",
-        "Capital columns use `BankState.capital`: a persisted regulatory/accounting bank-capital buffer seeded by bank calibration and updated by the bank P&L/loss waterfall. It is SFC-validated diagnostic state, not holder-resolved ledger-owned equity.",
+        BankCapitalSourceStatement,
+        "",
+        "`AssetType.Capital` remains an unsupported persisted diagnostic stock: SFC-validatable, but outside the supported transferable ledger-owned stock slice.",
         "",
         "## Target Bands",
         "",

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
@@ -1,5 +1,10 @@
 package com.boombustgroup.amorfati.diagnostics
 
+import com.boombustgroup.amorfati.agents.Banking
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+import com.boombustgroup.amorfati.fp.FixedPointBase
+import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -111,8 +116,31 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
     bankCsv should include("PKO BP")
     report should include("--seed-start 2")
     report should include("ReserveToDeposits")
-    report should include("regulatory/accounting bank-capital buffer")
-    report should include("not holder-resolved ledger-owned equity")
+    report should include(BankCapitalSourceStatement)
+    report should include("unsupported persisted diagnostic stock")
   }
+
+  it should "source benchmark capital only from BankState.capital" in {
+    given SimParams = SimParams.defaults
+
+    val init         = WorldInit.initialize(InitRandomness.Contract.fromSeed(1L))
+    val shiftedBanks = init.banks.zipWithIndex.map: (bank, idx) =>
+      bank.copy(capital = PLN(100000000L + idx.toLong * 1000000L))
+    val shiftedInit  = init.copy(banks = shiftedBanks)
+
+    val (metrics, bankRows) = computeSeed(Config(runId = "bank-spec", seeds = 1), 1L, shiftedInit)
+    val bankBalances        = shiftedInit.ledgerFinancialState.banks
+    val bankStocks          = bankBalances.map(LedgerFinancialState.projectBankFinancialStocks)
+    val corpBondHoldings    = Banking.bankCorpBondHoldingsFromVector(bankBalances.map(_.corpBond))
+    val aggregate           = Banking.aggregateFromBankStocks(shiftedBanks, bankStocks, corpBondHoldings)
+    val totalAssets         = bankRows.map(_.assets).sumPln
+
+    bankRows.map(_.capital) shouldBe shiftedBanks.map(_.capital)
+    metricValue(metrics, "CapitalToAssets") shouldBe ObservedValue.Finite(BigDecimal(aggregate.capital.toLong) / BigDecimal(totalAssets.toLong))
+    metricValue(metrics, "AggregateCar") shouldBe ObservedValue.Finite(BigDecimal(aggregate.car.toLong) / BigDecimal(FixedPointBase.Scale))
+  }
+
+  private def metricValue(rows: Vector[SeedMetric], id: String): ObservedValue =
+    rows.find(_.target.id == id).map(_.value).getOrElse(fail(s"Missing metric $id"))
 
 end BankBalanceSheetBenchmarkExportSpec


### PR DESCRIPTION
## Summary

- Strengthens the generated bank balance-sheet benchmark report with an explicit `BankState.capital` source statement.
- States that `LedgerFinancialState.BankBalances` intentionally has no capital field and that the diagnostic must not infer holder-resolved bank equity.
- Adds an anti-drift test proving benchmark bank rows and aggregate capital ratios source capital from `BankState.capital` while ledger balances stay unchanged.

## Validation

- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec"`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec com.boombustgroup.amorfati.engine.ledger.AssetOwnershipContractSpec"`

Closes #577.