### PR TITLE
Calibrate NBFI credit renewal

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -1178,7 +1178,7 @@ NBFI credit is counter-cyclical to bank tightness:
 
 ```text
 bankTightness = clamp((bankNplRatio - 0.03) / 0.03, 0, 1)
-origination = domesticConsumption * creditBaseRate
+origination = loanStock * creditBaseRate
               * (1 + countercyclical * bankTightness)
 repayment = loanStock / creditMaturity
 defaults = loanStock * defaultBase
@@ -1188,9 +1188,12 @@ loanStock' = max(loanStock + origination - repayment - defaults, 0)
 
 The timeseries exposes `NbfiNetStockFlow` as `origination - repayment -
 defaults`, plus `NbfiOriginationToStock`, `NbfiRepaymentToStock`, and
-`NbfiDefaultsToStock` to attribute loan-book runoff. `NbfiDepositDrainToAum`
-diagnoses TFI fund-flow pressure relative to AUM; deposit drain is a banking
-deposit/AUM channel, not a direct term in the NBFI loan-stock identity.
+`NbfiDefaultsToStock` to attribute loan-book renewal or runoff. `creditBaseRate`
+is a monthly stock-renewal rate calibrated against scheduled repayment and
+baseline defaults, with the counter-cyclical multiplier adding origination when
+bank NPL tightness rises. `NbfiDepositDrainToAum` diagnoses TFI fund-flow
+pressure relative to AUM; deposit drain is a banking deposit/AUM channel, not a
+direct term in the NBFI loan-stock identity.
 
 ### Quasi-Fiscal BGK/PFR
 

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -169,7 +169,7 @@ a concrete diagnostic artifact path.
 | `informal.unempThreshold`, `cyclicalSens`, `smoothing` | `MODEL_BEHAVIOR_CALIBRATION` | `MISSING_VALIDATION_EVIDENCE` |  |  | Counter-cyclical informal-sector response | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `soe.dividendFiscalThreshold`, `dividendFiscalSensitivity` | `MODEL_BEHAVIOR_CALIBRATION` | `MISSING_VALIDATION_EVIDENCE` |  |  | Fiscal-pressure dividend response | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `soe.firingReduction`, `investmentMultiplier`, `energyPassthrough` | `MODEL_BEHAVIOR_CALIBRATION` | `MISSING_VALIDATION_EVIDENCE` |  |  | SOE labor buffer, directed investment, energy pass-through | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
-| `nbfi.creditBaseRate` | `HISTORICAL_FIT` | docs/empirical-validation/baseline-validation-snapshot.csv | Credit/GDP |  | Non-bank credit contribution to aggregate credit | EmpiricalValidationExport records the current credit/GDP bridge while NBFI split extraction remains partial. |
+| `nbfi.creditBaseRate` | `HISTORICAL_FIT` | docs/private-credit-renewal-calibration.md | 20260525-610-nbfi-only |  | Private credit renewal calibration | Issue #610 documents the Nix-built 10-seed 60-month NBFI stock-renewal calibration and terminal private-credit split. |
 | `nbfi.defaultBase`, `defaultUnempSens` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | NBFI default dynamics | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 
 ## Transformation Rules
@@ -454,7 +454,7 @@ a concrete diagnostic artifact path.
 | `nbfi.tfiInitAum` | `448.3e9` | raw PLN | Analizy/IZFiA fund assets, March 2026 | TFI AUM | Scaled by gdpRatio | `NbfiConfig`, `SimParams` | `EMPIRICAL` |
 | `nbfi.creditInitStock` | `234e9` | raw PLN | ZPL active leasing and leasing-loan portfolio, end-2025 | NBFI credit stock | Scaled by gdpRatio | `NbfiConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40, 0.10, 0.10` | share | Structural TFI portfolio-allocation prior | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `ASSUMED` |
-| `nbfi.creditBaseRate` | `0.005` | monthly share | UNKNOWN_SOURCE | NBFI credit origination rate | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `nbfi.creditBaseRate` | `0.031` | monthly share | #610 private-credit renewal calibration | NBFI credit origination stock-renewal rate | Direct fraction of opening loan stock | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `nbfi.creditRate` | `0.10` | annual rate | Structural NBFI loan-rate prior | NBFI loan rate | .monthly in income | `NbfiConfig` | `ASSUMED` |
 | `nbfi.defaultBase`, `defaultUnempSens` | `0.002, 3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `quasiFiscal.issuanceShare` | `0.40` | share | Code note bridge: NIK bridge prior | BGK/PFR share of capital programs | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/docs/household-credit-stress-calibration.md
