### PR TITLE
Fail fast on all-failed bank resolution

### DIFF
--- a/docs/bank-failure-ablations.md
+++ b/docs/bank-failure-ablations.md
@@ -38,5 +38,6 @@ full model simulation.
 
 These scenarios are diagnostics, not candidate policy settings. A scenario that
 materially delays or prevents failures identifies a channel that needs deeper
-economic or accounting work before all-failed bank resolution semantics are
-changed.
+economic or accounting work before an explicit bridge-bank recapitalization,
+nationalization, or shutdown mechanism can replace the current all-failed
+fail-fast boundary.

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -892,6 +892,10 @@ banks entering resolution in the current failure event set. P&A resolution then
 transfers deposits, government bonds, performing loans, consumer loans, and
 corporate-bond holdings to the healthiest surviving bank. Firms and households
 routed to failed banks are reassigned to the absorber.
+If every bank has failed while deposits still need resolution, the baseline
+path fails fast. Selecting a failed row as the absorber would be an implicit
+bridge-bank recapitalization or nationalization mechanism, so it must be added
+as an explicit SFC/fiscal mechanism before such runs are considered valid.
 In later months, a failed-bank row is an inert shell: ordinary lending, P&L,
 ECL migration, NPL write-off, and deposit-flow updates are skipped unless an
 explicit resolution or reconciliation mechanism changes the row.
@@ -903,12 +907,10 @@ multiple triggers are true, the priority is negative capital, then CAR breach,
 then LCR/liquidity breach. `BankFailure_FirstNewReasonCode` records the first
 new failure reason in bank-id order using `0 = none`, `1 = negative capital`,
 `2 = CAR breach`, `3 = LCR/liquidity breach`, `4 = all-failed fallback`, and
-`5 = invariant mismatch`. `BankFailure_AllFailedFallback` flags the current
-bridge-bank/resolution fallback where all banks have already failed and the
-absorber is selected from that failed set; this is the path #549 must decide
-whether to recapitalize or fail fast. `BankFailure_InvariantViolation` should
-remain zero and means the failure-event diagnostics do not reconcile to the
-new-failure count.
+`5 = invariant mismatch`. `BankFailure_AllFailedFallback` is retained as a
+stable diagnostic column and should remain zero under fail-fast all-failed
+semantics. `BankFailure_InvariantViolation` should remain zero and means the
+failure-event diagnostics do not reconcile to the new-failure count.
 
 ## Fiscal, Monetary, Bond-Market, And External Rules
 

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -710,6 +710,11 @@ object Banking:
 
   /** BFG P&A resolution: transfer deposits, bonds, performing loans, consumer
     * loans from failed banks to the healthiest surviving bank.
+    *
+    * An all-failed banking sector is deliberately fail-fast. Reviving one
+    * failed row as an active bridge bank would be a
+    * recapitalization/nationalization mechanism, and that must be modeled
+    * explicitly before it can enter the baseline resolution path.
     */
   def resolveFailures(
       banks: Vector[BankState],
@@ -724,20 +729,23 @@ object Banking:
     val newlyFailed    = banks.zip(financialStocks).filter((b, stocks) => b.failed && stocks.totalDeposits > PLN.Zero)
     if newlyFailed.isEmpty then ResolutionResult(banks, financialStocks, BankId.NoBank, holderBalances)
     else
-      val allFailedFallbackUsed = banks.forall(_.failed)
-      val absorberId            = healthiestBankId(banks, financialStocks, bankCorpBondHoldingsFromVector(holderBalances))
-      val toAbsorb              = newlyFailed.filter((bank, _) => bank.id != absorberId)
+      if banks.forall(_.failed) then
+        throw IllegalStateException(
+          "Banking.resolveFailures encountered an all-failed banking sector with unresolved deposits. Explicit bridge-bank recapitalization or all-failed shutdown semantics are required; refusing to resurrect a failed bank as Active(0).",
+        )
+      val absorberId     = healthiestBankId(banks, financialStocks, bankCorpBondHoldingsFromVector(holderBalances))
+      val toAbsorb       = newlyFailed.filter((bank, _) => bank.id != absorberId)
       // Single-pass PLN aggregation of all flows from failed banks (exact Long addition)
-      val addDep                = toAbsorb.map(_._2.totalDeposits).sumPln
-      val addLoans              = toAbsorb.map((bank, stocks) => stocks.firmLoan - bank.nplAmount).sumPln
-      val addAfs                = toAbsorb.map(_._2.govBondAfs).sumPln
-      val addHtm                = toAbsorb.map(_._2.govBondHtm).sumPln
-      val addCorpB              = toAbsorb.flatMap((bank, _) => holderBalances.lift(bank.id.toInt)).sumPln
-      val addCC                 = toAbsorb.map(_._2.consumerLoan).sumPln
-      val addIB                 = toAbsorb.map(_._2.interbankLoan).sumPln
-      val addBailedInDep        = toAbsorb.map(_._2.bailedInDeposits).sumPln
+      val addDep         = toAbsorb.map(_._2.totalDeposits).sumPln
+      val addLoans       = toAbsorb.map((bank, stocks) => stocks.firmLoan - bank.nplAmount).sumPln
+      val addAfs         = toAbsorb.map(_._2.govBondAfs).sumPln
+      val addHtm         = toAbsorb.map(_._2.govBondHtm).sumPln
+      val addCorpB       = toAbsorb.flatMap((bank, _) => holderBalances.lift(bank.id.toInt)).sumPln
+      val addCC          = toAbsorb.map(_._2.consumerLoan).sumPln
+      val addIB          = toAbsorb.map(_._2.interbankLoan).sumPln
+      val addBailedInDep = toAbsorb.map(_._2.bailedInDeposits).sumPln
       // Weighted yield: Σ(htmBonds × htmBookYield) — PLN × Rate → PLN
-      val htmYieldWt            = toAbsorb.map((bank, stocks) => stocks.govBondHtm * bank.htmBookYield).sumPln
+      val htmYieldWt     = toAbsorb.map((bank, stocks) => stocks.govBondHtm * bank.htmBookYield).sumPln
 
       val resolvedRows      = banks
         .zip(financialStocks)
@@ -781,16 +789,17 @@ object Banking:
         else if bank.failed && stocks.totalDeposits == PLN.Zero then PLN.Zero
         else holderBalances(index)
       }
