### PR TITLE
Add scheduled nightly diagnostics workflow

### DIFF
--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -2,9 +2,11 @@ name: Nightly Diagnostics
 
 on:
   schedule:
-    # GitHub cron is UTC. 22:30 UTC is 23:30 Warsaw in CET and 00:30 Warsaw in
-    # CEST, avoiding a DST-dependent attempt to mean exact local midnight.
-    - cron: "30 22 * * *"
+    # GitHub cron is UTC. Both entries are needed to hit 02:00 Europe/Warsaw
+    # across DST; the schedule gate below skips whichever one is not 02:00
+    # locally on that date.
+    - cron: "0 0 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       profile:
@@ -43,7 +45,39 @@ jobs:
 
       - uses: cachix/install-nix-action@v31.10.6
 
+      - name: Check 02:00 Warsaw schedule window
+        id: schedule_window
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          should_run=true
+          warsaw_time="$(TZ=Europe/Warsaw date '+%Y-%m-%d %H:%M:%S %Z')"
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            warsaw_hour="$(TZ=Europe/Warsaw date '+%H')"
+            if [[ "${warsaw_hour}" != "02" ]]; then
+              should_run=false
+            fi
+          fi
+
+          {
+            echo "should_run=${should_run}"
+            echo "warsaw_time=${warsaw_time}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Skip non-02:00 Warsaw scheduled trigger
+        if: ${{ steps.schedule_window.outputs.should_run != 'true' }}
+        run: |
+          {
+            echo "### Nightly Diagnostics"
+            echo
+            echo "Skipped scheduled trigger because local Warsaw time was not 02:00."
+            echo
+            echo "- Warsaw time: \`${{ steps.schedule_window.outputs.warsaw_time }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Resolve diagnostics run metadata
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
         id: meta
         shell: bash
         run: |
@@ -75,9 +109,11 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Build assembled jar under Nix
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
         run: nix develop --command sbt assembly
 
       - name: Run diagnostics profile from assembled jar
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
         id: diagnostics
         shell: bash
         run: |
@@ -108,7 +144,7 @@ jobs:
           exit 0
 
       - name: Report diagnostics result
-        if: always()
+        if: ${{ always() && steps.schedule_window.outputs.should_run == 'true' }}
         shell: bash
         env:
           RUN_ID: ${{ steps.meta.outputs.run_id }}

--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -36,33 +36,62 @@ jobs:
       OUT_DIR: target/nightly-diagnostics
       JAR_PATH: target/scala-3.8.2/amor-fati.jar
     steps:
-      - name: Check out HEAD of main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-          submodules: recursive
-
-      - uses: cachix/install-nix-action@v31.10.6
-
       - name: Check 02:00 Warsaw schedule window
         id: schedule_window
         shell: bash
+        env:
+          SCHEDULE_CRON: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
 
           should_run=true
-          warsaw_time="$(TZ=Europe/Warsaw date '+%Y-%m-%d %H:%M:%S %Z')"
+          schedule_reason="manual dispatch"
+          scheduled_cron="${SCHEDULE_CRON:-manual}"
+          scheduled_epoch="$(date +%s)"
+
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
-            warsaw_hour="$(TZ=Europe/Warsaw date '+%H')"
-            if [[ "${warsaw_hour}" != "02" ]]; then
+            utc_date="$(date -u '+%Y-%m-%d')"
+            case "${scheduled_cron}" in
+              "0 0 * * *") scheduled_hour=00 ;;
+              "0 1 * * *") scheduled_hour=01 ;;
+              *)
+                scheduled_hour="$(date -u '+%H')"
+                schedule_reason="unknown scheduled cron '${scheduled_cron}'"
+                ;;
+            esac
+            scheduled_epoch="$(date -u -d "${utc_date} ${scheduled_hour}:00:00" '+%s')"
+          fi
+
+          warsaw_time="$(TZ=Europe/Warsaw date -d "@${scheduled_epoch}" '+%Y-%m-%d %H:%M:%S %Z')"
+          warsaw_hour="$(TZ=Europe/Warsaw date -d "@${scheduled_epoch}" '+%H')"
+          warsaw_zone="$(TZ=Europe/Warsaw date -d "@${scheduled_epoch}" '+%Z')"
+          prev_warsaw_hour="$(TZ=Europe/Warsaw date -d "@$((scheduled_epoch - 3600))" '+%H')"
+          prev_warsaw_zone="$(TZ=Europe/Warsaw date -d "@$((scheduled_epoch - 3600))" '+%Z')"
+          next_warsaw_hour="$(TZ=Europe/Warsaw date -d "@$((scheduled_epoch + 3600))" '+%H')"
+          next_warsaw_zone="$(TZ=Europe/Warsaw date -d "@$((scheduled_epoch + 3600))" '+%Z')"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            should_run=false
+            if [[ "${scheduled_cron}" == "0 0 * * *" && "${warsaw_hour}" == "02" && "${warsaw_zone}" == "CEST" && ! ( "${next_warsaw_hour}" == "02" && "${next_warsaw_zone}" == "CET" ) ]]; then
+              should_run=true
+              schedule_reason="02:00 Warsaw during CEST"
+            elif [[ "${scheduled_cron}" == "0 1 * * *" && "${warsaw_hour}" == "02" && "${warsaw_zone}" == "CET" ]]; then
+              should_run=true
+              schedule_reason="02:00 Warsaw during CET"
+            elif [[ "${scheduled_cron}" == "0 1 * * *" && "${warsaw_hour}" == "03" && "${warsaw_zone}" == "CEST" && "${prev_warsaw_hour}" == "01" && "${prev_warsaw_zone}" == "CET" ]]; then
+              should_run=true
+              schedule_reason="spring DST gap: 02:00 Warsaw does not exist, running at 03:00 CEST"
+            else
               should_run=false
