### PR TITLE
Add bank resolution Monte Carlo diagnostics

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -919,6 +919,15 @@ In later months, a failed-bank row is an inert shell: ordinary lending, P&L,
 ECL migration, NPL write-off, and deposit-flow updates are skipped unless an
 explicit resolution or reconciliation mechanism changes the row.
 
+Resolution-count diagnostics are emitted as `BankResolution_*` seed timeseries
+columns. They report active bank rows, failed bank rows, newly failed banks,
+distinct event-based bail-in entries, P&A-resolved bank rows, the stable
+all-failed fallback flag, explicit bridge recapitalization amount, and an
+invalid-active-bank invariant flag. `BankResolution_BridgeRecapitalization`
+remains zero until a bridge or nationalization mechanism is implemented.
+`BankResolution_InvalidActiveBankInvariant` should remain zero and means an
+active bank ended the month with negative capital.
+
 Failure-trigger diagnostics are emitted as `BankFailure_*` seed timeseries
 columns. `BankFailure_NewNegativeCapital`, `BankFailure_NewCarBreach`, and
 `BankFailure_NewLiquidityBreach` count newly failed banks by primary trigger; if

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -227,14 +227,16 @@ valuation losses, interbank contagion losses, failure-related capital
 destruction, reconciliation residuals, and closing capital. The `BankEcl_*`
 block attributes IFRS 9 provision changes
 to opening/closing allowance, an all-Stage-1 baseline allowance, excess
-allowance, and S2/S3 migration shares. The `BankFailure_*` block identifies the
+allowance, and S2/S3 migration shares. The `BankResolution_*` block reports
+active/failed bank counts, new failures, event-based bail-in entries, P&A
+resolved banks, bridge recapitalization, all-failed fallback, and the
+invalid-active-bank invariant flag. The `BankFailure_*` block identifies the
 monthly primary trigger for newly failed banks. The `BankCreditLoss_*` block
 reports realized loss/default/write-off rates by major exposure class and keeps
 them separate from `BankCapital_EclProvisionChange`. The
 `BankReconciliation_*` block identifies the bank row that absorbed the exactness
 patch, reports capital and CAR before/after that patch, and flags material
-residuals or residual-induced failure-threshold crossings. No extra flag is
-needed for these aggregate diagnostics.
+residuals or residual-induced failure-threshold crossings.
 
 Firm-level micro snapshots are optional and off by default. Enable them with
 `--firm-snapshots terminal`, `--firm-snapshots every:12`, or

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -218,6 +218,7 @@ object Banking:
       absorberId: BankId,
       bankCorpBondHoldings: Vector[PLN] = Vector.empty,
       allFailedFallbackUsed: Boolean = false,
