### PR TITLE
Enforce post-reconciliation bank failure invariant

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -758,7 +758,11 @@ absolute size is at least 1 bp of target-bank pre-patch capital.
 `BankReconciliation_CrossedFailureThreshold` is `1` only when the patch moves
 the target bank from no failure trigger to a post-patch failure trigger; the
 post-patch reason code uses the same `0..5` reason-code mapping as
-`BankFailure_FirstNewReasonCode`.
+`BankFailure_FirstNewReasonCode`. When the patched active bank has a
+post-residual failure reason, the banking stage runs a final failure,
+bail-in, and P&A resolution pass before month close; an active bank must not
+finish the month with residual-induced negative capital or a valid failure
+trigger.
 `BankCapital_DepositBailInLoss` is also reported for resolution analysis, but it
 is a depositor haircut rather than an equity-capital P&L term.
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -1215,7 +1215,7 @@ object BankingEconomics:
           reasonBefore = reasonBefore,
           reasonAfter = reasonAfter,
         )
-        if reconciliationDiagnostics.crossedFailureThreshold == 0 || afterBank.failed then
+        if reasonAfter.isEmpty || afterBank.failed then
           AggregateReconciliationResult(
             nextBanks,
             nextStocks,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -269,6 +269,8 @@ capital residual is at least 1 bp of the target bank's pre-patch capital.
 `BankReconciliation_CrossedFailureThreshold` is `1` when the patch alone moves
 the target bank from no failure trigger to a failure trigger; the post-patch
 reason code uses the same reason-code mapping as `BankFailure_FirstNewReasonCode`.
+If the patched active bank has a post-residual failure reason, the banking stage
+runs a final failure, bail-in, and P&A resolution pass before month close.
 
 ## Household Liquidity Diagnostics
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -157,6 +157,19 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     LedgerFinancialState.projectBankFinancialStocks(result.ledgerFinancialState.banks.head) shouldBe alignedOpeningStocks
   }
 
+  it should "resolve a bank made insolvent by aggregate capital reconciliation" in {
+    val prepared       = preparedBankingStep()
+    val stressedFirmS5 = prepared.s5.copy(nplLoss = prepared.s5.nplLoss + PLN(250000000000L))
+
+    val result = prepared.run(s5Override = stressedFirmS5)
+
+    result.bankReconciliationDiagnostics.crossedFailureThreshold shouldBe 1
+    result.bankReconciliationDiagnostics.postResidualReasonCode shouldBe Banking.BankFailureReason.NegativeCapital.code
+    result.banks.exists(bank => bank.id.toInt == result.bankReconciliationDiagnostics.targetBankId && bank.failed) shouldBe true
+    result.banks.filterNot(_.failed).foreach(_.capital should be >= PLN.Zero)
+    result.bankFailureDiagnostics.newNegativeCapital should be >= 1
+  }
+
   it should "realign consumer-loan book distribution to household bank routing without changing the aggregate stock" in {
     val households        = Vector(
       TestHouseholdState(id = HhId(0), skill = Share.decimal(7, 1), mpc = Share.decimal(8, 1), status = HhStatus.Unemployed(0), bankId = BankId(0)),
@@ -213,6 +226,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
         worldOverride: World = world,
         ledgerFinancialStateOverride: LedgerFinancialState = ledgerFinancialState,
         banksOverride: Vector[Banking.BankState] = banks,
+        s5Override: FirmEconomics.StepOutput = s5,
     ): BankingEconomics.StepOutput =
       val bankingRng = MonthRandomness.Contract.fromSeed(TestSeed).stages.newStreams().bankingEconomics
       BankingEconomics.runStep(
@@ -223,7 +237,7 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
           s2,
           s3,
           s4,
-          s5,
+          s5Override,
           s6,
           s7,
           s8,


### PR DESCRIPTION
## Summary

- Runs the final post-reconciliation failure path whenever the patched active bank has a post-residual failure reason, not only when diagnostics mark a fresh threshold crossing.
- Adds an end-to-end BankingEconomicsSpec case where a negative aggregate capital residual makes the target bank insolvent and verifies it is resolved before month close.
- Documents that residual-induced active-bank failure triggers a final failure, bail-in, and P&A pass.

## Validation

- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.agents.BankingSectorSpec"

Closes #548.
Refs #546.