### PR TITLE
Calibrate external-sector baseline exports

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -1089,7 +1089,12 @@ update.
 
 Exports come from GVC sector exports when available; otherwise they follow
 foreign GDP growth, real exchange-rate competitiveness, and automation-related
-unit-labor-cost effects.
+unit-labor-cost effects. GVC sector exports also include a domestic export
+capacity term: each sector is anchored on its first observed real output, and
+subsequent export demand realization scales with the sector's real-output ratio
+using `gvc.exportCapacityElasticity`. This keeps the empirical opening export
+base intact while allowing exports to move with domestic supply capacity over a
+multi-year baseline run.
 
 Imports include household consumption imports, technology and investment
 imports, imported intermediates, and tourism imports. Imported intermediates

--- a/docs/calibration-register.md
+++ b/docs/calibration-register.md
@@ -40,7 +40,7 @@ These counts are rendered from `CalibrationProvenance.Baseline` at generation ti
 | `EMPIRICAL_TRANSFORMED` | 17 |
 | `CODE_NOTE_EMPIRICAL` | 61 |
 | `ASSUMED` | 33 |
-| `TUNED_NEEDS_VALIDATION` | 88 |
+| `TUNED_NEEDS_VALIDATION` | 89 |
 | `POLICY_SCENARIO` | 7 |
 | `PLACEHOLDER` | 1 |
 | `UNKNOWN_SOURCE` | 0 |
@@ -76,7 +76,7 @@ a concrete diagnostic artifact path.
 
 | Validation mode | Count | Linked evidence paths | Missing evidence paths |
 | --- | ---: | ---: | ---: |
-| `HISTORICAL_FIT` | 31 | 4 | 27 |
+| `HISTORICAL_FIT` | 32 | 5 | 27 |
 | `STYLIZED_FACT_TARGET` | 11 | 7 | 4 |
 | `SENSITIVITY_RANGE` | 32 | 5 | 27 |
 | `MODEL_BEHAVIOR_CALIBRATION` | 14 | 0 | 14 |
@@ -157,6 +157,7 @@ a concrete diagnostic artifact path.
 | `openEcon.portfolioSensitivity`, `riskPremiumSensitivity` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Portfolio/risk premium response | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `fdi.profitShiftRate`, `repatriationRate` | `SENSITIVITY_RANGE` | `MISSING_VALIDATION_EVIDENCE` |  |  | Profit shifting and dividend repatriation | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `fdi.maProb`, `maSizeMin` | `MODEL_BEHAVIOR_CALIBRATION` | `MISSING_VALIDATION_EVIDENCE` |  |  | Domestic firm acquisition probability and eligibility | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
+| `gvc.exportCapacityElasticity` | `HISTORICAL_FIT` | docs/external-sector-baseline-calibration.md | 20260525-617-external-baseline-after035 |  | Current-account and trade-balance baseline path | Issue #617 documents the Nix-built 5-seed 60-month external-sector baseline calibration and before/after BoP decomposition. |
 | `gvc.commodityVolatility`, `commodityMeanReversion` | `HISTORICAL_FIT` | `MISSING_VALIDATION_EVIDENCE` |  |  | No-shock baseline commodity path; explicit energy-shock scenario carries crisis dynamics | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `immigration.monthlyRate`, `foreignWage` | `HISTORICAL_FIT` | `MISSING_VALIDATION_EVIDENCE` |  |  | Base labor-immigration rate and reference wage; moderated after 48m diagnostics showed the prior pull channel added roughly 3% of represented working-age population per year and over-amplified real GDP catch-up | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
 | `immigration.returnRate`, `returnUnempThreshold`, `returnUnempSensitivity` | `HISTORICAL_FIT` | `MISSING_VALIDATION_EVIDENCE` |  |  | Baseline and unemployment-sensitive return migration | Expected validation mode is classified, but no concrete validation artifact is linked yet. |
