### PR TITLE
Converge diagnostic CSV exports

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -5,10 +5,11 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.montecarlo.{McCsvFile, McCsvSchema}
 import com.boombustgroup.amorfati.types.*
+import zio.ZIO
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import scala.math.BigDecimal.RoundingMode
 import scala.util.Try
 
@@ -449,23 +450,26 @@ object BankBalanceSheetBenchmarkExport:
             result.paths.foreach(path => println(path.toString))
 
   def run(config: Config): Either[String, ExportResult] =
-    validate(config).flatMap: validConfig =>
-      given SimParams = SimParams.defaults
+    DiagnosticIo.unsafeRun(runZIO(config))
 
-      val attempts = validConfig.seedRange.map: seed =>
-        Try(WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))).toEither.left
-          .map(ex => s"Seed $seed crashed during initialization: ${ex.getMessage}")
-          .map(init => computeSeed(validConfig, seed, init))
+  def runZIO(config: Config): ZIO[Any, String, ExportResult] =
+    ZIO
+      .fromEither(validate(config))
+      .flatMap: validConfig =>
+        given SimParams = SimParams.defaults
 
-      attempts.collectFirst { case Left(err) => err } match
-        case Some(err) => Left(err)
-        case None      =>
-          val results     = attempts.collect { case Right(result) => result }
-          val seedMetrics = results.flatMap(_._1)
-          val bankRows    = results.flatMap(_._2)
-          val summary     = summarize(validConfig, seedMetrics)
-          val paths       = writeArtifacts(validConfig, seedMetrics, summary, bankRows)
-          Right(ExportResult(paths, seedMetrics, summary, bankRows))
+        for
+          results    <- ZIO.foreach(validConfig.seedRange): seed =>
+            ZIO
+              .attempt:
+                val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
+                computeSeed(validConfig, seed, init)
+              .mapError(ex => s"Seed $seed crashed during initialization or benchmark computation: ${ex.getMessage}")
+          seedMetrics = results.flatMap(_._1)
+          bankRows    = results.flatMap(_._2)
+          summary     = summarize(validConfig, seedMetrics)
+          paths      <- writeArtifactsZIO(validConfig, seedMetrics, summary, bankRows)
+        yield ExportResult(paths, seedMetrics, summary, bankRows)
 
   def parseArgs(args: Vector[String]): Either[String, Config] =
     def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
@@ -549,106 +553,125 @@ object BankBalanceSheetBenchmarkExport:
     val rows    = context.rows.map(_.copy(runId = config.runId))
     (metrics, rows)
 
-  private def writeArtifacts(
+  private def writeArtifactsZIO(
       config: Config,
       seedMetrics: Vector[SeedMetric],
       summary: Vector[SummaryMetric],
       bankRows: Vector[BankRow],
-  ): Vector[Path] =
-    Files.createDirectories(config.runRoot)
+  ): ZIO[Any, String, Vector[Path]] =
     val seedMetricsPath = config.runRoot.resolve("bank-balance-sheet-seed-metrics.csv")
-    val summaryPath     = config.runRoot.resolve("bank-balance-sheet-summary.csv")
-    val targetPath      = config.runRoot.resolve("bank-balance-sheet-targets.csv")
+    val summaryCsvPath  = config.runRoot.resolve("bank-balance-sheet-summary.csv")
+    val targetCsvPath   = config.runRoot.resolve("bank-balance-sheet-targets.csv")
     val bankRowsPath    = config.runRoot.resolve("bank-balance-sheet-bank-rows.csv")
-    val reportPath      = config.runRoot.resolve("bank-balance-sheet-report.md")
-    Files.writeString(seedMetricsPath, renderSeedMetricsCsv(seedMetrics), StandardCharsets.UTF_8)
-    Files.writeString(summaryPath, renderSummaryCsv(summary), StandardCharsets.UTF_8)
-    Files.writeString(targetPath, renderTargetsCsv(Targets), StandardCharsets.UTF_8)
-    Files.writeString(bankRowsPath, renderBankRowsCsv(bankRows), StandardCharsets.UTF_8)
-    Files.writeString(reportPath, renderReport(config, summary), StandardCharsets.UTF_8)
-    Vector(seedMetricsPath, summaryPath, targetPath, bankRowsPath, reportPath)
+    val reportMdPath    = config.runRoot.resolve("bank-balance-sheet-report.md")
+    for
+      seedPath    <- McCsvFile.writeAll(seedMetricsPath, seedMetrics, SeedMetricsCsvSchema)(DiagnosticIo.outputFailure)
+      summaryPath <- McCsvFile.writeAll(summaryCsvPath, summary, SummaryCsvSchema)(DiagnosticIo.outputFailure)
+      targetPath  <- McCsvFile.writeAll(targetCsvPath, Targets, TargetsCsvSchema)(DiagnosticIo.outputFailure)
+      bankPath    <- McCsvFile.writeAll(bankRowsPath, bankRows, BankRowsCsvSchema)(DiagnosticIo.outputFailure)
+      reportPath  <- DiagnosticIo.writeText(reportMdPath, renderReport(config, summary))
+    yield Vector(seedPath, summaryPath, targetPath, bankPath, reportPath)
+
+  private[diagnostics] val SeedMetricsCsvSchema: McCsvSchema[SeedMetric] =
+    McCsvSchema(
+      header = "RunId;Seed;Metric;Label;Value;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation",
+      render = row =>
+        Vector(
+          row.runId,
+          row.seed.toString,
+          row.target.id,
+          row.target.label,
+          renderValue(row.value),
+          row.target.unit,
+          row.target.guardrailClass.token,
+          row.target.vintage,
+          row.target.lower.map(renderDecimal).getOrElse(""),
+          row.target.upper.map(renderDecimal).getOrElse(""),
+          row.status.token,
+          row.target.sourceNote,
+          row.target.interpretation,
+        ).map(csv).mkString(";"),
+    )
+
+  private[diagnostics] val SummaryCsvSchema: McCsvSchema[SummaryMetric] =
+    McCsvSchema(
+      header = "RunId;Seeds;Metric;Label;Mean;Min;Max;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation",
+      render = row =>
+        Vector(
+          row.runId,
+          row.seeds.toString,
+          row.target.id,
+          row.target.label,
+          renderValue(row.mean),
+          row.min.map(renderDecimal).getOrElse(""),
+          row.max.map(renderDecimal).getOrElse(""),
+          row.target.unit,
+          row.target.guardrailClass.token,
+          row.target.vintage,
+          row.target.lower.map(renderDecimal).getOrElse(""),
+          row.target.upper.map(renderDecimal).getOrElse(""),
+          row.status.token,
+          row.target.sourceNote,
+          row.target.interpretation,
+        ).map(csv).mkString(";"),
+    )
+
+  private[diagnostics] val TargetsCsvSchema: McCsvSchema[TargetBand] =
+    McCsvSchema(
+      header = "Metric;Label;Unit;GuardrailClass;Vintage;Lower;Upper;SourceNote;Interpretation",
+      render = target =>
+        Vector(
+          target.id,
+          target.label,
+          target.unit,
+          target.guardrailClass.token,
+          target.vintage,
+          target.lower.map(renderDecimal).getOrElse(""),
+          target.upper.map(renderDecimal).getOrElse(""),
+          target.sourceNote,
+          target.interpretation,
+        ).map(csv).mkString(";"),
+    )
+
+  private[diagnostics] val BankRowsCsvSchema: McCsvSchema[BankRow] =
+    McCsvSchema(
+      header =
+        "RunId;Seed;BankId;BankName;Capital;Assets;Deposits;TotalCredit;CapitalAdequacyRatio;EffectiveMinCar;CarBuffer;Lcr;Nsfr;CreditShare;DepositShare;AssetShare",
+      render = row =>
+        Vector(
+          row.runId,
+          row.seed.toString,
+          row.bankId.toString,
+          row.bankName,
+          renderPln(row.capital),
+          renderPln(row.assets),
+          renderPln(row.deposits),
+          renderPln(row.totalCredit),
+          renderDecimal(row.capitalAdequacyRatio),
+          renderDecimal(row.effectiveMinCar),
+          renderDecimal(row.carBuffer),
+          renderDecimal(row.lcr),
+          renderDecimal(row.nsfr),
+          renderDecimal(row.creditShare),
+          renderDecimal(row.depositShare),
+          renderDecimal(row.assetShare),
+        ).map(csv).mkString(";"),
+    )
 
   private[diagnostics] def renderSeedMetricsCsv(rows: Vector[SeedMetric]): String =
-    val header = "RunId;Seed;Metric;Label;Value;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
-    val body   = rows.map: row =>
-      Vector(
-        row.runId,
-        row.seed.toString,
-        row.target.id,
-        row.target.label,
-        renderValue(row.value),
-        row.target.unit,
-        row.target.guardrailClass.token,
-        row.target.vintage,
-        row.target.lower.map(renderDecimal).getOrElse(""),
-        row.target.upper.map(renderDecimal).getOrElse(""),
-        row.status.token,
-        row.target.sourceNote,
-        row.target.interpretation,
-      ).map(csv).mkString(";")
-    (header +: body).mkString("\n") + "\n"
+    renderCsv(SeedMetricsCsvSchema, rows)
 
   private[diagnostics] def renderSummaryCsv(rows: Vector[SummaryMetric]): String =
