### PR TITLE
Add NBFI credit stock diagnostics

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -68,7 +68,7 @@ runtime ledger flows and validates SFC identities.
 | Firm production, investment, technology, financing, default, entry | `agents/Firm.scala`, `engine/economics/FirmEconomics.scala`, `engine/mechanisms/FirmEntry.scala` | `TotalAdoption`, `AutoRatio`, `HybridRatio`, `Automation_TechCapex`, `Automation_TechImports`, `Automation_TechLoans`, `Automation_UpgradeFailures`, `Automation_AiDebtTrap`, `Automation_NewFullAi`, `Automation_NewHybrid`, `Adoption_MicroShare`, `Adoption_SmallShare`, `Adoption_MediumShare`, `Adoption_LargeShare`, `Adoption_CashQ1`-`Q4`, `Adoption_DebtQ1`-`Q4`, sector `*_Auto`, sector `*_Sigma`, `GrossInvestment`, `FirmCredit_NewLoans`, `FirmCredit_PrincipalRepaid`, `FirmCredit_GrossDefault`, `FirmCredit_NetStockFlow`, `FirmCredit_CreditDemand`, `FirmCredit_BankRejected`, `AggCapitalStock`, `AggInventoryStock`, `InventoryChange`, `AggEnergyCost`, `GreenInvestment`, `FirmBirths`, `FirmDeaths`, `NetEntry`, `LivingFirmCount`, `CorpBondIssuance`, `EquityIssuanceTotal` |
 | Banking and monetary plumbing | `agents/Banking.scala`, `engine/economics/BankingEconomics.scala`, `agents/EclStaging.scala`, `agents/DepositMobility.scala`, `agents/InterbankContagion.scala` | `NPL`, `MinBankCAR`, `MaxBankNPL`, `MinBankLCR`, `MinBankNSFR`, `BankFailures`, `BankFailure_*`, `BankEcl_*`, `BankCreditLoss_*`, `BankReconciliation_*`, `InterbankRate`, `WIBOR_1M`, `WIBOR_3M`, `WIBOR_6M`, `BfgLevyTotal`, `BailInLoss`, `M0`, `M1`, `M2`, `M3`, `CreditMultiplier` |
 | Fiscal, NBP, bond market, external sector | `agents/Nbp.scala`, `engine/markets/OpenEconomy.scala`, `engine/economics/OpenEconEconomics.scala`, `engine/markets/CorporateBondMarket.scala`, `engine/markets/BondAuction.scala` | `RefRate`, `BondYield`, `WeightedCoupon`, `BondsOutstanding`, `NbpBondHoldings`, `ForeignBondHoldings`, `QeActive`, `FxReserves`, `FxInterventionAmt`, `CurrentAccount`, `CapitalAccount`, `TradeBalance_OE`, `Exports_OE`, `TotalImports_OE`, `NFA`, `FDI` |
-| Insurance, NBFI, quasi-fiscal, local government | `agents/Insurance.scala`, `agents/Nbfi.scala`, `agents/QuasiFiscal.scala`, `agents/Jst.scala` | `InsLifeReserves`, `InsNonLifeReserves`, `InsLifePremium`, `InsNonLifePremium`, `InsLifeClaims`, `InsNonLifeClaims`, `NbfiTfiAum`, `NbfiOrigination`, `NbfiDefaults`, `NbfiBankTightness`, `QfBondsOutstanding`, `QfIssuance`, `QfLoanPortfolio`, `Esa2010DebtToGdp`, `JstRevenue`, `JstSpending`, `JstDebt`, `JstDeposits` |
+| Insurance, NBFI, quasi-fiscal, local government | `agents/Insurance.scala`, `agents/Nbfi.scala`, `agents/QuasiFiscal.scala`, `agents/Jst.scala` | `InsLifeReserves`, `InsNonLifeReserves`, `InsLifePremium`, `InsNonLifePremium`, `InsLifeClaims`, `InsNonLifeClaims`, `NbfiTfiAum`, `NbfiLoanStock`, `NbfiOrigination`, `NbfiRepayment`, `NbfiDefaults`, `NbfiNetStockFlow`, `NbfiBankTightness`, `NbfiDepositDrainToAum`, `QfBondsOutstanding`, `QfIssuance`, `QfLoanPortfolio`, `Esa2010DebtToGdp`, `JstRevenue`, `JstSpending`, `JstDebt`, `JstDeposits` |
 
 ## Household Rules
 