@@ -397,6 +398,7 @@ a concrete diagnostic artifact path.
 | `gvc.exportShares` | `[0.05, 0.55, 0.15, 0.03, 0.02, 0.20]` | share by sector | Code note bridge: GUS bridge prior | Sector export shares | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.depth` | `[0.35, 0.75, 0.30, 0.40, 0.10, 0.45]` | share by sector | Code note bridge: WIOD/OECD ICIO | GVC backward linkage | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02, 0.015` | annual rate | Code note bridge: ECB/IMF | Foreign inflation/growth | .monthly where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.exportCapacityElasticity` | `0.35` | coefficient | #617 external-sector baseline calibration | GVC export realization response to domestic sector output capacity | Sector output is anchored on the first observed real output; later export demand is multiplied by (realOutput / anchor)^elasticity | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
 | `gvc.commodityVolatility`, `commodityMeanReversion` | `0.015, 0.08` | monthly sigma / share | #461 GDP-growth calibration | No-shock baseline commodity path; explicit energy-shock scenario carries crisis dynamics | Mean-reverting stochastic process plus scenario shock | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
 | `gvc.demandShockMonth`, `commodityShockMonth` | `0, 0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
 | `immigration.monthlyRate`, `foreignWage` | `0.0008, 6500` | monthly share / PLN | #461 labor/GDP calibration | Base labor-immigration rate and reference wage; moderated after 48m diagnostics showed the prior pull channel added roughly 3% of represented working-age population per year and over-amplified real GDP catch-up | Direct | `ImmigrationConfig` | `TUNED_NEEDS_VALIDATION` |

