### PR TITLE
Add fiscal deficit closure diagnostics

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchema.scala
@@ -129,6 +129,10 @@ object McTimeseriesSchema:
     )
     lazy val monthlyGdp: PLN                                                                        = world.cachedMonthlyGdpProxy
     lazy val annualizedGdp: PLN                                                                     = monthlyGdp * 12
+    lazy val govSocialFundSubventions: PLN                                                          =
+      world.social.zus.govSubvention + world.social.nfz.govSubvention + world.social.earmarked.totalGovSubvention
+    lazy val govTotalOutlays: PLN                                                                   = world.gov.domesticBudgetOutlays + govSocialFundSubventions
+    lazy val govPrimaryDeficit: PLN                                                                 = world.gov.deficit - world.gov.debtServiceSpend
     lazy val sectorOutputs: Vector[PLN]                                                             =
       world.flows.sectorOutputs match
         case outputs if outputs.length == p.sectorDefs.length => outputs
@@ -374,8 +378,13 @@ object McTimeseriesSchema:
     ColumnDef.macroPln("GovCapitalSpendDomestic", ctx => ctx.world.gov.govCapitalSpend),
     ColumnDef.macroPln("GovDomesticBudgetDemand", ctx => ctx.world.gov.domesticBudgetDemand),
     ColumnDef.macroPln("GovDomesticBudgetOutlays", ctx => ctx.world.gov.domesticBudgetOutlays),
+    ColumnDef.macroPln("GovSocialFundSubventions", ctx => ctx.govSocialFundSubventions),
+    ColumnDef.macroPln("GovTotalOutlays", ctx => ctx.govTotalOutlays),
     ColumnDef.macroPln("GovDeficit", ctx => ctx.world.gov.deficit),
+    ColumnDef.macroPln("GovPrimaryDeficit", ctx => ctx.govPrimaryDeficit),
     ColumnDef("GovOutlaysToGdp", ctx => if ctx.monthlyGdp > PLN.Zero then ctx.world.gov.domesticBudgetOutlays / ctx.monthlyGdp else Scalar.Zero),
+    ColumnDef("GovTotalOutlaysToGdp", ctx => if ctx.monthlyGdp > PLN.Zero then ctx.govTotalOutlays / ctx.monthlyGdp else Scalar.Zero),
+    ColumnDef("GovPrimaryDeficitToGdp", ctx => if ctx.monthlyGdp > PLN.Zero then ctx.govPrimaryDeficit / ctx.monthlyGdp else Scalar.Zero),
     ColumnDef.macroPln("EuProjectCapitalTotal", ctx => ctx.world.gov.euProjectCapital),
     ColumnDef.macroPln("PublicCapitalStock", ctx => ctx.world.gov.publicCapitalStock),
     ColumnDef.macroPln("EuCofinancingDomestic", ctx => ctx.world.gov.euCofinancing),

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md
@@ -83,6 +83,29 @@ fold state needed for summaries.
 many monthly snapshots the runner materializes, but it is not part of
 `SimParams` and should not leak into economic decision rules.
 
+## Timeseries Fiscal Diagnostics
+
+The timeseries fiscal block keeps the domestic-demand budget and the deficit
+closure view separate. `GovDomesticBudgetOutlays` covers central-budget
+domestic outlays visible on `GovState`: unemployment benefits, social transfers,
+current purchases, domestic capital purchases, debt service, and EU
+co-financing. It intentionally excludes social-fund top-ups because ZUS, NFZ,
+and earmarked funds are reported in the social block.
+
+`GovSocialFundSubventions` sums `ZusGovSubvention`, `NfzGovSubvention`, and
+`EarmarkedGovSubvention`. `GovTotalOutlays` then reconciles to the fiscal
+deficit identity:
+
+```text
+GovTotalOutlays = GovDomesticBudgetOutlays + GovSocialFundSubventions
+GovDeficit      = GovTotalOutlays - GovTotalRevenue
+```
+
+`GovPrimaryDeficit` removes `DebtService` from `GovDeficit`, so fiscal drift can
+be split into the primary balance and the interest-cost channel. The
+`*ToGdp` columns use the monthly flow divided by the current monthly GDP proxy,
+matching the annualized flow-ratio convention used by `DeficitToGdp`.
+
 ## Timeseries Automation Diagnostics
 
 The timeseries schema includes generic monthly automation diagnostics:

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McTimeseriesSchemaSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
-import com.boombustgroup.amorfati.agents.{Banking, EclStaging, Firm, Household, Nbfi, TechState}
+import com.boombustgroup.amorfati.agents.{Banking, EarmarkedFunds, EclStaging, Firm, Household, Nbfi, SocialSecurity, TechState}
 import com.boombustgroup.amorfati.config.{HousingConfig, SimParams}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.{
@@ -127,8 +127,13 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     "GovCapitalSpendDomestic",
     "GovDomesticBudgetDemand",
     "GovDomesticBudgetOutlays",
+    "GovSocialFundSubventions",
+    "GovTotalOutlays",
     "GovDeficit",
+    "GovPrimaryDeficit",
     "GovOutlaysToGdp",
+    "GovTotalOutlaysToGdp",
+    "GovPrimaryDeficitToGdp",
     "EuProjectCapitalTotal",
     "PublicCapitalStock",
     "EuCofinancingDomestic",
@@ -511,7 +516,7 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     MetricValue.fromRaw(Share.fraction(numerator, denominator).toLong)
 
   "McTimeseriesSchema" should "expose the stable schema contract" in {
-    McTimeseriesSchema.nCols shouldBe 449
+    McTimeseriesSchema.nCols shouldBe 454
     McTimeseriesSchema.colNames.toVector shouldBe expectedColNames
   }
 
@@ -1058,6 +1063,11 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
           euCofinancing = PLN.Zero,
         ),
       ),