@@ -1167,6 +1167,12 @@ defaults = loanStock * defaultBase
            * (1 + defaultUnempSensitivity * max(unemploymentRate - 0.05, 0))
 loanStock' = max(loanStock + origination - repayment - defaults, 0)
 ```
+
+The timeseries exposes `NbfiNetStockFlow` as `origination - repayment -
+defaults`, plus `NbfiOriginationToStock`, `NbfiRepaymentToStock`, and
+`NbfiDefaultsToStock` to attribute loan-book runoff. `NbfiDepositDrainToAum`
+diagnoses TFI fund-flow pressure relative to AUM; deposit drain is a banking
+deposit/AUM channel, not a direct term in the NBFI loan-stock identity.
 
 ### Quasi-Fiscal BGK/PFR
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -223,7 +223,9 @@ The seed time-series files also include always-on aggregate diagnostic blocks
 for household liquidity, firm automation/adoption, firm credit, bank capital,
 and bank failure triggers. The `FirmCredit_*` columns reconcile firm-loan
 origination, principal repayment, default, NPL recovery/loss, investment credit
-demand, bank rejection, and cash-financed investment. The consumer-credit block
+demand, bank rejection, and cash-financed investment. The `Nbfi*` credit columns
+reconcile NBFI origination, repayment, defaults, net stock flow, bank tightness,
+and TFI deposit-drain pressure. The consumer-credit block
 uses `ConsumerCredit_*` columns to
 reconcile approved origination, principal repayment, default, bridge charge-off,
 NPL stock, and borrower-side versus bank-side rejection. The bank capital block

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -102,6 +102,10 @@ object McTimeseriesSchema:
       (world.real.grossInvestment - world.flows.firmInvestmentCreditApproved).max(PLN.Zero)
     lazy val consumerLoanStock: PLN                                                                 = bankAgg.consumerLoans
     lazy val nbfiLoanStock: PLN                                                                     = ledgerFinancialState.funds.nbfi.nbfiLoanStock
+    lazy val nbfiOrigination: PLN                                                                   = world.financialMarkets.nbfi.lastNbfiOrigination
+    lazy val nbfiRepayment: PLN                                                                     = world.financialMarkets.nbfi.lastNbfiRepayment
+    lazy val nbfiDefaults: PLN                                                                      = world.financialMarkets.nbfi.lastNbfiDefaultAmount
+    lazy val nbfiNetStockFlow: PLN                                                                  = nbfiOrigination - nbfiRepayment - nbfiDefaults
     lazy val eclStage1: PLN                                                                         = banks.map(b => b.eclStaging.stage1).sumPln
     lazy val eclStage2: PLN                                                                         = banks.map(b => b.eclStaging.stage2).sumPln
     lazy val eclStage3: PLN                                                                         = banks.map(b => b.eclStaging.stage3).sumPln
@@ -592,8 +596,13 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("NbfiTfiAum", ctx => ctx.ledgerFinancialState.funds.nbfi.tfiUnit),
     ColumnDef.macroPln("NbfiTfiGovBondHoldings", ctx => ctx.ledgerFinancialState.funds.nbfi.govBondHoldings),
     ColumnDef.macroPln("NbfiLoanStock", ctx => ctx.nbfiLoanStock),
-    ColumnDef.macroPln("NbfiOrigination", ctx => ctx.world.financialMarkets.nbfi.lastNbfiOrigination),
-    ColumnDef.macroPln("NbfiDefaults", ctx => ctx.world.financialMarkets.nbfi.lastNbfiDefaultAmount),
+    ColumnDef.macroPln("NbfiOrigination", ctx => ctx.nbfiOrigination),
+    ColumnDef.macroPln("NbfiRepayment", ctx => ctx.nbfiRepayment),
+    ColumnDef.macroPln("NbfiDefaults", ctx => ctx.nbfiDefaults),
+    ColumnDef.macroPln("NbfiNetStockFlow", ctx => ctx.nbfiNetStockFlow),
+    ColumnDef("NbfiOriginationToStock", ctx => ctx.flowToStockRate(ctx.nbfiOrigination, ctx.nbfiLoanStock)),
+    ColumnDef("NbfiRepaymentToStock", ctx => ctx.flowToStockRate(ctx.nbfiRepayment, ctx.nbfiLoanStock)),
+    ColumnDef("NbfiDefaultsToStock", ctx => ctx.flowToStockRate(ctx.nbfiDefaults, ctx.nbfiLoanStock)),
     ColumnDef("NbfiBankTightness", ctx => ctx.world.financialMarkets.nbfi.lastBankTightness),
     // Quasi-fiscal (BGK/PFR)
     ColumnDef.macroPln("QfBondsOutstanding", ctx => ctx.ledgerFinancialState.funds.quasiFiscal.bondsOutstanding),
@@ -609,6 +618,10 @@ object McTimeseriesSchema:
         else Scalar.Zero,
     ),
     ColumnDef.macroPln("NbfiDepositDrain", ctx => ctx.world.financialMarkets.nbfi.lastDepositDrain),
+    ColumnDef(
+      "NbfiDepositDrainToAum",
+      ctx => ctx.flowToStockRate(ctx.world.financialMarkets.nbfi.lastDepositDrain, ctx.ledgerFinancialState.funds.nbfi.tfiUnit),
+    ),
     // AFS/HTM bond portfolio split
     ColumnDef.macroPln("BankAfsBonds", ctx => ctx.bankAgg.afsBonds),
     ColumnDef.macroPln("BankHtmBonds", ctx => ctx.bankAgg.htmBonds),
@@ -1004,7 +1017,18 @@ object McTimeseriesSchema:
     val NbpBondHoldings: Col                           = lookup("NbpBondHoldings")
     val PpkBondHoldings: Col                           = lookup("PpkBondHoldings")
     val InsGovBondHoldings: Col                        = lookup("InsGovBondHoldings")
+    val NbfiTfiAum: Col                                = lookup("NbfiTfiAum")
     val NbfiTfiGovBondHoldings: Col                    = lookup("NbfiTfiGovBondHoldings")
+    val NbfiLoanStock: Col                             = lookup("NbfiLoanStock")
+    val NbfiOrigination: Col                           = lookup("NbfiOrigination")
+    val NbfiRepayment: Col                             = lookup("NbfiRepayment")
+    val NbfiDefaults: Col                              = lookup("NbfiDefaults")
+    val NbfiNetStockFlow: Col                          = lookup("NbfiNetStockFlow")
+    val NbfiOriginationToStock: Col                    = lookup("NbfiOriginationToStock")
+    val NbfiRepaymentToStock: Col                      = lookup("NbfiRepaymentToStock")
+    val NbfiDefaultsToStock: Col                       = lookup("NbfiDefaultsToStock")
+    val NbfiDepositDrain: Col                          = lookup("NbfiDepositDrain")
+    val NbfiDepositDrainToAum: Col                     = lookup("NbfiDepositDrainToAum")
     val QeActive: Col                                  = lookup("QeActive")
     val DebtService: Col                               = lookup("DebtService")
     val NbpRemittance: Col                             = lookup("NbpRemittance")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -330,6 +330,34 @@ investment not financed by approved investment credit. The `Tech*` columns cover
 automation and hybrid upgrade credit demand, including otherwise feasible
 upgrades rejected by the relationship bank.
 
+## NBFI Credit Diagnostics
+
+The monthly timeseries NBFI block relevant to non-bank credit runoff is:
+
+```text
+NbfiLoanStock
+NbfiOrigination
+NbfiRepayment
+NbfiDefaults
+NbfiNetStockFlow
+NbfiOriginationToStock
+NbfiRepaymentToStock
+NbfiDefaultsToStock
+NbfiBankTightness
+NbfiDepositDrain
+NbfiDepositDrainToAum
+```
+
+`NbfiNetStockFlow` reports the expected monthly NBFI credit-book flow as
+origination minus repayment minus defaults. Comparing month-over-month
+`NbfiLoanStock` deltas to `NbfiNetStockFlow` isolates any residual stock
+movement. The three `*ToStock` rates identify whether runoff is driven by low
+origination, scheduled repayment, or default. `NbfiBankTightness` is the
+bank-NPL-driven counter-cyclical origination signal, while
+`NbfiDepositDrainToAum` shows whether TFI fund-flow pressure is material
+relative to TFI AUM. TFI deposit drain affects banking-system deposits and AUM;
+it is not a direct term in the NBFI loan-stock identity.
+
 ## Household Liquidity Diagnostics
 
 The timeseries schema and terminal `_hh.csv` summary include generic household

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
-import com.boombustgroup.amorfati.agents.{Banking, EclStaging, Firm, Household, TechState}
+import com.boombustgroup.amorfati.agents.{Banking, EclStaging, Firm, Household, Nbfi, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{
@@ -269,7 +269,12 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "NbfiTfiGovBondHoldings",
     "NbfiLoanStock",
     "NbfiOrigination",
+    "NbfiRepayment",
     "NbfiDefaults",
+    "NbfiNetStockFlow",
+    "NbfiOriginationToStock",
+    "NbfiRepaymentToStock",
+    "NbfiDefaultsToStock",
     "NbfiBankTightness",
     "QfBondsOutstanding",
     "QfNbpHoldings",
@@ -277,6 +282,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "QfIssuance",
     "Esa2010DebtToGdp",
     "NbfiDepositDrain",
+    "NbfiDepositDrainToAum",
     "BankAfsBonds",
     "BankHtmBonds",
     "EclStage1",
@@ -486,7 +492,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 424
+    McTimeseriesSchema.nCols shouldBe 430
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -662,6 +668,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     val bankCorpBonds = PLN(25) * initState.ledgerFinancialState.banks.length
     val mortgageStock = PLN(20)
     val nbfiLoans     = PLN(6)
+    val nbfiAum       = PLN(30)
     val totalCredit   = bankFirmLoans + consumerLoans + mortgageStock + nbfiLoans
     val annualGdp     = PLN(10) * 12
     val firmDefault   = PLN(10)
@@ -672,7 +679,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
       households = householdRows,
       banks = initState.ledgerFinancialState.banks.map(_.copy(firmLoan = PLN(10), consumerLoan = PLN(2), corpBond = PLN(25))),
       funds = initState.ledgerFinancialState.funds.copy(
-        nbfi = initState.ledgerFinancialState.funds.nbfi.copy(nbfiLoanStock = nbfiLoans),
+        nbfi = initState.ledgerFinancialState.funds.nbfi.copy(tfiUnit = nbfiAum, nbfiLoanStock = nbfiLoans),
       ),
     )
     val banks         = init.banks.map(_.copy(consumerNpl = PLN(1)))
@@ -688,6 +695,17 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
       real = init.world.real.copy(
         housing = init.world.real.housing.copy(lastDefault = PLN(6)),
         grossInvestment = PLN(15),
+      ),
+      financialMarkets = init.world.financialMarkets.copy(
+        nbfi = Nbfi.State(
+          lastTfiNetInflow = PLN(3),
+          lastNbfiOrigination = PLN(5),
+          lastNbfiRepayment = PLN(2),
+          lastNbfiDefaultAmount = PLN(1),
+          lastNbfiInterestIncome = PLN.Zero,
+          lastBankTightness = Share.decimal(25, 2),
+          lastDepositDrain = PLN(3),
+        ),
       ),
       flows = init.world.flows.copy(
         monthlyGdpProxy = PLN(10),
@@ -759,6 +777,16 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "ConsumerCredit_BankRejectedToDemand") shouldBe MetricValue.fromRaw((PLN(6) / PLN(20)).toLong)
     valueAt(row, "ConsumerCredit_ShortfallToApprovedOrigination") shouldBe MetricValue.fromRaw((PLN(4) / PLN(8)).toLong)
     valueAt(row, "NbfiLoanStock") shouldBe polandScale(nbfiLoans)
+    valueAt(row, "NbfiOrigination") shouldBe polandScale(PLN(5))
+    valueAt(row, "NbfiRepayment") shouldBe polandScale(PLN(2))
+    valueAt(row, "NbfiDefaults") shouldBe polandScale(PLN(1))
+    valueAt(row, "NbfiNetStockFlow") shouldBe polandScale(PLN(2))
+    valueAt(row, "NbfiOriginationToStock") shouldBe MetricValue.fromRaw((PLN(5) / nbfiLoans).toLong)
+    valueAt(row, "NbfiRepaymentToStock") shouldBe MetricValue.fromRaw((PLN(2) / nbfiLoans).toLong)
+    valueAt(row, "NbfiDefaultsToStock") shouldBe MetricValue.fromRaw((PLN(1) / nbfiLoans).toLong)
+    valueAt(row, "NbfiBankTightness") shouldBe MetricValue.fromRaw(Share.decimal(25, 2).toLong)
+    valueAt(row, "NbfiDepositDrain") shouldBe polandScale(PLN(3))
+    valueAt(row, "NbfiDepositDrainToAum") shouldBe MetricValue.fromRaw((PLN(3) / nbfiAum).toLong)
     valueAt(row, "TotalCreditStock") shouldBe polandScale(totalCredit)
     valueAt(row, "BankFirmLoansToGdp") shouldBe MetricValue.fromRaw((bankFirmLoans / annualGdp).toLong)
     valueAt(row, "ConsumerLoansToGdp") shouldBe MetricValue.fromRaw((consumerLoans / annualGdp).toLong)


### PR DESCRIPTION
## Summary
- add focused NBFI timeseries diagnostics for repayment, net stock flow, flow-to-stock rates, and deposit-drain-to-AUM pressure
- update the stable McTimeseriesSchema contract and coverage for the NBFI credit block
- document that TFI deposit drain affects deposits and AUM, not the NBFI loan-stock identity directly

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- sbt "testOnly com.boombustgroup.amorfati.agents.ShadowBankingSpec"
- git diff --check

Closes #604.
Refs #523.