-    val header = "RunId;Seeds;Metric;Label;Mean;Min;Max;Unit;GuardrailClass;Vintage;Lower;Upper;Status;SourceNote;Interpretation"
-    val body   = rows.map: row =>
-      Vector(
-        row.runId,
-        row.seeds.toString,
-        row.target.id,
-        row.target.label,
-        renderValue(row.mean),
-        row.min.map(renderDecimal).getOrElse(""),
-        row.max.map(renderDecimal).getOrElse(""),
-        row.target.unit,
-        row.target.guardrailClass.token,
-        row.target.vintage,
-        row.target.lower.map(renderDecimal).getOrElse(""),
-        row.target.upper.map(renderDecimal).getOrElse(""),
-        row.status.token,
-        row.target.sourceNote,
-        row.target.interpretation,
-      ).map(csv).mkString(";")
-    (header +: body).mkString("\n") + "\n"
+    renderCsv(SummaryCsvSchema, rows)
 
   private[diagnostics] def renderTargetsCsv(targets: Vector[TargetBand]): String =
-    val header = "Metric;Label;Unit;GuardrailClass;Vintage;Lower;Upper;SourceNote;Interpretation"
-    val body   = targets.map: target =>
-      Vector(
-        target.id,
-        target.label,
-        target.unit,
-        target.guardrailClass.token,
-        target.vintage,
-        target.lower.map(renderDecimal).getOrElse(""),
-        target.upper.map(renderDecimal).getOrElse(""),
-        target.sourceNote,
-        target.interpretation,
-      ).map(csv).mkString(";")
-    (header +: body).mkString("\n") + "\n"
+    renderCsv(TargetsCsvSchema, targets)
 
   private[diagnostics] def renderBankRowsCsv(rows: Vector[BankRow]): String =
-    val header =
-      "RunId;Seed;BankId;BankName;Capital;Assets;Deposits;TotalCredit;CapitalAdequacyRatio;EffectiveMinCar;CarBuffer;Lcr;Nsfr;CreditShare;DepositShare;AssetShare"
-    val body   = rows.map: row =>
-      Vector(
-        row.runId,
-        row.seed.toString,
-        row.bankId.toString,
-        row.bankName,
-        renderPln(row.capital),
-        renderPln(row.assets),
-        renderPln(row.deposits),
-        renderPln(row.totalCredit),
-        renderDecimal(row.capitalAdequacyRatio),
-        renderDecimal(row.effectiveMinCar),
-        renderDecimal(row.carBuffer),
-        renderDecimal(row.lcr),
-        renderDecimal(row.nsfr),
-        renderDecimal(row.creditShare),
-        renderDecimal(row.depositShare),
-        renderDecimal(row.assetShare),
-      ).map(csv).mkString(";")
-    (header +: body).mkString("\n") + "\n"
+    renderCsv(BankRowsCsvSchema, rows)
+
+  private def renderCsv[A](schema: McCsvSchema[A], rows: Vector[A]): String =
+    (schema.header +: rows.map(schema.render)).mkString("\n") + "\n"
 
   private[diagnostics] def renderReport(config: Config, summary: Vector[SummaryMetric]): String =
     val command     =

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/EmpiricalValidationExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/EmpiricalValidationExport.scala
@@ -1,6 +1,8 @@
 package com.boombustgroup.amorfati.diagnostics
 
+import com.boombustgroup.amorfati.montecarlo.{McCsvFile, McCsvSchema}
 import com.boombustgroup.amorfati.util.BuildInfo
+import zio.ZIO
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -177,15 +179,18 @@ object EmpiricalValidationExport:
             result.paths.foreach(path => println(path.toString))
 
   def run(config: Config): Either[String, ExportResult] =
-    validate(config).flatMap: validConfig =>
-      for
-        sourceRows <- readSourceManifest(validConfig.sourceManifest)
-        baseRun    <- readOrBuildRunManifest(validConfig)
-        modelRun   <- inferSeedCount(baseRun)
-        output     <- MonteCarloOutput.load(modelRun)
-        snapshot    = buildSnapshot(sourceRows, modelRun, output)
-        paths      <- writeArtifacts(validConfig.out, sourceRows, modelRun, snapshot)
-      yield ExportResult(paths, snapshot)
+    DiagnosticIo.unsafeRun(runZIO(config))
+
+  def runZIO(config: Config): ZIO[Any, String, ExportResult] =
+    for
+      validConfig <- ZIO.fromEither(validate(config))
+      sourceRows  <- ZIO.fromEither(readSourceManifest(validConfig.sourceManifest))
+      baseRun     <- ZIO.fromEither(readOrBuildRunManifest(validConfig))
+      modelRun    <- ZIO.fromEither(inferSeedCount(baseRun))
+      output      <- ZIO.fromEither(MonteCarloOutput.load(modelRun))
+      snapshot     = buildSnapshot(sourceRows, modelRun, output)
+      paths       <- writeArtifactsZIO(validConfig.out, sourceRows, modelRun, snapshot)
+    yield ExportResult(paths, snapshot)
 
   def parseArgs(args: Vector[String]): Either[String, CliCommand] =
     def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
@@ -393,22 +398,20 @@ object EmpiricalValidationExport:
             base
     derived.mkString(" ")
 
-  private def writeArtifacts(
+  private def writeArtifactsZIO(
       out: Path,
       sourceRows: Vector[SourceManifestRow],
       modelRun: ModelRunManifest,
       snapshot: Vector[SnapshotRow],
-  ): Either[String, Vector[Path]] =
-    Try {
-      Files.createDirectories(out)
-      val sourceManifestPath = out.resolve("source-manifest.csv")
-      val runManifestPath    = out.resolve("model-run-manifest.csv")
-      val snapshotCsvPath    = out.resolve("baseline-validation-snapshot.csv")
-      Files.writeString(sourceManifestPath, renderSourceManifest(sourceRows), StandardCharsets.UTF_8)
-      Files.writeString(runManifestPath, renderModelRunManifest(modelRun), StandardCharsets.UTF_8)
-      Files.writeString(snapshotCsvPath, renderSnapshotCsv(snapshot), StandardCharsets.UTF_8)
-      Vector(sourceManifestPath, runManifestPath, snapshotCsvPath)
-    }.toEither.left.map(err => s"Failed to write empirical validation artifacts: ${err.getMessage}")
+  ): ZIO[Any, String, Vector[Path]] =
+    val sourceManifestPath = out.resolve("source-manifest.csv")
+    val runManifestPath    = out.resolve("model-run-manifest.csv")
+    val snapshotCsvPath    = out.resolve("baseline-validation-snapshot.csv")
+    for
+      sourcePath   <- McCsvFile.writeAll(sourceManifestPath, sourceRows, SourceManifestCsvSchema)(DiagnosticIo.outputFailure)
+      runPath      <- McCsvFile.writeAll(runManifestPath, Vector(modelRun), ModelRunManifestCsvSchema)(DiagnosticIo.outputFailure)
+      snapshotPath <- McCsvFile.writeAll(snapshotCsvPath, snapshot, SnapshotCsvSchema)(DiagnosticIo.outputFailure)
+    yield Vector(sourcePath, runPath, snapshotPath)
 
   private final case class MonteCarloOutput(
       timeSeries: Vector[Vector[CsvRow]],
@@ -577,62 +580,69 @@ object EmpiricalValidationExport:
         cells += cell.toString
         Right(cells.result().map(_.trim))
 
-  private def renderSourceManifest(rows: Vector[SourceManifestRow]): String =
-    val body = rows.map: row =>
-      Vector(
-        row.target,
-        row.sourceProvider,
-        row.sourceUrl,
-        row.datasetCode,
-        row.vintage,
-        row.accessedAt.map(_.toString).getOrElse(""),
-        row.licenseOrReuseNote,
-        row.frequency,
-        row.unit,
-        row.transformation,
-        row.modelTarget.render,
-        row.status.token,
-        row.empiricalValue.map(formatDecimal).getOrElse(""),
-        row.tolerance.map(formatDecimal).getOrElse(""),
-        row.criterion,
-        row.notes,
-      ).map(csv).mkString(";")
-    (SourceManifestHeader.mkString(";") +: body).mkString("\n") + "\n"
+  private[diagnostics] lazy val SourceManifestCsvSchema: McCsvSchema[SourceManifestRow] =
+    McCsvSchema(
+      header = SourceManifestHeader.mkString(";"),
+      render = row =>
+        Vector(
+          row.target,
+          row.sourceProvider,
+          row.sourceUrl,
+          row.datasetCode,
+          row.vintage,
+          row.accessedAt.map(_.toString).getOrElse(""),
+          row.licenseOrReuseNote,
+          row.frequency,
+          row.unit,
+          row.transformation,
+          row.modelTarget.render,
+          row.status.token,
+          row.empiricalValue.map(formatDecimal).getOrElse(""),
+          row.tolerance.map(formatDecimal).getOrElse(""),
+          row.criterion,
+          row.notes,
+        ).map(csv).mkString(";"),
+    )
 
-  private def renderModelRunManifest(manifest: ModelRunManifest): String =
-    val row = Vector(
-      manifest.runId,
-      manifest.outputPrefix,
-      manifest.durationMonths.toString,
-      manifest.seedCount.toString,
-      manifest.commit,
-      manifest.parameterBranch,
-      manifest.outputDir.toString,
-    ).map(csv).mkString(";")
-    Vector(ModelRunManifestHeader.mkString(";"), row).mkString("\n") + "\n"
+  private[diagnostics] lazy val ModelRunManifestCsvSchema: McCsvSchema[ModelRunManifest] =
+    McCsvSchema(
+      header = ModelRunManifestHeader.mkString(";"),
+      render = manifest =>
+        Vector(
+          manifest.runId,
+          manifest.outputPrefix,
+          manifest.durationMonths.toString,
+          manifest.seedCount.toString,
+          manifest.commit,
+          manifest.parameterBranch,
+          manifest.outputDir.toString,
+        ).map(csv).mkString(";"),
+    )
 
-  private def renderSnapshotCsv(rows: Vector[SnapshotRow]): String =
-    val body = rows.map: row =>
-      Vector(
-        row.target,
-        row.sourceProvider,
-        row.sourceUrl,
-        row.datasetCode,
-        row.vintage,
-        row.accessedAt.map(_.toString).getOrElse(""),
-        row.frequency,
-        row.unit,
-        row.transformation,
-        row.modelRun,
-        row.modelTarget,
-        row.empiricalValue.map(formatSnapshotDecimal).getOrElse(""),
-        row.modelValue.map(formatSnapshotDecimal).getOrElse(""),
-        row.tolerance.map(formatSnapshotDecimal).getOrElse(""),
-        row.criterion,
-        row.status.token,
-        row.notes,
-      ).map(csv).mkString(";")
-    (SnapshotHeader.mkString(";") +: body).mkString("\n") + "\n"
+  private[diagnostics] lazy val SnapshotCsvSchema: McCsvSchema[SnapshotRow] =
+    McCsvSchema(
+      header = SnapshotHeader.mkString(";"),
+      render = row =>
+        Vector(
+          row.target,
+          row.sourceProvider,
+          row.sourceUrl,
+          row.datasetCode,
+          row.vintage,
+          row.accessedAt.map(_.toString).getOrElse(""),
+          row.frequency,
+          row.unit,
+          row.transformation,
+          row.modelRun,
+          row.modelTarget,
+          row.empiricalValue.map(formatSnapshotDecimal).getOrElse(""),
+          row.modelValue.map(formatSnapshotDecimal).getOrElse(""),
+          row.tolerance.map(formatSnapshotDecimal).getOrElse(""),
+          row.criterion,
+          row.status.token,
+          row.notes,
+        ).map(csv).mkString(";"),
+    )
 
   private def csv(value: String): String =
     if value.exists(ch => ch == ';' || ch == '"' || ch == '\n') then "\"" + value.replace("\"", "\"\"") + "\""

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LoanOriginationQualityExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LoanOriginationQualityExport.scala
@@ -1,17 +1,15 @@
 package com.boombustgroup.amorfati.diagnostics
 
-import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
 import com.boombustgroup.amorfati.agents.{Banking, BankruptReason, Firm, HhFinancialDistressState, HhStatus, Household, TechState}
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, LedgerFinancialState}
-import com.boombustgroup.amorfati.engine.{MonthDriver, MonthRandomness}
 import com.boombustgroup.amorfati.fp.FixedPointBase
