### PR TITLE
Extract RuntimeFlowExecutor from FlowSimulation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -123,8 +123,9 @@ exactness, each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, records monetary flows, delegates trace construction, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates runtime execution and trace construction, and returns typed `nextState` for month `t+1`. |
 | `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |
+| `RuntimeFlowExecutor.scala` | Executes emitted runtime batches through the ledger interpreter, captures delta-ledger evidence, and maps execution failures consistently. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `HhTotalIncome`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |
 | `NfzFlows.scala` | NFZ (National Health Fund): 9% składka zdrowotna, healthcare spending, gov subvention |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -53,23 +53,14 @@ object FlowSimulation:
         ledgerFinancialState = init.ledgerFinancialState,
       )
 
+  /** Runtime ledger execution evidence produced by [[RuntimeFlowExecutor]]. */
+  type ExecutionResult = RuntimeFlowExecutor.Result
+
   /** Household micro snapshot boundary aligned with household-income flows.
     */
   case class HouseholdSnapshotState(
       households: Vector[Household.State],
       ledgerFinancialState: LedgerFinancialState,
-  )
-
-  /** Executed aggregate batch deltas on top of an empty runtime ledger shell.
-    *
-    * This is not a closing stock snapshot. `deltaLedger` stores the net monthly
-    * delta per synthetic runtime slot, and `netDelta` is the conservation check
-    * over that delta space.
-    */
-  case class ExecutionResult(
-      topology: RuntimeLedgerTopology,
-      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
-      netDelta: Long,
   )
 
   /** All calculus results needed to feed flow mechanisms. */
@@ -492,10 +483,7 @@ object FlowSimulation:
     val input                   = stepInput(stateIn, randomness, traceFirmDecisions)
     val outcome                 = computeMonthOutcome(input)
     val flows                   = emitAllBatches(outcome.flowPlan.calculus)
-    val execution               = executeBatches(flows).fold(
-      err => throw new IllegalStateException(s"Ledger batch execution failed: $err"),
-      identity,
-    )
+    val execution               = RuntimeFlowExecutor.executeOrThrow(flows)
     val semanticNextState       = advanceState(input, outcome)
     val runtimeProjection       = RuntimeFlowProjection.materializeSupportedState(
       opening = stateIn.ledgerFinancialState,
@@ -827,18 +815,6 @@ object FlowSimulation:
         banking = s9,
       ),
     )
-
-  private def executeBatches(flows: Vector[BatchedFlow])(using topology: RuntimeLedgerTopology): Either[String, ExecutionResult] =
-    val state = topology.emptyExecutionState()
-    ImperativeInterpreter
-      .planAndApplyAll(state, flows)
-      .map: _ =>
-        val deltaLedger = state.snapshot
-        ExecutionResult(
-          topology = topology,
-          deltaLedger = deltaLedger,
-          netDelta = topology.netDelta(deltaLedger),
-        )
 
   private def runtimeState(
       w: World,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala
@@ -1,0 +1,40 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.ledger.*
+
+/** Executes runtime ledger batches against the explicit month topology.
+  *
+  * Flow emission decides what should be booked; this module owns the runtime
+  * interpreter call, delta capture, and execution-failure mapping.
+  */
+object RuntimeFlowExecutor:
+
+  /** Executed aggregate batch deltas on top of an empty runtime ledger shell.
+    *
+    * This is not a closing stock snapshot. `deltaLedger` stores the net monthly
+    * delta per synthetic runtime slot, and `netDelta` is the conservation check
+    * over that delta space.
+    */
+  case class Result(
+      topology: RuntimeLedgerTopology,
+      deltaLedger: Map[(EntitySector, AssetType, Int), Long],
+      netDelta: Long,
+  )
+
+  def execute(flows: Vector[BatchedFlow])(using topology: RuntimeLedgerTopology): Either[String, Result] =
+    val state = topology.emptyExecutionState()
+    ImperativeInterpreter
+      .planAndApplyAll(state, flows)
+      .map: _ =>
+        val deltaLedger = state.snapshot
+        Result(
+          topology = topology,
+          deltaLedger = deltaLedger,
+          netDelta = topology.netDelta(deltaLedger),
+        )
+
+  def executeOrThrow(flows: Vector[BatchedFlow])(using RuntimeLedgerTopology): Result =
+    execute(flows).fold(err => throw executionFailure(err), identity)
+
+  def executionFailure(error: String): IllegalStateException =
+    IllegalStateException(s"Ledger batch execution failed: $error")

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutorSpec.scala
@@ -1,0 +1,47 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.ledger.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RuntimeFlowExecutorSpec extends AnyFlatSpec with Matchers:
+
+  private given RuntimeLedgerTopology = RuntimeLedgerTopology.zeroPopulation
+
+  private def validTransfer(amount: Long): BatchedFlow =
+    val topology = summon[RuntimeLedgerTopology]
+    BatchedFlow.Broadcast(
+      from = EntitySector.Government,
+      fromIndex = topology.government.sovereignIssuer,
+      to = EntitySector.Households,
+      amounts = Array(amount),
+      targetIndices = Array(topology.households.aggregate),
+      asset = AssetType.Cash,
+      mechanism = FlowMechanism.GovPurchases,
+    )
+
+  "RuntimeFlowExecutor" should "execute runtime batches and capture delta ledger evidence" in {
+    val topology = summon[RuntimeLedgerTopology]
+    val result   = RuntimeFlowExecutor.execute(Vector(validTransfer(100L))) match
+      case Right(value) => value
+      case Left(error)  => fail(error)
+
+    result.topology shouldBe topology
+    result.netDelta shouldBe 0L
+    result.deltaLedger((EntitySector.Government, AssetType.Cash, topology.government.sovereignIssuer)) shouldBe -100L
+    result.deltaLedger((EntitySector.Households, AssetType.Cash, topology.households.aggregate)) shouldBe 100L
+  }
+
+  it should "return interpreter validation failures without throwing" in {
+    RuntimeFlowExecutor.execute(Vector(validTransfer(-1L))) match
+      case Left(error)  => error should include("negative")
+      case Right(value) => fail(s"Expected runtime execution failure, got $value")
+  }
+
+  it should "map execution failures through one exception path for month-step callers" in {
+    val err = intercept[IllegalStateException]:
+      RuntimeFlowExecutor.executeOrThrow(Vector(validTransfer(-1L)))
+
+    err.getMessage should include("Ledger batch execution failed")
+    err.getMessage should include("negative")
+  }


### PR DESCRIPTION
Closes #651.

Summary:
- extracts runtime batch execution, delta-ledger capture, and execution-failure mapping into RuntimeFlowExecutor
- keeps FlowSimulation.ExecutionResult source-compatible as an alias to RuntimeFlowExecutor.Result
- updates engine README and adds isolated executor coverage

Validation:
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.RuntimeFlowExecutorSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationRuntimeProjectionSpec com.boombustgroup.amorfati.engine.ledger.RuntimeMechanismSurvivabilitySpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system documentation to reflect the runtime execution architecture.

* **Refactor**
  * Reorganized runtime execution flow for improved code structure and maintainability.

* **Tests**
  * Added test coverage for batch execution, including error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->