### PR TITLE
Expose technology candidate credit approval diagnostics

### DIFF
--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -40,7 +40,7 @@ These counts are rendered from `CalibrationProvenance.Baseline` at generation ti
 | `EMPIRICAL_TRANSFORMED` | 17 |
 | `CODE_NOTE_EMPIRICAL` | 61 |
 | `ASSUMED` | 33 |
-| `TUNED_NEEDS_VALIDATION` | 86 |
+| `TUNED_NEEDS_VALIDATION` | 88 |
 | `POLICY_SCENARIO` | 7 |
 | `PLACEHOLDER` | 1 |
 | `UNKNOWN_SOURCE` | 0 |
@@ -76,9 +76,9 @@ a concrete diagnostic artifact path.
 
 | Validation mode | Count | Linked evidence paths | Missing evidence paths |
 | --- | ---: | ---: | ---: |
-| `HISTORICAL_FIT` | 30 | 4 | 26 |
+| `HISTORICAL_FIT` | 31 | 4 | 27 |
 | `STYLIZED_FACT_TARGET` | 11 | 7 | 4 |
-| `SENSITIVITY_RANGE` | 31 | 5 | 26 |
+| `SENSITIVITY_RANGE` | 32 | 5 | 27 |
 | `MODEL_BEHAVIOR_CALIBRATION` | 14 | 0 | 14 |
 
 ### Evidence Paths
@@ -148,7 +148,9 @@ a concrete diagnostic artifact path.
 | `monetary.taylorInertia` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Policy-rate smoothing | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `monetary.maxRateChange` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Monthly policy-rate adjustment cap | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `monetary.nairu` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | NAIRU | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
+| `banking.firmCreditMinApprovalProb`, `firmCreditNplApprovalPenalty`, `firmCreditReserveDeficitPenalty` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Firm-credit stochastic approval after CAR/LCR/NSFR gates pass | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `banking.depositPanicRate` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Panic switching after failure | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
+| `banking.eclMigrationSensitivity`, `eclGdpSensitivity`, `eclMaxMigration` | `HISTORICAL_FIT` | `MISSING_VALIDATION_EVIDENCE` |  |  | Stage 1 to Stage 2 migration under unemployment deterioration or GDP contraction | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `forex.irpSensitivity`, `exRateAdjSpeed` | `SENSITIVITY_RANGE` | docs/sensitivity-robustness-workflow.md | sensitivity-summary.csv | external-risk-off | FX and external-balance sensitivity | SensitivityRobustnessExport varies IRP sensitivity in the external-risk-off scenario and reports FX/current-account metrics. |
 | `priceLevel.importPush` | `HISTORICAL_FIT` | `MISSING_VALIDATION_EVIDENCE` |  |  | Imported inflation pass-through to CPI | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `openEcon.erElasticity` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Exchange-rate elasticity of trade | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