+              schedule_reason="scheduled cron does not correspond to the selected 02:00 Warsaw occurrence"
             fi
           fi
 
           {
             echo "should_run=${should_run}"
             echo "warsaw_time=${warsaw_time}"
+            echo "schedule_reason=${schedule_reason}"
+            echo "scheduled_cron=${scheduled_cron}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Skip non-02:00 Warsaw scheduled trigger
@@ -74,7 +103,19 @@ jobs:
             echo "Skipped scheduled trigger because local Warsaw time was not 02:00."
             echo
             echo "- Warsaw time: \`${{ steps.schedule_window.outputs.warsaw_time }}\`"
+            echo "- Schedule reason: \`${{ steps.schedule_window.outputs.schedule_reason }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Check out HEAD of main
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v31.10.6
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
 
       - name: Resolve diagnostics run metadata
         if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
@@ -106,14 +147,34 @@ jobs:
             echo "- Commit: \`${sha}\`"
             echo "- Run id: \`${run_id}\`"
             echo "- Output root: \`${run_root}\`"
+            echo "- Warsaw schedule time: \`${{ steps.schedule_window.outputs.warsaw_time }}\`"
+            echo "- Schedule reason: \`${{ steps.schedule_window.outputs.schedule_reason }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Build assembled jar under Nix
+        id: build
         if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
-        run: nix develop --command sbt assembly
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${OUT_DIR}"
+          start_seconds="$(date +%s)"
+          set +e
+          nix develop --command sbt assembly 2>&1 | tee "${OUT_DIR}/build.log"
+          exit_code="${PIPESTATUS[0]}"
+          set -e
+          end_seconds="$(date +%s)"
+
+          {
+            echo "exit_code=${exit_code}"
+            echo "duration_seconds=$((end_seconds - start_seconds))"
+          } >> "${GITHUB_OUTPUT}"
+
+          exit 0
 
       - name: Run diagnostics profile from assembled jar
-        if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
+        if: ${{ steps.schedule_window.outputs.should_run == 'true' && steps.build.outputs.exit_code == '0' }}
         id: diagnostics
         shell: bash
         run: |
@@ -150,9 +211,12 @@ jobs:
           RUN_ID: ${{ steps.meta.outputs.run_id }}
           RUN_ROOT: ${{ steps.meta.outputs.run_root }}
           COMMIT_SHA: ${{ steps.meta.outputs.sha }}
-          EXIT_CODE: ${{ steps.diagnostics.outputs.exit_code }}
-          DURATION_SECONDS: ${{ steps.diagnostics.outputs.duration_seconds }}
+          BUILD_EXIT_CODE: ${{ steps.build.outputs.exit_code }}
+          BUILD_DURATION_SECONDS: ${{ steps.build.outputs.duration_seconds }}
+          DIAGNOSTICS_EXIT_CODE: ${{ steps.diagnostics.outputs.exit_code }}
+          DIAGNOSTICS_DURATION_SECONDS: ${{ steps.diagnostics.outputs.duration_seconds }}
           MANIFEST_PATH: ${{ steps.meta.outputs.run_root }}/run-manifest.json
+          BUILD_LOG_PATH: target/nightly-diagnostics/build.log
           LOG_PATH: target/nightly-diagnostics/diagnostics.log
         run: |
           set -euo pipefail
@@ -165,15 +229,23 @@ jobs:
           profile = os.environ.get("PROFILE", "unknown")
           run_id = os.environ.get("RUN_ID", "unknown")
           commit = os.environ.get("COMMIT_SHA", "unknown")
-          exit_code = os.environ.get("EXIT_CODE") or "not-run"
-          duration = os.environ.get("DURATION_SECONDS") or "not-recorded"
+          build_exit_code = os.environ.get("BUILD_EXIT_CODE") or "not-run"
+          build_duration = os.environ.get("BUILD_DURATION_SECONDS") or "not-recorded"
+          diagnostics_exit_code = os.environ.get("DIAGNOSTICS_EXIT_CODE") or "not-run"
+          diagnostics_duration = os.environ.get("DIAGNOSTICS_DURATION_SECONDS") or "not-recorded"
           manifest_path = Path(os.environ.get("MANIFEST_PATH", ""))
+          build_log_path = Path(os.environ.get("BUILD_LOG_PATH", ""))
           log_path = Path(os.environ.get("LOG_PATH", ""))
 
           status = "MISSING_MANIFEST"
           reason = ""
           failed_step = ""
-          if manifest_path.is_file():
+          if build_exit_code not in ("0", "not-run"):
+              status = "BUILD_FAILED"
+              if build_log_path.is_file():
+                  lines = build_log_path.read_text(errors="replace").splitlines()
+                  reason = "\n".join(lines[-40:])
+          elif manifest_path.is_file():
               try:
                   data = json.loads(manifest_path.read_text())
                   status = data.get("status", "UNKNOWN")
@@ -198,8 +270,10 @@ jobs:
               out.write(f"- Profile: `{profile}`\n")
               out.write(f"- Commit: `{commit}`\n")
               out.write(f"- Run id: `{run_id}`\n")
-              out.write(f"- Exit code: `{exit_code}`\n")
-              out.write(f"- Runtime seconds: `{duration}`\n")
+              out.write(f"- Build exit code: `{build_exit_code}`\n")
+              out.write(f"- Build runtime seconds: `{build_duration}`\n")
+              out.write(f"- Diagnostics exit code: `{diagnostics_exit_code}`\n")
+              out.write(f"- Diagnostics runtime seconds: `{diagnostics_duration}`\n")
               out.write(f"- Manifest: `{manifest_path}`\n")
               if failed_step:
                   out.write(f"- Failed step: `{failed_step}`\n")
@@ -210,6 +284,9 @@ jobs:
                   out.write("\n```\n")
           PY
 
-          if [[ "${EXIT_CODE:-}" =~ ^[0-9]+$ ]] && [[ "${EXIT_CODE}" != "0" ]]; then
-            exit "${EXIT_CODE}"
+          if [[ "${BUILD_EXIT_CODE:-}" =~ ^[0-9]+$ ]] && [[ "${BUILD_EXIT_CODE}" != "0" ]]; then
+            exit "${BUILD_EXIT_CODE}"
+          fi
+          if [[ "${DIAGNOSTICS_EXIT_CODE:-}" =~ ^[0-9]+$ ]] && [[ "${DIAGNOSTICS_EXIT_CODE}" != "0" ]]; then
+            exit "${DIAGNOSTICS_EXIT_CODE}"
           fi

--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -1,0 +1,179 @@
+name: Nightly Diagnostics
+
+on:
+  schedule:
+    # GitHub cron is UTC. 22:30 UTC is 23:30 Warsaw in CET and 00:30 Warsaw in
+    # CEST, avoiding a DST-dependent attempt to mean exact local midnight.
+    - cron: "30 22 * * *"
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "Diagnostics profile to run from the assembled jar"
+        required: true
+        default: nightly
+        type: choice
+        options:
+          - smoke
+          - nightly
+          - extended
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-diagnostics-${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }}
+  cancel-in-progress: false
+
+jobs:
+  diagnostics:
+    name: Run ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }} diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      PROFILE: ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }}
+      OUT_DIR: target/nightly-diagnostics
+      JAR_PATH: target/scala-3.8.2/amor-fati.jar
+    steps:
+      - name: Check out HEAD of main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v31.10.6
+
+      - name: Resolve diagnostics run metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short HEAD)"
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            run_id="${PROFILE}-$(date -u +%Y%m%d)-${short_sha}"
+          else
+            run_id="${PROFILE}-manual-$(date -u +%Y%m%d-%H%M)-${short_sha}"
+          fi
+          run_root="${OUT_DIR}/${PROFILE}/${run_id}"
+
+          {
+            echo "sha=${sha}"
+            echo "short_sha=${short_sha}"
+            echo "run_id=${run_id}"
+            echo "run_root=${run_root}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Nightly Diagnostics"
+            echo
+            echo "- Profile: \`${PROFILE}\`"
+            echo "- Commit: \`${sha}\`"
+            echo "- Run id: \`${run_id}\`"
+            echo "- Output root: \`${run_root}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Build assembled jar under Nix
+        run: nix develop --command sbt assembly
+
+      - name: Run diagnostics profile from assembled jar
+        id: diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${OUT_DIR}"
+          export GITHUB_REF_NAME=main
+          export GITHUB_SHA="${{ steps.meta.outputs.sha }}"
+
+          start_seconds="$(date +%s)"
+          set +e
+          nix develop --command java -cp "${JAR_PATH}" \
+            com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner \
+            --profile "${PROFILE}" \
+            --out "${OUT_DIR}" \
+            --run-id "${{ steps.meta.outputs.run_id }}" \
+            --jar-path "${JAR_PATH}" \
+            --require-main 2>&1 | tee "${OUT_DIR}/diagnostics.log"
+          exit_code="${PIPESTATUS[0]}"
+          set -e
+          end_seconds="$(date +%s)"
+
+          {
+            echo "exit_code=${exit_code}"
+            echo "duration_seconds=$((end_seconds - start_seconds))"
+          } >> "${GITHUB_OUTPUT}"
+
+          exit 0
+
+      - name: Report diagnostics result
+        if: always()
+        shell: bash
+        env:
+          RUN_ID: ${{ steps.meta.outputs.run_id }}
+          RUN_ROOT: ${{ steps.meta.outputs.run_root }}
+          COMMIT_SHA: ${{ steps.meta.outputs.sha }}
+          EXIT_CODE: ${{ steps.diagnostics.outputs.exit_code }}
+          DURATION_SECONDS: ${{ steps.diagnostics.outputs.duration_seconds }}
+          MANIFEST_PATH: ${{ steps.meta.outputs.run_root }}/run-manifest.json
+          LOG_PATH: target/nightly-diagnostics/diagnostics.log
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          profile = os.environ.get("PROFILE", "unknown")
+          run_id = os.environ.get("RUN_ID", "unknown")
+          commit = os.environ.get("COMMIT_SHA", "unknown")
+          exit_code = os.environ.get("EXIT_CODE") or "not-run"
+          duration = os.environ.get("DURATION_SECONDS") or "not-recorded"
+          manifest_path = Path(os.environ.get("MANIFEST_PATH", ""))
+          log_path = Path(os.environ.get("LOG_PATH", ""))
+
+          status = "MISSING_MANIFEST"
+          reason = ""
+          failed_step = ""
+          if manifest_path.is_file():
+              try:
+                  data = json.loads(manifest_path.read_text())
+                  status = data.get("status", "UNKNOWN")
+                  reason = data.get("error") or ""
+                  for step in data.get("steps", []):
+                      if step.get("status") == "FAILED":
+                          failed_step = step.get("id", "")
+                          reason = reason or step.get("error") or ""
+                          break
+              except Exception as exc:
+                  status = "MALFORMED_MANIFEST"
+                  reason = f"{type(exc).__name__}: {exc}"
+          elif log_path.is_file():
+              lines = log_path.read_text(errors="replace").splitlines()
+              reason = "\n".join(lines[-20:])
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a", encoding="utf-8") as out:
+              out.write("\n")
+              out.write("### Result\n\n")
+              out.write(f"- Status: `{status}`\n")
+              out.write(f"- Profile: `{profile}`\n")
+              out.write(f"- Commit: `{commit}`\n")
+              out.write(f"- Run id: `{run_id}`\n")
+              out.write(f"- Exit code: `{exit_code}`\n")
+              out.write(f"- Runtime seconds: `{duration}`\n")
+              out.write(f"- Manifest: `{manifest_path}`\n")
+              if failed_step:
+                  out.write(f"- Failed step: `{failed_step}`\n")
+              if reason:
+                  out.write("\n#### Failure Reason\n\n")
+                  out.write("```text\n")
+                  out.write(reason[-4000:])
+                  out.write("\n```\n")
+          PY
+
+          if [[ "${EXIT_CODE:-}" =~ ^[0-9]+$ ]] && [[ "${EXIT_CODE}" != "0" ]]; then
+            exit "${EXIT_CODE}"
+          fi

--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -108,13 +108,14 @@ jobs:
 
       - name: Check out HEAD of main
         if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: main
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
-      - uses: cachix/install-nix-action@v31.10.6
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
         if: ${{ steps.schedule_window.outputs.should_run == 'true' }}
 
       - name: Resolve diagnostics run metadata

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -109,6 +109,44 @@ and SHA-256 when available, command line, tool versions, step seed/month
 settings, step output directories, artifact paths, timestamps, and final
 status.
 
+## Scheduled Workflow
+
+The GitHub Actions workflow `.github/workflows/nightly-diagnostics.yml` runs the
+same jar/Nix path. It is intentionally not attached to `pull_request`, so long
+diagnostics do not block normal PR feedback.
+
+Triggers:
+
+- `schedule`: runs the `nightly` profile against `HEAD` of `main`
+- `workflow_dispatch`: lets maintainers manually select `smoke`, `nightly`, or
+  `extended`
+
+The workflow checks out `main`, builds the assembled jar with:
+
+```bash
+nix develop --command sbt assembly
+```
+
+and runs:
+
+```bash
+nix develop --command java -cp target/scala-3.8.2/amor-fati.jar \
+  com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner \
+  --profile <profile> \
+  --out target/nightly-diagnostics \
+  --run-id <resolved-run-id> \
+  --jar-path target/scala-3.8.2/amor-fati.jar \
+  --require-main
+```
+
+The scheduled cron is `30 22 * * *` UTC. This is 23:30 Warsaw during CET and
+00:30 Warsaw during CEST. The workflow deliberately chooses a stable UTC time
+instead of claiming exact local midnight across daylight-saving transitions.
+
+The job summary reports the profile, commit SHA, run id, runtime, manifest path,
+terminal status, and failure reason when the runner produces one. Uploading full
+diagnostic artifacts and retention policy is tracked separately by #635.
+
 ## Profile Matrix
 
 | Profile | Intended Trigger | Horizon | Purpose |
@@ -263,13 +301,9 @@ diagnostics. Ten-year cycle claims should return only after the long-horizon
 research milestone defines interpretation rules, diagnostics, and validation
 targets.
 
-## Future Implementation Notes
+## Implementation Notes
 
-The scheduled workflow should not encode a long list of ad hoc shell commands
-directly in YAML. Prefer a single jar-runnable diagnostics profile runner that
-executes these logical steps from a profile id, calls existing Scala
-diagnostic `run` or `runZIO` methods, emits a run manifest, and lets GitHub
-Actions select a profile such as `--profile nightly`.
-
-GitHub cron runs in UTC. Any target such as Warsaw midnight needs an explicit
-UTC and daylight-saving-time decision before the workflow is scheduled.
+The scheduled workflow does not encode a long list of ad hoc diagnostic
+commands directly in YAML. It builds the assembled jar, invokes the single
+jar-runnable diagnostics profile runner, and lets the Scala runner own profile
+step selection, manifest emission, output layout, and clean-ref validation.

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -139,9 +139,11 @@ nix develop --command java -cp target/scala-3.8.2/amor-fati.jar \
   --require-main
 ```
 
-The scheduled cron is `30 22 * * *` UTC. This is 23:30 Warsaw during CET and
-00:30 Warsaw during CEST. The workflow deliberately chooses a stable UTC time
-instead of claiming exact local midnight across daylight-saving transitions.
+The scheduled workflow targets 02:00 Europe/Warsaw. GitHub cron only supports
+UTC, so the workflow registers both `0 0 * * *` and `0 1 * * *` UTC and then
+uses a lightweight gate step to continue only when `TZ=Europe/Warsaw` resolves
+to local hour `02`. This keeps the intended Polish-time schedule across CET and
+CEST without moving the long diagnostics into PR checks.
 
 The job summary reports the profile, commit SHA, run id, runtime, manifest path,
 terminal status, and failure reason when the runner produces one. Uploading full

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -141,13 +141,18 @@ nix develop --command java -cp target/scala-3.8.2/amor-fati.jar \
 
 The scheduled workflow targets 02:00 Europe/Warsaw. GitHub cron only supports
 UTC, so the workflow registers both `0 0 * * *` and `0 1 * * *` UTC and then
-uses a lightweight gate step to continue only when `TZ=Europe/Warsaw` resolves
-to local hour `02`. This keeps the intended Polish-time schedule across CET and
-CEST without moving the long diagnostics into PR checks.
+uses a lightweight gate step to continue only for the intended local-time
+occurrence. In ordinary CEST this is `0 0 * * *`; in ordinary CET this is
+`0 1 * * *`. On the autumn DST transition, where local 02:00 occurs twice, the
+workflow keeps the second occurrence in CET and skips the first one. On the
+spring DST transition, where local 02:00 does not exist, the workflow runs at
+the first valid post-transition slot, 03:00 CEST. The gate runs before checkout
+or Nix setup, so skipped scheduled events are cheap.
 
 The job summary reports the profile, commit SHA, run id, runtime, manifest path,
-terminal status, and failure reason when the runner produces one. Uploading full
-diagnostic artifacts and retention policy is tracked separately by #635.
+terminal status, build/runtime exit codes, and failure reason when either the
+build or diagnostics runner produces one. Uploading full diagnostic artifacts
+and retention policy is tracked separately by #635.
 
 ## Profile Matrix
 


### PR DESCRIPTION
## Summary
- add a dedicated Nightly Diagnostics workflow with scheduled and manual triggers
- run diagnostics against checkout of `HEAD` on `main` using the Nix + assembled-jar profile runner path
- report profile, commit SHA, run id, build/runtime durations, build/runtime exit codes, manifest path, terminal status, and failure reason in the job summary
- schedule for 02:00 Europe/Warsaw with explicit DST handling: ordinary CET/CEST, spring gap fallback, and autumn duplicate-hour de-duplication
- document the workflow, UTC/DST decision, and separation from artifact upload policy

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-diagnostics.yml"); puts "workflow yaml ok"'`
- `git diff --check`
- local Python model check for 2026 winter, summer, spring DST, and autumn DST gate cases

Notes: full diagnostic execution is not repeated here; #633 already validated the same jar/Nix runner path, and this change wires it into GitHub Actions without attaching it to PR checks.

Closes #632