--- a/docs/external-sector-baseline-calibration.md
+++ b/docs/external-sector-baseline-calibration.md
@@ -1,0 +1,102 @@
+# External-Sector Baseline Calibration
+
+Issue: #617
+
+This note records the baseline calibration that followed the current-account
+closure audit in #522 and the diagnostic export added in #616. The accounting
+identity was already exact: `CurrentAccountClosureResidual` stayed at zero. The
+remaining problem was behavioral. In a 60-month baseline run, GVC exports drifted
+down relative to domestic output capacity, which pushed the current-account
+deficit mechanically wider even though the closure terms balanced.
+
+## Decision
+
+Keep `openEcon.exportBase` unchanged. Add a domestic export-capacity term inside
+`GvcTrade`:
+
+```text
+sectorExportDemand = foreign demand
+                   * real exchange-rate effect
+                   * automation effect
+                   * (realSectorOutput / openingRealSectorOutput)^gvc.exportCapacityElasticity
+                   * disruption effect
+```
+
+The opening real sector output is anchored on the first observed sector-output
+vector. This preserves the empirical opening export base while allowing realized
+exports to move with domestic supply capacity over a multi-year baseline.
+
+The calibrated value is:
+
+```text
+gvc.exportCapacityElasticity = 0.35
+```
+
+A trial value of `0.55` was rejected. It improved the external balance more
+aggressively but produced an all-failed banking-sector path in the Nix/JAR
+5-seed 60-month validation run, so it was not a stable baseline setting.
+
+## Validation
+
+Fresh JAR:
+
+```sh
+nix develop -c sbt assembly
+```
+
+Baseline command:
+
+```sh
+nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 5 issue617-external-baseline --duration 60 --run-id 20260525-617-external-baseline-after035 --firm-snapshots none --household-snapshots none
+```
+
+The run completed all five seeds and wrote:
+
+```text
+mc/issue617-external-baseline_20260525-617-external-baseline-after035_60m_seed001.csv
+mc/issue617-external-baseline_20260525-617-external-baseline-after035_60m_seed002.csv
+mc/issue617-external-baseline_20260525-617-external-baseline-after035_60m_seed003.csv
+mc/issue617-external-baseline_20260525-617-external-baseline-after035_60m_seed004.csv
+mc/issue617-external-baseline_20260525-617-external-baseline-after035_60m_seed005.csv
+```
+
+Annual ratios are computed as `sum(flow) / sum(MonthlyGdpProxy)` across the five
+seeds in each 12-month window. M60 rows are seed means.
+
+## Results
+
+Before: post-#616 baseline,
+`run-id=20260525-external-baseline-before`.
+
+After: `gvc.exportCapacityElasticity=0.35`,
+`run-id=20260525-617-external-baseline-after035`.
+
+| Window | CA/GDP before | CA/GDP after | Trade/GDP before | Trade/GDP after | Exports/GDP before | Exports/GDP after | Imports/GDP before | Imports/GDP after |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Y1 | -6.50% | -6.14% | -5.05% | -4.67% | 47.81% | 48.17% | 52.86% | 52.84% |
+| Y2 | -4.71% | -3.84% | -3.95% | -2.97% | 44.39% | 45.40% | 48.33% | 48.37% |
+| Y3 | -6.51% | -4.85% | -5.42% | -3.68% | 41.79% | 43.54% | 47.21% | 47.22% |
+| Y4 | -8.58% | -6.38% | -6.49% | -4.30% | 39.99% | 42.11% | 46.49% | 46.41% |
+| Y5 | -10.10% | -7.78% | -6.90% | -4.59% | 39.08% | 41.13% | 45.98% | 45.72% |
+
+| M60 metric | Before | After |
+| --- | ---: | ---: |
+| CurrentAccountToGdp | -11.42% | -9.15% |
+| TradeBalanceToGdp | -7.91% | -5.55% |
+| ExportsToGdp | 36.63% | 38.73% |
+| ImportsToGdp | 44.54% | 44.29% |
+| CurrentAccountPrimaryIncomeToGdp | -0.95% | -0.74% |
+| CurrentAccountSecondaryIncomeToGdp | 0.89% | 0.87% |
+| ImportedIntermToImports | 73.52% | 73.29% |
+| ExRate | 4.4431 | 4.3482 |
+| BankResolution_AllFailedFallback | 0 | 0 |
+| BankFailure_AllFailedFallback | 0 | 0 |
+| max abs CurrentAccountClosureResidual | 0 | 0 |
+
+## Interpretation
+
+The calibration reduces the mechanical widening of the current-account deficit
+without forcing a surplus or masking the structural external deficit. The
+improvement comes from export realization tracking domestic output capacity; the
+import side remains largely unchanged, and the current-account accounting
+closure remains exact.