@@ -355,6 +357,7 @@ a concrete diagnostic artifact path.
 | `banking.minCar` | `0.08` | multiplier/share | Code note bridge: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.loanRecovery` | `0.30` | share | Structural corporate-loan workout recovery prior | Corporate loan recovery | Direct | `BankingConfig` | `ASSUMED` |
 | `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note bridge: NBP bridge prior maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.firmCreditMinApprovalProb`, `firmCreditNplApprovalPenalty`, `firmCreditReserveDeficitPenalty` | `0.10, 3.0, 0.50` | share/coefficient | #523 candidate-gate diagnostic prior | Firm-credit stochastic approval after CAR/LCR/NSFR gates pass | Direct | `BankingConfig`, `Banking.creditApproval` | `TUNED_NEEDS_VALIDATION` |
 | `banking.reserveReq` | `0.035` | share | Code note bridge: NBP bridge prior | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.lcrMin`, `nsfrMin` | `1.0, 1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
@@ -365,7 +368,7 @@ a concrete diagnostic artifact path.
 | `banking.htmShare` | `0.60` | share | Code note bridge: NBP bridge prior | HTM share of gov bond portfolio | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
 | `banking.depositPanicRate` | `0.03` | monthly share | Code note bridge: Diamond-Dybvig mechanism | Panic switching after failure | Direct | `BankingConfig` | `TUNED_NEEDS_VALIDATION` |
 | `banking.eclRate1`, `eclRate2`, `eclRate3` | `0.01, 0.08, 0.50` | share | Code note bridge: KNF IFRS 9 | ECL provision rates | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
-| `banking.eclMigrationSensitivity`, `eclGdpSensitivity`, `eclMaxMigration` | `3.0, 5.0, 0.20` | coefficient/share | Code note bridge: IFRS 9 significant-increase-in-credit-risk stress rule | Stage 1 to Stage 2 migration under unemployment deterioration or GDP contraction | Applied to `max(0, unemployment_t - unemployment_ref)` and `max(0, -gdpGrowth_t)`; `unemployment_ref` is carried from the lagged pipeline and bootstrapped from the opening Poland baseline | `EclStaging`, `BankingEconomics` | `TUNED_NEEDS_VALIDATION` |
+| `banking.eclMigrationSensitivity`, `eclGdpSensitivity`, `eclMaxMigration` | `3.0, 5.0, 0.20` | coefficient/share | Code note bridge: IFRS 9 significant-increase-in-credit-risk stress rule | Stage 1 to Stage 2 migration under unemployment deterioration or GDP contraction | Applied to max(0, unemployment_t - unemployment_ref) and max(0, -gdpGrowth_t); unemployment_ref is carried from the lagged pipeline and bootstrapped from the opening Poland baseline | `EclStaging`, `BankingEconomics` | `TUNED_NEEDS_VALIDATION` |
 
 ## External Sector And Financial Markets
 

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -55,11 +55,6 @@ object Banking:
   private val CarPenaltyThreshMult: Multiplier = Multiplier.decimal(15, 1) // CAR penalty kicks in below minCar × 1.5
   private val CarPenaltyScale: Multiplier      = Multiplier(2)             // bps per unit of CAR shortfall
 
-  // Credit approval
-  private val MinApprovalProb: Share         = Share.decimal(1, 1) // floor: 10% approval even under max stress
-  private val NplApprovalPenalty: Multiplier = Multiplier(3)       // approval drop per unit NPL ratio (e.g. NPL 10% → 30pp)
-  private val ReserveDeficitPenalty: Share   = Share.decimal(5, 1) // 50pp approval drop when free reserves < 0
-
   // Crowding-out (gov bonds vs firm loans)
   private val CrowdingOutSensitivity: Multiplier = Multiplier.decimal(30, 2) // 30% of bond yield gap passed through to lending spread
 
@@ -568,10 +563,11 @@ object Banking:
       val lcrOk                                                             = currentLcr >= p.banking.lcrMin
       val currentNsfr                                                       = nsfr(bank, stocks, corpBondHoldings)
       val nsfrOk                                                            = currentNsfr >= p.banking.nsfrMin
-      val nplPenalty                                                        = nplRatio(bank, stocks) * NplApprovalPenalty // Share * Multiplier → Multiplier
+      val nplPenalty                                                        = nplRatio(bank, stocks) * p.banking.firmCreditNplApprovalPenalty // Share * Multiplier → Multiplier
       val freeReserves                                                      = stocks.totalDeposits * (Share.One - p.banking.reserveReq) - stocks.firmLoan - govBondHoldings(stocks)
-      val resPenalty                                                        = if freeReserves > PLN.Zero then Share.Zero else ReserveDeficitPenalty
-      val approvalP                                                         = (Share.One - nplPenalty.toShare - resPenalty).max(MinApprovalProb)
+      val postLoanFreeReserves                                              = freeReserves - amount
+      val resPenalty                                                        = if postLoanFreeReserves > PLN.Zero then Share.Zero else p.banking.firmCreditReserveDeficitPenalty
+      val approvalP                                                         = (Share.One - nplPenalty.toShare - resPenalty).max(p.banking.firmCreditMinApprovalProb)
       def audit(reason: Option[CreditRejectionReason]): CreditApprovalAudit =
         CreditApprovalAudit(
           rejectionReason = reason,

--- a/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Firm.scala
@@ -219,6 +219,8 @@ object Firm:
       techSelectedCreditDemand: PLN = PLN.Zero,    // Actual selected technology-upgrade bank credit requested
       techSelectedCreditApproved: PLN = PLN.Zero,  // Actual selected technology-upgrade bank credit approved
       techSelectedCreditRejected: PLN = PLN.Zero,  // Actual selected technology-upgrade bank credit rejected by bank supply
+      techCandidateCreditDemand: PLN = PLN.Zero,   // Otherwise feasible technology-upgrade candidate bank credit requested
+      techCandidateCreditApproved: PLN = PLN.Zero, // Otherwise feasible technology-upgrade candidate bank credit approved
       techCandidateCreditRejected: PLN = PLN.Zero, // Otherwise feasible technology-upgrade candidate rejected by bank supply
       investmentCreditRejectionBreakdown: CreditRejectionBreakdown = CreditRejectionBreakdown.zero,
       techCreditRejectionBreakdown: CreditRejectionBreakdown = CreditRejectionBreakdown.zero,
@@ -427,6 +429,10 @@ object Firm:
       techCreditDecisionType: Option[DecisionTrace.DecisionType] = None,
       techCreditSource: Option[DecisionTrace.TechCreditSource] = None,
       techCreditNeed: Option[PLN] = None,
+      techCandidateCreditDemand: PLN = PLN.Zero,
+      techCandidateCreditApproved: PLN = PLN.Zero,
+      techCandidateCreditRejected: PLN = PLN.Zero,
+      techCandidateCreditRejectionBreakdown: CreditRejectionBreakdown = CreditRejectionBreakdown.zero,
       implementationFailureProbability: Option[Share] = None,
       implementationRoll: Option[Share] = None,
       upgradeEfficiencyDraw: Option[Scalar] = None,
@@ -458,6 +464,10 @@ object Firm:
         techCreditDecisionType = next.techCreditDecisionType.orElse(techCreditDecisionType),
         techCreditSource = next.techCreditSource.orElse(techCreditSource),
         techCreditNeed = next.techCreditNeed.orElse(techCreditNeed),
+        techCandidateCreditDemand = techCandidateCreditDemand + next.techCandidateCreditDemand,
+        techCandidateCreditApproved = techCandidateCreditApproved + next.techCandidateCreditApproved,
+        techCandidateCreditRejected = techCandidateCreditRejected + next.techCandidateCreditRejected,
+        techCandidateCreditRejectionBreakdown = techCandidateCreditRejectionBreakdown + next.techCandidateCreditRejectionBreakdown,
         implementationFailureProbability = next.implementationFailureProbability.orElse(implementationFailureProbability),
         implementationRoll = next.implementationRoll.orElse(implementationRoll),
         upgradeEfficiencyDraw = next.upgradeEfficiencyDraw.orElse(upgradeEfficiencyDraw),
@@ -496,10 +506,33 @@ object Firm:
       techCreditNeed = Some(need),
     )
 
-  private def bankRejectedTechDemandAudit(candidate: UpgradeCandidate, decisionType: DecisionTrace.DecisionType): DecisionAudit =
+  private def techCandidateCreditAudit(candidate: UpgradeCandidate): DecisionAudit =
+    if candidate.profitable && candidate.canPay && candidate.ready then
+      val approved = if candidate.bankOk then candidate.loan else PLN.Zero
+      val rejected = if candidate.bankOk then PLN.Zero else candidate.loan
+      DecisionAudit(
+        techCandidateCreditDemand = candidate.loan,
+        techCandidateCreditApproved = approved,
+        techCandidateCreditRejected = rejected,
+        techCandidateCreditRejectionBreakdown = CreditRejectionBreakdown.from(candidate.credit.audit.rejectionReason, rejected),
+      )
+    else DecisionAudit()
+
+  private def rejectedTechCandidateTraceAudit(candidate: UpgradeCandidate, decisionType: DecisionTrace.DecisionType): DecisionAudit =
     if !candidate.bankOk && candidate.profitable && candidate.canPay && candidate.ready then
       selectedTechBankAudit(candidate.credit, candidate.loan, decisionType, DecisionTrace.TechCreditSource.BankRejectedCandidate)
     else DecisionAudit()
+
+  private def primaryRejectedTechCandidateTraceAudit(fullAi: UpgradeCandidate, hybrid: UpgradeCandidate): DecisionAudit =
+    val candidates = Vector(
+      fullAi -> DecisionTrace.DecisionType.FullAiUpgrade,
+      hybrid -> DecisionTrace.DecisionType.HybridUpgrade,
+    )
+    candidates
+      .collectFirst:
+        case (candidate, decisionType) if !candidate.bankOk && candidate.profitable && candidate.canPay && candidate.ready =>
+          selectedTechBankAudit(candidate.credit, candidate.loan, decisionType, DecisionTrace.TechCreditSource.BankRejectedCandidate)
+      .getOrElse(DecisionAudit())
 
   private def fullAiBankAudit(credit: CreditDecision): DecisionAudit =
     DecisionAudit(
@@ -1023,26 +1056,17 @@ object Firm:
     val canPay     = financialStocks.cash > upDown
     val ready      = firm.digitalReadiness >= p.firm.fullAiReadinessMin
     val bankCredit = bankCreditDecision(upLoan)
-    val bankOk     = bankCredit.approved
+    val candidate  = UpgradeCandidate(upCapex, upLoan, upDown, profitable, canPay, ready, bankCredit)
 
     val prob: Share =
-      if profitable && canPay && ready && bankOk then
-        ((firm.riskProfile * RiskWeightHybUpgrade) + (w.real.automationRatio * AutoRatioWeight)) * firm.digitalReadiness
+      if candidate.feasible then ((firm.riskProfile * RiskWeightHybUpgrade) + (w.real.automationRatio * AutoRatioWeight)) * firm.digitalReadiness
       else Share.Zero
     val audit       = DecisionAudit(
-      fullAiFeasible = Some(profitable && canPay && ready && bankOk),
+      fullAiFeasible = Some(candidate.feasible),
       fullAiAdoptionProbability = Some(prob.min(Share.One)),
     ).merge(fullAiBankAudit(bankCredit))
-      .merge(
-        if !bankOk && profitable && canPay && ready then
-          selectedTechBankAudit(
-            bankCredit,
-            upLoan,
-            DecisionTrace.DecisionType.FullAiUpgrade,
-            DecisionTrace.TechCreditSource.BankRejectedCandidate,
-          )
-        else DecisionAudit(),
-      )
+      .merge(techCandidateCreditAudit(candidate))
+      .merge(rejectedTechCandidateTraceAudit(candidate, DecisionTrace.DecisionType.FullAiUpgrade))
     val roll        = Share.random(rng)
 
     if roll < prob then
@@ -1400,8 +1424,9 @@ object Firm:
       adoptionRoll = Some(roll),
     ).merge(fullAiBankAudit(ai.credit))
       .merge(hybridBankAudit(hyb.credit))
-      .merge(bankRejectedTechDemandAudit(ai, DecisionTrace.DecisionType.FullAiUpgrade))
-      .merge(bankRejectedTechDemandAudit(hyb, DecisionTrace.DecisionType.HybridUpgrade))
+      .merge(techCandidateCreditAudit(ai))
+      .merge(techCandidateCreditAudit(hyb))
+      .merge(primaryRejectedTechCandidateTraceAudit(ai, hyb))
 
     if roll < pFull then
       val upgrade = rollFullAiUpgrade(firm, pnl, ai, rng)
@@ -1569,10 +1594,7 @@ object Firm:
         case _                                                          => decisionCreditNeed(decision.decision).max(result.techNewLoan)
     val selectedApproved  = result.techNewLoan.min(selectedDemand)
     val selectedRejected  = (selectedDemand - selectedApproved).max(PLN.Zero)
-    val candidateRejected =
-      decision.audit.techCreditSource match
-        case Some(DecisionTrace.TechCreditSource.BankRejectedCandidate) => decision.audit.techCreditNeed.getOrElse(PLN.Zero)
-        case _                                                          => PLN.Zero
+    val candidateRejected = decision.audit.techCandidateCreditRejected
     val demand            = selectedDemand + candidateRejected
     val approved          = selectedApproved
     val rejected          = selectedRejected + candidateRejected
@@ -1583,9 +1605,11 @@ object Firm:
       techSelectedCreditDemand = selectedDemand,
       techSelectedCreditApproved = selectedApproved,
       techSelectedCreditRejected = selectedRejected,
+      techCandidateCreditDemand = decision.audit.techCandidateCreditDemand,
+      techCandidateCreditApproved = decision.audit.techCandidateCreditApproved,
       techCandidateCreditRejected = candidateRejected,
       techCreditRejectionBreakdown = CreditRejectionBreakdown.from(decision.audit.selectedBankApprovalAudit.rejectionReason, selectedRejected) +
-        CreditRejectionBreakdown.from(decision.audit.selectedBankApprovalAudit.rejectionReason, candidateRejected),
+        decision.audit.techCandidateCreditRejectionBreakdown,
     )
 
   // ---- Execute (pure dispatch, zero RandomStream calls) ----

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -106,6 +106,12 @@ import com.boombustgroup.amorfati.types.*
   * @param hoardingSensitivity
   *   speed of hoarding onset: factor = 1 − sensitivity × (NPL − threshold). At
   *   10.0, a 10pp NPL overshoot → full freeze.
+  * @param firmCreditMinApprovalProb
+  *   floor on stochastic firm-credit approval after balance-sheet gates pass
+  * @param firmCreditNplApprovalPenalty
+  *   stochastic approval penalty per unit bank NPL ratio
+  * @param firmCreditReserveDeficitPenalty
+  *   stochastic approval penalty when free reserves are negative
   * @param eclRate1
   *   Stage 1 (performing) ECL provision rate (12-month ECL, KNF: ~1%)
   * @param eclRate2
@@ -192,6 +198,10 @@ case class BankingConfig(
     interbankRecoveryRate: Share = Share.decimal(40, 2),
     hoardingNplThreshold: Share = Share.decimal(5, 2),
     hoardingSensitivity: Multiplier = Multiplier(10),
+    // Firm-credit stochastic approval
+    firmCreditMinApprovalProb: Share = Share.decimal(1, 1),
+    firmCreditNplApprovalPenalty: Multiplier = Multiplier(3),
+    firmCreditReserveDeficitPenalty: Share = Share.decimal(5, 1),
     // IFRS 9 ECL staging
     eclRate1: Share = Share.decimal(1, 2),
     eclRate2: Share = Share.decimal(8, 2),
@@ -208,6 +218,15 @@ case class BankingConfig(
   require(
     osiiBuffers.length == p2rAddons.length,
     s"osiiBuffers must have the same length as p2rAddons: expected ${p2rAddons.length}, actual ${osiiBuffers.length}",
+  )
+  require(
+    firmCreditMinApprovalProb >= Share.Zero && firmCreditMinApprovalProb <= Share.One,
+    s"firmCreditMinApprovalProb must be in [0,1]: $firmCreditMinApprovalProb",
+  )
+  require(firmCreditNplApprovalPenalty >= Multiplier.Zero, s"firmCreditNplApprovalPenalty must be non-negative: $firmCreditNplApprovalPenalty")
+  require(
+    firmCreditReserveDeficitPenalty >= Share.Zero && firmCreditReserveDeficitPenalty <= Share.One,
+    s"firmCreditReserveDeficitPenalty must be in [0,1]: $firmCreditReserveDeficitPenalty",
   )
   p2rAddons.zipWithIndex.foreach: (addon, idx) =>
     require(

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -626,6 +626,7 @@ object CalibrationProvenance:
 | `banking.minCar` | `0.08` | multiplier/share | Code note bridge: Basel III CRR | Minimum capital adequacy | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.loanRecovery` | `0.30` | share | Structural corporate-loan workout recovery prior | Corporate loan recovery | Direct | `BankingConfig` | `ASSUMED` |
 | `banking.firmLoanAmortRate` | `1/60` | monthly rate | Code note bridge: NBP bridge prior maturity | Five-year average loan maturity | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |
+| `banking.firmCreditMinApprovalProb`, `firmCreditNplApprovalPenalty`, `firmCreditReserveDeficitPenalty` | `0.10`, `3.0`, `0.50` | share/coefficient | #523 candidate-gate diagnostic prior | Firm-credit stochastic approval after CAR/LCR/NSFR gates pass | Direct | `BankingConfig`, `Banking.creditApproval` | `TUNED_NEEDS_VALIDATION` |
 | `banking.reserveReq` | `0.035` | share | Code note bridge: NBP bridge prior | Required reserve ratio | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.lcrMin`, `nsfrMin` | `1.0`, `1.0` | multiplier | Basel III | Minimum LCR/NSFR | Direct | `BankingConfig` | `EMPIRICAL` |
 | `banking.p2rAddons` | `[0.015, 0.010, 0.030, 0.015, 0.020, 0.025, 0.020, 0.020, 0.025, 0.020]` | multiplier by bank | Code note bridge: KNF bridge prior | SREP/P2R add-ons | Direct | `BankingConfig` | `CODE_NOTE_EMPIRICAL` |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/World.scala
@@ -477,6 +477,8 @@ case class FlowState(
     firmTechSelectedCreditDemand: PLN = PLN.Zero,                                           // actual selected technology-upgrade bank credit requested
     firmTechSelectedCreditApproved: PLN = PLN.Zero,                                         // actual selected technology-upgrade bank credit approved
     firmTechSelectedCreditRejected: PLN = PLN.Zero,                                         // actual selected technology-upgrade bank credit rejected by bank supply
+    firmTechCandidateCreditDemand: PLN = PLN.Zero,                                          // otherwise feasible technology-upgrade candidate bank credit requested
+    firmTechCandidateCreditApproved: PLN = PLN.Zero,                                        // otherwise feasible technology-upgrade candidate bank credit approved
     firmTechCandidateCreditRejected: PLN = PLN.Zero,                                        // otherwise feasible technology-upgrade candidate rejected by bank supply
     firmCreditRejectedByReason: CreditRejectionBreakdown = CreditRejectionBreakdown.zero,   // firm bank-credit rejections by primary reason
     firmBirths: Int = 0,                                                                    // new firms (recycled + net new)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FirmEconomics.scala
@@ -52,6 +52,8 @@ object FirmEconomics:
       techSelectedCreditDemand: PLN,    // actual selected technology-upgrade bank credit requested
       techSelectedCreditApproved: PLN,  // actual selected technology-upgrade bank credit approved
       techSelectedCreditRejected: PLN,  // actual selected technology-upgrade bank credit rejected by bank supply
+      techCandidateCreditDemand: PLN,   // otherwise feasible technology-upgrade candidate bank credit requested
+      techCandidateCreditApproved: PLN, // otherwise feasible technology-upgrade candidate bank credit approved
       techCandidateCreditRejected: PLN, // otherwise feasible technology-upgrade candidate rejected by bank supply
       creditRejectedByReason: CreditRejectionBreakdown,
   ):
@@ -79,12 +81,16 @@ object FirmEconomics:
       techSelectedCreditDemand + o.techSelectedCreditDemand,
       techSelectedCreditApproved + o.techSelectedCreditApproved,
       techSelectedCreditRejected + o.techSelectedCreditRejected,
+      techCandidateCreditDemand + o.techCandidateCreditDemand,
+      techCandidateCreditApproved + o.techCandidateCreditApproved,
       techCandidateCreditRejected + o.techCandidateCreditRejected,
       creditRejectedByReason + o.creditRejectedByReason,
     )
 
   private object FirmFlows:
     val zero: FirmFlows = FirmFlows(
+      PLN.Zero,
+      PLN.Zero,
       PLN.Zero,
       PLN.Zero,
       PLN.Zero,
@@ -257,6 +263,8 @@ object FirmEconomics:
       sumTechSelectedCreditDemand: PLN,           // actual selected technology-upgrade bank credit requested
       sumTechSelectedCreditApproved: PLN,         // actual selected technology-upgrade bank credit approved
       sumTechSelectedCreditRejected: PLN,         // actual selected technology-upgrade bank credit rejected by bank supply
+      sumTechCandidateCreditDemand: PLN,          // otherwise feasible technology-upgrade candidate bank credit requested
+      sumTechCandidateCreditApproved: PLN,        // otherwise feasible technology-upgrade candidate bank credit approved
       sumTechCandidateCreditRejected: PLN,        // otherwise feasible technology-upgrade candidate rejected by bank supply
       sumCreditRejectedByReason: CreditRejectionBreakdown,
       postFirmCrossSectorHires: Int,              // cross-sector hires in labor matching
@@ -471,6 +479,8 @@ object FirmEconomics:
             techSelectedCreditDemand = r.techSelectedCreditDemand,
             techSelectedCreditApproved = r.techSelectedCreditApproved,
             techSelectedCreditRejected = r.techSelectedCreditRejected,
+            techCandidateCreditDemand = r.techCandidateCreditDemand,
+            techCandidateCreditApproved = r.techCandidateCreditApproved,
             techCandidateCreditRejected = r.techCandidateCreditRejected,
             creditRejectedByReason = r.investmentCreditRejectionBreakdown + r.techCreditRejectionBreakdown,
           ),
@@ -951,6 +961,8 @@ object FirmEconomics:
       sumTechSelectedCreditDemand = flows.techSelectedCreditDemand,
       sumTechSelectedCreditApproved = flows.techSelectedCreditApproved,
       sumTechSelectedCreditRejected = flows.techSelectedCreditRejected,
+      sumTechCandidateCreditDemand = flows.techCandidateCreditDemand,
+      sumTechCandidateCreditApproved = flows.techCandidateCreditApproved,
       sumTechCandidateCreditRejected = flows.techCandidateCreditRejected,
       sumCreditRejectedByReason = flows.creditRejectedByReason,
       postFirmCrossSectorHires = crossSectorHires,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/WorldAssemblyEconomics.scala
@@ -413,6 +413,8 @@ object WorldAssemblyEconomics:
       firmTechSelectedCreditDemand = in.s5.sumTechSelectedCreditDemand,
       firmTechSelectedCreditApproved = in.s5.sumTechSelectedCreditApproved,
       firmTechSelectedCreditRejected = in.s5.sumTechSelectedCreditRejected,
+      firmTechCandidateCreditDemand = in.s5.sumTechCandidateCreditDemand,
+      firmTechCandidateCreditApproved = in.s5.sumTechCandidateCreditApproved,
       firmTechCandidateCreditRejected = in.s5.sumTechCandidateCreditRejected,
       firmCreditRejectedByReason = in.s5.sumCreditRejectedByReason,
       firmBirths = 0,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -523,7 +523,13 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("FirmCredit_TechSelectedDemand", ctx => ctx.world.flows.firmTechSelectedCreditDemand),
     ColumnDef.macroPln("FirmCredit_TechSelectedApproved", ctx => ctx.world.flows.firmTechSelectedCreditApproved),
     ColumnDef.macroPln("FirmCredit_TechSelectedBankRejected", ctx => ctx.world.flows.firmTechSelectedCreditRejected),
+    ColumnDef.macroPln("FirmCredit_TechCandidateDemand", ctx => ctx.world.flows.firmTechCandidateCreditDemand),
+    ColumnDef.macroPln("FirmCredit_TechCandidateApproved", ctx => ctx.world.flows.firmTechCandidateCreditApproved),
     ColumnDef.macroPln("FirmCredit_TechCandidateBankRejected", ctx => ctx.world.flows.firmTechCandidateCreditRejected),
+    ColumnDef(
+      "FirmCredit_TechCandidateApprovalRate",
+      ctx => ctx.flowToFlowRatio(ctx.world.flows.firmTechCandidateCreditApproved, ctx.world.flows.firmTechCandidateCreditDemand),
+    ),
     // Consumer Credit
     ColumnDef.macroPln("ConsumerLoans", ctx => ctx.consumerLoanStock),
     ColumnDef(
@@ -1112,7 +1118,10 @@ object McTimeseriesSchema:
     val FirmCreditTechSelectedDemand: Col              = lookup("FirmCredit_TechSelectedDemand")
     val FirmCreditTechSelectedApproved: Col            = lookup("FirmCredit_TechSelectedApproved")
     val FirmCreditTechSelectedBankRejected: Col        = lookup("FirmCredit_TechSelectedBankRejected")
+    val FirmCreditTechCandidateDemand: Col             = lookup("FirmCredit_TechCandidateDemand")
+    val FirmCreditTechCandidateApproved: Col           = lookup("FirmCredit_TechCandidateApproved")
     val FirmCreditTechCandidateBankRejected: Col       = lookup("FirmCredit_TechCandidateBankRejected")
+    val FirmCreditTechCandidateApprovalRate: Col       = lookup("FirmCredit_TechCandidateApprovalRate")
     val ConsumerPrincipal: Col                         = lookup("ConsumerPrincipal")
     val ConsumerCreditNetStockFlow: Col                = lookup("ConsumerCredit_NetStockFlow")
     val ConsumerCreditUnderwrittenNetFlow: Col         = lookup("ConsumerCredit_UnderwrittenNetFlow")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -320,7 +320,10 @@ FirmCredit_TechBankRejected
 FirmCredit_TechSelectedDemand
 FirmCredit_TechSelectedApproved
 FirmCredit_TechSelectedBankRejected
+FirmCredit_TechCandidateDemand
+FirmCredit_TechCandidateApproved
 FirmCredit_TechCandidateBankRejected
+FirmCredit_TechCandidateApprovalRate
 ```
 
 `FirmCredit_NetStockFlow` reports the bank-book flow currently applied to the