+      social = init.world.social.copy(
+        zus = SocialSecurity.ZusState(PLN.Zero, PLN.Zero, PLN(3)),
+        nfz = SocialSecurity.NfzState(PLN.Zero, PLN.Zero, PLN(2)),
+        earmarked = EarmarkedFunds.State.zero.copy(totalGovSubvention = PLN(1)),
+      ),
       flows = init.world.flows.copy(
         monthlyGdpProxy = PLN(100),
         sectorOutputs = Vector.fill(summon[SimParams].sectorDefs.length)(PLN.Zero),
@@ -1069,8 +1079,13 @@ class McTimeseriesSchemaSpec extends AnyFlatSpec with Matchers:
     valueAt(row, "GovDividendRevenue") shouldBe polandScale(PLN(5))
     valueAt(row, "GovTotalRevenue") shouldBe polandScale(PLN(35))
     valueAt(row, "GovDeficit") shouldBe polandScale(PLN(4))
+    valueAt(row, "GovSocialFundSubventions") shouldBe polandScale(PLN(6))
+    valueAt(row, "GovTotalOutlays") shouldBe polandScale(PLN(38))
+    valueAt(row, "GovPrimaryDeficit") shouldBe polandScale(PLN(2))
     valueAt(row, "GovRevenueToGdp") shouldBe MetricValue.fromRaw(Share.decimal(35, 2).toLong)
     valueAt(row, "GovOutlaysToGdp") shouldBe MetricValue.fromRaw(Share.decimal(32, 2).toLong)
+    valueAt(row, "GovTotalOutlaysToGdp") shouldBe MetricValue.fromRaw(Share.decimal(38, 2).toLong)
+    valueAt(row, "GovPrimaryDeficitToGdp") shouldBe MetricValue.fromRaw(Share.decimal(2, 2).toLong)
   }
 
   it should "emit total GFCF and investment-to-GDP ratios" in {


### PR DESCRIPTION
## Summary
- add fiscal timeseries columns for social-fund subventions, total outlays, primary deficit, and GDP ratios
- document the domestic-outlays vs deficit-closure convention in the Monte Carlo README
- extend the stable timeseries schema spec to assert the new fiscal identities

## Interpretation
This PR does not recalibrate fiscal policy. For #521 we now treat the observed 5-year Poland fiscal path as a plausible current-policy / high-deficit baseline rather than a calibration bug: a roughly 6-7% deficit can persist or increase under the intended scenario assumption.

The useful problem is therefore attribution and auditability: current CSVs expose GovDomesticBudgetOutlays and the social-fund subvention pieces, but they do not expose one total-outlays row that reconciles directly to GovDeficit. This PR adds that closure surface so future runs can distinguish primary deficit, debt service, and ZUS/NFZ/earmarked top-ups without manual post-processing.

## #521 evidence from current main
Nix-built JAR before the schema patch: 6ab462f5cdc6aa805b24a11520feeed12a459b56.

Run:
```bash
nix develop -c sbt assembly
nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 10 issue521-fiscal-drift --duration 60 --run-id 20260525-521-fiscal-drift --firm-snapshots none --household-snapshots none
```

Current path:
- terminal DebtToGdp: 64.53% mean [57.15..70.74]
- terminal Esa2010DebtToGdp: 73.14% [65.45..79.54]
- terminal DeficitToGdp: 6.76% [5.57..7.77]
- terminal fiscal rule binding: Art. 86/216, GovSpendingCutRatio mean 8.90%

Terminal deficit attribution from the same run:
- GovTotalRevenue: 89.55bn PLN/month
- GovDomesticBudgetOutlays: 110.45bn
- social-fund subventions: 10.47bn
- derived total outlays: 120.91bn
- GovDeficit: 31.36bn
- primary deficit: 18.39bn
- debt service: 12.97bn

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McTimeseriesSchemaSpec"
- nix develop -c sbt assembly, jar hash baea40647dc6ea5b757aeb747ddf6e4aa8b158ac
- nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 1 issue521-fiscal-diagnostics-smoke --duration 3 --run-id 20260525-521-fiscal-diagnostics-smoke --firm-snapshots none --household-snapshots none
- git diff --check

Refs #521