+++ b/docs/household-credit-stress-calibration.md
@@ -76,6 +76,9 @@ If the 60-month baseline falls below the band while
 `MortgageOriginationSupplyConstrained` is false, the relevant calibration lever
 is `housing.originationRate` relative to scheduled amortization, gross default,
 and GDP growth rather than a bank-resolution supply cap.
+For the non-bank credit slice, `NbfiOriginationToStock` is a stock-renewal rate;
+compare it directly with `NbfiRepaymentToStock` and `NbfiDefaultsToStock` before
+attributing aggregate private-credit compression to household stress.
 Mortgage principal and interest ratios decompose `MortgageDebtServiceToIncome`;
 they are internal diagnostics, not standalone empirical acceptance bands.
 `ConsumerDebtServiceToIncome` is also a household cash-flow burden: principal

--- a/docs/private-credit-renewal-calibration.md
+++ b/docs/private-credit-renewal-calibration.md
@@ -1,0 +1,82 @@
+# Private Credit Renewal Calibration
+
+Issue #610 re-checks the 60-month Poland baseline after the #523 final run
+showed private-credit compression that was no longer caused by bank-resolution
+fallbacks.
+
+## Accepted Change
+
+NBFI credit origination is stock-renewal based:
+
+```text
+origination = openingNbfiLoanStock * nbfi.creditBaseRate
+              * (1 + countercyclical * bankTightness)
+```
+
+The baseline `nbfi.creditBaseRate` is `0.031` per month. This is calibrated
+against the 36-month scheduled repayment rate and baseline defaults, so NBFI
+loan stock no longer mechanically runs off because origination was tied to
+domestic consumption rather than the opening book.
+
+## Rejected Levers
+
+Two wider renewal levers were tested and rejected for this PR:
+
+- Increasing `housing.originationRate` to `0.0045` improved the mortgage slice
+  but caused an all-failed banking-sector failure in the 10-seed 60-month run.
+- Partial firm-credit approval after hard full-size rejection also caused an
+  all-failed banking-sector failure in the 10-seed 60-month run.
+
+Those channels need a follow-up that treats bank-capital consequences
+explicitly instead of calibrating private credit by adding bank exposure.
+
+## Validation Run
+
+Command:
+
+```bash
+nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 10 issue610-nbfi-final --duration 60 --run-id 20260525-610-final-nbfi --firm-snapshots none --household-snapshots none
+```
+
+JAR hash: `fe8e8e0d472a2488d44de95379d8b1db3de38c4b`.
+
+The run completed all 10 seeds and wrote:
+
+```text
+mc/issue610-nbfi-final_20260525-610-final-nbfi_60m_seed001.csv
+...
+mc/issue610-nbfi-final_20260525-610-final-nbfi_60m_seed010.csv
+```
+
+Terminal `TotalCreditToGdp` improved from the #523 final baseline mean of
+`18.17%` to `21.50%` (`20.81%` to `22.17%` seed range). The terminal split was:
+
+| Metric | Mean | Seed range |
+| --- | ---: | ---: |
+| `BankFirmLoansToGdp` | `6.13%` | `5.81%` to `6.42%` |
+| `ConsumerLoansToGdp` | `2.12%` | `2.00%` to `2.24%` |
+| `MortgageToGdp` | `8.76%` | `8.20%` to `9.10%` |
+| `NbfiLoansToGdp` | `4.50%` | `4.21%` to `4.67%` |
+
+The NBFI terminal flow decomposition was:
+
+| Metric | Mean |
+| --- | ---: |
+| `NbfiOriginationToStock` | `3.10%` |
+| `NbfiRepaymentToStock` | `2.77%` |
+| `NbfiDefaultsToStock` | `0.21%` |
+| `NbfiNetStockFlow` | `0.29bn PLN/month` |
+
+Bank-resolution sanity stayed clean:
+
+| Metric | Terminal result |
+| --- | ---: |
+| `BankResolution_AllFailedFallback` | `0` all seeds |
+| `BankFailure_AllFailedFallback` | `0` all seeds |
+| `BankResolution_InvalidActiveBankInvariant` | `0` all seeds |
+| `BankFailure_InvariantViolation` | `0` all seeds |
+
+The remaining compression is therefore not an NBFI renewal-base artifact. The
+remaining structural channels are firm-credit renewal, household credit/default
+pressure, mortgage renewal under bank-capital consequences, and GDP denominator
+growth.

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbfi.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbfi.scala
@@ -127,11 +127,13 @@ object Nbfi:
     val excessReturn = (fundReturn - depositRate).clamp(-ExcessReturnCap, ExcessReturnCap)
     base * (Multiplier.One + (excessReturn * ExcessReturnSens).toMultiplier)
 