@@ -342,8 +345,9 @@ LCR, NSFR, stochastic approval roll, or unclassified legacy/boolean paths. The
 investment credit. `FirmCredit_TechDemand`, `FirmCredit_TechApproved`, and
 `FirmCredit_TechBankRejected` remain the aggregate technology-credit surface.
 The `TechSelected*` columns isolate the actually selected automation or hybrid
-upgrade path, while `FirmCredit_TechCandidateBankRejected` isolates otherwise
-feasible upgrade candidates blocked by the relationship bank.
+upgrade path. The `TechCandidate*` columns expose the full otherwise-feasible
+upgrade candidate surface before adoption choice, including the candidate
+approval rate used to calibrate bank-side stochastic credit gating.
 
 ## NBFI Credit Diagnostics
 

--- a/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/agents/BankingSectorSpec.scala
@@ -149,6 +149,14 @@ class BankingSectorSpec extends AnyFlatSpec with Matchers:
     healthyAudit.approvalRoll should not be empty
   }
 
+  it should "apply reserve-pressure approval penalty to the requested firm loan" in {
+    val tightLiquidity = mkBankRow(deposits = PLN(1000000), loans = PLN(900000), capital = PLN(300000))
+    val approval       = Banking.creditApproval(tightLiquidity.bank, tightLiquidity.stocks, PLN(100000), RandomStream.seeded(42), Multiplier.Zero, PLN.Zero)
+
+    approval.approvalProbability shouldBe Some(Share.decimal(5, 1))
+    approval.approvalRoll should not be empty
+  }
+
   "Banking.interbankRate" should "use explicit financial stocks" in {
     val healthy  = Vector(mkBankRow(id = 0), mkBankRow(id = 1))
     val stressed = Vector(

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -39,11 +39,11 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
 
   "Baseline calibration provenance" should "preserve the active default inventory status counts in code" in {
     CalibrationProvenance.Baseline.parseErrors shouldBe empty
-    CalibrationProvenance.Baseline.parameters should have size 242
+    CalibrationProvenance.Baseline.parameters should have size 243
     CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 36)
     CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 17)
     CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 61)