-      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds, allFailedFallbackUsed)
+      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds)
 
   /** Find the healthiest surviving bank.
     *
     * Banks with no material risk-weighted assets get the CAR safe floor, so
     * they are excluded from CAR ranking while any risk-bearing survivor exists.
     * This prevents empty balance-sheet shells from attracting all
-    * flight-to-safety deposits or failure-resolution assets. Falls back to
-    * highest capital if all candidates have failed or all survivors are
-    * non-risk-bearing.
+    * flight-to-safety deposits or failure-resolution assets. If no active bank
+    * exists, callers must fail fast or invoke an explicit
+    * recapitalization/shutdown mechanism instead of silently selecting a failed
+    * row.
     */
   def healthiestBankId(
       banks: Vector[BankState],
@@ -802,7 +811,10 @@ object Banking:
       s"Banking.healthiestBankId requires aligned banks and financial stocks, got ${banks.length} banks and ${financialStocks.length} stock rows",
     )
     val alive = banks.zip(financialStocks).filterNot(_._1.failed)
-    if alive.isEmpty then banks.maxBy(_.capital.toLong).id
+    if alive.isEmpty then
+      throw IllegalStateException(
+        "Banking.healthiestBankId cannot select an absorber because every bank is failed. Explicit bridge-bank recapitalization or all-failed shutdown semantics are required.",
+      )
     else
       val riskBearingAlive = alive.filter: (bank, stocks) =>
         riskWeightedAssets(stocks.firmLoan, stocks.consumerLoan, bankCorpBondHoldings(bank.id)) > MinBalanceThreshold

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -303,13 +303,14 @@ object BankCapitalDiagnostics:
   *
   * Reason-code mapping for `firstNewReasonCode`: 0 = none, 1 = negative
   * capital, 2 = CAR breach, 3 = LCR/liquidity breach, 4 = all-failed resolution