--- a/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala
@@ -269,49 +269,49 @@ object CalibrationProvenance:
 
     private val validationEvidenceById: Map[String, CalibrationValidationEvidence] =
       Vector(
-        "pop.firmSizeDist"          -> linkedEvidence(
+        "pop.firmSizeDist"             -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Firm-size distribution family",
           "EmpiricalValidationExport exposes the current aggregate firm-size bridge.",
           artifactLabel = Some("Firm-size distribution"),
         ),
-        "pop.firmSizeMicroShare"    -> linkedEvidence(
+        "pop.firmSizeMicroShare"       -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Micro-enterprise share",
           "EmpiricalValidationExport compares the terminal micro-firm share to the GUS active-enterprise comparator.",
           artifactLabel = Some("Firm-size distribution - Micro"),
         ),
-        "pop.firmSizeSmallShare"    -> linkedEvidence(
+        "pop.firmSizeSmallShare"       -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Small-enterprise share",
           "EmpiricalValidationExport compares the terminal small-firm share to the GUS active-enterprise comparator.",
           artifactLabel = Some("Firm-size distribution - Small"),
         ),
-        "pop.firmSizeMediumShare"   -> linkedEvidence(
+        "pop.firmSizeMediumShare"      -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Medium-enterprise share",
           "EmpiricalValidationExport compares the terminal medium-firm share to the GUS active-enterprise comparator.",
           artifactLabel = Some("Firm-size distribution - Medium"),
         ),
-        "pop.firmSizeLargeShare"    -> linkedEvidence(
+        "pop.firmSizeLargeShare"       -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Large-enterprise share",
           "EmpiricalValidationExport compares the terminal large-firm share to the GUS active-enterprise comparator.",
           artifactLabel = Some("Firm-size distribution - Large"),
         ),
-        "sectorDefs.share"          -> linkedEvidence(
+        "sectorDefs.share"             -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Six-sector output and employment bridge",
           "EmpiricalValidationExport carries the sectoral-output bridge as missing-data evidence until a full source crosswalk is available.",
           artifactLabel = Some("Sectoral output"),
         ),
-        "household.mpc"             -> linkedEvidence(
+        "household.mpc"                -> linkedEvidence(
           CalibrationValidationMode.SensitivityRange,
           "docs/sensitivity-robustness-workflow.md",
           "Consumption-led demand sensitivity",
@@ -319,14 +319,14 @@ object CalibrationProvenance:
           artifactLabel = Some("sensitivity-summary.csv"),
           scenarioIds = Vector("mpc-low", "mpc-high"),
         ),
-        "firm.productivityGrowth"   -> linkedEvidence(
+        "firm.productivityGrowth"      -> linkedEvidence(
           CalibrationValidationMode.HistoricalFit,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Baseline GDP growth path",
           "EmpiricalValidationExport records the current GDP-growth bridge and model output used to judge the productivity/catch-up path.",
           artifactLabel = Some("GDP growth"),
         ),
-        "capital.adjustSpeed"       -> linkedEvidence(
+        "capital.adjustSpeed"          -> linkedEvidence(
           CalibrationValidationMode.SensitivityRange,
           "docs/sensitivity-robustness-workflow.md",
           "Investment and balance-sheet sensitivity",
@@ -334,14 +334,14 @@ object CalibrationProvenance:
           artifactLabel = Some("sensitivity-summary.csv"),
           scenarioIds = Vector("investment-fast"),
         ),
-        "fiscal.govInitCapital"     -> linkedEvidence(
+        "fiscal.govInitCapital"        -> linkedEvidence(
           CalibrationValidationMode.HistoricalFit,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Public investment and fiscal stance bridge",
           "EmpiricalValidationExport keeps the current fiscal coverage bridge visible while public-capital stock validation remains partial.",
           artifactLabel = Some("Fiscal stance - state budget expenditure plan 2026"),
         ),
-        "monetary.neutralRate"      -> linkedEvidence(
+        "monetary.neutralRate"         -> linkedEvidence(
           CalibrationValidationMode.SensitivityRange,
           "docs/sensitivity-robustness-workflow.md",
           "Monetary-policy sensitivity",
@@ -349,7 +349,7 @@ object CalibrationProvenance:
           artifactLabel = Some("sensitivity-summary.csv"),
           scenarioIds = Vector("monetary-tight"),
         ),
-        "forex.irpSensitivity"      -> linkedEvidence(
+        "forex.irpSensitivity"         -> linkedEvidence(
           CalibrationValidationMode.SensitivityRange,
           "docs/sensitivity-robustness-workflow.md",
           "FX and external-balance sensitivity",
@@ -357,7 +357,7 @@ object CalibrationProvenance:
           artifactLabel = Some("sensitivity-summary.csv"),
           scenarioIds = Vector("external-risk-off"),
         ),
-        "pricing.demandSensitivity" -> linkedEvidence(
+        "pricing.demandSensitivity"    -> linkedEvidence(
           CalibrationValidationMode.SensitivityRange,
           "docs/sensitivity-robustness-workflow.md",
           "Price-level and markup sensitivity",
@@ -365,14 +365,14 @@ object CalibrationProvenance:
           artifactLabel = Some("sensitivity-summary.csv"),
           scenarioIds = Vector("markup-high"),
         ),
-        "housing.originationRate"   -> linkedEvidence(
+        "housing.originationRate"      -> linkedEvidence(
           CalibrationValidationMode.HistoricalFit,
           "docs/empirical-validation/baseline-validation-snapshot.csv",
           "Mortgage origination/default bridge",
           "EmpiricalValidationExport carries mortgage stock and default-flow validation rows for the housing credit channel.",
           artifactLabel = Some("Housing and mortgages - mortgage default bridge"),
         ),
-        "household.ccEligRate"      -> linkedEvidence(
+        "household.ccEligRate"         -> linkedEvidence(
           CalibrationValidationMode.StylizedFactTarget,
           "docs/household-credit-stress-calibration.md",
           "Liquidity shortfall versus approved consumer-credit origination",
@@ -380,12 +380,19 @@ object CalibrationProvenance:
           artifactLabel = Some("household-credit-stress-summary.csv"),
           scenarioIds = Vector("issue-534"),
         ),
-        "nbfi.creditBaseRate"       -> linkedEvidence(
+        "nbfi.creditBaseRate"          -> linkedEvidence(
           CalibrationValidationMode.HistoricalFit,
           "docs/private-credit-renewal-calibration.md",
           "Private credit renewal calibration",
           "Issue #610 documents the Nix-built 10-seed 60-month NBFI stock-renewal calibration and terminal private-credit split.",
           artifactLabel = Some("20260525-610-nbfi-only"),
+        ),
+        "gvc.exportCapacityElasticity" -> linkedEvidence(
+          CalibrationValidationMode.HistoricalFit,
+          "docs/external-sector-baseline-calibration.md",
+          "Current-account and trade-balance baseline path",
+          "Issue #617 documents the Nix-built 5-seed 60-month external-sector baseline calibration and before/after BoP decomposition.",
+          artifactLabel = Some("20260525-617-external-baseline-after035"),
         ),
       ).toMap
 
@@ -661,6 +668,7 @@ object CalibrationProvenance:
 | `gvc.exportShares` | `[0.05, 0.55, 0.15, 0.03, 0.02, 0.20]` | share by sector | Code note bridge: GUS bridge prior | Sector export shares | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.depth` | `[0.35, 0.75, 0.30, 0.40, 0.10, 0.45]` | share by sector | Code note bridge: WIOD/OECD ICIO | GVC backward linkage | Direct | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
 | `gvc.foreignInflation`, `foreignGdpGrowth` | `0.02`, `0.015` | annual rate | Code note bridge: ECB/IMF | Foreign inflation/growth | `.monthly` where used | `GvcConfig` | `CODE_NOTE_EMPIRICAL` |
+| `gvc.exportCapacityElasticity` | `0.35` | coefficient | #617 external-sector baseline calibration | GVC export realization response to domestic sector output capacity | Sector output is anchored on the first observed real output; later export demand is multiplied by `(realOutput / anchor)^elasticity` | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
 | `gvc.commodityVolatility`, `commodityMeanReversion` | `0.015`, `0.08` | monthly sigma / share | #461 GDP-growth calibration | No-shock baseline commodity path; explicit `energy-shock` scenario carries crisis dynamics | Mean-reverting stochastic process plus scenario shock | `GvcConfig`, `GvcTrade` | `TUNED_NEEDS_VALIDATION` |
 | `gvc.demandShockMonth`, `commodityShockMonth` | `0`, `0` | month | Scenario switches | No baseline external shocks | Direct | `GvcConfig` | `POLICY_SCENARIO` |
 | `immigration.monthlyRate`, `foreignWage` | `0.0008`, `6500` | monthly share / PLN | #461 labor/GDP calibration | Base labor-immigration rate and reference wage; moderated after 48m diagnostics showed the prior pull channel added roughly 3% of represented working-age population per year and over-amplified real GDP catch-up | Direct | `ImmigrationConfig` | `TUNED_NEEDS_VALIDATION` |

--- a/src/main/scala/com/boombustgroup/amorfati/config/GvcConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/GvcConfig.scala
@@ -24,6 +24,9 @@ import com.boombustgroup.amorfati.types.*
   *   annual foreign (trading partner) inflation rate (ECB/IMF)
   * @param foreignGdpGrowth
   *   annual foreign GDP growth rate (ECB/IMF projections)
+  * @param exportCapacityElasticity
+  *   elasticity of foreign export demand realization to domestic sector output
+  *   capacity, anchored on the first observed real sector output
   * @param erPassthrough
   *   exchange rate pass-through to non-EU import prices (Campa & Goldberg 2005)
   * @param euErPassthrough
@@ -58,6 +61,7 @@ case class GvcConfig(
       Vector(Share.decimal(35, 2), Share.decimal(75, 2), Share.decimal(30, 2), Share.decimal(40, 2), Share.decimal(10, 2), Share.decimal(45, 2)),
     foreignInflation: Rate = Rate.decimal(2, 2),
     foreignGdpGrowth: Rate = Rate.decimal(15, 3),
+    exportCapacityElasticity: Coefficient = Coefficient.decimal(35, 2),
     erPassthrough: Coefficient = Coefficient.decimal(60, 2),
     euErPassthrough: Coefficient = Coefficient.decimal(15, 2),
     demandShockMonth: Int = 0,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala
@@ -14,8 +14,9 @@ import com.boombustgroup.amorfati.util.Distributions
   * supply, price index, and supply-chain disruption state.
   *
   * Export demand: foreign GDP growth × real ER elasticity × automation boost ×
-  * (1 − disruption). Import demand: sector output × GVC depth × differentiated
-  * ER pass-through (EU vs non-EU). Disruptions recover at configurable rate.
+  * domestic output capacity × (1 − disruption). Import demand: sector output ×
+  * GVC depth × differentiated ER pass-through (EU vs non-EU). Disruptions
+  * recover at configurable rate.
   *
   * Calibration: GUS foreign-trade bridge prior, NBP BoP statistics, OECD TiVA.
   */
@@ -41,6 +42,7 @@ object GvcTrade:
       totalIntermImports: PLN = PLN.Zero,
       sectorExports: Vector[PLN] = Vector.fill(6)(PLN.Zero),
       sectorImports: Vector[PLN] = Vector.fill(6)(PLN.Zero),
+      sectorOutputAnchors: Vector[PLN] = Vector.empty,
       disruptionIndex: Share = Share.Zero,
       foreignPriceIndex: PriceIndex = PriceIndex.Base,
       tradeConcentration: Share = Share.Zero,
@@ -121,10 +123,12 @@ object GvcTrade:
     val shockActive      = p.gvc.demandShockMonth > 0 && in.month.toInt >= p.gvc.demandShockMonth
     val shockMag         = if shockActive then p.gvc.demandShockSize else Share.Zero
     val updatedFirms     = evolveFirms(in.prev.foreignFirms, monthlyInflation, shockActive, in.month)
+    val realOutputs      = realSectorOutputs(in.sectorOutputs, in.priceLevel)
+    val outputAnchors    = sectorOutputAnchors(in.prev, realOutputs, nSectors)
     val elapsedMonths    = in.month.previousCompleted.toInt
     val foreignGdpFactor = compoundedGrowth(p.gvc.foreignGdpGrowth.monthly.growthMultiplier, elapsedMonths)
     val erEffect         = realExchangeRateEffect(in.priceLevel, in.exchangeRate)
-    val exports          = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio)
+    val exports          = computeSectorExports(updatedFirms, nSectors, foreignGdpFactor, erEffect, in.autoRatio, realOutputs, outputAnchors)
     val imports          = computeSectorImports(updatedFirms, nSectors, in.sectorOutputs, in.priceLevel, in.exchangeRate)
 
     State(
@@ -133,6 +137,7 @@ object GvcTrade:
       totalIntermImports = sumPln(imports),
       sectorExports = exports,
       sectorImports = imports,
+      sectorOutputAnchors = outputAnchors,
       disruptionIndex = weightedDisruption(updatedFirms),
       foreignPriceIndex = newForeignPrice,
       tradeConcentration = hhi(p.gvc.euTradeShare),
@@ -170,15 +175,30 @@ object GvcTrade:
       foreignGdpFactor: Multiplier,
       erEffect: Scalar,
       autoRatio: Share,
-  ): Vector[PLN] =
+      realOutputs: Vector[PLN],
+      outputAnchors: Vector[PLN],
+  )(using p: SimParams): Vector[PLN] =
     val autoBoost = (autoRatio * AutomationExportBoost).growthMultiplier
     (0 until nSectors)
       .map: s =>
-        val sectorFirms = firms.filter(_.sectorId == s)
-        val demand      = sumPln(sectorFirms.map(_.baseExportDemand)) * foreignGdpFactor
-        val disruption  = weightedSectorDisruption(sectorFirms, _.baseExportDemand)
-        ((erEffect * demand) * autoBoost) * (Share.One - disruption)
+        val sectorFirms    = firms.filter(_.sectorId == s)
+        val demand         = sumPln(sectorFirms.map(_.baseExportDemand)) * foreignGdpFactor
+        val capacityEffect = exportCapacityEffect(realOutputs(s), outputAnchors(s))
+        val disruption     = weightedSectorDisruption(sectorFirms, _.baseExportDemand)
+        (((erEffect * demand) * capacityEffect) * autoBoost) * (Share.One - disruption)
       .toVector
+
+  private def realSectorOutputs(sectorOutputs: Vector[PLN], priceLevel: PriceIndex): Vector[PLN] =
+    val price = priceLevel.toMultiplier
+    sectorOutputs.map(_ / price)
+
+  private def sectorOutputAnchors(prev: State, realOutputs: Vector[PLN], nSectors: Int): Vector[PLN] =
+    if prev.sectorOutputAnchors.lengthCompare(nSectors) == 0 then prev.sectorOutputAnchors
+    else realOutputs.map(_.max(PLN(1)))
+
+  private def exportCapacityEffect(realOutput: PLN, anchor: PLN)(using p: SimParams): Multiplier =
+    if realOutput > PLN.Zero && anchor > PLN.Zero then realOutput.ratioTo(anchor).pow(p.gvc.exportCapacityElasticity.toScalar).toMultiplier
+    else Multiplier.Zero
 
   private def computeSectorImports(
       firms: Vector[ForeignFirm],

--- a/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/CalibrationProvenanceSpec.scala
@@ -39,11 +39,11 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
 
   "Baseline calibration provenance" should "preserve the active default inventory status counts in code" in {
     CalibrationProvenance.Baseline.parseErrors shouldBe empty
-    CalibrationProvenance.Baseline.parameters should have size 243
+    CalibrationProvenance.Baseline.parameters should have size 244
     CalibrationProvenance.Baseline.statusCounts should contain(Empirical -> 36)
     CalibrationProvenance.Baseline.statusCounts should contain(EmpiricalTransformed -> 17)
     CalibrationProvenance.Baseline.statusCounts should contain(CodeNoteEmpirical -> 61)
-    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 88)
+    CalibrationProvenance.Baseline.statusCounts should contain(TunedNeedsValidation -> 89)
     CalibrationProvenance.Baseline.statusCounts.getOrElse(UnknownSource, 0) shouldBe 0
     CalibrationProvenance.Baseline.statusCounts should contain(Placeholder -> 1)
     CalibrationProvenance.Baseline.statusCounts should contain(Assumed -> 33)
@@ -134,7 +134,7 @@ class CalibrationProvenanceSpec extends AnyFlatSpec with Matchers:
     val pathCounts = CalibrationProvenance.Baseline.tunedValidationEvidencePathCounts
 
     CalibrationProvenance.Baseline.tunedValidationEvidenceErrors shouldBe empty
-    tuned should have size 88
+    tuned should have size 89
     tuned.flatMap(_.validationEvidence) should have size tuned.size
     CalibrationProvenance.Baseline.tunedValidationModeCounts.values.sum shouldBe tuned.size
     CalibrationValidationMode.values.foreach: mode =>

--- a/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/ExternalSectorSpec.scala
@@ -18,11 +18,12 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
 
   private def baseInput(
       prev: GvcTrade.State = GvcTrade.initial,
+      outputs: Vector[PLN] = sectorOutputs,
       er: BigDecimal = decimal(p.forex.baseExRate),
       price: BigDecimal = BigDecimal("1.0"),
       autoR: BigDecimal = BigDecimal("0.0"),
       month: Int = 30,
-  ) = GvcTrade.StepInput(prev, sectorOutputs, priceIndexBD(price), exchangeRateBD(er), shareBD(autoR), ExecutionMonth(month), rng = RandomStream.seeded(42))
+  ) = GvcTrade.StepInput(prev, outputs, priceIndexBD(price), exchangeRateBD(er), shareBD(autoR), ExecutionMonth(month), rng = RandomStream.seeded(42))
 
   // ---- Initialization ----
 
@@ -78,6 +79,15 @@ class ExternalSectorSpec extends AnyFlatSpec with Matchers:
 
     r.totalExports shouldBe init.totalExports
     r.sectorExports shouldBe init.sectorExports
+  }
+
+  it should "scale export demand with domestic sector output after anchoring" in {
+    val anchored = GvcTrade.step(baseInput(prev = GvcTrade.initial, month = 1))
+    val flat     = GvcTrade.step(baseInput(prev = anchored, month = 2))
+    val expanded = GvcTrade.step(baseInput(prev = anchored, outputs = sectorOutputs.map(_ * Multiplier(2)), month = 2))
+
+    anchored.sectorOutputAnchors shouldBe sectorOutputs
+    expanded.totalExports should be > flat.totalExports
   }
 
   it should "produce positive total intermediate imports" in {


### PR DESCRIPTION
## Summary

- add `gvc.exportCapacityElasticity` and make GVC exports scale with domestic real sector-output capacity after the opening anchor
- keep `openEcon.exportBase` unchanged, so the empirical opening export base remains the source of level calibration
- add validation/provenance docs for the #617 external-sector baseline run and regenerate the calibration register

## Validation

- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.engine.ExternalSectorSpec com.boombustgroup.amorfati.engine.ExternalSectorPropertySpec com.boombustgroup.amorfati.config.CalibrationProvenanceSpec com.boombustgroup.amorfati.config.CalibrationRegisterRendererSpec"`
- `nix develop -c sbt assembly`
- `nix develop -c java -jar target/scala-3.8.2/amor-fati.jar 5 issue617-external-baseline --duration 60 --run-id 20260525-617-external-baseline-after035 --firm-snapshots none --household-snapshots none`

## Result

- M60 `CurrentAccountToGdp`: `-11.42%` -> `-9.15%`
- Y5 `CA/GDP`: `-10.10%` -> `-7.78%`
- M60 `TradeBalanceToGdp`: `-7.91%` -> `-5.55%`
- M60 `ExportsToGdp`: `36.63%` -> `38.73%`
- `CurrentAccountClosureResidual`: stays `0`
- all five seeds completed; no all-failed banking fallback

Note: a trial elasticity of `0.55` was rejected because it improved the external balance more aggressively but triggered an all-failed banking-sector path in the Nix/JAR 5-seed 60-month run. The committed `0.35` setting is the stable conservative calibration.

Closes #617
