### PR TITLE
Key ECL migration to baseline deterioration

### DIFF
--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -86,7 +86,11 @@ credit-stress calibration ranges. ECL bands are model-semantics checks: they ask
 whether the opening loan book is already staged and provisioned before monthly
 ECL dynamics begin. The current opening ECL bridge assigns the covered firm and
 consumer loan book to Stage 1; calibrated opening Stage 2/3 shares remain a
-separate banking-risk calibration step. `banking.initDeposits` is the aggregate
+separate banking-risk calibration step. Monthly Stage 1 to Stage 2 migration is
+keyed to deterioration over the carried reference unemployment rate, bootstrapped
+from the model-start Poland baseline, and to GDP contraction. The opening
+unemployment level can therefore sit above NAIRU without being treated as a
+recurring ECL stress shock. `banking.initDeposits` is the aggregate
 opening customer-deposit stock: firm cash receives the corporate split, household
 demand deposits are normalized to the residual, and `BankInit` derives bank
 deposit liabilities from those holder-side balances. Deposit split, reserves,

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -714,7 +714,22 @@ ratio floor.
 Opening IFRS 9 ECL staging is seeded from the bank-owned firm and consumer loan
 book as all-performing Stage 1 exposure. The opening allowance is therefore a
 pre-existing baseline allowance, while `BankCapital_EclProvisionChange` measures
-monthly movement in that allowance.
+monthly movement in that allowance. Stage 1 to Stage 2 migration is driven by
+stress deterioration, not by the absolute opening unemployment level. The
+unemployment trigger uses the increase over the carried reference unemployment
+rate, normally the previous month's pipeline value bootstrapped from the model
+start Poland baseline, plus any same-month GDP contraction:
+
+```text
+eclMigrationRate =
+  eclMigrationSensitivity * max(0, unemployment_t - unemployment_ref)
+  + eclGdpSensitivity * max(0, -gdpGrowth_t)
+```
+
+The result is clamped by `banking.eclMaxMigration`. A stable baseline can remain
+above NAIRU without mechanically migrating the loan book to Stage 2, while
+unemployment deterioration and GDP contraction still raise lifetime-ECL
+provisions.
 
 The monthly bank-capital diagnostic waterfall is:
 

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -365,6 +365,7 @@ a concrete diagnostic artifact path.
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01, 0.08, 0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.eclMigrationSensitivity`, `eclGdpSensitivity`, `eclMaxMigration` | `3.0, 5.0, 0.20` | coefficient/share | Code note bridge: IFRS 9 significant-increase-in-credit-risk stress rule | Stage 1 to Stage 2 migration under unemployment deterioration or GDP contraction | Applied to `max(0, unemployment_t - unemployment_ref)` and `max(0, -gdpGrowth_t)`; `unemployment_ref` is carried from the lagged pipeline and bootstrapped from the opening Poland baseline | `EclStaging`, `BankingEconomics` | `TUNED_NEEDS_VALIDATION` |
 
 ## External Sector And Financial Markets
 

--- a/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
@@ -54,16 +54,20 @@ object EclStaging:
 
   /** Compute macro-driven S1→S2 migration rate.
     *
-    * When unemployment rises above NAIRU or GDP contracts, a fraction of
-    * performing loans migrates to Stage 2 (significant credit risk increase).
+    * When unemployment deteriorates relative to the carried reference level or
+    * GDP contracts, a fraction of performing loans migrates to Stage 2
+    * (significant credit risk increase). The reference level is usually the
+    * previous month's unemployment rate, bootstrapped at model start from the
+    * opening macro baseline, so an opening unemployment level above NAIRU does
+    * not by itself create recurring stress migration.
     *
-    * migrationRate = sensitivity × max(0, unemployment − nairu) +
+    * migrationRate = sensitivity × max(0, unemployment − reference) +
     * gdpSensitivity × max(0, −gdpGrowth) Clamped to [0, maxMigration].
     */
-  private[amorfati] def migrationRate(unemployment: Share, gdpGrowthMonthly: Coefficient)(using p: SimParams): Share =
-    val unempExcess: Share          = (unemployment - p.monetary.nairu).max(Share.Zero)
+  private[amorfati] def migrationRate(unemployment: Share, referenceUnemployment: Share, gdpGrowthMonthly: Coefficient)(using p: SimParams): Share =
+    val unempDeterioration: Share   = (unemployment - referenceUnemployment).max(Share.Zero)
     val gdpContraction: Coefficient = (-gdpGrowthMonthly).max(Coefficient.Zero)
-    val rawMigration: Coefficient   = p.banking.eclMigrationSensitivity * unempExcess + p.banking.eclGdpSensitivity * gdpContraction
+    val rawMigration: Coefficient   = p.banking.eclMigrationSensitivity * unempDeterioration + p.banking.eclGdpSensitivity * gdpContraction
     rawMigration.max(Coefficient.Zero).min(p.banking.eclMaxMigration.toCoefficient).toShare
 
   /** Monthly ECL staging step for a single bank.
@@ -76,6 +80,8 @@ object EclStaging:
     *   new defaults this month (→ Stage 3)
     * @param unemployment
     *   current unemployment rate
+    * @param referenceUnemployment
+    *   carried baseline/lagged unemployment used to measure deterioration
     * @param gdpGrowthMonthly
     *   month-on-month GDP growth
     */
@@ -84,9 +90,10 @@ object EclStaging:
       totalLoans: PLN,
       nplNew: PLN,
       unemployment: Share,
+      referenceUnemployment: Share,
       gdpGrowthMonthly: Coefficient,
   )(using p: SimParams): StepResult =
-    val migration: Share = migrationRate(unemployment, gdpGrowthMonthly)
+    val migration: Share = migrationRate(unemployment, referenceUnemployment, gdpGrowthMonthly)
 
     // Stage transitions
     val s1ToS2: PLN = prev.stage1 * migration             // macro-driven migration

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -113,7 +113,8 @@ import com.boombustgroup.amorfati.types.*
   * @param eclRate3
   *   Stage 3 (default) ECL provision rate (1 − recovery, KNF: ~50%)
   * @param eclMigrationSensitivity
-  *   sensitivity of S1→S2 migration to unemployment excess above NAIRU
+  *   sensitivity of S1→S2 migration to unemployment deterioration over the
+  *   carried reference unemployment rate
   * @param eclGdpSensitivity
   *   sensitivity of S1→S2 migration to GDP contraction
   * @param eclMaxMigration

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -636,6 +636,7 @@ object CalibrationProvenance:
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01`, `0.08`, `0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.eclMigrationSensitivity`, `eclGdpSensitivity`, `eclMaxMigration` | `3.0`, `5.0`, `0.20` | coefficient/share | Code note bridge: IFRS 9 significant-increase-in-credit-risk stress rule | Stage 1 to Stage 2 migration under unemployment deterioration or GDP contraction | Applied to `max(0, unemployment_t - unemployment_ref)` and `max(0, -gdpGrowth_t)`; `unemployment_ref` is carried from the lagged pipeline and bootstrapped from the opening Poland baseline | `EclStaging`, `BankingEconomics` | `TUNED_NEEDS_VALIDATION` |
 | `forex.baseExRate` | `4.2537` | PLN/EUR | NBP table A, 2026-04-29 | Starting exchange rate | Direct | `ForexConfig` | `EMPIRICAL` |
 | `forex.foreignRate` | `0.0215` | annual rate | ECB main refinancing rate | Foreign reference rate | Direct | `ForexConfig` | `EMPIRICAL` |
 | `forex.importPropensity` | `0.22` | GDP share | GUS/NBP imports-to-GDP bridge, 2026-04-30 | Aggregate import-to-GDP ratio | Direct | `ForexConfig` | `EMPIRICAL_TRANSFORMED` |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -712,8 +712,10 @@ object BankingEconomics:
 
     // IFRS 9 ECL staging: provision change hits capital
     val unemployment: Share              = in.w.unemploymentRate(in.s2.employed)