-  /** NBFI credit origination: counter-cyclical to bank tightness. */
-  def nbfiOrigination(domesticCons: PLN, bankNplRatio: Share)(using p: SimParams): PLN =
+  /** NBFI credit origination: stock-renewal flow, counter-cyclical to bank
+    * tightness.
+    */
+  def nbfiOrigination(loanStock: PLN, bankNplRatio: Share)(using p: SimParams): PLN =
     val tight       = bankTightness(bankNplRatio)
     val cyclicalAdj = Multiplier.One + (p.nbfi.countercyclical * tight).toMultiplier
-    domesticCons * p.nbfi.creditBaseRate * cyclicalAdj
+    loanStock * p.nbfi.creditBaseRate * cyclicalAdj
 
   /** NBFI loan repayment: stock / maturity. */
   def nbfiRepayment(loanStock: PLN)(using p: SimParams): PLN =
@@ -158,7 +160,7 @@ object Nbfi:
       corpBondYield: Rate,                             // corporate bond yield (annualised)
       equityReturn: Rate,                              // equity monthly return
       depositRate: Rate,                               // bank deposit rate (TFI opportunity cost)
-      domesticCons: PLN,                               // domestic consumption (NBFI credit base)
+      @scala.annotation.unused domesticCons: PLN,      // macro context; NBFI credit is stock-renewal based
       corpBondDefaultLoss: PLN,
   )
 
@@ -194,7 +196,7 @@ object Nbfi:
 
     // NBFI credit: counter-cyclical origination → repayment → defaults
     val tight          = bankTightness(input.bankNplRatio)
-    val origination    = nbfiOrigination(input.domesticCons, input.bankNplRatio)
+    val origination    = nbfiOrigination(opening.nbfiLoanStock, input.bankNplRatio)
     val repayment      = nbfiRepayment(opening.nbfiLoanStock)
     val defaults       = nbfiDefaults(opening.nbfiLoanStock, input.unempRate)
     val newLoanStock   = (opening.nbfiLoanStock + origination - repayment - defaults).max(PLN.Zero)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Nbfi.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Nbfi.scala
@@ -160,7 +160,6 @@ object Nbfi:
       corpBondYield: Rate,                             // corporate bond yield (annualised)
       equityReturn: Rate,                              // equity monthly return
       depositRate: Rate,                               // bank deposit rate (TFI opportunity cost)
