### PR TITLE
Extract MonthTraceBuilder from FlowSimulation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthRandomness.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthRandomness.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.random.{RandomStream, SeedDerivation}
 /** Explicit month-step randomness contract.
   *
   * Deterministic replay of one monthly step starts when both the state boundary
-  * and the month `rootSeed` are fixed. All stage and mechanism streams are
+  * and the month `rootSeed` are fixed. All stage and closing streams are
   * derived deterministically from that explicit seed and stay independent.
   */
 object MonthRandomness:

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -34,7 +34,7 @@ engine/
 | `MonthExecution.scala` | Same-month result of the ordered economics pipeline; consumed by flow planning, semantic projection, and month closing. |
 | `MonthClosing.scala` | Explicit closing input/result contracts: derived mechanisms, diagnostics, agent lifecycle input, and realized month-`t` closing state. |
 | `MonthWorkflow.scala` | Minimal identity-monad DSL used to express the deterministic month transition as a typed `for`-comprehension without adding runtime effects. |
-| `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and assembly streams for deterministic replay and auditability. |
+| `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and closing streams for deterministic replay and auditability. |
 | `MonthDriver.scala` | Shared month-by-month unfold driver over the explicit `FlowSimulation.step` boundary. |
 | `OperationalSignals.scala` | Explicit same-month signal surface for month-`t` operational execution, kept distinct from persisted start-of-month `DecisionSignals`. |
 | `SignalExtraction.scala` | Explicit closed-to-next-pre boundary: derives next-month `DecisionSignals` and typed seed provenance from realized month-`t` outcomes. |