+    val referenceUnemployment: Share     = eclReferenceUnemployment(in)
     val gdpGrowth: Coefficient           = eclGdpGrowth(in)
-    val eclResult: EclStaging.StepResult = EclStaging.step(b.eclStaging, newLoansTotal + stocks.consumerLoan, bankNplNew, unemployment, gdpGrowth)
+    val eclResult: EclStaging.StepResult =
+      EclStaging.step(b.eclStaging, newLoansTotal + stocks.consumerLoan, bankNplNew, unemployment, referenceUnemployment, gdpGrowth)
 
     SingleBankUpdate(
       bank = b.copy(
@@ -1000,7 +1002,7 @@ object BankingEconomics:
       BankFailureDiagnostics.fromEvents(failureEvents, resolveResult.allFailedFallbackUsed || reconciled.allFailedFallbackUsed, invariantMismatches)
     val anyFailureForMobility = anyFailed || reconciled.newFailuresDelta > 0
     val eclGdpGrowthMonthly   = eclGdpGrowth(in)
-    val eclMigrationRate      = EclStaging.migrationRate(in.w.unemploymentRate(in.s2.employed), eclGdpGrowthMonthly)
+    val eclMigrationRate      = EclStaging.migrationRate(in.w.unemploymentRate(in.s2.employed), eclReferenceUnemployment(in), eclGdpGrowthMonthly)
     val eclDiagnostics        = computeBankEclDiagnostics(in.banks, finalFailureBanks, eclMigrationRate, eclGdpGrowthMonthly)
 
     // Repair stale failed-bank routing every month; mobility validates survivor bankIds.
@@ -1105,6 +1107,10 @@ object BankingEconomics:
   private def eclGdpGrowth(in: StepInput): Coefficient =
     val prevGdp = in.w.cachedMonthlyGdpProxy
     if prevGdp > PLN.Zero then (in.s7.gdp.ratioTo(prevGdp) - Scalar.One).toCoefficient else Coefficient.Zero
+
+  private def eclReferenceUnemployment(in: StepInput)(using p: SimParams): Share =
+    val lagged = in.w.pipeline.laggedUnemploymentRate
+    if lagged > Share.Zero then lagged else p.pop.initialUnemploymentRate
 
   private def computeBankEclDiagnostics(
       openingBanks: Vector[Banking.BankState],

--- a/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/EclStagingSpec.scala
@@ -13,30 +13,31 @@ class EclStagingSpec extends AnyFlatSpec with Matchers:
   private val loans = PLN(10000000000L)
   private val init  = EclStaging.State(loans, PLN.Zero, PLN.Zero) // all S1
 
-  "migrationRate" should "be zero when unemployment below NAIRU and GDP growing" in {
-    val rate = EclStaging.migrationRate(Share.decimal(3, 2), Coefficient.decimal(1, 2))
+  "migrationRate" should "be zero when unemployment is stable above NAIRU and GDP is growing" in {
+    val rate = EclStaging.migrationRate(Share.decimal(61, 3), Share.decimal(61, 3), Coefficient.decimal(1, 2))
     decimal(rate) shouldBe BigDecimal("0.0") +- BigDecimal("0.001")
   }
 
-  it should "increase with unemployment above NAIRU" in {
-    val low  = EclStaging.migrationRate(Share.decimal(6, 2), Coefficient.Zero)
-    val high = EclStaging.migrationRate(Share.decimal(10, 2), Coefficient.Zero)
+  it should "increase with unemployment deterioration relative to reference unemployment" in {
+    val reference = Share.decimal(61, 3)
+    val low       = EclStaging.migrationRate(Share.decimal(7, 2), reference, Coefficient.Zero)
+    val high      = EclStaging.migrationRate(Share.decimal(10, 2), reference, Coefficient.Zero)
     decimal(high) should be > decimal(low)
   }
 
   it should "increase with GDP contraction" in {
-    val growing     = EclStaging.migrationRate(Share.decimal(5, 2), Coefficient.decimal(1, 2))
-    val contracting = EclStaging.migrationRate(Share.decimal(5, 2), Coefficient.decimal(-2, 2))
+    val growing     = EclStaging.migrationRate(Share.decimal(61, 3), Share.decimal(61, 3), Coefficient.decimal(1, 2))
+    val contracting = EclStaging.migrationRate(Share.decimal(61, 3), Share.decimal(61, 3), Coefficient.decimal(-2, 2))
     decimal(contracting) should be > decimal(growing)
   }
 
   it should "not exceed maxMigration" in {
-    val extreme = EclStaging.migrationRate(Share.decimal(50, 2), Coefficient.decimal(-20, 2))
+    val extreme = EclStaging.migrationRate(Share.decimal(50, 2), Share.decimal(5, 2), Coefficient.decimal(-20, 2))
     decimal(extreme) should be <= decimal(summon[SimParams].banking.eclMaxMigration)
   }
 
   "EclStaging.step" should "keep all loans in S1 when economy is stable" in {
-    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(4, 2), Coefficient.decimal(1, 2))
+    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(61, 3), Share.decimal(61, 3), Coefficient.decimal(1, 2))
     decimal(result.newStaging.stage1) shouldBe decimal(loans) +- BigDecimal("1.0")
     decimal(result.newStaging.stage2) shouldBe BigDecimal("0.0") +- BigDecimal("1.0")
   }
@@ -51,7 +52,7 @@ class EclStagingSpec extends AnyFlatSpec with Matchers:
   }
 
   "EclStaging.step" should "migrate S1->S2 when unemployment rises" in {
-    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Coefficient.Zero)
+    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Share.decimal(61, 3), Coefficient.Zero)
     decimal(result.newStaging.stage2) should be > BigDecimal("0.0")
     decimal(result.newStaging.stage1) should be < decimal(loans)
   }