-      @scala.annotation.unused domesticCons: PLN,      // macro context; NBFI credit is stock-renewal based
       corpBondDefaultLoss: PLN,
   )
 

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -382,10 +382,10 @@ object CalibrationProvenance:
         ),
         "nbfi.creditBaseRate"       -> linkedEvidence(
           CalibrationValidationMode.HistoricalFit,
-          "docs/empirical-validation/baseline-validation-snapshot.csv",
-          "Non-bank credit contribution to aggregate credit",
-          "EmpiricalValidationExport records the current credit/GDP bridge while NBFI split extraction remains partial.",
-          artifactLabel = Some("Credit/GDP"),
+          "docs/private-credit-renewal-calibration.md",
+          "Private credit renewal calibration",
+          "Issue #610 documents the Nix-built 10-seed 60-month NBFI stock-renewal calibration and terminal private-credit split.",
+          artifactLabel = Some("20260525-610-nbfi-only"),
         ),
       ).toMap
 
@@ -710,7 +710,7 @@ object CalibrationProvenance:
 | `nbfi.tfiInitAum` | `448.3e9` | raw PLN | Analizy/IZFiA fund assets, March 2026 | TFI AUM | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `EMPIRICAL` |
 | `nbfi.creditInitStock` | `234e9` | raw PLN | ZPL active leasing and leasing-loan portfolio, end-2025 | NBFI credit stock | Scaled by `gdpRatio` | `NbfiConfig`, `SimParams` | `EMPIRICAL_TRANSFORMED` |
 | `nbfi.tfiGovBondShare`, `tfiCorpBondShare`, `tfiEquityShare` | `0.40`, `0.10`, `0.10` | share | Structural TFI portfolio-allocation prior | TFI portfolio allocation | Portfolio rebalance target | `NbfiConfig` | `ASSUMED` |