-    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 87)
+    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 88)
     CalibrationProvenance.Baseline.statusCounts.getOrElse(UnknownSource, 0) shouldBe 0
     CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 1)
     CalibrationProvenance.Baseline.statusCounts should contain(Assumed -> 33)
@@ -134,7 +134,7 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     val pathCounts = CalibrationProvenance.Baseline.tunedValidationEvidencePathCounts
 
     CalibrationProvenance.Baseline.tunedValidationEvidenceErrors shouldBe empty
-    tuned should have size 87
+    tuned should have size 88
     tuned.flatMap(_.validationEvidence) should have size tuned.size
     CalibrationProvenance.Baseline.tunedValidationModeCounts.values.sum shouldBe tuned.size
     CalibrationValidationMode.values.foreach: mode =>

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -223,7 +223,10 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "FirmCredit_TechSelectedDemand",
     "FirmCredit_TechSelectedApproved",
     "FirmCredit_TechSelectedBankRejected",
+    "FirmCredit_TechCandidateDemand",
+    "FirmCredit_TechCandidateApproved",
     "FirmCredit_TechCandidateBankRejected",
+    "FirmCredit_TechCandidateApprovalRate",
     "ConsumerLoans",
     "ConsumerNplRatio",
     "ConsumerOrigination",
@@ -508,7 +511,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 446
+    McTimeseriesSchema.nCols shouldBe 449
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -748,6 +751,8 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
         firmTechSelectedCreditDemand = PLN(4),
         firmTechSelectedCreditApproved = PLN(3),
         firmTechSelectedCreditRejected = PLN(1),