@@ -59,25 +60,25 @@ class EclStagingSpec extends AnyFlatSpec with Matchers:
   "EclStaging.step" should "move defaults to S3" in {
     val nplNew = PLN(100000000)
     val s2Init = EclStaging.State(loans - nplNew, nplNew, PLN.Zero)
-    val result = EclStaging.step(s2Init, loans, nplNew, Share.decimal(4, 2), Coefficient.decimal(1, 2))
+    val result = EclStaging.step(s2Init, loans, nplNew, Share.decimal(4, 2), Share.decimal(4, 2), Coefficient.decimal(1, 2))
     decimal(result.newStaging.stage3) should be > BigDecimal("0.0")
   }
 
   "EclStaging.step" should "increase provisions when loans migrate S1->S2" in {
-    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Coefficient.decimal(-2, 2))
+    val result = EclStaging.step(init, loans, PLN.Zero, Share.decimal(10, 2), Share.decimal(61, 3), Coefficient.decimal(-2, 2))
     // S1->S2 migration -> higher provisions -> positive provisionChange
     decimal(result.provisionChange) should be > BigDecimal("0.0")
   }
 
   "EclStaging.step" should "preserve total loans across stages" in {
-    val result = EclStaging.step(init, loans, PLN(50000000), Share.decimal(8, 2), Coefficient.decimal(-1, 2))
+    val result = EclStaging.step(init, loans, PLN(50000000), Share.decimal(8, 2), Share.decimal(61, 3), Coefficient.decimal(-1, 2))
     val total  = result.newStaging.stage1 + result.newStaging.stage2 + result.newStaging.stage3
     decimal(total) shouldBe decimal(loans) +- BigDecimal("1.0")
   }
 
   "EclStaging.step" should "cure some S3 loans back to S2" in {
     val s3Init = EclStaging.State(PLN.Zero, PLN.Zero, loans)
-    val result = EclStaging.step(s3Init, loans, PLN.Zero, Share.decimal(4, 2), Coefficient.decimal(1, 2))
+    val result = EclStaging.step(s3Init, loans, PLN.Zero, Share.decimal(4, 2), Share.decimal(4, 2), Coefficient.decimal(1, 2))
     decimal(result.newStaging.stage2) should be > BigDecimal("0.0")
     decimal(result.newStaging.stage3) should be < decimal(loans)
   }

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -39,11 +39,11 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
 
   "Baseline calibration provenance" should "preserve the active default inventory status counts in code" in {
     CalibrationProvenance.Baseline.parseErrors shouldBe empty
-    CalibrationProvenance.Baseline.parameters should have size 241
+    CalibrationProvenance.Baseline.parameters should have size 242
     CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 36)
     CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 17)
     CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 61)