+      resolvedBankCount: Int = 0,
   )
 
   /** Auditable result of a firm-credit approval check. `approvalRoll` is
@@ -789,7 +790,7 @@ object Banking:
         else if bank.failed && stocks.totalDeposits == PLN.Zero then PLN.Zero
         else holderBalances(index)
       }
-      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds)
+      ResolutionResult(resolved, resolvedStocks, absorberId, resolvedCorpBonds, resolvedBankCount = toAbsorb.size)
 
   /** Find the healthiest surviving bank.
     *

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -331,6 +331,48 @@ object BankFailureDiagnostics:
       firstNewBankId = firstEvent.map(_.bankId.toInt).getOrElse(-1),
     )
 
+/** Monthly bank-resolution diagnostics for Monte Carlo timeseries.
+  *
+  * These fields are intentionally count-oriented and sit beside the richer
+  * `BankFailure_*`, `BankCapital_*`, and `BankReconciliation_*` blocks so a run
+  * can distinguish credit-demand weakness from bank-supply collapse.
+  */
+case class BankResolutionDiagnostics(
+    activeBanks: Int = 0,                   // active bank rows after monthly failure/resolution
+    failedBanks: Int = 0,                   // failed bank rows after monthly failure/resolution
+    newFailures: Int = 0,                   // banks newly marked failed during the month
+    bailInEvents: Int = 0,                  // distinct newly failed bank ids eligible for event-based bail-in
+    resolvedBanks: Int = 0,                 // failed bank rows whose balance sheets were transferred by P&A
+    allFailedFallback: Int = 0,             // stable legacy flag; current semantics fail fast before fallback
+    bridgeRecapitalization: PLN = PLN.Zero, // explicit bridge/nationalization recap amount; zero until modeled
+    invalidActiveBankInvariant: Int = 0,    // 1 when an active bank ends the month with negative capital
+)
+
+object BankResolutionDiagnostics:
+  val zero: BankResolutionDiagnostics = BankResolutionDiagnostics()
+
+  def fromState(
+      banks: Vector[Banking.BankState],
+      newFailures: Int,
+      bailInEvents: Int,
+      resolvedBanks: Int,
+      allFailedFallbackUsed: Boolean,
+      bridgeRecapitalization: PLN = PLN.Zero,
+  ): BankResolutionDiagnostics =
+    val activeBanks   = banks.count(bank => !bank.failed)
+    val failedBanks   = banks.size - activeBanks
+    val invalidActive = banks.exists(bank => !bank.failed && bank.capital < PLN.Zero)
+    BankResolutionDiagnostics(
+      activeBanks = activeBanks,
+      failedBanks = failedBanks,
+      newFailures = newFailures,
+      bailInEvents = bailInEvents,
+      resolvedBanks = resolvedBanks,
+      allFailedFallback = if allFailedFallbackUsed then 1 else 0,
+      bridgeRecapitalization = bridgeRecapitalization,
+      invalidActiveBankInvariant = if invalidActive then 1 else 0,
+    )
+
 /** Diagnostics for the aggregate-exactness patch applied to one bank row.
   *
   * `capitalResidual` has the same sign as the patch: positive adds bank
@@ -430,6 +472,7 @@ case class FlowState(
     bfgLevyTotal: PLN = PLN.Zero,                                                           // BFG resolution levy from all banks
     bankCapital: BankCapitalDiagnostics = BankCapitalDiagnostics.zero,                      // monthly bank-capital waterfall diagnostics
     bankFailure: BankFailureDiagnostics = BankFailureDiagnostics.zero,                      // monthly bank-failure trigger diagnostics
+    bankResolution: BankResolutionDiagnostics = BankResolutionDiagnostics.zero,             // monthly bank-resolution count diagnostics
     bankReconciliation: BankReconciliationDiagnostics = BankReconciliationDiagnostics.zero, // exactness-patch impact on target bank capital/CAR
     bankEcl: BankEclDiagnostics = BankEclDiagnostics.zero,                                  // IFRS 9 ECL allowance and staging diagnostics
 )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomics.scala
@@ -65,6 +65,7 @@ object BankingEconomics:
       interbankContagionLoss: PLN,                                  // counterparty losses from failed-bank interbank exposures
       bankCapitalDiagnostics: BankCapitalDiagnostics,               // aggregate monthly bank-capital waterfall diagnostics
       bankFailureDiagnostics: BankFailureDiagnostics,               // monthly bank-failure trigger diagnostics
+      bankResolutionDiagnostics: BankResolutionDiagnostics,         // monthly bank-resolution count diagnostics
       bankReconciliationDiagnostics: BankReconciliationDiagnostics, // exactness-patch impact on target bank capital/CAR
       bankEclDiagnostics: BankEclDiagnostics,                       // IFRS 9 ECL allowance and migration diagnostics
       monAgg: Option[Banking.MonetaryAggregates],                   // M0/M1/M2/M3 (when credit diagnostics on)
@@ -158,6 +159,7 @@ object BankingEconomics:
       capitalReconciliationResidual: PLN,                           // exactness correction applied to one per-bank capital row
       bankCapitalTerms: BankCapitalTerms,                           // shared capital-waterfall terms used by reconciliation and diagnostics
       bankFailureDiagnostics: BankFailureDiagnostics,               // failure trigger reason diagnostics for this month
+      bankResolutionDiagnostics: BankResolutionDiagnostics,         // resolution count diagnostics for this month
       bankReconciliationDiagnostics: BankReconciliationDiagnostics, // exactness-patch impact on target bank capital/CAR
       bankEclDiagnostics: BankEclDiagnostics,                       // IFRS 9 ECL allowance and migration diagnostics
       resolvedBank: Banking.Aggregate,                              // aggregate banking sector after resolution
@@ -195,6 +197,7 @@ object BankingEconomics:
       failureEvents: Vector[Banking.FailureEvent],
       allFailedFallbackUsed: Boolean,
       bankReconciliationDiagnostics: BankReconciliationDiagnostics,
+      resolvedBanksDelta: Int = 0,
   )
 
   private case class BankCapitalTerms(
@@ -332,6 +335,7 @@ object BankingEconomics:
       interbankContagionLoss = multi.interbankContagionLoss,
       bankCapitalDiagnostics = bankCapitalDiagnostics,
       bankFailureDiagnostics = multi.bankFailureDiagnostics,
+      bankResolutionDiagnostics = multi.bankResolutionDiagnostics,
       bankReconciliationDiagnostics = multi.bankReconciliationDiagnostics,
       bankEclDiagnostics = multi.bankEclDiagnostics,
       monAgg = monAgg,
@@ -1000,6 +1004,14 @@ object BankingEconomics:
     val invariantMismatches   = math.abs(totalNewFailures - failureEvents.length)
     val failureDiagnostics    =
       BankFailureDiagnostics.fromEvents(failureEvents, resolveResult.allFailedFallbackUsed || reconciled.allFailedFallbackUsed, invariantMismatches)
+    val resolutionDiagnostics =
+      BankResolutionDiagnostics.fromState(
+        banks = finalFailureBanks,
+        newFailures = totalNewFailures,
+        bailInEvents = failureEvents.map(_.bankId).distinct.size,
+        resolvedBanks = resolveResult.resolvedBankCount + reconciled.resolvedBanksDelta,
+        allFailedFallbackUsed = resolveResult.allFailedFallbackUsed || reconciled.allFailedFallbackUsed,
+      )
     val anyFailureForMobility = anyFailed || reconciled.newFailuresDelta > 0
     val eclGdpGrowthMonthly   = eclGdpGrowth(in)
     val eclMigrationRate      = EclStaging.migrationRate(in.w.unemploymentRate(in.s2.employed), eclReferenceUnemployment(in), eclGdpGrowthMonthly)
@@ -1048,6 +1060,7 @@ object BankingEconomics:
       capitalReconciliationResidual = reconciled.capitalResidual,
       bankCapitalTerms = bankCapitalTerms,
       bankFailureDiagnostics = failureDiagnostics,
+      bankResolutionDiagnostics = resolutionDiagnostics,
       bankReconciliationDiagnostics = reconciled.bankReconciliationDiagnostics,
       bankEclDiagnostics = eclDiagnostics,
       resolvedBank = Banking.aggregateFromBankStocks(finalFailureBanks, finalFailureStocks, finalCorpBondLookup),
@@ -1268,6 +1281,7 @@ object BankingEconomics:
               failCheck.events,
               resolved.allFailedFallbackUsed,
               reconciliationDiagnostics,
+              resolvedBanksDelta = resolved.resolvedBankCount,
             )
 
   private def aggregateReconciliationTarget(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -408,6 +408,7 @@ object WorldAssemblyEconomics:
       bfgLevyTotal = in.s9.bfgLevy,
       bankCapital = in.s9.bankCapitalDiagnostics,
       bankFailure = in.s9.bankFailureDiagnostics,
+      bankResolution = in.s9.bankResolutionDiagnostics,
       bankReconciliation = in.s9.bankReconciliationDiagnostics,
       bankEcl = in.s9.bankEclDiagnostics,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -76,6 +76,7 @@ object McTimeseriesSchema:
       Banking.aggregateFromBankStocks(banks, ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks), bankCorpBondHoldings)
     lazy val bankCapital: BankCapitalDiagnostics                                                    = world.flows.bankCapital
     lazy val bankFailure: BankFailureDiagnostics                                                    = world.flows.bankFailure
+    lazy val bankResolution: BankResolutionDiagnostics                                              = world.flows.bankResolution
     lazy val bankReconciliation: BankReconciliationDiagnostics                                      = world.flows.bankReconciliation
     lazy val bankEcl: BankEclDiagnostics                                                            = world.flows.bankEcl
     lazy val ledgerBankStocksById: Map[BankId, Banking.BankFinancialStocks]                         =
@@ -422,6 +423,14 @@ object McTimeseriesSchema:
       ctx => if ctx.aliveBankRows.isEmpty then Share.Zero else ctx.aliveBankRows.map((bank, stocks) => Banking.nplRatio(bank, stocks)).max,
     ),
     ColumnDef("BankFailures", ctx => ctx.banks.count(_.failed)),
+    ColumnDef("BankResolution_ActiveBanks", ctx => ctx.banks.count(bank => !bank.failed)),
+    ColumnDef("BankResolution_FailedBanks", ctx => ctx.banks.count(_.failed)),
+    ColumnDef("BankResolution_NewFailures", ctx => ctx.bankResolution.newFailures),
+    ColumnDef("BankResolution_BailInEvents", ctx => ctx.bankResolution.bailInEvents),
+    ColumnDef("BankResolution_ResolvedBanks", ctx => ctx.bankResolution.resolvedBanks),
+    ColumnDef("BankResolution_AllFailedFallback", ctx => ctx.bankResolution.allFailedFallback),
+    ColumnDef.macroPln("BankResolution_BridgeRecapitalization", ctx => ctx.bankResolution.bridgeRecapitalization),
+    ColumnDef("BankResolution_InvalidActiveBankInvariant", ctx => ctx.bankResolution.invalidActiveBankInvariant),
     ColumnDef("BankFailure_NewNegativeCapital", ctx => ctx.bankFailure.newNegativeCapital),
     ColumnDef("BankFailure_NewCarBreach", ctx => ctx.bankFailure.newCarBreach),
     ColumnDef("BankFailure_NewLiquidityBreach", ctx => ctx.bankFailure.newLiquidityBreach),
@@ -955,6 +964,14 @@ object McTimeseriesSchema:
     val MinBankCAR: Col                                = lookup("MinBankCAR")
     val MaxBankNPL: Col                                = lookup("MaxBankNPL")
     val BankFailures: Col                              = lookup("BankFailures")
+    val BankResolutionActiveBanks: Col                 = lookup("BankResolution_ActiveBanks")
+    val BankResolutionFailedBanks: Col                 = lookup("BankResolution_FailedBanks")
+    val BankResolutionNewFailures: Col                 = lookup("BankResolution_NewFailures")
+    val BankResolutionBailInEvents: Col                = lookup("BankResolution_BailInEvents")
+    val BankResolutionResolvedBanks: Col               = lookup("BankResolution_ResolvedBanks")
+    val BankResolutionAllFailedFallback: Col           = lookup("BankResolution_AllFailedFallback")
+    val BankResolutionBridgeRecapitalization: Col      = lookup("BankResolution_BridgeRecapitalization")
+    val BankResolutionInvalidActiveBankInvariant: Col  = lookup("BankResolution_InvalidActiveBankInvariant")
     val BankFailureNewNegativeCapital: Col             = lookup("BankFailure_NewNegativeCapital")
     val BankFailureNewCarBreach: Col                   = lookup("BankFailure_NewCarBreach")
     val BankFailureNewLiquidityBreach: Col             = lookup("BankFailure_NewLiquidityBreach")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -226,6 +226,14 @@ tracks the ordinary consumer-loan capital loss used by the bank waterfall.
 The seed timeseries also includes monthly failure-trigger diagnostics:
 
 ```text
+BankResolution_ActiveBanks
+BankResolution_FailedBanks
+BankResolution_NewFailures
+BankResolution_BailInEvents
+BankResolution_ResolvedBanks
+BankResolution_AllFailedFallback
+BankResolution_BridgeRecapitalization
+BankResolution_InvalidActiveBankInvariant
 BankFailure_NewNegativeCapital
 BankFailure_NewCarBreach
 BankFailure_NewLiquidityBreach
@@ -244,6 +252,14 @@ BankReconciliation_MaterialResidual
 BankReconciliation_CrossedFailureThreshold
 BankReconciliation_PostResidualReasonCode
 ```
+
+`BankResolution_*` columns provide the first-pass state counts for explaining
+credit-supply collapse: active and failed bank rows after month close, newly
+failed banks, distinct event-based bail-in entries, and P&A-resolved bank rows.
+`BankResolution_BridgeRecapitalization` remains zero until an explicit bridge or
+nationalization mechanism is implemented. `BankResolution_InvalidActiveBankInvariant`
+should remain zero; a non-zero value means an active bank ended the month with
+negative capital.
 
 `BankFailure_NewNegativeCapital`, `BankFailure_NewCarBreach`, and
 `BankFailure_NewLiquidityBreach` count newly failed banks by primary trigger.

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -239,6 +239,7 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     decimal(result.financialStocks(0).totalDeposits) shouldBe BigDecimal("800000.0") +- BigDecimal("0.01")
     result.financialStocks(1).totalDeposits shouldBe PLN.Zero
     result.bankCorpBondHoldings shouldBe Vector(PLN(1250), PLN.Zero)
+    result.resolvedBankCount shouldBe 1
   }
 
   "Banking.allocateBondIssuance" should "distribute new bonds by deposits and update HTM yield" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/KnfBfgSpec.scala
@@ -156,6 +156,7 @@ class KnfBfgSpec extends AnyFlatSpec with Matchers:
     result.financialStocks(1).bailedInDeposits shouldBe PLN(450000)
     decimal(Banking.govBondHoldings(result.financialStocks(1))) shouldBe BigDecimal("15e9") +- BigDecimal("1.0")
     decimal(result.financialStocks.map(_.interbankLoan).sumPln) shouldBe BigDecimal("0.0") +- BigDecimal("1e-6")
+    result.resolvedBankCount shouldBe 1
   }
 
   it should "fail fast when all banks fail instead of creating an implicit bridge bank" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/BankingEconomicsSpec.scala
@@ -168,6 +168,11 @@ class BankingEconomicsSpec extends AnyFlatSpec with Matchers:
     result.banks.exists(bank => bank.id.toInt == result.bankReconciliationDiagnostics.targetBankId && bank.failed) shouldBe true
     result.banks.filterNot(_.failed).foreach(_.capital should be >= PLN.Zero)
     result.bankFailureDiagnostics.newNegativeCapital should be >= 1
+    result.bankResolutionDiagnostics.activeBanks + result.bankResolutionDiagnostics.failedBanks shouldBe result.banks.size
+    result.bankResolutionDiagnostics.newFailures shouldBe result.bankCapitalDiagnostics.newFailures
+    result.bankResolutionDiagnostics.bailInEvents shouldBe result.bankResolutionDiagnostics.newFailures
+    result.bankResolutionDiagnostics.resolvedBanks should be >= 1
+    result.bankResolutionDiagnostics.invalidActiveBankInvariant shouldBe 0
   }
 
   it should "realign consumer-loan book distribution to household bank routing without changing the aggregate stock" in {

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -4,7 +4,14 @@ import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.agents.{Banking, EclStaging, Firm, Household, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.{BankCapitalDiagnostics, BankEclDiagnostics, BankFailureDiagnostics, BankReconciliationDiagnostics, World}
+import com.boombustgroup.amorfati.engine.{
+  BankCapitalDiagnostics,
+  BankEclDiagnostics,
+  BankFailureDiagnostics,
+  BankReconciliationDiagnostics,
+  BankResolutionDiagnostics,
+  World,
+}
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -157,6 +164,14 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "MinBankCAR",
     "MaxBankNPL",
     "BankFailures",
+    "BankResolution_ActiveBanks",
+    "BankResolution_FailedBanks",
+    "BankResolution_NewFailures",
+    "BankResolution_BailInEvents",
+    "BankResolution_ResolvedBanks",
+    "BankResolution_AllFailedFallback",
+    "BankResolution_BridgeRecapitalization",
+    "BankResolution_InvalidActiveBankInvariant",
     "BankFailure_NewNegativeCapital",
     "BankFailure_NewCarBreach",
     "BankFailure_NewLiquidityBreach",
@@ -443,7 +458,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 388
+    McTimeseriesSchema.nCols shouldBe 396
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -777,6 +792,36 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "BankFailure_InvariantViolation") shouldBe MetricValue.Zero
     valueAt(row, "BankFailure_FirstNewReasonCode") shouldBe MetricValue.fromInt(3)
     valueAt(row, "BankFailure_FirstNewBankId") shouldBe MetricValue.fromInt(4)
+  }
+
+  it should "emit bank resolution count diagnostics" in {
+    val banks       = init.banks.zipWithIndex.map: (bank, idx) =>
+      if idx < 2 then bank.copy(status = Banking.BankStatus.Failed(ExecutionMonth.First))
+      else bank
+    val diagnostics = BankResolutionDiagnostics(
+      newFailures = 3,
+      bailInEvents = 3,
+      resolvedBanks = 2,
+      allFailedFallback = 0,
+      bridgeRecapitalization = PLN(7),
+      invalidActiveBankInvariant = 1,
+    )
+    val world       = init.world.copy(
+      flows = init.world.flows.copy(
+        sectorOutputs = Vector.fill(summon[SimParams].sectorDefs.length)(PLN.Zero),
+        bankResolution = diagnostics,
+      ),
+    )
+    val row         = computeRow(world, banks = banks)
+
+    valueAt(row, "BankResolution_ActiveBanks") shouldBe MetricValue.fromInt(banks.count(bank => !bank.failed))
+    valueAt(row, "BankResolution_FailedBanks") shouldBe MetricValue.fromInt(2)
+    valueAt(row, "BankResolution_NewFailures") shouldBe MetricValue.fromInt(3)
+    valueAt(row, "BankResolution_BailInEvents") shouldBe MetricValue.fromInt(3)
+    valueAt(row, "BankResolution_ResolvedBanks") shouldBe MetricValue.fromInt(2)
+    valueAt(row, "BankResolution_AllFailedFallback") shouldBe MetricValue.Zero
+    valueAt(row, "BankResolution_BridgeRecapitalization") shouldBe polandScale(PLN(7))
+    valueAt(row, "BankResolution_InvalidActiveBankInvariant") shouldBe MetricValue.fromInt(1)
   }
 
   it should "emit bank reconciliation residual impact diagnostics" in {


### PR DESCRIPTION
## Summary

- Adds a focused `BankResolution_*` Monte Carlo timeseries block for active/failed bank counts, new failures, bail-in events, P&A-resolved banks, all-failed fallback, bridge recapitalization, and invalid-active-bank invariant.
- Tracks P&A resolved-bank counts directly from `Banking.resolveFailures` instead of inferring them from failed-bank totals.
- Wires bank resolution diagnostics through `BankingEconomics`, `WorldAssemblyEconomics`, `FlowState`, and `McTimeseriesSchema`.
- Documents the new diagnostics in the Monte Carlo README, behavioral rules, and operations docs.

## Validation

- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.engine.KnfBfgSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"`
- `sbt "testOnly com.boombustgroup.amorfati.montecarlo.McRunnerOutputSpec"`

Closes #551.
Refs #546.