-  * fallback, 5 = invariant mismatch.
+  * fallback (stable legacy diagnostic; current all-failed semantics fail fast),
+  * 5 = invariant mismatch.
   */
 case class BankFailureDiagnostics(
     newNegativeCapital: Int = 0, // newly failed banks whose primary trigger was negative capital
     newCarBreach: Int = 0,       // newly failed banks whose primary trigger was the consecutive low-CAR rule
     newLiquidityBreach: Int = 0, // newly failed banks whose primary trigger was the LCR liquidity rule
-    allFailedFallback: Int = 0,  // 1 when resolution had to choose an absorber from an all-failed bank set
+    allFailedFallback: Int = 0,  // stable legacy column; should stay 0 because all-failed resolution now fails fast
     invariantViolation: Int = 0, // failure-event accounting mismatch, should remain zero
     firstNewReasonCode: Int = 0, // reason code for first new failure event in bank-id order, or 0 when none
     firstNewBankId: Int = -1,    // bank id for first new failure event, or -1 when none

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -249,9 +249,11 @@ BankReconciliation_PostResidualReasonCode
 `BankFailure_NewLiquidityBreach` count newly failed banks by primary trigger.
 If several triggers are true in the same month, the primary reason priority is
 negative capital, then CAR breach, then LCR/liquidity breach.
-`BankFailure_AllFailedFallback` is `1` when purchase-and-assumption resolution
-had to choose an absorber from an all-failed bank set. This is a bridge-bank /
-resolution-semantics warning, not an ordinary failure trigger.
+`BankFailure_AllFailedFallback` is retained as a stable diagnostic column and
+should remain zero under the current fail-fast all-failed semantics: if every
+bank has failed while deposits still need resolution, the run is invalid until
+an explicit bridge-bank recapitalization, nationalization, or shutdown
+mechanism is implemented.
 `BankFailure_InvariantViolation` should stay zero; a non-zero value means the
 failure-event diagnostics no longer reconcile to the new-failure count and the
 run should be treated as an invalid model state. `BankFailure_FirstNewReasonCode`

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -158,8 +158,8 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
     decimal(result.financialStocks.map(_.interbankLoan).sumPln) shouldBe BigDecimal("0.0") +- BigDecimal("1e-6")
   }
 
-  it should "create a bridge bank when all banks fail and preserve aggregate bond stock" in {
-    val rows   = Vector(
+  it should "fail fast when all banks fail instead of creating an implicit bridge bank" in {
+    val rows = Vector(
       mkBankRow(
         id = 0,
         deposits = PLN(500000),
@@ -188,23 +188,24 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
         status = BankStatus.Failed(ExecutionMonth(3)),
       ),
     )
-    val before = stocks(rows).map(s => decimal(Banking.govBondHoldings(s))).sum
-    val result = Banking.resolveFailures(banks(rows), stocks(rows))
-    val after  = result.financialStocks.map(s => decimal(Banking.govBondHoldings(s))).sum
+    val ex   = intercept[IllegalStateException]:
+      Banking.resolveFailures(banks(rows), stocks(rows))
 
-    after shouldBe before +- BigDecimal("1.0")
-    result.banks.exists(!_.failed) shouldBe true
-    result.allFailedFallbackUsed shouldBe true
+    ex.getMessage should include("all-failed banking sector")
+    ex.getMessage should include("refusing to resurrect a failed bank")
   }
 
-  "Banking.healthiestBankId" should "return bank with highest capital when all fail" in {
+  "Banking.healthiestBankId" should "fail fast when all banks have failed" in {
     val rows = Vector(
       mkBankRow(id = 0, deposits = PLN(500000), loans = PLN(100000), capital = PLN(-20000), status = BankStatus.Failed(ExecutionMonth(3))),
       mkBankRow(id = 1, deposits = PLN(300000), loans = PLN(80000), capital = PLN(-5000), status = BankStatus.Failed(ExecutionMonth(3))),
       mkBankRow(id = 2, deposits = PLN(200000), loans = PLN(60000), capital = PLN(-15000), status = BankStatus.Failed(ExecutionMonth(3))),
     )
+    val ex   = intercept[IllegalStateException]:
+      Banking.healthiestBankId(banks(rows), stocks(rows))
 
-    Banking.healthiestBankId(banks(rows), stocks(rows)) shouldBe BankId(1)
+    ex.getMessage should include("every bank is failed")
+    ex.getMessage should include("recapitalization")
   }
 
   "World defaults" should "keep bfgFundBalance and bailInLoss at zero" in {


### PR DESCRIPTION
## Summary

- Replaces implicit all-failed bridge-bank resurrection with an explicit fail-fast boundary.
- Makes Banking.resolveFailures refuse all-failed unresolved deposits until bridge-bank recapitalization, nationalization, or shutdown semantics are modeled.
- Makes Banking.healthiestBankId fail fast when no active absorber exists.
- Updates resolution diagnostics docs while keeping BankFailure_AllFailedFallback schema-stable.

## Validation

- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.DepositMobilitySpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"

Closes #549.
Refs #546.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated failure-resolution guidance and diagnostic references for all-failed banking scenarios.

* **Changes**
  * System now enforces immediate failure when the entire banking sector fails, requiring explicit recapitalization or shutdown mechanisms to be defined before proceeding with resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->