+        firmTechCandidateCreditDemand = PLN(20),
+        firmTechCandidateCreditApproved = PLN(16),
         firmTechCandidateCreditRejected = PLN(4),
         firmCreditRejectedByReason = Firm.CreditRejectionBreakdown(carGate = PLN(7), stochastic = PLN(5)),
         bankCapital = bankCapital,
@@ -795,7 +800,10 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "FirmCredit_TechSelectedDemand") shouldBe polandScale(PLN(4))
     valueAt(row, "FirmCredit_TechSelectedApproved") shouldBe polandScale(PLN(3))
     valueAt(row, "FirmCredit_TechSelectedBankRejected") shouldBe polandScale(PLN(1))
+    valueAt(row, "FirmCredit_TechCandidateDemand") shouldBe polandScale(PLN(20))
+    valueAt(row, "FirmCredit_TechCandidateApproved") shouldBe polandScale(PLN(16))
     valueAt(row, "FirmCredit_TechCandidateBankRejected") shouldBe polandScale(PLN(4))
+    valueAt(row, "FirmCredit_TechCandidateApprovalRate") shouldBe MetricValue.fromRaw((PLN(16) / PLN(20)).toLong)
     valueAt(row, "ConsumerLoans") shouldBe polandScale(consumerLoans)
     valueAt(row, "ConsumerNplRatio") shouldBe MetricValue.fromRaw((consumerNpl / consumerLoans).toLong)
     valueAt(row, "ConsumerOrigination") shouldBe polandScale(PLN(12))