-    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 86)
+    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 87)
     CalibrationProvenance.Baseline.statusCounts.getOrElse(UnknownSource, 0) shouldBe 0
     CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 1)
     CalibrationProvenance.Baseline.statusCounts should contain(Assumed -> 33)
@@ -134,7 +134,7 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     val pathCounts = CalibrationProvenance.Baseline.tunedValidationEvidencePathCounts
 
     CalibrationProvenance.Baseline.tunedValidationEvidenceErrors shouldBe empty
-    tuned should have size 86
+    tuned should have size 87
     tuned.flatMap(_.validationEvidence) should have size tuned.size
     CalibrationProvenance.Baseline.tunedValidationModeCounts.values.sum shouldBe tuned.size
     CalibrationValidationMode.values.foreach: mode =>

--- a/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
@@ -43,6 +43,7 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
     agg.unemployed shouldBe expectedUnemployed
     unempRate shouldBe Share.fraction(expectedUnemployed, laborForce)
     decimal(unempRate) shouldBe decimal(p.pop.initialUnemploymentRate) +- (BigDecimal(1) / BigDecimal(laborForce))
+    decimal(init.world.pipeline.laggedUnemploymentRate) shouldBe decimal(p.pop.initialUnemploymentRate) +- (BigDecimal(1) / BigDecimal(laborForce))
     decimal(annualGdp) shouldBe decimal(p.pop.realGdp) +- BigDecimal("1000000.0")
   }
 


### PR DESCRIPTION
## Summary

- Changes IFRS 9 Stage 1 to Stage 2 migration from an absolute unemployment-above-NAIRU trigger to deterioration over a carried reference unemployment rate plus GDP contraction.
- Wires the ECL reference to the lagged pipeline unemployment rate, bootstrapped from the model-start Poland baseline, so opening unemployment above NAIRU is not treated as recurring stress by itself.
- Keeps opening ECL provisions seeded through the existing all-Stage-1 covered-loan book and documents the convention in behavioral, benchmark, and calibration docs.
- Updates tests for stable baseline, unemployment deterioration, GDP contraction, seeded opening provisions, and provenance inventory counts.

## Validation

- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.EclStagingSpec com.boombustgroup.amorfati.init.WorldInitSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- sbt "testOnly com.boombustgroup.amorfati.agents.EclStagingSpec com.boombustgroup.amorfati.init.WorldInitSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec com.boombustgroup.amorfati.config.CalibrationProvenanceSpec"

Closes #553.
Refs #546.