-| `nbfi.creditBaseRate` | `0.005` | monthly share | UNKNOWN_SOURCE | NBFI credit origination rate | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
+| `nbfi.creditBaseRate` | `0.031` | monthly share | #610 private-credit renewal calibration | NBFI credit origination stock-renewal rate | Direct fraction of opening loan stock | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `nbfi.creditRate` | `0.10` | annual rate | Structural NBFI loan-rate prior | NBFI loan rate | `.monthly` in income | `NbfiConfig` | `ASSUMED` |
 | `nbfi.defaultBase`, `defaultUnempSens` | `0.002`, `3.0` | share/coefficient | UNKNOWN_SOURCE | NBFI default dynamics | Direct | `NbfiConfig` | `TUNED_NEEDS_VALIDATION` |
 | `quasiFiscal.issuanceShare` | `0.40` | share | Code note bridge: NIK bridge prior | BGK/PFR share of capital programs | Direct | `QuasiFiscalConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/NbfiConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/NbfiConfig.scala
@@ -31,7 +31,9 @@ import com.boombustgroup.amorfati.types.*
   *   initial leasing and leasing-loan active portfolio in raw PLN (ZPL
   *   end-2025: ~234 mld, scaled by gdpRatio)
   * @param creditBaseRate
-  *   base monthly NBFI credit origination rate (fraction of stock)
+  *   base monthly NBFI credit origination rate as a fraction of opening loan
+  *   stock; calibrated to renew the 36-month book after scheduled repayment and
+  *   baseline defaults
   * @param creditRate
   *   NBFI lending rate (higher than bank rate due to risk profile)
   * @param countercyclical
@@ -52,7 +54,7 @@ case class NbfiConfig(
     tfiInflowRate: Share = Share.decimal(1, 3),
     tfiRebalanceSpeed: Coefficient = Coefficient.decimal(5, 2),
     creditInitStock: PLN = PLN(234000000000L), // raw — scaled by gdpRatio
-    creditBaseRate: Share = Share.decimal(5, 3),
+    creditBaseRate: Share = Share.decimal(31, 3),
     creditRate: Rate = Rate.decimal(10, 2),
     countercyclical: Coefficient = Coefficient(2),
     creditMaturity: Scalar = Scalar(36),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -474,7 +474,6 @@ object OpenEconEconomics:
           corpBondYield = newCorpBondYield,
           equityReturn = in.s7.equityAfterForeignStock.monthlyReturn,
           depositRate = nbfiDepositRate,
-          domesticCons = in.s3.domesticCons,
           corpBondDefaultLoss = corpBondDefaultLoss,
         ),
       )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -394,7 +394,9 @@ baseline, mortgage origination is not wired to a binding bank-supply gate:
 60-month baseline falls below the mortgage/GDP calibration band while this flag
 is false, the calibration mechanism is `housing.originationRate` relative to
 scheduled amortization, gross default, and GDP growth, not bank-resolution
-supply.
+supply. NBFI credit renewal is likewise stock based: `NbfiOriginationToStock`
+should be compared with `NbfiRepaymentToStock` and `NbfiDefaultsToStock` to
+separate insufficient origination from ordinary maturity/default runoff.
 
 ## Household Liquidity Diagnostics
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ShadowBankingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ShadowBankingSpec.scala
@@ -27,7 +27,6 @@ class ShadowBankingSpec extends AnyFlatSpec with Matchers:
       corpBondYield: Rate = Rate.decimal(7, 2),
       equityReturn: Rate = Rate.decimal(5, 3),
       depositRate: Rate = Rate.decimal(3, 2),
-      domesticCons: PLN = PLN(100000000),
       prevCorpBondHoldings: PLN = initialCorpBondHoldings,
       corpBondDefaultLoss: PLN = PLN.Zero,
   ): Nbfi.StepResult =
@@ -43,7 +42,6 @@ class ShadowBankingSpec extends AnyFlatSpec with Matchers:
         corpBondYield = corpBondYield,
         equityReturn = equityReturn,
         depositRate = depositRate,
-        domesticCons = domesticCons,
         corpBondDefaultLoss = corpBondDefaultLoss,
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/agents/ShadowBankingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/ShadowBankingSpec.scala
@@ -129,7 +129,7 @@ class ShadowBankingSpec extends AnyFlatSpec with Matchers:
 
   // ---- nbfiOrigination ----
 
-  "Nbfi.nbfiOrigination" should "be proportional to consumption" in {
+  "Nbfi.nbfiOrigination" should "be proportional to loan stock" in {
     val o1 = Nbfi.nbfiOrigination(PLN(1000000), Share.decimal(2, 2))
     val o2 = Nbfi.nbfiOrigination(PLN(2000000), Share.decimal(2, 2))
     decimal(o2 / o1) shouldBe BigDecimal("2.0") +- BigDecimal("0.01")


### PR DESCRIPTION
## Summary
- switch NBFI origination from domestic-consumption based flow to opening-loan-stock renewal
- calibrate nbfi.creditBaseRate to 0.031 per month against 36-month repayment plus baseline defaults
- document the #610 validation run, terminal private-credit split, and rejected mortgage / firm-credit levers

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.agents.ShadowBankingSpec"
- nix develop -c sbt assembly
- nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 10 issue610-nbfi-final --duration 60 --run-id 20260525-610-final-nbfi --firm-snapshots none --household-snapshots none

Final 10-seed 60m mean TotalCreditToGdp: 21.50%, range 20.81% to 22.17%. Bank all-failed and invariant diagnostics stayed at 0 across all seeds.

Closes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NBFI credit origination methodology documentation with clarified calibration approach.
  * Added private credit renewal calibration documentation with validation results showing improved credit-to-GDP metrics.
  * Enhanced guidance for interpreting credit renewal rates and household stress diagnostics.

* **Parameter Updates**
  * Recalibrated NBFI credit base rate (0.005 → 0.031) based on private credit renewal validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->