### PR DESCRIPTION
## Summary
- add full technology-candidate credit demand/approved/rejected diagnostics and candidate approval rate to monthly timeseries
- aggregate all otherwise-feasible full-AI/hybrid candidates instead of only the single trace-selected rejected candidate
- move firm-credit stochastic approval knobs from hard-coded Banking constants into BankingConfig for future calibration sweeps
- document the candidate-credit semantics and provenance

## Calibration readout
Using the new denominator on a 5 seed x 60 month run, baseline candidate approval is 95.76% by amount. The low legacy tech approval rate is therefore mostly a denominator/interpretation artifact, not evidence that the stochastic gate should be loosened immediately. Late months still show CAR pressure, so default values are left unchanged.

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.FirmSpec com.boombustgroup.amorfati.engine.economics.FirmEconomicsSpec com.boombustgroup.amorfati.engine.economics.WorldAssemblyEconomicsSpec"
- nix develop -c sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.FirmSpec com.boombustgroup.amorfati.engine.economics.FirmEconomicsSpec com.boombustgroup.amorfati.engine.economics.WorldAssemblyEconomicsSpec"
- nix develop -c sbt assembly
- nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 5 issue523-candidate-approval --duration 60 --run-id 20260525-523-candidate-approval --firm-snapshots none --household-snapshots none --firm-decision-trace none
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Banking credit approval parameters are now configurable via system settings, replacing hard-coded values. Customize minimum approval probability, NPL penalty, and reserve deficit penalty.
  * Enhanced technology upgrade credit diagnostics now separately track candidate credit demand and approved amounts for deeper visibility into credit selection outcomes.

* **Documentation**
  * Updated guidance on available technology upgrade credit metrics in system output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->