-import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
+import com.boombustgroup.amorfati.montecarlo.{McCsvFile, McCsvSchema, McDiagnosticRunner, McSeedMonth}
 import com.boombustgroup.amorfati.types.*
+import zio.ZIO
+import zio.stream.ZStream
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import scala.math.BigDecimal.RoundingMode
 import scala.util.Try
 
@@ -132,10 +130,20 @@ object LoanOriginationQualityExport:
 
   final case class ExportResult(
       paths: Vector[Path],
-      householdRows: Vector[HhOriginationRow],
-      firmRows: Vector[FirmOriginationRow],
       summaryRows: Vector[SummaryRow],
   )
+
+  private final case class ReportStats(
+      householdRows: Int,
+      householdBadRows: Int,
+      firmRows: Int,
+      firmBadRows: Int,
+  ):
+    def householdBadRate: Option[BigDecimal] =
+      if householdRows > 0 then Some(BigDecimal(householdBadRows) / BigDecimal(householdRows)) else None
+
+    def firmBadRate: Option[BigDecimal] =
+      if firmRows > 0 then Some(BigDecimal(firmBadRows) / BigDecimal(firmRows)) else None
 
   private final case class HhMonthOutcome(
       month: Int,
@@ -170,10 +178,189 @@ object LoanOriginationQualityExport:
       approvedPrincipal: PLN,
   )
 
