### PR TITLE
Extract NextStateAdvancer from FlowSimulation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -123,9 +123,10 @@ exactness, each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates runtime execution and trace construction, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates runtime execution, next-state advancement, and trace construction, and returns typed `nextState` for month `t+1`. |
 | `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |
 | `RuntimeFlowExecutor.scala` | Executes emitted runtime batches through the ledger interpreter, captures delta-ledger evidence, and maps execution failures consistently. |
+| `NextStateAdvancer.scala` | Owns the closed-month -> next-pre transition: applies extracted `SeedOut`, enforces seed timing invariants, and materializes runtime-supported ledger deltas into the next `SimState`. |
 | `FlowMechanism.scala` | Enum of ~80 named flow mechanisms (e.g. `HhTotalIncome`, `HhConsumption`, `BankBfgLevy`). Each flow in the system maps to exactly one mechanism. |
 | `ZusFlows.scala` | ZUS/FUS pensions: contributions (HH → FUS), pensions (FUS → HH), gov subvention covering deficit |
 | `NfzFlows.scala` | NFZ (National Health Fund): 9% składka zdrowotna, healthcare spending, gov subvention |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -7,7 +7,7 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.assembly.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit, LedgerFinancialState, RuntimeFlowProjection}
+import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit, LedgerFinancialState}
 import com.boombustgroup.amorfati.engine.markets.CorporateBondMarket
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
@@ -484,14 +484,16 @@ object FlowSimulation:
     val outcome                 = computeMonthOutcome(input)
     val flows                   = emitAllBatches(outcome.flowPlan.calculus)
     val execution               = RuntimeFlowExecutor.executeOrThrow(flows)
-    val semanticNextState       = advanceState(input, outcome)
-    val runtimeProjection       = RuntimeFlowProjection.materializeSupportedState(
-      opening = stateIn.ledgerFinancialState,
-      semanticClosing = semanticNextState.ledgerFinancialState,
-      deltaLedger = execution.deltaLedger,
-      topology = execution.topology,
+    val nextState               = NextStateAdvancer.advance(
+      NextStateAdvancer.Input(
+        stateIn = input.stateIn,
+        executionMonth = input.executionMonth,
+        seedIn = input.seedIn,
+        closed = outcome.closed,
+        seedOut = outcome.seedOut,
+        execution = execution,
+      ),
     )
-    val nextState               = semanticNextState.copy(ledgerFinancialState = runtimeProjection.ledgerFinancialState)
     val sfcFlows                = buildSfcFlows(outcome.semanticProjection, flows, nextState.world.plumbing.fofResidual)
     val sfcResult               = Sfc.validate(
       prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, stateIn.ledgerFinancialState),
@@ -1196,28 +1198,3 @@ object FlowSimulation:
         seedOut = seedOut,
         traceCore = traceCore,
       )
-
-  private def advanceState(
-      input: StepInput,
-      outcome: MonthOutcome,
-  ): SimState =
-    val closing     = outcome.closed.closing
-    val nextSeed    = outcome.seedOut.nextSeed
-    val nextWorld   = closing.world.copy(pipeline = closing.world.pipeline.withDecisionSignals(nextSeed))
-    val currentSeed = input.seedIn.decisionSignals
-
-    // `advanceState` is the only legal `post -> next-pre` transition:
-    // closed month still sees the old seed; next state applies `seedOut`.
-    require(currentSeed == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
-    require(closing.world.seedIn == currentSeed, "ClosedMonth world must remain on the pre-step seed until advanceState runs")
-    require(nextWorld.seedIn == nextSeed, "advanceState must be the transition that applies SeedOut to the next boundary")
-
-    new SimState(
-      completedMonth = input.executionMonth.completed,
-      world = nextWorld,
-      firms = closing.firms,
-      households = closing.households,
-      banks = closing.banks,
-      householdAggregates = closing.householdAggregates,
-      ledgerFinancialState = closing.ledgerFinancialState,
-    )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
@@ -38,8 +38,14 @@ object NextStateAdvancer:
     val nextWorld   = closing.world.copy(pipeline = closing.world.pipeline.withDecisionSignals(nextSeed))
     val currentSeed = input.seedIn.decisionSignals
 
+    val expectedExecutionMonth = input.stateIn.completedMonth.next
+
     // This is the only legal closed-month -> next-pre transition: the closed
     // month still sees the old seed, while the next boundary applies SeedOut.
+    require(
+      input.executionMonth == expectedExecutionMonth,
+      s"NextStateAdvancer input.executionMonth ${input.executionMonth.toInt} must equal input.stateIn.completedMonth.next ${expectedExecutionMonth.toInt} before constructing FlowSimulation.SimState",
+    )
     require(currentSeed == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
     require(closing.world.seedIn == currentSeed, "ClosedMonth world must remain on the pre-step seed until NextStateAdvancer runs")
     require(nextWorld.seedIn == nextSeed, "NextStateAdvancer must be the transition that applies SeedOut to the next boundary")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
@@ -1,0 +1,55 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.engine.{MonthSemantics, SimulationMonth}
+import com.boombustgroup.amorfati.engine.ledger.RuntimeFlowProjection
+
+/** Advances a realized closed month into the next pre-month simulation state.
+  *
+  * Month closing still belongs to month `t`; this module is the explicit
+  * boundary where the extracted `SeedOut` becomes the persisted month `t + 1`
+  * decision surface and runtime-supported ledger deltas are materialized.
+  */
+object NextStateAdvancer:
+
+  /** Explicit input for the closed-month -> next-pre boundary. */
+  case class Input(
+      stateIn: FlowSimulation.SimState,
+      executionMonth: SimulationMonth.ExecutionMonth,
+      seedIn: MonthSemantics.SeedIn,
+      closed: MonthSemantics.ClosedMonth,
+      seedOut: MonthSemantics.SeedOut,
+      execution: RuntimeFlowExecutor.Result,
+  )
+
+  def advance(input: Input): FlowSimulation.SimState =
+    val semanticState     = advanceSemanticState(input)
+    val runtimeProjection = RuntimeFlowProjection.materializeSupportedState(
+      opening = input.stateIn.ledgerFinancialState,
+      semanticClosing = semanticState.ledgerFinancialState,
+      deltaLedger = input.execution.deltaLedger,
+      topology = input.execution.topology,
+    )
+
+    semanticState.copy(ledgerFinancialState = runtimeProjection.ledgerFinancialState)
+
+  private def advanceSemanticState(input: Input): FlowSimulation.SimState =
+    val closing     = input.closed.closing
+    val nextSeed    = input.seedOut.nextSeed
+    val nextWorld   = closing.world.copy(pipeline = closing.world.pipeline.withDecisionSignals(nextSeed))
+    val currentSeed = input.seedIn.decisionSignals
+
+    // This is the only legal closed-month -> next-pre transition: the closed
+    // month still sees the old seed, while the next boundary applies SeedOut.
+    require(currentSeed == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
+    require(closing.world.seedIn == currentSeed, "ClosedMonth world must remain on the pre-step seed until NextStateAdvancer runs")
+    require(nextWorld.seedIn == nextSeed, "NextStateAdvancer must be the transition that applies SeedOut to the next boundary")
+
+    FlowSimulation.SimState(
+      completedMonth = input.executionMonth.completed,
+      world = nextWorld,
+      firms = closing.firms,
+      households = closing.households,
+      banks = closing.banks,
+      householdAggregates = closing.householdAggregates,
+      ledgerFinancialState = closing.ledgerFinancialState,
+    )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -490,7 +490,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     result.trace.seedTransition.seedOut shouldBe seedOut.nextSeed
   }
 
-  it should "accept an explicit month-step randomness contract with named stage and assembly streams" in {
+  it should "accept an explicit month-step randomness contract with named stage and closing streams" in {
     val state      = stateFromSeed()
     val contract   = monthRandomness(1234L)
     val fromSeed   = FlowSimulation.step(state, contract)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
@@ -1,7 +1,16 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthBoundarySnapshot, MonthClosingResult, MonthSemantics, MonthTimingTrace, SignalExtraction, World}
+import com.boombustgroup.amorfati.engine.{
+  DecisionSignals,
+  MonthBoundarySnapshot,
+  MonthClosingResult,
+  MonthSemantics,
+  MonthTimingTrace,
+  SignalExtraction,
+  SimulationMonth,
+  World,
+}
 import com.boombustgroup.amorfati.types.{PLN, Share}
 import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -38,6 +47,18 @@ class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
     err.getMessage.should(include("StepInput seedIn"))
   }
 
+  it should "reject an execution month that does not follow the opening completed month" in {
+    val state    = stateFromSeed()
+    val nextSeed = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
+
+    val err = intercept[IllegalArgumentException]:
+      NextStateAdvancer.advance(input(state, nextSeed, executionMonth = Some(state.completedMonth.next.next)))
+
+    err.getMessage.should(include("input.executionMonth"))
+    err.getMessage.should(include("input.stateIn.completedMonth.next"))
+    err.getMessage.should(include("FlowSimulation.SimState"))
+  }
+
   it should "reject a closed month that already applied the next seed" in {
     val state       = stateFromSeed()
     val nextSeed    = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
@@ -52,13 +73,14 @@ class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
   private def input(
       state: FlowSimulation.SimState,
       nextSeed: DecisionSignals,
+      executionMonth: Option[SimulationMonth.ExecutionMonth] = None,
       seedIn: Option[MonthSemantics.SeedIn] = None,
       closed: Option[MonthSemantics.ClosedMonth] = None,
       execution: Option[RuntimeFlowExecutor.Result] = None,
   ): NextStateAdvancer.Input =
     NextStateAdvancer.Input(
       stateIn = state,
-      executionMonth = state.completedMonth.next,
+      executionMonth = executionMonth.getOrElse(state.completedMonth.next),
       seedIn = seedIn.getOrElse(MonthSemantics.seedIn(state.world.seedIn)),
       closed = closed.getOrElse(closedMonth(state)),
       seedOut = seedOut(nextSeed),

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
@@ -1,0 +1,128 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.{DecisionSignals, MonthBoundarySnapshot, MonthClosingResult, MonthSemantics, MonthTimingTrace, SignalExtraction, World}
+import com.boombustgroup.amorfati.types.{PLN, Share}
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
+  import RuntimeFlowsTestSupport.*
+
+  private given SimParams = SimParams.defaults
+
+  "NextStateAdvancer" should "apply SeedOut at the next-pre boundary and materialize runtime ledger deltas" in {
+    val state     = stateFromSeed()
+    val nextSeed  = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
+    val execution = executeNfzTransfer(state, PLN(12345))
+
+    val nextState = NextStateAdvancer.advance(input(state, nextSeed, execution = Some(execution)))
+
+    nextState.completedMonth.shouldBe(state.completedMonth.next.completed)
+    nextState.world.seedIn.shouldBe(nextSeed)
+    nextState.firms.shouldBe(state.firms)
+    nextState.households.shouldBe(state.households)
+    nextState.banks.shouldBe(state.banks)
+    nextState.ledgerFinancialState.funds.nfzCash.shouldBe(state.ledgerFinancialState.funds.nfzCash + PLN(12345))
+  }
+
+  it should "reject a step input seed that does not match the opening state" in {
+    val state    = stateFromSeed()
+    val nextSeed = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
+    val badSeed  = state.world.seedIn.copy(laggedHiringSlack = Share.Zero)
+
+    val err = intercept[IllegalArgumentException]:
+      NextStateAdvancer.advance(input(state, nextSeed, seedIn = Some(MonthSemantics.seedIn(badSeed))))
+
+    err.getMessage.should(include("StepInput seedIn"))
+  }
+
+  it should "reject a closed month that already applied the next seed" in {
+    val state       = stateFromSeed()
+    val nextSeed    = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
+    val seededWorld = state.world.copy(pipeline = state.world.pipeline.withDecisionSignals(nextSeed))
+
+    val err = intercept[IllegalArgumentException]:
+      NextStateAdvancer.advance(input(state, nextSeed, closed = Some(closedMonth(state, world = Some(seededWorld)))))
+
+    err.getMessage.should(include("ClosedMonth world must remain on the pre-step seed"))
+  }
+
+  private def input(
+      state: FlowSimulation.SimState,
+      nextSeed: DecisionSignals,
+      seedIn: Option[MonthSemantics.SeedIn] = None,
+      closed: Option[MonthSemantics.ClosedMonth] = None,
+      execution: Option[RuntimeFlowExecutor.Result] = None,
+  ): NextStateAdvancer.Input =
+    NextStateAdvancer.Input(
+      stateIn = state,
+      executionMonth = state.completedMonth.next,
+      seedIn = seedIn.getOrElse(MonthSemantics.seedIn(state.world.seedIn)),
+      closed = closed.getOrElse(closedMonth(state)),
+      seedOut = seedOut(nextSeed),
+      execution = execution.getOrElse(emptyExecution(state)),
+    )
+
+  private def closedMonth(state: FlowSimulation.SimState, world: Option[World] = None): MonthSemantics.ClosedMonth =
+    val closingWorld = world.getOrElse(state.world)
+    val closing      = MonthClosingResult(
+      world = closingWorld,
+      firms = state.firms,
+      households = state.households,
+      banks = state.banks,
+      householdAggregates = state.householdAggregates,
+      ledgerFinancialState = state.ledgerFinancialState,
+      startupAbsorptionRate = state.world.seedIn.startupAbsorptionRate,
+    )
+
+    MonthSemantics.closedMonth(
+      FlowSimulation.ClosedMonthBoundary(
+        closing = closing,
+        boundaryOut = MonthBoundarySnapshot.capture(closingWorld, state.firms, state.households, state.banks, state.ledgerFinancialState),
+        timing = MonthTimingTrace(Vector.empty),
+      ),
+    )
+
+  private def seedOut(signals: DecisionSignals): MonthSemantics.SeedOut =
+    MonthSemantics.seedOut(
+      SignalExtraction.compute(
+        SignalExtraction.Input(
+          labor = SignalExtraction.LaborOutcomes(
+            unemploymentRate = signals.unemploymentRate,
+            laggedHiringSlack = signals.laggedHiringSlack,
+            startupAbsorptionRate = signals.startupAbsorptionRate,
+          ),
+          nominal = SignalExtraction.NominalOutcomes(
+            inflation = signals.inflation,
+            expectedInflation = signals.expectedInflation,
+          ),
+          demand = SignalExtraction.DemandOutcomes(
+            sectorDemandMult = signals.sectorDemandMult,
+            sectorDemandPressure = signals.sectorDemandPressure,
+            sectorHiringSignal = signals.sectorHiringSignal,
+          ),
+        ),
+      ),
+    )
+
+  private def emptyExecution(state: FlowSimulation.SimState): RuntimeFlowExecutor.Result =
+    given RuntimeLedgerTopology = RuntimeLedgerTopology.fromState(state)
+    RuntimeFlowExecutor.executeOrThrow(Vector.empty)
+
+  private def executeNfzTransfer(state: FlowSimulation.SimState, amount: PLN): RuntimeFlowExecutor.Result =
+    given topology: RuntimeLedgerTopology = RuntimeLedgerTopology.fromState(state)
+    RuntimeFlowExecutor.executeOrThrow(
+      Vector(
+        BatchedFlow.Broadcast(
+          from = EntitySector.Government,
+          fromIndex = topology.government.sovereignIssuer,
+          to = EntitySector.Funds,
+          amounts = Array(amount.toLong),
+          targetIndices = Array(topology.funds.nfz),
+          asset = AssetType.Cash,
+          mechanism = FlowMechanism.GovPurchases,
+        ),
+      ),
+    )


### PR DESCRIPTION
Closes #652.

Summary:
- extracts the closed-month -> next-pre transition into NextStateAdvancer
- moves seed timing invariant checks and runtime-supported ledger materialization out of FlowSimulation
- adds direct NextStateAdvancer coverage for SeedOut application, runtime ledger projection, and invariant failures
- updates engine README and the stale randomness test wording from assembly streams to closing streams

Validation:
- sbt scalafmtAll
- sbt Test/compile
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.NextStateAdvancerSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.assembly.SignalTimingRegressionSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized month-boundary state advancement logic into a dedicated component to improve code modularity and maintainability.

* **Documentation**
  * Updated component responsibility descriptions in engine documentation.

* **Tests**
  * Added comprehensive test suite validating month-step boundary behavior.
  * Updated test descriptions for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->