@@ -123,7 +123,8 @@ exactness, each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, records monetary flows, emits `MonthTrace`, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, records monetary flows, delegates trace construction, and returns typed `nextState` for month `t+1`. |
+| `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `HhTotalIncome`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |
 | `NfzFlows.scala` | NFZ (National Health Fund): 9% składka zdrowotna, healthcare spending, gov subvention |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -453,7 +453,7 @@ object FlowSimulation:
         closed: MonthSemantics.ClosedMonth,
         seedOut: MonthSemantics.SeedOut,
     ): Program[MonthTraceCore] =
-      MonthWorkflow.pure(deriveTraceCore(pre, closed, seedOut))
+      MonthWorkflow.pure(MonthTraceBuilder.core(pre, closed, seedOut))
 
   /** Full month-step contract.
     *
@@ -513,10 +513,11 @@ object FlowSimulation:
       executionDeltaLedger = Sfc.ExecutionDeltaLedger.fromRaw(execution.deltaLedger),
       deltaLedgerNet = execution.netDelta,
     )
-    val monthTrace              = buildMonthTrace(
-      input = input,
-      outcome = outcome,
-      nextState = nextState,
+    val monthTrace              = MonthTraceBuilder.build(
+      executionMonth = input.executionMonth,
+      randomness = input.randomness,
+      core = outcome.traceCore,
+      endState = nextState,
       executedFlows = sfcFlows,
       sfcResult = sfcResult,
     )
@@ -1158,31 +1159,6 @@ object FlowSimulation:
   private def buildOperationalSignals(signalView: MonthSemantics.SignalView): MonthSemantics.Operational =
     MonthSemantics.operational(operationalSignals(signalView.labor, signalView.demand))
 
-  private def buildTimingInputs(
-      signalView: MonthSemantics.SignalView,
-      closing: MonthClosingResult,
-  ): MonthTimingInputs =
-    MonthTimingInputs(
-      labor = MonthTimingPayload.LaborSignals(
-        operationalHiringSlack = signalView.labor.operationalHiringSlack,
-      ),
-      demand = MonthTimingPayload.DemandSignals(
-        sectorDemandMult = signalView.demand.sectorMults,
-        sectorDemandPressure = signalView.demand.sectorDemandPressure,
-        sectorHiringSignal = signalView.demand.sectorHiringSignal,
-      ),
-      nominal = MonthTimingPayload.NominalSignals(
-        realizedInflation = closing.world.inflation,
-        expectedInflation = closing.world.mechanisms.expectations.expectedInflation,
-      ),
-      firmDynamics = MonthTimingPayload.FirmDynamics(
-        startupAbsorptionRate = closing.startupAbsorptionRate,
-        firmBirths = closing.world.flows.firmBirths,
-        firmDeaths = closing.world.flows.firmDeaths,
-        netFirmBirths = closing.world.flows.netFirmBirths,
-      ),
-    )
-
   private def buildClosedMonthBoundary(
       closingInput: MonthSemantics.ClosingInput,
       signalView: MonthSemantics.SignalView,
@@ -1200,7 +1176,7 @@ object FlowSimulation:
           closing.banks,
           closing.ledgerFinancialState,
         ),
-        timing = MonthTimingTrace.fromInputs(buildTimingInputs(signalView, closing)),
+        timing = MonthTraceBuilder.timingTrace(signalView, closing),
       ),
     )
 
@@ -1221,17 +1197,6 @@ object FlowSimulation:
           sectorHiringSignal = signalView.demand.sectorHiringSignal,
         ),
       ),
-    )
-
-  private def deriveTraceCore(
-      input: StepInput,
-      closed: MonthSemantics.ClosedMonth,
-      seedOut: MonthSemantics.SeedOut,
-  ): MonthTraceCore =
-    MonthTraceCore(
-      boundary = MonthBoundaryTrace.from(input.boundaryIn, closed.boundaryOut),
-      seedTransition = SeedTransitionTrace.from(input.seedIn, seedOut),
-      timing = closed.timing,
     )
 
   private def computeMonthOutcome(input: StepInput)(using p: SimParams): MonthOutcome =
@@ -1279,29 +1244,4 @@ object FlowSimulation:
       banks = closing.banks,
       householdAggregates = closing.householdAggregates,
       ledgerFinancialState = closing.ledgerFinancialState,
-    )
-
-  private def buildMonthTrace(
-      input: StepInput,
-      outcome: MonthOutcome,
-      nextState: SimState,
-      executedFlows: Sfc.SemanticFlows,
-      sfcResult: Sfc.SfcResult,
-  ): MonthTrace =
-    val projectedBoundary = outcome.traceCore.boundary.copy(
-      endSnapshot = MonthBoundarySnapshot.capture(
-        nextState.world,
-        nextState.firms,
-        nextState.households,
-        nextState.banks,
-        nextState.ledgerFinancialState,
-      ),
-    )
-    val projectedCore     = outcome.traceCore.copy(boundary = projectedBoundary)
-    MonthTrace.fromCore(
-      executionMonth = input.executionMonth,
-      randomness = input.randomness,
-      core = projectedCore,
-      executedFlows = executedFlows,
-      validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthTraceBuilder.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthTraceBuilder.scala
@@ -1,0 +1,77 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.accounting.Sfc
+import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
+
+/** Builds the month trace from explicit month-step boundaries.
+  *
+  * FlowSimulation owns the transition itself; this module owns the audit
+  * artifact assembled from that transition.
+  */
+object MonthTraceBuilder:
+
+  def timingTrace(
+      signalView: MonthSemantics.SignalView,
+      closing: MonthClosingResult,
+  ): MonthTimingTrace =
+    MonthTimingTrace.fromInputs(
+      MonthTimingInputs(
+        labor = MonthTimingPayload.LaborSignals(
+          operationalHiringSlack = signalView.labor.operationalHiringSlack,
+        ),
+        demand = MonthTimingPayload.DemandSignals(
+          sectorDemandMult = signalView.demand.sectorMults,
+          sectorDemandPressure = signalView.demand.sectorDemandPressure,
+          sectorHiringSignal = signalView.demand.sectorHiringSignal,
+        ),
+        nominal = MonthTimingPayload.NominalSignals(
+          realizedInflation = closing.world.inflation,
+          expectedInflation = closing.world.mechanisms.expectations.expectedInflation,
+        ),
+        firmDynamics = MonthTimingPayload.FirmDynamics(
+          startupAbsorptionRate = closing.startupAbsorptionRate,
+          firmBirths = closing.world.flows.firmBirths,
+          firmDeaths = closing.world.flows.firmDeaths,
+          netFirmBirths = closing.world.flows.netFirmBirths,
+        ),
+      ),
+    )
+
+  def core(
+      pre: FlowSimulation.StepInput,
+      closed: MonthSemantics.ClosedMonth,
+      seedOut: MonthSemantics.SeedOut,
+  ): MonthTraceCore =
+    MonthTraceCore(
+      boundary = MonthBoundaryTrace.from(pre.boundaryIn, closed.boundaryOut),
+      seedTransition = SeedTransitionTrace.from(pre.seedIn, seedOut),
+      timing = closed.timing,
+    )
+
+  def build(
+      executionMonth: ExecutionMonth,
+      randomness: MonthRandomness.Contract,
+      core: MonthTraceCore,
+      endState: FlowSimulation.SimState,
+      executedFlows: Sfc.SemanticFlows,
+      sfcResult: Sfc.SfcResult,
+  ): MonthTrace =
+    val projectedBoundary = core.boundary.copy(
+      endSnapshot = MonthBoundarySnapshot.capture(
+        endState.world,
+        endState.firms,
+        endState.households,
+        endState.banks,
+        endState.ledgerFinancialState,
+      ),
+    )
+    val projectedCore     = core.copy(boundary = projectedBoundary)
+
+    MonthTrace.fromCore(
+      executionMonth = executionMonth,
+      randomness = randomness,
+      core = projectedCore,
+      executedFlows = executedFlows,
+      validations = Vector(MonthValidation.fromSfcResult(sfcResult)),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthTraceBuilder.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthTraceBuilder.scala
@@ -11,6 +11,9 @@ import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
   */
 object MonthTraceBuilder:
 
+  /** Creates the timing-envelope trace from same-month signals and realized
+    * closed-month values.
+    */
   def timingTrace(
       signalView: MonthSemantics.SignalView,
       closing: MonthClosingResult,
@@ -38,6 +41,9 @@ object MonthTraceBuilder:
       ),
     )
 
+  /** Builds the reusable trace core at the explicit pre -> closed-month
+    * boundary, before SFC execution details are attached.
+    */
   def core(
       pre: FlowSimulation.StepInput,
       closed: MonthSemantics.ClosedMonth,
@@ -49,6 +55,9 @@ object MonthTraceBuilder:
       timing = closed.timing,
     )
 
+  /** Finalizes the full month trace with the projected end snapshot, executed
+    * semantic flows, and validation results.
+    */
   def build(
       executionMonth: ExecutionMonth,
       randomness: MonthRandomness.Contract,


### PR DESCRIPTION
Closes #649.

Summary:
- extracts month trace assembly into MonthTraceBuilder
- keeps FlowSimulation focused on month transition execution and next-state advancement
- updates engine README and MonthRandomness wording for stage/closing streams

Validation:
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.MonthTraceSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.assembly.SignalTimingRegressionSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engine documentation to clarify randomness and trace construction behavior.

* **Refactor**
  * Reorganized internal simulation tracing for improved code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->