-  private final case class SeedRawRows(
-      householdRows: Vector[HhOriginationRow],
-      firmRows: Vector[FirmOriginationRow],
+  private enum LoanRow:
+    case Household(row: HhOriginationRow)
+    case Firm(row: FirmOriginationRow)
+
+  private final case class CohortKey(
+      borrowerType: String,
+      cohortType: String,
+      cohortValue: String,
   )
+
+  private final class CohortAccumulator:
+    private var rowCount          = 0
+    private var approvedRowCount  = 0
+    private var rejectedRowCount  = 0
+    private var approvedPrincipal = PLN.Zero
+    private var futureBadRowCount = 0
+    private var riskRatioSum      = BigDecimal(0)
+    private var riskRatioCount    = 0
+    private var bankCarSum        = BigDecimal(0)
+    private var bankCarCount      = 0
+
+    def add(
+        approved: Boolean,
+        rejected: Boolean,
+        principal: PLN,
+        futureBad: Boolean,
+        riskRatio: Option[BigDecimal],
+        bankCar: BigDecimal,
+    ): Unit =
+      rowCount += 1
+      if approved then approvedRowCount += 1
+      if rejected then rejectedRowCount += 1
+      approvedPrincipal += principal
+      if futureBad then futureBadRowCount += 1
+      riskRatio.foreach: value =>
+        riskRatioSum += value
+        riskRatioCount += 1
+      bankCarSum += bankCar
+      bankCarCount += 1
+
+    def toSummaryRow(runId: String, key: CohortKey): SummaryRow =
+      SummaryRow(
+        runId = runId,
+        borrowerType = key.borrowerType,
+        cohortType = key.cohortType,
+        cohortValue = key.cohortValue,
+        rows = rowCount,
+        approvedRows = approvedRowCount,
+        rejectedRows = rejectedRowCount,
+        approvedPrincipal = approvedPrincipal,
+        futureBadRows = futureBadRowCount,
+        futureBadRate = if rowCount > 0 then Some(BigDecimal(futureBadRowCount) / BigDecimal(rowCount)) else None,
+        meanRiskRatio = if riskRatioCount > 0 then Some((riskRatioSum / BigDecimal(riskRatioCount)).setScale(6, RoundingMode.HALF_UP)) else None,
+        meanBankCar = if bankCarCount > 0 then Some((bankCarSum / BigDecimal(bankCarCount)).setScale(6, RoundingMode.HALF_UP)) else None,
+        interpretation = key.borrowerType match
+          case "Household" => "HH future bad rows mean later default/write-off or bankruptcy inside the configured observation window."
+          case "Firm"      => "Firm future bad rows mean later bankruptcy inside the configured observation window; mean risk ratio is DSCR proxy."
+          case other       => s"$other future bad rows are diagnostic cohort counts.",
+      )
+
+  private final class LoanSummaryAccumulator:
+    private val cohorts = scala.collection.mutable.Map.empty[CohortKey, CohortAccumulator]
+    private var hhRows  = 0
+    private var hhBad   = 0
+    private var fRows   = 0
+    private var fBad    = 0
+
+    def add(row: LoanRow): LoanSummaryAccumulator =
+      row match
+        case LoanRow.Household(hh) => addHousehold(hh)
+        case LoanRow.Firm(firm)    => addFirm(firm)
+      this
+
+    def reportStats: ReportStats =
+      ReportStats(hhRows, hhBad, fRows, fBad)
+
+    def summaryRows(runId: String): Vector[SummaryRow] =
+      HouseholdCohortTypes.flatMap(cohortRows(runId, "Household", _)) ++
+        FirmCohortTypes.flatMap(cohortRows(runId, "Firm", _))
+
+    private def addHousehold(row: HhOriginationRow): Unit =
+      val futureBad = row.futureDefaultWithinWindow || row.futureBankruptcyWithinWindow
+      hhRows += 1
+      if futureBad then hhBad += 1
+      householdCohorts(row).foreach: (cohortType, cohortValue) =>
+        addCohort(
+          CohortKey("Household", cohortType, cohortValue),
+          approved = row.approvedPrincipal > PLN.Zero,
+          rejected = row.rejectedPrincipal > PLN.Zero || row.bankRejectedPrincipal > PLN.Zero,
+          approvedPrincipal = row.approvedPrincipal,
+          futureBad = futureBad,
+          riskRatio = row.totalDsr,
+          bankCar = row.bankCar,
+        )
+
+    private def addFirm(row: FirmOriginationRow): Unit =
+      val futureBad = row.futureBankruptWithinWindow || row.sameMonthBankrupt
+      fRows += 1
+      if futureBad then fBad += 1
+      firmCohorts(row).foreach: (cohortType, cohortValue) =>
+        addCohort(
+          CohortKey("Firm", cohortType, cohortValue),
+          approved = row.approvedPrincipal > PLN.Zero,
+          rejected = row.bankRejected,
+          approvedPrincipal = row.approvedPrincipal,
+          futureBad = futureBad,
+          riskRatio = row.dscrProxy,
+          bankCar = row.bankCar,
+        )
+
+    private def addCohort(
+        key: CohortKey,
+        approved: Boolean,
+        rejected: Boolean,
+        approvedPrincipal: PLN,
+        futureBad: Boolean,
+        riskRatio: Option[BigDecimal],
+        bankCar: BigDecimal,
+    ): Unit =
+      val cohort = cohorts.getOrElseUpdate(key, new CohortAccumulator)
+      cohort.add(approved, rejected, approvedPrincipal, futureBad, riskRatio, bankCar)
+
+    private def cohortRows(runId: String, borrowerType: String, cohortType: String): Vector[SummaryRow] =
+      cohorts
+        .collect:
+          case (key, accumulator) if key.borrowerType == borrowerType && key.cohortType == cohortType =>
+            accumulator.toSummaryRow(runId, key)
+        .toVector
+        .sortBy(_.cohortValue)
+
+  private final class SeedRowWindow(config: Config, seed: Long)(using SimParams):
+    private val rawHhEvents   = scala.collection.mutable.Map.empty[Int, scala.collection.mutable.ArrayBuffer[HhOriginationRow]]
+    private val rawFirmEvents = scala.collection.mutable.Map.empty[Int, scala.collection.mutable.ArrayBuffer[FirmOriginationRow]]
+    private val hhOutcomes    = scala.collection.mutable.Map.empty[(Int, Int), HhMonthOutcome]
+    private val firmOutcomes  = scala.collection.mutable.Map.empty[(Int, Int), FirmMonthOutcome]
+
+    def observe(month: McSeedMonth): Vector[LoanRow] =
+      val monthHhEvents    = scala.collection.mutable.ArrayBuffer.empty[(HhOriginationRow, Int)]
+      val monthFirmEvents  = scala.collection.mutable.ArrayBuffer.empty[(FirmOriginationRow, Int)]
+      val monthHhOutcomes  = scala.collection.mutable.ArrayBuffer.empty[HhMonthOutcome]
+      val monthFirmOutcome = scala.collection.mutable.ArrayBuffer.empty[FirmMonthOutcome]
+
+      collectHouseholdMonth(config, seed, month, monthHhEvents, monthHhOutcomes)
+      collectFirmMonth(config, seed, month, monthFirmEvents, monthFirmOutcome)
+
+      monthHhEvents.foreach: (row, originationMonth) =>
+        rawHhEvents.getOrElseUpdate(originationMonth, scala.collection.mutable.ArrayBuffer.empty) += row
+      monthFirmEvents.foreach: (row, originationMonth) =>
+        rawFirmEvents.getOrElseUpdate(originationMonth, scala.collection.mutable.ArrayBuffer.empty) += row
+      monthHhOutcomes.foreach(outcome => hhOutcomes += ((outcome.householdId, outcome.month) -> outcome))
+      monthFirmOutcome.foreach(outcome => firmOutcomes += ((outcome.firmId, outcome.month) -> outcome))
+
+      flushReady(month.executionMonth.toInt, force = false)
+
+    def finish(): Vector[LoanRow] =
+      flushReady(config.months, force = true)
+
+    private def flushReady(currentMonth: Int, force: Boolean): Vector[LoanRow] =
+      val readyMonths = pendingOriginationMonths.filter(origin => force || origin + config.outcomeWindow <= currentMonth).sorted
+      if readyMonths.isEmpty then Vector.empty
+      else
+        val hhByKey   = hhOutcomes.toMap
+        val firmByKey = firmOutcomes.toMap
+        val rows      = readyMonths.flatMap: originationMonth =>
+          val hhRows   = rawHhEvents
+            .remove(originationMonth)
+            .fold(Vector.empty[HhOriginationRow])(_.toVector)
+            .map(row => LoanRow.Household(enrichHouseholdOutcome(config, row, originationMonth, hhByKey)))
+          val firmRows = rawFirmEvents
+            .remove(originationMonth)
+            .fold(Vector.empty[FirmOriginationRow])(_.toVector)
+            .map(row => LoanRow.Firm(enrichFirmOutcome(config, row, originationMonth, firmByKey)))
+          hhRows ++ firmRows
+        evictExpiredOutcomes()
+        rows.toVector
+
+    private def pendingOriginationMonths: Vector[Int] =
+      (rawHhEvents.keysIterator ++ rawFirmEvents.keysIterator).toVector.distinct
+
+    private def evictExpiredOutcomes(): Unit =
+      val retainFrom = pendingOriginationMonths.minOption.fold(Int.MaxValue)(_ + 1)
+      hhOutcomes.keysIterator.filter { case (_, month) => month < retainFrom }.toVector.foreach(hhOutcomes.remove)
+      firmOutcomes.keysIterator.filter { case (_, month) => month < retainFrom }.toVector.foreach(firmOutcomes.remove)
 
   private[diagnostics] val HouseholdHeader: String =
     Vector(
@@ -260,6 +447,12 @@ object LoanOriginationQualityExport:
   private[diagnostics] val SummaryHeader: String =
     "RunId;BorrowerType;CohortType;CohortValue;Rows;ApprovedRows;RejectedRows;ApprovedPrincipal;FutureBadRows;FutureBadRate;MeanRiskRatio;MeanBankCar;Interpretation"
 
+  private val HouseholdCohortTypes: Vector[String] =
+    Vector("IncomeDecile", "OpeningDistress", "TotalDsrBand", "OpeningBankCarBand")
+
+  private val FirmCohortTypes: Vector[String] =
+    Vector("Sector", "SizeClass", "TechState", "OpeningBankCarBand")
+
   def main(args: Array[String]): Unit =
     parseArgs(args.toVector) match
       case Left(_) if args.contains("--help") =>
@@ -278,17 +471,30 @@ object LoanOriginationQualityExport:
             result.paths.foreach(path => println(path.toString))
 
   def run(config: Config): Either[String, ExportResult] =
-    validate(config).flatMap: validConfig =>
-      val attempts = validConfig.seedRange.map(seed => runSeed(validConfig, seed))
-      attempts.collectFirst { case Left(err) => err } match
-        case Some(err) => Left(err)
-        case None      =>
-          val rawRows       = attempts.collect { case Right(rows) => rows }
-          val householdRows = rawRows.flatMap(_.householdRows)
-          val firmRows      = rawRows.flatMap(_.firmRows)
-          val summaryRows   = summarize(validConfig, householdRows, firmRows)
-          val paths         = writeArtifacts(validConfig, householdRows, firmRows, summaryRows)
-          Right(ExportResult(paths, householdRows, firmRows, summaryRows))
+    DiagnosticIo.unsafeRun(runZIO(config))
+
+  def runZIO(config: Config): ZIO[Any, String, ExportResult] =
+    ZIO
+      .fromEither(validate(config))
+      .flatMap: validConfig =>
+        val hhCsvPath      = validConfig.runRoot.resolve("loan-origination-quality-households.csv")
+        val firmCsvPath    = validConfig.runRoot.resolve("loan-origination-quality-firms.csv")
+        val rowOutputPaths = Vector(hhCsvPath, firmCsvPath)
+        for
+          summaryAccumulator <- McCsvFile.writeSplitFold(
+            hhCsvPath,
+            firmCsvPath,
+            loanRows(validConfig),
+            HouseholdRowsCsvSchema,
+            FirmRowsCsvSchema,
+            new LoanSummaryAccumulator,
+          ) {
+            case LoanRow.Household(row) => Left(row)
+            case LoanRow.Firm(row)      => Right(row)
+          }((acc, row) => acc.add(row))(DiagnosticIo.outputFailure)
+          summaryRows         = summaryAccumulator.summaryRows(validConfig.runId)
+          paths              <- writeArtifactsZIO(validConfig, rowOutputPaths, summaryAccumulator.reportStats, summaryRows)
+        yield ExportResult(paths, summaryRows)
 
   def parseArgs(args: Vector[String]): Either[String, Config] =
     def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
@@ -326,52 +532,45 @@ object LoanOriginationQualityExport:
       .flatMap(valid => Either.cond(valid.outcomeWindow >= 0, valid, "--outcome-window must be >= 0"))
       .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
 
-  private def runSeed(config: Config, seed: Long): Either[String, SeedRawRows] =
+  private def loanRows(config: Config): ZStream[Any, String, LoanRow] =
+    McDiagnosticRunner
+      .runScenarioSeedStreams(
+        Vector(config.runId -> SimParams.defaults),
+        config.seedRange,
+        config.months,
+        _._1,
+        _._2,
+        traceFirmDecisions = true,
+      )((_, seed, months) => computeSeedRows(config, seed, months))
+
+  private def computeSeedRows(
+      config: Config,
+      seed: Long,
+      months: ZStream[Any, String, McSeedMonth],
+  ): ZStream[Any, String, LoanRow] =
     given SimParams = SimParams.defaults
-    val init        = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
-    val initState   = FlowSimulation.SimState.fromInit(init)
-    val runtime     = Sfc.RuntimeState(initState.world, initState.firms, initState.households, initState.banks, initState.ledgerFinancialState)
-    val initErrors  = InitCheck.validate(runtime)
-    if initErrors.nonEmpty then Left(s"Seed $seed failed init checks: ${initErrors.mkString("; ")}")
-    else
-      val rawHhEvents             = scala.collection.mutable.ArrayBuffer.empty[(HhOriginationRow, Int)]
-      val rawFirmEvents           = scala.collection.mutable.ArrayBuffer.empty[(FirmOriginationRow, Int)]
-      val hhOutcomes              = scala.collection.mutable.ArrayBuffer.empty[HhMonthOutcome]
-      val firmOutcomes            = scala.collection.mutable.ArrayBuffer.empty[FirmMonthOutcome]
-      val steps                   = MonthDriver
-        .unfoldSteps(initState, traceFirmDecisions = true): state =>
-          Some(MonthRandomness.Contract.fromSeed(runtimeRootSeed(seed, state)))
-        .take(config.months)
-      var failure: Option[String] = None
+    val window      = new SeedRowWindow(config, seed)
 
-      while steps.hasNext && failure.isEmpty do
-        val output = steps.next()
-        output.sfcResult match
-          case Left(errors) =>
-            failure = Some(s"Seed $seed failed SFC at month ${output.executionMonth.toInt}: ${errors.mkString("; ")}")
-          case Right(())    =>
-            collectHouseholdMonth(config, seed, output, rawHhEvents, hhOutcomes)
-            collectFirmMonth(config, seed, output, rawFirmEvents, firmOutcomes)
-
-      failure match
-        case Some(err) => Left(err)
-        case None      =>
-          val hhByKey   = hhOutcomes.toVector.groupBy(outcome => (outcome.householdId, outcome.month)).view.mapValues(_.head).toMap
-          val firmByKey = firmOutcomes.toVector.groupBy(outcome => (outcome.firmId, outcome.month)).view.mapValues(_.head).toMap
-          val hhRows    = rawHhEvents.toVector.map((row, month) => enrichHouseholdOutcome(config, row, month, hhByKey))
-          val firmRows  = rawFirmEvents.toVector.map((row, month) => enrichFirmOutcome(config, row, month, firmByKey))
-          Right(SeedRawRows(hhRows, firmRows))
+    months
+      .mapZIO: month =>
+        ZIO
+          .attempt(window.observe(month))
+          .mapError(err => s"Seed $seed failed loan origination diagnostics at month ${month.executionMonth.toInt}: ${err.getMessage}")
+      .mapConcat(identity) ++
+      ZStream
+        .fromZIO(ZIO.attempt(window.finish()).mapError(err => s"Seed $seed failed loan origination diagnostics during final flush: ${err.getMessage}"))
+        .mapConcat(identity)
 
   private def collectHouseholdMonth(
       config: Config,
       seed: Long,
-      output: FlowSimulation.StepOutput,
+      output: McSeedMonth,
       rows: scala.collection.mutable.ArrayBuffer[(HhOriginationRow, Int)],
       outcomes: scala.collection.mutable.ArrayBuffer[HhMonthOutcome],
   )(using p: SimParams): Unit =
     val month             = output.executionMonth.toInt
-    val openingHouseholds = output.stateIn.households
-    val openingBalances   = output.stateIn.ledgerFinancialState.households
+    val openingHouseholds = output.openingState.households
+    val openingBalances   = output.openingState.ledgerFinancialState.households
     val closingHouseholds = output.householdSnapshotState.households
     val flows             = output.householdMonthlyFlows
     require(openingHouseholds.length == openingBalances.length, "Loan origination HH diagnostics require aligned opening household balances")
@@ -379,8 +578,8 @@ object LoanOriginationQualityExport:
     require(openingHouseholds.length == flows.length, "Loan origination HH diagnostics require aligned household flows")
 
     val incomeDeciles = incomeDecileByHousehold(flows)
-    val nBanks        = output.stateIn.banks.length
-    val bankStocks    = output.stateIn.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
+    val nBanks        = output.openingState.banks.length
+    val bankStocks    = output.openingState.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
 
     openingHouseholds
       .zip(openingBalances)
@@ -405,9 +604,9 @@ object LoanOriginationQualityExport:
         if householdCreditObserved(flow) then
           val bankId           = opening.bankId.toInt
           require(bankId >= 0 && bankId < nBanks, s"Household ${opening.id.toInt} references invalid bank id $bankId")
-          val bank             = output.stateIn.banks(bankId)
+          val bank             = output.openingState.banks(bankId)
           val stocks           = bankStocks(bankId)
-          val corpBondHoldings = CorporateBondOwnership.bankHolderFor(output.stateIn.ledgerFinancialState, bank.id)
+          val corpBondHoldings = CorporateBondOwnership.bankHolderFor(output.openingState.ledgerFinancialState, bank.id)
           val totalDebtService = flow.mortgageDebtService + flow.consumerDebtService
           rows += (
             HhOriginationRow(
@@ -456,16 +655,16 @@ object LoanOriginationQualityExport:
   private def collectFirmMonth(
       config: Config,
       seed: Long,
-      output: FlowSimulation.StepOutput,
+      output: McSeedMonth,
       rows: scala.collection.mutable.ArrayBuffer[(FirmOriginationRow, Int)],
       outcomes: scala.collection.mutable.ArrayBuffer[FirmMonthOutcome],
   )(using p: SimParams): Unit =
     val month           = output.executionMonth.toInt
-    val openingFirms    = output.stateIn.firms
-    val openingBalances = output.stateIn.ledgerFinancialState.firms
-    val closingFirms    = output.nextState.firms
-    val nBanks          = output.stateIn.banks.length
-    val bankStocks      = output.stateIn.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
+    val openingFirms    = output.openingState.firms
+    val openingBalances = output.openingState.ledgerFinancialState.firms
+    val closingFirms    = output.state.firms
+    val nBanks          = output.openingState.banks.length
+    val bankStocks      = output.openingState.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
     require(openingFirms.length == openingBalances.length, "Loan origination firm diagnostics require aligned opening firm balances")
 
     closingFirms.foreach: firm =>
@@ -488,9 +687,9 @@ object LoanOriginationQualityExport:
         val balances           = balanceById.getOrElse(trace.firmId, throw IllegalStateException(s"Missing opening firm balances ${trace.firmId.toInt}"))
         val bankId             = trace.bankId.toInt
         require(bankId >= 0 && bankId < nBanks, s"Firm ${trace.firmId.toInt} references invalid bank id $bankId")
-        val bank               = output.stateIn.banks(bankId)
+        val bank               = output.openingState.banks(bankId)
         val stocks             = bankStocks(bankId)
-        val corpBondHoldings   = CorporateBondOwnership.bankHolderFor(output.stateIn.ledgerFinancialState, bank.id)
+        val corpBondHoldings   = CorporateBondOwnership.bankHolderFor(output.openingState.ledgerFinancialState, bank.id)
         val monthlyDebtService = trace.principalRepaid + trace.firmLoanBefore * trace.lendingRate.monthly
         creditLegs.foreach: leg =>
           val approved = leg.bankApproval.contains(true) || leg.approvedPrincipal > PLN.Zero
@@ -575,209 +774,154 @@ object LoanOriginationQualityExport:
       householdRows: Vector[HhOriginationRow],
       firmRows: Vector[FirmOriginationRow],
   ): Vector[SummaryRow] =
-    val hhGroups   = Vector(
-      "IncomeDecile"       -> ((row: HhOriginationRow) => row.incomeDecile),
-      "OpeningDistress"    -> ((row: HhOriginationRow) => row.openingFinancialDistressState),
-      "TotalDsrBand"       -> ((row: HhOriginationRow) => dsrBand(row.totalDsr)),
-      "OpeningBankCarBand" -> ((row: HhOriginationRow) => carBand(row.bankCar)),
-    )
-    val firmGroups = Vector(
-      "Sector"             -> ((row: FirmOriginationRow) => row.sector),
-      "SizeClass"          -> ((row: FirmOriginationRow) => row.sizeClass),
-      "TechState"          -> ((row: FirmOriginationRow) => row.techState),
-      "OpeningBankCarBand" -> ((row: FirmOriginationRow) => carBand(row.bankCar)),
-    )
-    hhGroups.flatMap((name, key) => summarizeHouseholds(config.runId, name, householdRows, key)) ++
-      firmGroups.flatMap((name, key) => summarizeFirms(config.runId, name, firmRows, key))
+    val accumulator = new LoanSummaryAccumulator
+    householdRows.foreach(row => accumulator.add(LoanRow.Household(row)))
+    firmRows.foreach(row => accumulator.add(LoanRow.Firm(row)))
+    accumulator.summaryRows(config.runId)
 
-  private def summarizeHouseholds(
-      runId: String,
-      cohortType: String,
-      rows: Vector[HhOriginationRow],
-      key: HhOriginationRow => String,
-  ): Vector[SummaryRow] =
-    rows
-      .groupBy(key)
-      .toVector
-      .sortBy(_._1)
-      .map: (cohortValue, cohortRows) =>
-        val badRows = cohortRows.count(row => row.futureDefaultWithinWindow || row.futureBankruptcyWithinWindow)
-        SummaryRow(
-          runId = runId,
-          borrowerType = "Household",
-          cohortType = cohortType,
-          cohortValue = cohortValue,
-          rows = cohortRows.length,
-          approvedRows = cohortRows.count(_.approvedPrincipal > PLN.Zero),
-          rejectedRows = cohortRows.count(row => row.rejectedPrincipal > PLN.Zero || row.bankRejectedPrincipal > PLN.Zero),
-          approvedPrincipal = cohortRows.foldLeft(PLN.Zero)(_ + _.approvedPrincipal),
-          futureBadRows = badRows,
-          futureBadRate = if cohortRows.nonEmpty then Some(BigDecimal(badRows) / BigDecimal(cohortRows.length)) else None,
-          meanRiskRatio = mean(cohortRows.flatMap(_.totalDsr)),
-          meanBankCar = mean(cohortRows.map(_.bankCar)),
-          interpretation = "HH future bad rows mean later default/write-off or bankruptcy inside the configured observation window.",
-        )
-
-  private def summarizeFirms(
-      runId: String,
-      cohortType: String,
-      rows: Vector[FirmOriginationRow],
-      key: FirmOriginationRow => String,
-  ): Vector[SummaryRow] =
-    rows
-      .groupBy(key)
-      .toVector
-      .sortBy(_._1)
-      .map: (cohortValue, cohortRows) =>
-        val badRows = cohortRows.count(row => row.futureBankruptWithinWindow || row.sameMonthBankrupt)
-        SummaryRow(
-          runId = runId,
-          borrowerType = "Firm",
-          cohortType = cohortType,
-          cohortValue = cohortValue,
-          rows = cohortRows.length,
-          approvedRows = cohortRows.count(_.approvedPrincipal > PLN.Zero),
-          rejectedRows = cohortRows.count(_.bankRejected),
-          approvedPrincipal = cohortRows.foldLeft(PLN.Zero)(_ + _.approvedPrincipal),
-          futureBadRows = badRows,
-          futureBadRate = if cohortRows.nonEmpty then Some(BigDecimal(badRows) / BigDecimal(cohortRows.length)) else None,
-          meanRiskRatio = mean(cohortRows.flatMap(_.dscrProxy)),
-          meanBankCar = mean(cohortRows.map(_.bankCar)),
-          interpretation = "Firm future bad rows mean later bankruptcy inside the configured observation window; mean risk ratio is DSCR proxy.",
-        )
-
-  private def writeArtifacts(
+  private def writeArtifactsZIO(
       config: Config,
-      householdRows: Vector[HhOriginationRow],
-      firmRows: Vector[FirmOriginationRow],
+      rowOutputPaths: Vector[Path],
+      reportStats: ReportStats,
       summaryRows: Vector[SummaryRow],
-  ): Vector[Path] =
-    Files.createDirectories(config.runRoot)
-    val hhPath      = config.runRoot.resolve("loan-origination-quality-households.csv")
-    val firmPath    = config.runRoot.resolve("loan-origination-quality-firms.csv")
-    val summaryPath = config.runRoot.resolve("loan-origination-quality-summary.csv")
-    val reportPath  = config.runRoot.resolve("loan-origination-quality-report.md")
-    Files.writeString(hhPath, renderHouseholdRows(householdRows), StandardCharsets.UTF_8)
-    Files.writeString(firmPath, renderFirmRows(firmRows), StandardCharsets.UTF_8)
-    Files.writeString(summaryPath, renderSummaryRows(summaryRows), StandardCharsets.UTF_8)
-    Files.writeString(reportPath, renderReport(config, householdRows, firmRows, summaryRows), StandardCharsets.UTF_8)
-    Vector(hhPath, firmPath, summaryPath, reportPath)
+  ): ZIO[Any, String, Vector[Path]] =
+    val summaryCsvPath = config.runRoot.resolve("loan-origination-quality-summary.csv")
+    val reportMdPath   = config.runRoot.resolve("loan-origination-quality-report.md")
+    for
+      summaryPath <- McCsvFile.writeAll(summaryCsvPath, summaryRows, SummaryRowsCsvSchema)(DiagnosticIo.outputFailure)
+      reportPath  <- DiagnosticIo.writeText(reportMdPath, renderReport(config, reportStats, summaryRows))
+    yield rowOutputPaths ++ Vector(summaryPath, reportPath)
+
+  private[diagnostics] val HouseholdRowsCsvSchema: McCsvSchema[HhOriginationRow] =
+    McCsvSchema(
+      header = HouseholdHeader,
+      render = row =>
+        Vector(
+          text(row.runId),
+          row.seed.toString,
+          row.originationMonth.toString,
+          row.householdId.toString,
+          row.bankId.toString,
+          text(row.status),
+          row.incomeDecile,
+          row.openingFinancialDistressState,
+          row.closingFinancialDistressState,
+          row.openingDistressMonths.toString,
+          row.closingDistressMonths.toString,
+          row.wage.format(2),
+          row.openingDemandDeposit.format(2),
+          row.openingConsumerLoan.format(2),
+          row.openingMortgageLoan.format(2),
+          row.monthlyIncome.format(2),
+          row.mortgageDebtService.format(2),
+          row.consumerDebtService.format(2),
+          row.totalDebtService.format(2),
+          row.totalDsr.map(renderDecimal).getOrElse(""),
+          row.mortgageDsr.map(renderDecimal).getOrElse(""),
+          row.consumerDsr.map(renderDecimal).getOrElse(""),
+          row.creditCapacity.format(2),
+          row.creditAccessEligible.toString,
+          row.creditDemand.format(2),
+          row.approvedPrincipal.format(2),
+          row.rejectedPrincipal.format(2),
+          row.bankRejectedPrincipal.format(2),
+          renderDecimal(row.bankCar),
+          renderDecimal(row.bankLcr),
+          renderDecimal(row.bankNsfr),
+          row.sameMonthArrears.toString,
+          row.sameMonthDefault.toString,
+          row.futureArrearsWithinWindow.toString,
+          row.futureDefaultWithinWindow.toString,
+          row.futureBankruptcyWithinWindow.toString,
+          row.firstFutureDefaultMonth.fold("")(_.toString),
+          row.observedFutureMonths.toString,
+          row.futureWriteOffAmount.format(2),
+        ).mkString(";"),
+    )
+
+  private[diagnostics] val FirmRowsCsvSchema: McCsvSchema[FirmOriginationRow] =
+    McCsvSchema(
+      header = FirmHeader,
+      render = row =>
+        Vector(
+          text(row.runId),
+          row.seed.toString,
+          row.originationMonth.toString,
+          row.firmId.toString,
+          row.bankId.toString,
+          text(row.sector),
+          row.sizeClass,
+          row.techState,
+          row.decisionType,
+          row.creditPurpose,
+          row.bankApprovalObserved.toString,
+          row.bankApproved.toString,
+          row.bankRejected.toString,
+          row.observedCreditNeed.format(2),
+          row.approvedPrincipal.format(2),
+          row.cashBefore.format(2),
+          row.firmLoanBefore.format(2),
+          row.realizedPostTaxProfit.format(2),
+          row.grossInvestment.format(2),
+          row.principalRepaid.format(2),
+          row.monthlyDebtServiceProxy.format(2),
+          row.debtToCash.map(renderDecimal).getOrElse(""),
+          row.dscrProxy.map(renderDecimal).getOrElse(""),
+          row.workersBefore.toString,
+          row.workersAfter.toString,
+          row.foreignOwned.toString,
+          row.stateOwned.toString,
+          renderDecimal(row.bankCar),
+          renderDecimal(row.bankLcr),
+          renderDecimal(row.bankNsfr),
+          row.sameMonthBankrupt.toString,
+          row.futureBankruptWithinWindow.toString,
+          row.firstFutureBankruptcyMonth.fold("")(_.toString),
+          row.observedFutureMonths.toString,
+          text(row.bankruptcyReason),
+        ).mkString(";"),
+    )
+
+  private[diagnostics] val SummaryRowsCsvSchema: McCsvSchema[SummaryRow] =
+    McCsvSchema(
+      header = SummaryHeader,
+      render = row =>
+        Vector(
+          text(row.runId),
+          row.borrowerType,
+          row.cohortType,
+          text(row.cohortValue),
+          row.rows.toString,
+          row.approvedRows.toString,
+          row.rejectedRows.toString,
+          row.approvedPrincipal.format(2),
+          row.futureBadRows.toString,
+          row.futureBadRate.map(renderDecimal).getOrElse(""),
+          row.meanRiskRatio.map(renderDecimal).getOrElse(""),
+          row.meanBankCar.map(renderDecimal).getOrElse(""),
+          text(row.interpretation),
+        ).mkString(";"),
+    )
 
   private[diagnostics] def renderHouseholdRows(rows: Vector[HhOriginationRow]): String =
-    val body = rows.map: row =>
-      Vector(
-        text(row.runId),
-        row.seed.toString,
-        row.originationMonth.toString,
-        row.householdId.toString,
-        row.bankId.toString,
-        text(row.status),
-        row.incomeDecile,
-        row.openingFinancialDistressState,
-        row.closingFinancialDistressState,
-        row.openingDistressMonths.toString,
-        row.closingDistressMonths.toString,
-        row.wage.format(2),
-        row.openingDemandDeposit.format(2),
-        row.openingConsumerLoan.format(2),
-        row.openingMortgageLoan.format(2),
-        row.monthlyIncome.format(2),
-        row.mortgageDebtService.format(2),
-        row.consumerDebtService.format(2),
-        row.totalDebtService.format(2),
-        row.totalDsr.map(renderDecimal).getOrElse(""),
-        row.mortgageDsr.map(renderDecimal).getOrElse(""),
-        row.consumerDsr.map(renderDecimal).getOrElse(""),
-        row.creditCapacity.format(2),
-        row.creditAccessEligible.toString,
-        row.creditDemand.format(2),
-        row.approvedPrincipal.format(2),
-        row.rejectedPrincipal.format(2),
-        row.bankRejectedPrincipal.format(2),
-        renderDecimal(row.bankCar),
-        renderDecimal(row.bankLcr),
-        renderDecimal(row.bankNsfr),
-        row.sameMonthArrears.toString,
-        row.sameMonthDefault.toString,
-        row.futureArrearsWithinWindow.toString,
-        row.futureDefaultWithinWindow.toString,
-        row.futureBankruptcyWithinWindow.toString,
-        row.firstFutureDefaultMonth.fold("")(_.toString),
-        row.observedFutureMonths.toString,
-        row.futureWriteOffAmount.format(2),
-      ).mkString(";")
-    (HouseholdHeader +: body).mkString("", "\n", "\n")
+    renderCsv(HouseholdRowsCsvSchema, rows)
 
   private[diagnostics] def renderFirmRows(rows: Vector[FirmOriginationRow]): String =
-    val body = rows.map: row =>
-      Vector(
-        text(row.runId),
-        row.seed.toString,
-        row.originationMonth.toString,
-        row.firmId.toString,
-        row.bankId.toString,
-        text(row.sector),
-        row.sizeClass,
-        row.techState,
-        row.decisionType,
-        row.creditPurpose,
-        row.bankApprovalObserved.toString,
-        row.bankApproved.toString,
-        row.bankRejected.toString,
-        row.observedCreditNeed.format(2),
-        row.approvedPrincipal.format(2),
-        row.cashBefore.format(2),
-        row.firmLoanBefore.format(2),
-        row.realizedPostTaxProfit.format(2),
-        row.grossInvestment.format(2),
-        row.principalRepaid.format(2),
-        row.monthlyDebtServiceProxy.format(2),
-        row.debtToCash.map(renderDecimal).getOrElse(""),
-        row.dscrProxy.map(renderDecimal).getOrElse(""),
-        row.workersBefore.toString,
-        row.workersAfter.toString,
-        row.foreignOwned.toString,
-        row.stateOwned.toString,
-        renderDecimal(row.bankCar),
-        renderDecimal(row.bankLcr),
-        renderDecimal(row.bankNsfr),
-        row.sameMonthBankrupt.toString,
-        row.futureBankruptWithinWindow.toString,
-        row.firstFutureBankruptcyMonth.fold("")(_.toString),
-        row.observedFutureMonths.toString,
-        text(row.bankruptcyReason),
-      ).mkString(";")
-    (FirmHeader +: body).mkString("", "\n", "\n")
+    renderCsv(FirmRowsCsvSchema, rows)
 
   private[diagnostics] def renderSummaryRows(rows: Vector[SummaryRow]): String =
-    val body = rows.map: row =>
-      Vector(
-        text(row.runId),
-        row.borrowerType,
-        row.cohortType,
-        text(row.cohortValue),
-        row.rows.toString,
-        row.approvedRows.toString,
-        row.rejectedRows.toString,
-        row.approvedPrincipal.format(2),
-        row.futureBadRows.toString,
-        row.futureBadRate.map(renderDecimal).getOrElse(""),
-        row.meanRiskRatio.map(renderDecimal).getOrElse(""),
-        row.meanBankCar.map(renderDecimal).getOrElse(""),
-        text(row.interpretation),
-      ).mkString(";")
-    (SummaryHeader +: body).mkString("", "\n", "\n")
+    renderCsv(SummaryRowsCsvSchema, rows)
+
+  private def renderCsv[A](schema: McCsvSchema[A], rows: Vector[A]): String =
+    (schema.header +: rows.map(schema.render)).mkString("\n") + "\n"
 
   private def renderReport(
       config: Config,
-      householdRows: Vector[HhOriginationRow],
-      firmRows: Vector[FirmOriginationRow],
+      reportStats: ReportStats,
       summaryRows: Vector[SummaryRow],
   ): String =
-    val hhBad       = householdRows.count(row => row.futureDefaultWithinWindow || row.futureBankruptcyWithinWindow)
-    val firmBad     = firmRows.count(row => row.futureBankruptWithinWindow || row.sameMonthBankrupt)
-    val hhBadRate   = if householdRows.nonEmpty then renderDecimal(BigDecimal(hhBad) / BigDecimal(householdRows.length)) else "NA"
-    val firmBadRate = if firmRows.nonEmpty then renderDecimal(BigDecimal(firmBad) / BigDecimal(firmRows.length)) else "NA"
+    val hhBadRate   = reportStats.householdBadRate.map(renderDecimal).getOrElse("NA")
+    val firmBadRate = reportStats.firmBadRate.map(renderDecimal).getOrElse("NA")
     val topRows     = summaryRows.sortBy(row => row.futureBadRate.getOrElse(BigDecimal(-1)))(using Ordering.BigDecimal.reverse).take(10)
     val table       =
       if topRows.isEmpty then "_No origination rows emitted in this fixture._"
@@ -806,8 +950,8 @@ object LoanOriginationQualityExport:
       "",
       "## Quick Read",
       "",
-      s"- Household rows: `${householdRows.length}`, future bad rate `${hhBadRate}`.",
-      s"- Firm rows: `${firmRows.length}`, future bad rate `${firmBadRate}`.",
+      s"- Household rows: `${reportStats.householdRows}`, future bad rate `${hhBadRate}`.",
+      s"- Firm rows: `${reportStats.firmRows}`, future bad rate `${firmBadRate}`.",
       "",
       "## Highest Future-Bad Cohorts",
       "",
@@ -819,6 +963,22 @@ object LoanOriginationQualityExport:
 
   private def futureMonths(originationMonth: Int, config: Config): Vector[Int] =
     ((originationMonth + 1) to (originationMonth + config.outcomeWindow).min(config.months)).toVector
+
+  private def householdCohorts(row: HhOriginationRow): Vector[(String, String)] =
+    Vector(
+      "IncomeDecile"       -> row.incomeDecile,
+      "OpeningDistress"    -> row.openingFinancialDistressState,
+      "TotalDsrBand"       -> dsrBand(row.totalDsr),
+      "OpeningBankCarBand" -> carBand(row.bankCar),
+    )
+
+  private def firmCohorts(row: FirmOriginationRow): Vector[(String, String)] =
+    Vector(
+      "Sector"             -> row.sector,
+      "SizeClass"          -> row.sizeClass,
+      "TechState"          -> row.techState,
+      "OpeningBankCarBand" -> carBand(row.bankCar),
+    )
 
   private def householdCreditObserved(flow: Household.MonthlyFlow): Boolean =
     flow.consumerCreditDemand > PLN.Zero ||
@@ -937,10 +1097,6 @@ object LoanOriginationQualityExport:
   private def fixed(value: Multiplier): BigDecimal =
     (BigDecimal(value.toLong) / FixedPointBase.ScaleDecimal).setScale(6, RoundingMode.HALF_UP)
 
-  private def mean(values: Vector[BigDecimal]): Option[BigDecimal] =
-    if values.isEmpty then None
-    else Some((values.sum / BigDecimal(values.length)).setScale(6, RoundingMode.HALF_UP))
-
   private def renderDecimal(value: BigDecimal): String =
     value.setScale(6, RoundingMode.HALF_UP).bigDecimal.stripTrailingZeros.toPlainString
 
@@ -956,9 +1112,6 @@ object LoanOriginationQualityExport:
   private def knownFlag(flag: String): Boolean =
     flag == "--seed-start" || flag == "--seeds" || flag == "--months" ||
       flag == "--outcome-window" || flag == "--run-id" || flag == "--out"
-
-  private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
-    seed * 10000L + state.completedMonth.toLong
 
   private val usage =
     """Usage: LoanOriginationQualityExport [--seed-start <long>] [--seeds <int>] [--months <int>] [--outcome-window <int>] [--out <path>] [--run-id <id>]

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McCsvFile.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McCsvFile.scala
@@ -36,6 +36,50 @@ private[amorfati] object McCsvFile:
   )(fold: (S, A) => S)(outputFailure: OutputFailure[E]): ZIO[Any, E, S] =
     writeFoldValidated(outputFile, rows, schema, initial)(fold)(outputFailure)(ZIO.succeed(_))
 
+  def writeSplitFold[E, A, L, R, S](
+      leftOutputFile: Path,
+      rightOutputFile: Path,
+      rows: ZStream[Any, E, A],
+      leftSchema: McCsvSchema[L],
+      rightSchema: McCsvSchema[R],
+      initial: S,
+  )(route: A => Either[L, R])(fold: (S, A) => S)(outputFailure: OutputFailure[E]): ZIO[Any, E, S] =
+    if leftOutputFile == rightOutputFile then
+      ZIO.fail(outputFailure("prepare split CSV outputs", leftOutputFile, IllegalArgumentException("leftOutputFile and rightOutputFile must be different")))
+    else
+      val leftTempFile  = leftOutputFile.resolveSibling(s"${leftOutputFile.getFileName.toString}.tmp")
+      val rightTempFile = rightOutputFile.resolveSibling(s"${rightOutputFile.getFileName.toString}.tmp")
+      val cleanupTemps  =
+        deleteIfExists(leftTempFile, outputFailure) *>
+          deleteIfExists(rightTempFile, outputFailure)
+      val rollback      =
+        deleteIfExists(leftOutputFile, outputFailure) *>
+          deleteIfExists(rightOutputFile, outputFailure) *>
+          cleanupTemps
+      val writeFiles    =
+        ZIO.scoped:
+          for
+            _           <- createParentDirectories(leftOutputFile, outputFailure)
+            _           <- createParentDirectories(rightOutputFile, outputFailure)
+            leftWriter  <- openWriter(leftTempFile, outputFailure)
+            rightWriter <- openWriter(rightTempFile, outputFailure)
+            _           <- writeLine(leftWriter, leftSchema.header, leftTempFile, outputFailure)
+            _           <- writeLine(rightWriter, rightSchema.header, rightTempFile, outputFailure)
+            finalState  <- rows.runFoldZIO(initial): (state, row) =>
+              val writeRow = route(row) match
+                case Left(left)   => writeLine(leftWriter, leftSchema.render(left), leftTempFile, outputFailure)
+                case Right(right) => writeLine(rightWriter, rightSchema.render(right), rightTempFile, outputFailure)
+              writeRow.as(fold(state, row))
+          yield finalState
+
+      writeFiles
+        .flatMap: finalState =>
+          (finalizeFile(leftTempFile, leftOutputFile, outputFailure) *>
+            finalizeFile(rightTempFile, rightOutputFile, outputFailure))
+            .as(finalState)
+            .onError(_ => rollback.ignore)
+        .onError(_ => cleanupTemps.ignore)
+
   private def writeFoldValidated[E, A, S, B](
       outputFile: Path,
       rows: ZStream[Any, E, A],

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunner.scala
@@ -20,10 +20,18 @@ private[amorfati] object McDiagnosticRunner:
       months: Int,
       params: SimParams,
       label: String = "baseline",
+      traceFirmDecisions: Boolean = false,
   )(
       reduce: (Long, ZStream[Any, String, McSeedMonth]) => ZIO[Any, String, A],
   ): ZStream[Any, String, A] =
-    runScenarioSeeds[(String, SimParams), A](Vector(label -> params), seeds, months, _._1, _._2) { (_, seed, monthsStream) =>
+    runScenarioSeeds[(String, SimParams), A](
+      Vector(label -> params),
+      seeds,
+      months,
+      _._1,
+      _._2,
+      traceFirmDecisions = traceFirmDecisions,
+    ) { (_, seed, monthsStream) =>
       reduce(seed, monthsStream)
     }
 
@@ -34,6 +42,7 @@ private[amorfati] object McDiagnosticRunner:
       scenarioId: Scenario => String,
       params: Scenario => SimParams,
       parallelism: Option[Int] = None,
+      traceFirmDecisions: Boolean = false,
   )(
       reduce: (Scenario, Long, ZStream[Any, String, McSeedMonth]) => ZIO[Any, String, A],
   ): ZStream[Any, String, A] =
@@ -45,7 +54,7 @@ private[amorfati] object McDiagnosticRunner:
     ZStream
       .fromIterable(jobs)
       .mapZIOPar(parallelism.getOrElse(seedParallelism(jobs.length))): job =>
-        runJob(job, months, params(job.scenario), reduce)
+        runJob(job, months, params(job.scenario), traceFirmDecisions, reduce)
 
   def runScenarioSeedStreams[Scenario, A](
       scenarios: Vector[Scenario],
@@ -54,6 +63,7 @@ private[amorfati] object McDiagnosticRunner:
       scenarioId: Scenario => String,
       params: Scenario => SimParams,
       parallelism: Option[Int] = None,
+      traceFirmDecisions: Boolean = false,
   )(
       rows: (Scenario, Long, ZStream[Any, String, McSeedMonth]) => ZStream[Any, String, A],
   ): ZStream[Any, String, A] =
@@ -65,12 +75,13 @@ private[amorfati] object McDiagnosticRunner:
     ZStream
       .fromIterable(jobs)
       .flatMapPar(parallelism.getOrElse(seedParallelism(jobs.length))): job =>
-        runJobStream(job, months, params(job.scenario), rows)
+        runJobStream(job, months, params(job.scenario), traceFirmDecisions, rows)
 
   private def runJob[Scenario, A](
       job: Job[Scenario],
       months: Int,
       params: SimParams,
+      traceFirmDecisions: Boolean,
       reduce: (Scenario, Long, ZStream[Any, String, McSeedMonth]) => ZIO[Any, String, A],
   ): ZIO[Any, String, A] =
     val context = s"Scenario ${job.scenarioId} seed ${job.seed}"
@@ -78,7 +89,7 @@ private[amorfati] object McDiagnosticRunner:
       ZIO.suspendSucceed:
         given SimParams  = params
         val monthsStream = McRunner
-          .seedMonths(job.seed, months)
+          .seedMonths(job.seed, months, traceFirmDecisions)
           .mapError(_.toString)
         reduce(job.scenario, job.seed, monthsStream)
           .catchAll(err => ZIO.fail(s"$context failed: $err"))
@@ -92,6 +103,7 @@ private[amorfati] object McDiagnosticRunner:
       job: Job[Scenario],
       months: Int,
       params: SimParams,
+      traceFirmDecisions: Boolean,
       rows: (Scenario, Long, ZStream[Any, String, McSeedMonth]) => ZStream[Any, String, A],
   ): ZStream[Any, String, A] =
     val context = s"Scenario ${job.scenarioId} seed ${job.seed}"
@@ -100,7 +112,7 @@ private[amorfati] object McDiagnosticRunner:
         ZIO.suspendSucceed:
           given SimParams  = params
           val monthsStream = McRunner
-            .seedMonths(job.seed, months)
+            .seedMonths(job.seed, months, traceFirmDecisions)
             .mapError(_.toString)
           ZIO.succeed:
             rows(job.scenario, job.seed, monthsStream)

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -72,8 +72,8 @@ object McRunner:
   /** Canonical monthly seed stream for diagnostics. This is the same runtime
     * path used by [[runZIO]], without production-only CSV/snapshot taps.
     */
-  private[amorfati] def seedMonths(seed: Long, durationMonths: Int)(using SimParams): ZStream[Any, SimError, McSeedMonth] =
-    seedStream(seed, durationMonths, traceFirmDecisions = false).map: snapshot =>
+  private[amorfati] def seedMonths(seed: Long, durationMonths: Int, traceFirmDecisions: Boolean = false)(using SimParams): ZStream[Any, SimError, McSeedMonth] =
+    seedStream(seed, durationMonths, traceFirmDecisions).map: snapshot =>
       McSeedMonth(
         snapshot.executionMonth,
         snapshot.monthData,
@@ -81,6 +81,7 @@ object McRunner:
         snapshot.state,
         snapshot.householdSnapshotState,
         snapshot.householdMonthlyFlows,
+        snapshot.firmDecisionTraces,
       )
 
   private def simulateMonths(seed: Long, initState: FlowSimulation.SimState, durationMonths: Int, traceFirmDecisions: Boolean)(using p: SimParams) =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McSeedMonth.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McSeedMonth.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.montecarlo
 
-import com.boombustgroup.amorfati.agents.Household
+import com.boombustgroup.amorfati.agents.{Firm, Household}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 
@@ -15,4 +15,5 @@ private[amorfati] final case class McSeedMonth(
     state: FlowSimulation.SimState,
     householdSnapshotState: FlowSimulation.HouseholdSnapshotState,
     householdMonthlyFlows: Vector[Household.MonthlyFlow],
+    firmDecisionTraces: Vector[Firm.DecisionTrace],
 )

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McCsvFileSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McCsvFileSpec.scala
@@ -35,6 +35,35 @@ class McCsvFileSpec extends AnyFlatSpec with Matchers:
       Files.exists(output) shouldBe false
       Files.exists(output.resolveSibling("values.csv.tmp")) shouldBe false
 
+  it should "split streamed rows across two CSV files while returning one fold state" in
+    withTempDir: dir =>
+      val leftOutput  = dir.resolve("left.csv")
+      val rightOutput = dir.resolve("nested").resolve("right.csv")
+      val rows        = ZStream.fromIterable(Vector(1, 2, 3, 4))
+      val result      = run:
+        McCsvFile.writeSplitFold(leftOutput, rightOutput, rows, schema, schema, Vector.newBuilder[Int]) { row =>
+          if row % 2 == 0 then Right(row) else Left(row)
+        }((builder, row) => builder += row)(outputFailure)
+
+      result.result() shouldBe Vector(1, 2, 3, 4)
+      Files.readAllLines(leftOutput, UTF_8).asScala.toVector shouldBe Vector("Value", "1", "3")
+      Files.readAllLines(rightOutput, UTF_8).asScala.toVector shouldBe Vector("Value", "2", "4")
+      Files.exists(leftOutput.resolveSibling("left.csv.tmp")) shouldBe false
+      Files.exists(rightOutput.resolveSibling("right.csv.tmp")) shouldBe false
+
+  it should "reject split CSV writes to the same output path" in
+    withTempDir: dir =>
+      val output = dir.resolve("same.csv")
+      val result = run:
+        McCsvFile
+          .writeSplitFold(output, output, ZStream.fromIterable(Vector(1)), schema, schema, ()) { row =>
+            Left(row)
+          }((_, _) => ())(outputFailure)
+          .either
+
+      result.left.getOrElse(fail("Expected split CSV path collision to fail")) should include("prepare split CSV outputs")
+      Files.exists(output) shouldBe false
+
   it should "not finalize a streaming CSV when a non-empty stream is required" in
     withTempDir: dir =>
       val output = dir.resolve("values.csv")


### PR DESCRIPTION
## Summary
- move legacy diagnostic CSV writes in bank balance-sheet benchmark and empirical validation onto McCsvFile/McCsvSchema
- run loan-origination diagnostics through McDiagnosticRunner with optional firm-decision traces from McRunner seed months
- stream loan-origination HH/firm rows into split McCsvFile sinks with bounded per-seed outcome-window state and summary/report aggregates only
- harden split CSV output path validation/rollback and bank benchmark per-seed error boundaries

## Validation
- nix develop --command sbt scalafmtCheckAll
- nix develop --command sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec com.boombustgroup.amorfati.diagnostics.LoanOriginationQualityExportSpec com.boombustgroup.amorfati.diagnostics.EmpiricalValidationExportSpec com.boombustgroup.amorfati.montecarlo.McCsvFileSpec"
- nix develop --command sbt "loanOriginationQuality --seeds 1 --months 3 --outcome-window 1 --out target/diagnostic-convergence-smoke --run-id loan626-streaming"
- nix develop --command sbt "bankBalanceSheetBenchmark --seeds 1 --out target/diagnostic-convergence-smoke --run-id bank626" "loanOriginationQuality --seeds 1 --months 3 --outcome-window 1 --out target/diagnostic-convergence-smoke --run-id loan626"
- nix develop --command sbt "scenarioRun --scenarios baseline --seeds 1 --months 1 --out target/diagnostic-convergence-smoke --run-id scenario626"
- git diff --check

Closes #626