### PR TITLE
Extract flow emission and SFC projection boundaries

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -123,7 +123,9 @@ exactness, each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates runtime execution, next-state advancement, and trace construction, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates flow emission, runtime execution, SFC projection, next-state advancement, and trace construction, and returns typed `nextState` for month `t+1`. |
+| `MonthFlowEmitter.scala` | Translates `MonthlyCalculus` into named runtime ledger batches without doing economics or validation. |
+| `SfcSemanticProjection.scala` | Converts executed runtime batches plus narrow semantic views into `Sfc.SemanticFlows` and runs the SFC validation boundary. |
 | `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |
 | `RuntimeFlowExecutor.scala` | Executes emitted runtime batches through the ledger interpreter, captures delta-ledger evidence, and maps execution failures consistently. |
 | `NextStateAdvancer.scala` | Owns the closed-month -> next-pre transition: applies extracted `SeedOut`, enforces seed timing invariants, and materializes runtime-supported ledger deltas into the next `SimState`. |
@@ -219,9 +221,9 @@ economics-stage market-clearing pipeline.
 1. Add a case to the `FlowMechanism` enum in `FlowMechanism.scala`.
 2. Add the mechanism to `FlowMechanism.emittedRuntimeMechanisms`.
 3. Create or extend the appropriate `*Flows.scala` to emit the flow.
-4. Wire the batch emission call in `FlowSimulation.emitAllBatches(...)` or the relevant aggregation point.
+4. Wire the batch emission call in `MonthFlowEmitter.emitAllBatches(...)` or the relevant aggregation point.
 5. Update `RuntimeMechanismSurvivability.scala` with the mechanism's audit class and ensure representative branch coverage exercises it.
-6. Update the SFC validation projection so exact stock-flow identities cover the new flow.
+6. Update `SfcSemanticProjection.scala` so exact stock-flow identities cover the new flow.
 
 **SFC rule:** Any flow that modifies bank capital, deposits, government
 debt, NFA, bond holdings, or interbank positions **must** be reflected in

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -203,146 +203,11 @@ object FlowSimulation:
     * here.
     */
   def emitAllBatches(c: MonthlyCalculus)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
-    Vector.concat(
-      // Tier 1: Social funds
-      ZusFlows.emitBatches(ZusFlows.ZusInput(c.zus)),
-      NfzFlows.emitBatches(NfzFlows.NfzInput(c.nfz)),
-      PpkFlows.emitBatches(PpkFlows.PpkInput(c.ppk)),
-      GovBondFlows.emitBatches(c.govBondRuntimeMovements),
-      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.earmarked)),
-      JstFlows.emitBatches(JstFlows.Input(c.firmTax, c.totalIncome, c.gdp, c.livingFirms, c.pitRevenue)),
-      // Tier 2: Agents
-      HouseholdFlows.emitBatches(
-        HouseholdFlows.Input(
-          c.consumption,
-          c.totalRent,
-          c.pitRevenue,
-          c.totalDepositInterest,
-          c.totalRemittances,
-          c.approvedCcOrigination,
-          c.liquidityShortfallFinancing,
-          c.totalCcPrincipal,
-          (c.totalCcDebtService - c.totalCcPrincipal).max(PLN.Zero),
-          c.totalCcDefault,
-        ),
-      ),
-      FirmFlows.emitBatches(
-        FirmFlows.Input(
-          c.totalIncome,
-          c.firmTax,
-          c.firmPrincipal,
-          c.firmNewLoans,
-          c.firmInterestIncome,
-          c.firmCapex,
-          c.firmEquityIssuance,
-          c.firmIoPayments,
-          c.firmNplLoss,
-          c.firmProfitShifting,
-          c.firmFdiRepatriation,
-          c.firmGrossInvestment,
-        ),
-      ),
-      InvestmentDepositSettlementFlows.emitBatches(InvestmentDepositSettlementFlows.Input(c.investNetDepositFlow)),
-      GovBudgetFlows.emitBatches(
-        GovBudgetFlows.Input(
-          vatRevenue = c.govVatRevenue,
-          exciseRevenue = c.govExciseRevenue,
-          customsDutyRevenue = c.govCustomsDutyRevenue,
-          govCurrentSpend = c.govCurrentSpend,
-          debtService = c.govDebtService,
-          unempBenefitSpend = c.totalUnempBenefits,
-          socialTransferSpend = c.totalSocialTransfers,
-          euCofinancing = c.govEuCofinancing,
-          govCapitalSpend = c.govCapitalSpend,
-          debtServiceRecipients = Some(c.govDebtServiceRecipients),
-        ),
-      ),
-      InsuranceFlows.emitBatches(
-        InsuranceFlows.Input(
-          employed = c.employed,
-          wage = c.wage,
-          unempRate = c.unemploymentRate,
-          currentLifeReserves = c.insuranceCurrentLifeReserves,
-          currentNonLifeReserves = c.insuranceCurrentNonLifeReserves,
-          prevGovBondHoldings = c.insurancePrevGovBonds,
-          prevCorpBondHoldings = c.insurancePrevCorpBonds,
-          corpBondDefaultLoss = c.insuranceCorpBondDefaultLoss,
-          prevEquityHoldings = c.insurancePrevEquity,
-          govBondYield = c.govBondYield,
-          corpBondYield = c.corpBondYield,
-          equityReturn = c.equityReturn,
-        ),
-      ),
-      // Tier 3: Financial markets
-      EquityFlows.emitBatches(
-        EquityFlows.Input(
-          c.equityDomDividends,
-          c.equityForDividends,
-          c.equityDivTax,
-          c.equityGovDividends,
-        ),
-      ),
-      EquityFlows.emitRevaluationBatches(c.equityRevaluation),
-      CorpBondFlows.emitBatches(
-        CorpBondFlows.Input(
-          coupon = c.corpBondCoupon,
-          defaultAmount = c.corpBondDefaultAmount,
-          issuance = c.corpBondIssuance,
-          amortization = c.corpBondAmortization,
-          couponRecipients = Some(c.corpBondCouponRecipients),
-          defaultRecipients = Some(c.corpBondDefaultRecipients),
-          issuanceRecipients = Some(c.corpBondIssuanceRecipients),
-          amortizationRecipients = Some(c.corpBondAmortizationRecipients),
-        ),
-      ),
-      MortgageFlows.emitBatches(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
-      OpenEconFlows.emitBatches(
-        OpenEconFlows.Input(
-          exports = c.exports,
-          imports = c.totalImports,
-          tourismExport = c.tourismExport,
-          tourismImport = c.tourismImport,
-          fdi = c.fdi,
-          portfolioFlows = c.portfolioFlows,
-          carryTradeFlow = c.carryTradeFlow,
-          primaryIncome = c.primaryIncome,
-          euFunds = c.euFunds,
-          diasporaInflow = c.diasporaInflow,
-          capitalFlightOutflow = c.capitalFlightOutflow,
-        ),
-      ),
-      BankingFlows.emitBatches(
-        BankingFlows.Input(
-          firmInterestIncome = c.firmInterestIncome,
-          firmNplLoss = c.firmNplLoss,
-          mortgageNplLoss = c.mortgageDefault * (Share.One - p.housing.mortgageRecovery),
-          consumerNplLoss = (c.totalCcDefault - c.liquidityShortfallFinancing).max(PLN.Zero) * (Share.One - p.household.ccNplRecovery),
-          govBondIncome = c.bankGovBondIncome,
-          reserveInterest = c.bankReserveInterest,
-          standingFacilityIncome = c.bankStandingFacility,
-          interbankInterest = c.bankInterbankInterest,
-          corpBondCoupon = c.bankCorpBondCoupon,
-          corpBondDefaultLoss = c.bankCorpBondLoss,
-          bfgLevy = c.bankBfgLevy,
-          unrealizedBondLoss = c.bankUnrealizedLoss,
-          bailInLoss = c.bankBailIn,
-          nbpRemittance = c.bankNbpRemittance,
-          fxReserveSettlement = c.bankFxReserveSettlement,
-          standingFacilityBackstop = c.bankStandingFacilityBackstop,
-        ),
-      ),
-      NbfiFlows.emitBatches(NbfiFlows.Input(c.nbfiDepositDrain, c.nbfiOrigination, c.nbfiRepayment, c.nbfiDefaultAmount)),
-      QuasiFiscalFlows.emitBatches(
-        QuasiFiscalFlows.Input(
-          bankBondIssuance = c.qfBankBondIssuance,
-          nbpBondAbsorption = c.qfNbpBondAbsorption,
-          bankBondAmortization = c.qfBankBondAmortization,
-          nbpBondAmortization = c.qfNbpBondAmortization,
-          lending = c.qfLending,
-          repayment = c.qfRepayment,
-        ),
-      ),
-    )
+    MonthFlowEmitter.emitAllBatches(c)
+
+  type ExecutedFlowEvidence = SfcSemanticProjection.ExecutedFlowEvidence
+  val ExecutedFlowEvidence: SfcSemanticProjection.ExecutedFlowEvidence.type =
+    SfcSemanticProjection.ExecutedFlowEvidence
 
   /** Typed month-`t` boundary input used internally by [[step]]. */
   case class StepInput(
@@ -482,7 +347,7 @@ object FlowSimulation:
     given RuntimeLedgerTopology = RuntimeLedgerTopology.fromState(stateIn)
     val input                   = stepInput(stateIn, randomness, traceFirmDecisions)
     val outcome                 = computeMonthOutcome(input)
-    val flows                   = emitAllBatches(outcome.flowPlan.calculus)
+    val flows                   = MonthFlowEmitter.emitAllBatches(outcome.flowPlan.calculus)
     val execution               = RuntimeFlowExecutor.executeOrThrow(flows)
     val nextState               = NextStateAdvancer.advance(
       NextStateAdvancer.Input(
@@ -494,14 +359,13 @@ object FlowSimulation:
         execution = execution,
       ),
     )
-    val sfcFlows                = buildSfcFlows(outcome.semanticProjection, flows, nextState.world.plumbing.fofResidual)
-    val sfcResult               = Sfc.validate(
-      prev = runtimeState(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, stateIn.ledgerFinancialState),
-      curr = runtimeState(nextState.world, nextState.firms, nextState.households, nextState.banks, nextState.ledgerFinancialState),
+    val sfcFlows                = SfcSemanticProjection.semanticFlows(outcome.semanticProjection, flows, nextState.world.plumbing.fofResidual)
+    val sfcResult               = SfcSemanticProjection.validate(
+      stateIn = stateIn,
+      nextState = nextState,
       flows = sfcFlows,
       batches = flows,
-      executionDeltaLedger = Sfc.ExecutionDeltaLedger.fromRaw(execution.deltaLedger),
-      deltaLedgerNet = execution.netDelta,
+      execution = execution,
     )
     val monthTrace              = MonthTraceBuilder.build(
       executionMonth = input.executionMonth,
@@ -818,15 +682,6 @@ object FlowSimulation:
       ),
     )
 
-  private def runtimeState(
-      w: World,
-      firms: Vector[Firm.State],
-      households: Vector[Household.State],
-      banks: Vector[Banking.BankState],
-      ledgerFinancialState: LedgerFinancialState,
-  ): Sfc.RuntimeState =
-    Sfc.RuntimeState(w, firms, households, banks, ledgerFinancialState)
-
   private def corpBondCouponRecipients(coupon: CorporateBondMarket.CouponResult): CorpBondFlows.HolderBreakdown =
     CorpBondFlows.HolderBreakdown(
       banks = coupon.bank,
@@ -888,240 +743,6 @@ object FlowSimulation:
           insurance = PLN.fromRaw(allocated(3)),
           nbfi = PLN.fromRaw(allocated(4)),
         )
-
-  private[flows] case class ExecutedFlowEvidence(
-      totals: Map[MechanismId, Long],
-      signedTotals: Map[MechanismId, Long],
-  ):
-    def amount(mechanism: MechanismId): PLN =
-      PLN.fromRaw(totals.getOrElse(mechanism, 0L))
-
-    def signedAmount(mechanism: MechanismId): PLN =
-      PLN.fromRaw(signedTotals.getOrElse(mechanism, 0L))
-
-    def sum(mechanisms: MechanismId*): PLN =
-      PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
-
-    def sumAll(mechanisms: Iterable[MechanismId]): PLN =
-      PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
-
-    def govSpending: PLN =
-      sumAll(ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms) +
-        sumAll(ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
-
-    def jstRevenue: PLN =
-      sumAll(ExecutedFlowEvidence.JstRevenueMechanisms)
-
-    def jstDepositChange: PLN =
-      jstRevenue - amount(FlowMechanism.JstSpending)
-
-    def insuranceNetDepositChange: PLN =
-      sum(FlowMechanism.InsLifeClaim, FlowMechanism.InsNonLifeClaim) -
-        sum(FlowMechanism.InsLifePremium, FlowMechanism.InsNonLifePremium)
-
-    def investNetDepositFlow: PLN =
-      signedAmount(FlowMechanism.InvestmentDepositSettlement)
-
-    def nbfiDepositDrain: PLN =
-      signedAmount(FlowMechanism.TfiDepositDrain)
-
-    /** Total BGK/PFR bond issuance. This intentionally includes both the
-      * commercial-bank leg and the separately addressable NBP absorption leg.
-      */
-    def quasiFiscalBondIssuance: PLN =
-      amount(FlowMechanism.QuasiFiscalBondIssuance) + amount(FlowMechanism.QuasiFiscalNbpAbsorption)
-
-    /** Total BGK/PFR bond amortization across bank and NBP holders. */
-    def quasiFiscalBondAmortization: PLN =
-      amount(FlowMechanism.QuasiFiscalBondAmortization) + amount(FlowMechanism.QuasiFiscalNbpBondAmortization)
-
-    /** NBP's purchase share of BGK/PFR issuance. Callers that already use
-      * `quasiFiscalBondIssuance` must not add this again.
-      */
-    def quasiFiscalNbpAbsorption: PLN =
-      amount(FlowMechanism.QuasiFiscalNbpAbsorption)
-
-    /** NBP holder leg of BGK/PFR bond amortization. Callers that already use
-      * `quasiFiscalBondAmortization` must not add this again.
-      */
-    def quasiFiscalNbpBondAmortization: PLN =
-      amount(FlowMechanism.QuasiFiscalNbpBondAmortization)
-
-    def quasiFiscalLending: PLN =
-      amount(FlowMechanism.QuasiFiscalLending)
-
-    def quasiFiscalRepayment: PLN =
-      amount(FlowMechanism.QuasiFiscalRepayment)
-
-    def quasiFiscalDepositChange: PLN =
-      signedAmount(FlowMechanism.QuasiFiscalLendingDeposit) +
-        signedAmount(FlowMechanism.QuasiFiscalRepaymentDeposit)
-
-  private[flows] object ExecutedFlowEvidence:
-    val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
-      Vector(
-        FlowMechanism.GovPurchases,
-        FlowMechanism.GovDebtService,
-        FlowMechanism.GovUnempBenefit,
-        FlowMechanism.GovSocialTransfer,
-        FlowMechanism.GovEuCofin,
-        FlowMechanism.GovCapitalInvestment,
-        FlowMechanism.JstGovSubvention,
-      )
-
-    val SocialFundGovSubventionMechanisms: Vector[MechanismId] =
-      Vector(
-        FlowMechanism.ZusGovSubvention,
-        FlowMechanism.NfzGovSubvention,
-        FlowMechanism.FpGovSubvention,
-        FlowMechanism.PfronGovSubvention,
-        FlowMechanism.FgspGovSubvention,
-      )
-
-    val JstRevenueMechanisms: Vector[MechanismId] =
-      Vector(FlowMechanism.JstRevenue, FlowMechanism.JstGovSubvention)
-
-    def from(batches: Vector[BatchedFlow]): ExecutedFlowEvidence =
-      val (totals, signedTotals): (Map[MechanismId, Long], Map[MechanismId, Long]) =
-        batches.foldLeft(
-          Map.empty[MechanismId, Long].withDefaultValue(0L),
-          Map.empty[MechanismId, Long].withDefaultValue(0L),
-        ):
-          case ((totalsAcc, signedAcc), batch) =>
-            val amount       = RuntimeLedgerTopology.totalTransferred(batch)
-            val signedAmount =
-              batch.mechanism match
-                case FlowMechanism.BankInterbankInterest | FlowMechanism.BankStandingFacility =>
-                  (batch.from, batch.to) match
-                    case (EntitySector.NBP, EntitySector.Banks) => amount
-                    case (EntitySector.Banks, EntitySector.NBP) => -amount
-                    case _                                      => amount
-                case FlowMechanism.InvestmentDepositSettlement                                =>
-                  (batch.from, batch.to) match
-                    case (EntitySector.Banks, EntitySector.Firms) => amount
-                    case (EntitySector.Firms, EntitySector.Banks) => -amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"InvestmentDepositSettlement batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
-                case FlowMechanism.TfiDepositDrain                                            =>
-                  (batch.from, batch.to) match
-                    case (EntitySector.Banks, EntitySector.Households) => amount
-                    case (EntitySector.Households, EntitySector.Banks) => -amount
-                    case _                                             =>
-                      throw new IllegalArgumentException(
-                        s"TfiDepositDrain batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
-                case FlowMechanism.QuasiFiscalLendingDeposit                                  =>
-                  (batch.from, batch.to) match
-                    case (EntitySector.Banks, EntitySector.Firms) => amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"QuasiFiscalLendingDeposit batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
-                case FlowMechanism.QuasiFiscalRepaymentDeposit                                =>
-                  (batch.from, batch.to) match
-                    case (EntitySector.Firms, EntitySector.Banks) => -amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"QuasiFiscalRepaymentDeposit batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
-                case _                                                                        => amount
-
-            (
-              totalsAcc.updated(batch.mechanism, totalsAcc(batch.mechanism) + amount),
-              signedAcc.updated(batch.mechanism, signedAcc(batch.mechanism) + signedAmount),
-            )
-
-      ExecutedFlowEvidence(totals, signedTotals)
-
-  private def buildSfcFlows(
-      semanticProjection: MonthSemantics.SemanticProjection,
-      batches: Vector[BatchedFlow],
-      fofResidual: PLN,
-  )(using p: SimParams): Sfc.SemanticFlows =
-    val firms    = semanticProjection.firms
-    val openEcon = semanticProjection.openEcon
-    val banking  = semanticProjection.banking
-    val evidence = ExecutedFlowEvidence.from(batches)
-    // Runtime-covered legs are sourced from executed flow evidence. Remaining
-    // month-semantics reads are diagnostics or stock projections without a
-    // first-class emitted mechanism yet.
-    Sfc.SemanticFlows(
-      govSpending = evidence.govSpending,
-      govRevenue = evidence.sum(GovBudgetFlows.CentralGovernmentRevenueMechanisms*),
-      nplLoss = evidence.amount(FlowMechanism.BankNplLoss),
-      interestIncome = evidence.amount(FlowMechanism.BankFirmInterest),
-      totalIncome = evidence.amount(FlowMechanism.HhTotalIncome),
-      totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
-      newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
-      nplRecovery = firms.nplNew * p.banking.loanRecovery,
-      currentAccount = openEcon.external.newBop.currentAccount,
-      valuationEffect = openEcon.external.oeValuationEffect,
-      bankBondIncome = evidence.amount(FlowMechanism.BankGovBondIncome),
-      qePurchase = evidence.amount(FlowMechanism.NbpQeGovBondPurchase),
-      newBondIssuance = banking.actualBondChange,
-      depositInterestPaid = evidence.amount(FlowMechanism.HhDepositInterest),
-      reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
-      standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
-      interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
-      jstDepositChange = evidence.jstDepositChange,
-      jstSpending = evidence.amount(FlowMechanism.JstSpending),
-      jstRevenue = evidence.jstRevenue,
-      zusContributions = evidence.amount(FlowMechanism.ZusContribution),
-      zusPensionPayments = evidence.amount(FlowMechanism.ZusPension),
-      zusGovSubvention = evidence.amount(FlowMechanism.ZusGovSubvention),
-      nfzContributions = evidence.amount(FlowMechanism.NfzContribution),
-      nfzSpending = evidence.amount(FlowMechanism.NfzSpending),
-      nfzGovSubvention = evidence.amount(FlowMechanism.NfzGovSubvention),
-      dividendIncome = evidence.amount(FlowMechanism.EquityDomDividend),
-      foreignDividendOutflow = evidence.amount(FlowMechanism.EquityForDividend),
-      dividendTax = evidence.amount(FlowMechanism.EquityDividendTax),
-      mortgageInterestIncome = evidence.amount(FlowMechanism.MortgageInterest),
-      mortgageNplLoss = evidence.amount(FlowMechanism.BankMortgageNplLoss),
-      mortgageOrigination = evidence.amount(FlowMechanism.MortgageOrigination),
-      mortgagePrincipalRepaid = evidence.amount(FlowMechanism.MortgageRepayment),
-      mortgageDefaultAmount = evidence.amount(FlowMechanism.MortgageDefault),
-      remittanceOutflow = evidence.amount(FlowMechanism.HhRemittance),
-      fofResidual = fofResidual,
-      consumerDebtService = evidence.amount(FlowMechanism.HhCcDebtService) + evidence.amount(FlowMechanism.HhCcInterest),
-      consumerNplLoss = evidence.amount(FlowMechanism.BankCcNplLoss),
-      consumerOrigination = evidence.amount(FlowMechanism.HhCcOrigination) + evidence.amount(FlowMechanism.HhLiquidityShortfallFinancing),
-      consumerLiquidityShortfallFinancing = evidence.amount(FlowMechanism.HhLiquidityShortfallFinancing),
-      consumerPrincipalRepaid = evidence.amount(FlowMechanism.HhCcDebtService),
-      consumerDefaultAmount = evidence.amount(FlowMechanism.HhCcDefault),
-      corpBondCouponIncome = evidence.amount(FlowMechanism.BankCorpBondCoupon),
-      corpBondDefaultLoss = evidence.amount(FlowMechanism.BankCorpBondLoss),
-      corpBondIssuance = evidence.amount(FlowMechanism.CorpBondIssuance),
-      corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
-      corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
-      insNetDepositChange = evidence.insuranceNetDepositChange,
-      nbfiDepositDrain = evidence.nbfiDepositDrain,
-      nbfiOrigination = evidence.amount(FlowMechanism.NbfiOrigination),
-      nbfiRepayment = evidence.amount(FlowMechanism.NbfiRepayment),
-      nbfiDefaultAmount = evidence.amount(FlowMechanism.NbfiDefault),
-      fdiProfitShifting = evidence.amount(FlowMechanism.FirmProfitShifting),
-      fdiRepatriation = evidence.amount(FlowMechanism.FirmFdiRepatriation),
-      diasporaInflow = evidence.amount(FlowMechanism.DiasporaInflow),
-      tourismExport = evidence.amount(FlowMechanism.TourismExport),
-      tourismImport = evidence.amount(FlowMechanism.TourismImport),
-      bfgLevy = evidence.amount(FlowMechanism.BankBfgLevy),
-      bailInLoss = evidence.amount(FlowMechanism.BankBailIn),
-      bankCapitalDestruction = banking.multiCapDestruction,
-      interbankContagionLoss = banking.interbankContagionLoss,
-      investNetDepositFlow = evidence.investNetDepositFlow,
-      firmPrincipalRepaid = evidence.amount(FlowMechanism.FirmLoanRepayment),
-      unrealizedBondLoss = evidence.amount(FlowMechanism.BankUnrealizedLoss),
-      htmRealizedLoss = banking.htmRealizedLoss,
-      eclProvisionChange = banking.eclProvisionChange,
-      quasiFiscalBondIssuance = evidence.quasiFiscalBondIssuance,
-      quasiFiscalBondAmortization = evidence.quasiFiscalBondAmortization,
-      quasiFiscalNbpBondAmortization = evidence.quasiFiscalNbpBondAmortization,
-      quasiFiscalNbpAbsorption = evidence.quasiFiscalNbpAbsorption,
-      quasiFiscalLending = evidence.quasiFiscalLending,
-      quasiFiscalRepayment = evidence.quasiFiscalRepayment,
-      quasiFiscalDepositChange = evidence.quasiFiscalDepositChange,
-    )
 
   private def operationalSignals(
       labor: LaborEconomics.StepOutput,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthFlowEmitter.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthFlowEmitter.scala
@@ -1,0 +1,154 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.BatchedFlow
+
+/** Translates monthly calculus into runtime ledger batches.
+  *
+  * Economics decides quantities and rates before this boundary. This module
+  * only maps those month-level quantities into named flow mechanisms.
+  */
+object MonthFlowEmitter:
+
+  def emitAllBatches(c: FlowSimulation.MonthlyCalculus)(using p: SimParams, topology: RuntimeLedgerTopology): Vector[BatchedFlow] =
+    Vector.concat(
+      // Tier 1: Social funds
+      ZusFlows.emitBatches(ZusFlows.ZusInput(c.zus)),
+      NfzFlows.emitBatches(NfzFlows.NfzInput(c.nfz)),
+      PpkFlows.emitBatches(PpkFlows.PpkInput(c.ppk)),
+      GovBondFlows.emitBatches(c.govBondRuntimeMovements),
+      EarmarkedFlows.emitBatches(EarmarkedFlows.Input(c.earmarked)),
+      JstFlows.emitBatches(JstFlows.Input(c.firmTax, c.totalIncome, c.gdp, c.livingFirms, c.pitRevenue)),
+      // Tier 2: Agents
+      HouseholdFlows.emitBatches(
+        HouseholdFlows.Input(
+          c.consumption,
+          c.totalRent,
+          c.pitRevenue,
+          c.totalDepositInterest,
+          c.totalRemittances,
+          c.approvedCcOrigination,
+          c.liquidityShortfallFinancing,
+          c.totalCcPrincipal,
+          (c.totalCcDebtService - c.totalCcPrincipal).max(PLN.Zero),
+          c.totalCcDefault,
+        ),
+      ),
+      FirmFlows.emitBatches(
+        FirmFlows.Input(
+          c.totalIncome,
+          c.firmTax,
+          c.firmPrincipal,
+          c.firmNewLoans,
+          c.firmInterestIncome,
+          c.firmCapex,
+          c.firmEquityIssuance,
+          c.firmIoPayments,
+          c.firmNplLoss,
+          c.firmProfitShifting,
+          c.firmFdiRepatriation,
+          c.firmGrossInvestment,
+        ),
+      ),
+      InvestmentDepositSettlementFlows.emitBatches(InvestmentDepositSettlementFlows.Input(c.investNetDepositFlow)),
+      GovBudgetFlows.emitBatches(
+        GovBudgetFlows.Input(
+          vatRevenue = c.govVatRevenue,
+          exciseRevenue = c.govExciseRevenue,
+          customsDutyRevenue = c.govCustomsDutyRevenue,
+          govCurrentSpend = c.govCurrentSpend,
+          debtService = c.govDebtService,
+          unempBenefitSpend = c.totalUnempBenefits,
+          socialTransferSpend = c.totalSocialTransfers,
+          euCofinancing = c.govEuCofinancing,
+          govCapitalSpend = c.govCapitalSpend,
+          debtServiceRecipients = Some(c.govDebtServiceRecipients),
+        ),
+      ),
+      InsuranceFlows.emitBatches(
+        InsuranceFlows.Input(
+          employed = c.employed,
+          wage = c.wage,
+          unempRate = c.unemploymentRate,
+          currentLifeReserves = c.insuranceCurrentLifeReserves,
+          currentNonLifeReserves = c.insuranceCurrentNonLifeReserves,
+          prevGovBondHoldings = c.insurancePrevGovBonds,
+          prevCorpBondHoldings = c.insurancePrevCorpBonds,
+          corpBondDefaultLoss = c.insuranceCorpBondDefaultLoss,
+          prevEquityHoldings = c.insurancePrevEquity,
+          govBondYield = c.govBondYield,
+          corpBondYield = c.corpBondYield,
+          equityReturn = c.equityReturn,
+        ),
+      ),
+      // Tier 3: Financial markets
+      EquityFlows.emitBatches(
+        EquityFlows.Input(
+          c.equityDomDividends,
+          c.equityForDividends,
+          c.equityDivTax,
+          c.equityGovDividends,
+        ),
+      ),
+      EquityFlows.emitRevaluationBatches(c.equityRevaluation),
+      CorpBondFlows.emitBatches(
+        CorpBondFlows.Input(
+          coupon = c.corpBondCoupon,
+          defaultAmount = c.corpBondDefaultAmount,
+          issuance = c.corpBondIssuance,
+          amortization = c.corpBondAmortization,
+          couponRecipients = Some(c.corpBondCouponRecipients),
+          defaultRecipients = Some(c.corpBondDefaultRecipients),
+          issuanceRecipients = Some(c.corpBondIssuanceRecipients),
+          amortizationRecipients = Some(c.corpBondAmortizationRecipients),
+        ),
+      ),
+      MortgageFlows.emitBatches(MortgageFlows.Input(c.mortgageOrigination, c.mortgageRepayment, c.mortgageInterest, c.mortgageDefault)),
+      OpenEconFlows.emitBatches(
+        OpenEconFlows.Input(
+          exports = c.exports,
+          imports = c.totalImports,
+          tourismExport = c.tourismExport,
+          tourismImport = c.tourismImport,
+          fdi = c.fdi,
+          portfolioFlows = c.portfolioFlows,
+          carryTradeFlow = c.carryTradeFlow,
+          primaryIncome = c.primaryIncome,
+          euFunds = c.euFunds,
+          diasporaInflow = c.diasporaInflow,
+          capitalFlightOutflow = c.capitalFlightOutflow,
+        ),
+      ),
+      BankingFlows.emitBatches(
+        BankingFlows.Input(
+          firmInterestIncome = c.firmInterestIncome,
+          firmNplLoss = c.firmNplLoss,
+          mortgageNplLoss = c.mortgageDefault * (Share.One - p.housing.mortgageRecovery),
+          consumerNplLoss = (c.totalCcDefault - c.liquidityShortfallFinancing).max(PLN.Zero) * (Share.One - p.household.ccNplRecovery),
+          govBondIncome = c.bankGovBondIncome,
+          reserveInterest = c.bankReserveInterest,
+          standingFacilityIncome = c.bankStandingFacility,
+          interbankInterest = c.bankInterbankInterest,
+          corpBondCoupon = c.bankCorpBondCoupon,
+          corpBondDefaultLoss = c.bankCorpBondLoss,
+          bfgLevy = c.bankBfgLevy,
+          unrealizedBondLoss = c.bankUnrealizedLoss,
+          bailInLoss = c.bankBailIn,
+          nbpRemittance = c.bankNbpRemittance,
+          fxReserveSettlement = c.bankFxReserveSettlement,
+          standingFacilityBackstop = c.bankStandingFacilityBackstop,
+        ),
+      ),
+      NbfiFlows.emitBatches(NbfiFlows.Input(c.nbfiDepositDrain, c.nbfiOrigination, c.nbfiRepayment, c.nbfiDefaultAmount)),
+      QuasiFiscalFlows.emitBatches(
+        QuasiFiscalFlows.Input(
+          bankBondIssuance = c.qfBankBondIssuance,
+          nbpBondAbsorption = c.qfNbpBondAbsorption,
+          bankBondAmortization = c.qfBankBondAmortization,
+          nbpBondAmortization = c.qfNbpBondAmortization,
+          lending = c.qfLending,
+          repayment = c.qfRepayment,
+        ),
+      ),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
@@ -1,0 +1,268 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.accounting.Sfc
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthSemantics
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+/** Projects executed runtime batches into the SFC semantic validation surface.
+  *
+  * Runtime execution is the cash-flow source of truth. This module translates
+  * those executed batches plus the narrow same-month semantic view into
+  * `Sfc.SemanticFlows`, then runs the SFC validation boundary.
+  */
+object SfcSemanticProjection:
+
+  def semanticFlows(
+      semanticProjection: MonthSemantics.SemanticProjection,
+      batches: Vector[BatchedFlow],
+      fofResidual: PLN,
+  )(using p: SimParams): Sfc.SemanticFlows =
+    val firms    = semanticProjection.firms
+    val openEcon = semanticProjection.openEcon
+    val banking  = semanticProjection.banking
+    val evidence = ExecutedFlowEvidence.from(batches)
+    // Runtime-covered legs are sourced from executed flow evidence. Remaining
+    // month-semantics reads are diagnostics or stock projections without a
+    // first-class emitted mechanism yet.
+    Sfc.SemanticFlows(
+      govSpending = evidence.govSpending,
+      govRevenue = evidence.sum(GovBudgetFlows.CentralGovernmentRevenueMechanisms*),
+      nplLoss = evidence.amount(FlowMechanism.BankNplLoss),
+      interestIncome = evidence.amount(FlowMechanism.BankFirmInterest),
+      totalIncome = evidence.amount(FlowMechanism.HhTotalIncome),
+      totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
+      newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
+      nplRecovery = firms.nplNew * p.banking.loanRecovery,
+      currentAccount = openEcon.external.newBop.currentAccount,
+      valuationEffect = openEcon.external.oeValuationEffect,
+      bankBondIncome = evidence.amount(FlowMechanism.BankGovBondIncome),
+      qePurchase = evidence.amount(FlowMechanism.NbpQeGovBondPurchase),
+      newBondIssuance = banking.actualBondChange,
+      depositInterestPaid = evidence.amount(FlowMechanism.HhDepositInterest),
+      reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
+      standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
+      interbankInterest = evidence.signedAmount(FlowMechanism.BankInterbankInterest),
+      jstDepositChange = evidence.jstDepositChange,
+      jstSpending = evidence.amount(FlowMechanism.JstSpending),
+      jstRevenue = evidence.jstRevenue,
+      zusContributions = evidence.amount(FlowMechanism.ZusContribution),
+      zusPensionPayments = evidence.amount(FlowMechanism.ZusPension),
+      zusGovSubvention = evidence.amount(FlowMechanism.ZusGovSubvention),
+      nfzContributions = evidence.amount(FlowMechanism.NfzContribution),
+      nfzSpending = evidence.amount(FlowMechanism.NfzSpending),
+      nfzGovSubvention = evidence.amount(FlowMechanism.NfzGovSubvention),
+      dividendIncome = evidence.amount(FlowMechanism.EquityDomDividend),
+      foreignDividendOutflow = evidence.amount(FlowMechanism.EquityForDividend),
+      dividendTax = evidence.amount(FlowMechanism.EquityDividendTax),
+      mortgageInterestIncome = evidence.amount(FlowMechanism.MortgageInterest),
+      mortgageNplLoss = evidence.amount(FlowMechanism.BankMortgageNplLoss),
+      mortgageOrigination = evidence.amount(FlowMechanism.MortgageOrigination),
+      mortgagePrincipalRepaid = evidence.amount(FlowMechanism.MortgageRepayment),
+      mortgageDefaultAmount = evidence.amount(FlowMechanism.MortgageDefault),
+      remittanceOutflow = evidence.amount(FlowMechanism.HhRemittance),
+      fofResidual = fofResidual,
+      consumerDebtService = evidence.amount(FlowMechanism.HhCcDebtService) + evidence.amount(FlowMechanism.HhCcInterest),
+      consumerNplLoss = evidence.amount(FlowMechanism.BankCcNplLoss),
+      consumerOrigination = evidence.amount(FlowMechanism.HhCcOrigination) + evidence.amount(FlowMechanism.HhLiquidityShortfallFinancing),
+      consumerLiquidityShortfallFinancing = evidence.amount(FlowMechanism.HhLiquidityShortfallFinancing),
+      consumerPrincipalRepaid = evidence.amount(FlowMechanism.HhCcDebtService),
+      consumerDefaultAmount = evidence.amount(FlowMechanism.HhCcDefault),
+      corpBondCouponIncome = evidence.amount(FlowMechanism.BankCorpBondCoupon),
+      corpBondDefaultLoss = evidence.amount(FlowMechanism.BankCorpBondLoss),
+      corpBondIssuance = evidence.amount(FlowMechanism.CorpBondIssuance),
+      corpBondAmortization = evidence.amount(FlowMechanism.CorpBondAmortization),
+      corpBondDefaultAmount = evidence.amount(FlowMechanism.CorpBondDefault),
+      insNetDepositChange = evidence.insuranceNetDepositChange,
+      nbfiDepositDrain = evidence.nbfiDepositDrain,
+      nbfiOrigination = evidence.amount(FlowMechanism.NbfiOrigination),
+      nbfiRepayment = evidence.amount(FlowMechanism.NbfiRepayment),
+      nbfiDefaultAmount = evidence.amount(FlowMechanism.NbfiDefault),
+      fdiProfitShifting = evidence.amount(FlowMechanism.FirmProfitShifting),
+      fdiRepatriation = evidence.amount(FlowMechanism.FirmFdiRepatriation),
+      diasporaInflow = evidence.amount(FlowMechanism.DiasporaInflow),
+      tourismExport = evidence.amount(FlowMechanism.TourismExport),
+      tourismImport = evidence.amount(FlowMechanism.TourismImport),
+      bfgLevy = evidence.amount(FlowMechanism.BankBfgLevy),
+      bailInLoss = evidence.amount(FlowMechanism.BankBailIn),
+      bankCapitalDestruction = banking.multiCapDestruction,
+      interbankContagionLoss = banking.interbankContagionLoss,
+      investNetDepositFlow = evidence.investNetDepositFlow,
+      firmPrincipalRepaid = evidence.amount(FlowMechanism.FirmLoanRepayment),
+      unrealizedBondLoss = evidence.amount(FlowMechanism.BankUnrealizedLoss),
+      htmRealizedLoss = banking.htmRealizedLoss,
+      eclProvisionChange = banking.eclProvisionChange,
+      quasiFiscalBondIssuance = evidence.quasiFiscalBondIssuance,
+      quasiFiscalBondAmortization = evidence.quasiFiscalBondAmortization,
+      quasiFiscalNbpBondAmortization = evidence.quasiFiscalNbpBondAmortization,
+      quasiFiscalNbpAbsorption = evidence.quasiFiscalNbpAbsorption,
+      quasiFiscalLending = evidence.quasiFiscalLending,
+      quasiFiscalRepayment = evidence.quasiFiscalRepayment,
+      quasiFiscalDepositChange = evidence.quasiFiscalDepositChange,
+    )
+
+  def validate(
+      stateIn: FlowSimulation.SimState,
+      nextState: FlowSimulation.SimState,
+      flows: Sfc.SemanticFlows,
+      batches: Vector[BatchedFlow],
+      execution: RuntimeFlowExecutor.Result,
+  )(using SimParams): Sfc.SfcResult =
+    Sfc.validate(
+      prev = runtimeState(stateIn),
+      curr = runtimeState(nextState),
+      flows = flows,
+      batches = batches,
+      executionDeltaLedger = Sfc.ExecutionDeltaLedger.fromRaw(execution.deltaLedger),
+      deltaLedgerNet = execution.netDelta,
+    )
+
+  def runtimeState(state: FlowSimulation.SimState): Sfc.RuntimeState =
+    Sfc.RuntimeState(state.world, state.firms, state.households, state.banks, state.ledgerFinancialState)
+
+  case class ExecutedFlowEvidence(
+      totals: Map[MechanismId, Long],
+      signedTotals: Map[MechanismId, Long],
+  ):
+    def amount(mechanism: MechanismId): PLN =
+      PLN.fromRaw(totals.getOrElse(mechanism, 0L))
+
+    def signedAmount(mechanism: MechanismId): PLN =
+      PLN.fromRaw(signedTotals.getOrElse(mechanism, 0L))
+
+    def sum(mechanisms: MechanismId*): PLN =
+      PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
+
+    def sumAll(mechanisms: Iterable[MechanismId]): PLN =
+      PLN.fromRaw(mechanisms.iterator.map(m => totals.getOrElse(m, 0L)).sum)
+
+    def govSpending: PLN =
+      sumAll(ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms) +
+        sumAll(ExecutedFlowEvidence.SocialFundGovSubventionMechanisms)
+
+    def jstRevenue: PLN =
+      sumAll(ExecutedFlowEvidence.JstRevenueMechanisms)
+
+    def jstDepositChange: PLN =
+      jstRevenue - amount(FlowMechanism.JstSpending)
+
+    def insuranceNetDepositChange: PLN =
+      sum(FlowMechanism.InsLifeClaim, FlowMechanism.InsNonLifeClaim) -
+        sum(FlowMechanism.InsLifePremium, FlowMechanism.InsNonLifePremium)
+
+    def investNetDepositFlow: PLN =
+      signedAmount(FlowMechanism.InvestmentDepositSettlement)
+
+    def nbfiDepositDrain: PLN =
+      signedAmount(FlowMechanism.TfiDepositDrain)
+
+    /** Total BGK/PFR bond issuance. This intentionally includes both the
+      * commercial-bank leg and the separately addressable NBP absorption leg.
+      */
+    def quasiFiscalBondIssuance: PLN =
+      amount(FlowMechanism.QuasiFiscalBondIssuance) + amount(FlowMechanism.QuasiFiscalNbpAbsorption)
+
+    /** Total BGK/PFR bond amortization across bank and NBP holders. */
+    def quasiFiscalBondAmortization: PLN =
+      amount(FlowMechanism.QuasiFiscalBondAmortization) + amount(FlowMechanism.QuasiFiscalNbpBondAmortization)
+
+    /** NBP's purchase share of BGK/PFR issuance. Callers that already use
+      * `quasiFiscalBondIssuance` must not add this again.
+      */
+    def quasiFiscalNbpAbsorption: PLN =
+      amount(FlowMechanism.QuasiFiscalNbpAbsorption)
+
+    /** NBP holder leg of BGK/PFR bond amortization. Callers that already use
+      * `quasiFiscalBondAmortization` must not add this again.
+      */
+    def quasiFiscalNbpBondAmortization: PLN =
+      amount(FlowMechanism.QuasiFiscalNbpBondAmortization)
+
+    def quasiFiscalLending: PLN =
+      amount(FlowMechanism.QuasiFiscalLending)
+
+    def quasiFiscalRepayment: PLN =
+      amount(FlowMechanism.QuasiFiscalRepayment)
+
+    def quasiFiscalDepositChange: PLN =
+      signedAmount(FlowMechanism.QuasiFiscalLendingDeposit) +
+        signedAmount(FlowMechanism.QuasiFiscalRepaymentDeposit)
+
+  object ExecutedFlowEvidence:
+    val CentralGovernmentSpendingMechanisms: Vector[MechanismId] =
+      Vector(
+        FlowMechanism.GovPurchases,
+        FlowMechanism.GovDebtService,
+        FlowMechanism.GovUnempBenefit,
+        FlowMechanism.GovSocialTransfer,
+        FlowMechanism.GovEuCofin,
+        FlowMechanism.GovCapitalInvestment,
+        FlowMechanism.JstGovSubvention,
+      )
+
+    val SocialFundGovSubventionMechanisms: Vector[MechanismId] =
+      Vector(
+        FlowMechanism.ZusGovSubvention,
+        FlowMechanism.NfzGovSubvention,
+        FlowMechanism.FpGovSubvention,
+        FlowMechanism.PfronGovSubvention,
+        FlowMechanism.FgspGovSubvention,
+      )
+
+    val JstRevenueMechanisms: Vector[MechanismId] =
+      Vector(FlowMechanism.JstRevenue, FlowMechanism.JstGovSubvention)
+
+    def from(batches: Vector[BatchedFlow]): ExecutedFlowEvidence =
+      val (totals, signedTotals): (Map[MechanismId, Long], Map[MechanismId, Long]) =
+        batches.foldLeft(
+          Map.empty[MechanismId, Long].withDefaultValue(0L),
+          Map.empty[MechanismId, Long].withDefaultValue(0L),
+        ):
+          case ((totalsAcc, signedAcc), batch) =>
+            val amount       = RuntimeLedgerTopology.totalTransferred(batch)
+            val signedAmount =
+              batch.mechanism match
+                case FlowMechanism.BankInterbankInterest | FlowMechanism.BankStandingFacility =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.NBP, EntitySector.Banks) => amount
+                    case (EntitySector.Banks, EntitySector.NBP) => -amount
+                    case _                                      => amount
+                case FlowMechanism.InvestmentDepositSettlement                                =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.Banks, EntitySector.Firms) => amount
+                    case (EntitySector.Firms, EntitySector.Banks) => -amount
+                    case _                                        =>
+                      throw new IllegalArgumentException(
+                        s"InvestmentDepositSettlement batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case FlowMechanism.TfiDepositDrain                                            =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.Banks, EntitySector.Households) => amount
+                    case (EntitySector.Households, EntitySector.Banks) => -amount
+                    case _                                             =>
+                      throw new IllegalArgumentException(
+                        s"TfiDepositDrain batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case FlowMechanism.QuasiFiscalLendingDeposit                                  =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.Banks, EntitySector.Firms) => amount
+                    case _                                        =>
+                      throw new IllegalArgumentException(
+                        s"QuasiFiscalLendingDeposit batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case FlowMechanism.QuasiFiscalRepaymentDeposit                                =>
+                  (batch.from, batch.to) match
+                    case (EntitySector.Firms, EntitySector.Banks) => -amount
+                    case _                                        =>
+                      throw new IllegalArgumentException(
+                        s"QuasiFiscalRepaymentDeposit batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case _                                                                        => amount
+
+            (
+              totalsAcc.updated(batch.mechanism, totalsAcc(batch.mechanism) + amount),
+              signedAcc.updated(batch.mechanism, signedAcc(batch.mechanism) + signedAmount),
+            )
+
+      ExecutedFlowEvidence(totals, signedTotals)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
@@ -223,12 +223,15 @@ object SfcSemanticProjection:
             val amount       = RuntimeLedgerTopology.totalTransferred(batch)
             val signedAmount =
               batch.mechanism match
-                case FlowMechanism.BankInterbankInterest | FlowMechanism.BankStandingFacility =>
+                case mechanism @ (FlowMechanism.BankInterbankInterest | FlowMechanism.BankStandingFacility) =>
                   (batch.from, batch.to) match
                     case (EntitySector.NBP, EntitySector.Banks) => amount
                     case (EntitySector.Banks, EntitySector.NBP) => -amount
-                    case _                                      => amount
-                case FlowMechanism.InvestmentDepositSettlement                                =>
+                    case _                                      =>
+                      throw new IllegalArgumentException(
+                        s"${bankIncomeMechanismLabel(mechanism)} batch has unsupported direction ${batch.from}->${batch.to}",
+                      )
+                case FlowMechanism.InvestmentDepositSettlement                                              =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Firms) => amount
                     case (EntitySector.Firms, EntitySector.Banks) => -amount
@@ -236,7 +239,7 @@ object SfcSemanticProjection:
                       throw new IllegalArgumentException(
                         s"InvestmentDepositSettlement batch has unsupported direction ${batch.from}->${batch.to}",
                       )
-                case FlowMechanism.TfiDepositDrain                                            =>
+                case FlowMechanism.TfiDepositDrain                                                          =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Households) => amount
                     case (EntitySector.Households, EntitySector.Banks) => -amount
@@ -244,21 +247,21 @@ object SfcSemanticProjection:
                       throw new IllegalArgumentException(
                         s"TfiDepositDrain batch has unsupported direction ${batch.from}->${batch.to}",
                       )
-                case FlowMechanism.QuasiFiscalLendingDeposit                                  =>
+                case FlowMechanism.QuasiFiscalLendingDeposit                                                =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Firms) => amount
                     case _                                        =>
                       throw new IllegalArgumentException(
                         s"QuasiFiscalLendingDeposit batch has unsupported direction ${batch.from}->${batch.to}",
                       )
-                case FlowMechanism.QuasiFiscalRepaymentDeposit                                =>
+                case FlowMechanism.QuasiFiscalRepaymentDeposit                                              =>
                   (batch.from, batch.to) match
                     case (EntitySector.Firms, EntitySector.Banks) => -amount
                     case _                                        =>
                       throw new IllegalArgumentException(
                         s"QuasiFiscalRepaymentDeposit batch has unsupported direction ${batch.from}->${batch.to}",
                       )
-                case _                                                                        => amount
+                case _                                                                                      => amount
 
             (
               totalsAcc.updated(batch.mechanism, totalsAcc(batch.mechanism) + amount),
@@ -266,3 +269,7 @@ object SfcSemanticProjection:
             )
 
       ExecutedFlowEvidence(totals, signedTotals)
+
+    private def bankIncomeMechanismLabel(mechanism: MechanismId): String =
+      if mechanism == FlowMechanism.BankInterbankInterest then "FlowMechanism.BankInterbankInterest"
+      else "FlowMechanism.BankStandingFacility"

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.types.*
-import com.boombustgroup.ledger.EntitySector
+import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -95,6 +95,25 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
       mechanismTotal(result.flows, FlowMechanism.InsNonLifeClaim)
 
     result.trace.executedFlows.insNetDepositChange shouldBe insuranceClaims - insurancePremiums
+  }
+
+  it should "reject unsupported signed bank-income flow directions" in {
+    val batch = BatchedFlow.Broadcast(
+      from = EntitySector.Government,
+      fromIndex = 0,
+      to = EntitySector.Banks,
+      amounts = Array(100L),
+      targetIndices = Array(0),
+      asset = AssetType.Cash,
+      mechanism = FlowMechanism.BankInterbankInterest,
+    )
+
+    val err = intercept[IllegalArgumentException]:
+      SfcSemanticProjection.ExecutedFlowEvidence.from(Vector(batch))
+
+    err.getMessage.should(include("FlowMechanism.BankInterbankInterest"))
+    err.getMessage.should(include("unsupported direction"))
+    err.getMessage.should(include("Government->Banks"))
   }
 
   it should "route deterministic NBFI and TFI calculus values into executed evidence" in {

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -33,9 +33,9 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
     val expectedJstRevenueMechanisms                =
       Vector(FlowMechanism.JstRevenue, FlowMechanism.JstGovSubvention)
 
-    FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms shouldBe expectedCentralGovernmentSpendingMechanisms
-    FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms shouldBe expectedSocialFundGovSubventionMechanisms
-    FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms shouldBe expectedJstRevenueMechanisms
+    SfcSemanticProjection.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms shouldBe expectedCentralGovernmentSpendingMechanisms
+    SfcSemanticProjection.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms shouldBe expectedSocialFundGovSubventionMechanisms
+    SfcSemanticProjection.ExecutedFlowEvidence.JstRevenueMechanisms shouldBe expectedJstRevenueMechanisms
 
     val govSpendingMechanisms              = expectedCentralGovernmentSpendingMechanisms ++ expectedSocialFundGovSubventionMechanisms
     val emittedGovSpending                 = mechanismsTotal(result.flows, govSpendingMechanisms)
@@ -107,8 +107,8 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
     )
     given RuntimeLedgerTopology  = topology
 
-    val batches  = FlowSimulation.emitAllBatches(calculus)
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val batches  = MonthFlowEmitter.emitAllBatches(calculus)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
 
     evidence.nbfiDepositDrain shouldBe PLN(-777000)
     evidence.amount(FlowMechanism.NbfiOrigination) shouldBe PLN(555000)
@@ -128,8 +128,8 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
     )
     given RuntimeLedgerTopology  = topology
 
-    val batches  = FlowSimulation.emitAllBatches(calculus)
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val batches  = MonthFlowEmitter.emitAllBatches(calculus)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
 
     evidence.quasiFiscalBondIssuance shouldBe PLN(1000000)
     evidence.quasiFiscalBondAmortization shouldBe PLN(300000)

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationSpec.scala
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.tags.Heavy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/** Tests FlowSimulation.emitAllBatches with MonthlyCalculus from
+/** Tests MonthFlowEmitter.emitAllBatches with MonthlyCalculus from
   * FlowSimulation.computeCalculus.
   *
   * Proves that the Contract-First pipeline design (MonthlyCalculus →
@@ -19,11 +19,11 @@ class FlowSimulationSpec extends AnyFlatSpec with Matchers:
 
   private given p: SimParams = SimParams.defaults
 
-  "FlowSimulation.emitAllBatches" should "match the step batch plan for computed calculus" in {
+  "MonthFlowEmitter.emitAllBatches" should "match the step batch plan for computed calculus" in {
     val state                   = stateFromSeed()
     val result                  = stepWithSeed(state)
     given RuntimeLedgerTopology = result.execution.topology
-    val flows                   = FlowSimulation.emitAllBatches(result.calculus)
+    val flows                   = MonthFlowEmitter.emitAllBatches(result.calculus)
 
     canonicalBatches(flows) shouldBe canonicalBatches(result.flows)
     result.execution.netDelta shouldBe 0L

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationStepSpec.scala
@@ -201,7 +201,7 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     mechanismTotal(result.flows, FlowMechanism.GovSocialTransfer) shouldBe result.calculus.totalSocialTransfers
 
     val emittedJstRevenue =
-      mechanismsTotal(result.flows, FlowSimulation.ExecutedFlowEvidence.JstRevenueMechanisms)
+      mechanismsTotal(result.flows, SfcSemanticProjection.ExecutedFlowEvidence.JstRevenueMechanisms)
     emittedJstRevenue shouldBe nextJst.revenue
     mechanismTotal(result.flows, FlowMechanism.JstSpending) shouldBe nextJst.spending
     emittedJstRevenue should not equal staleJstRevenue
@@ -210,8 +210,8 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val emittedGovSpending =
       mechanismsTotal(
         result.flows,
-        FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
-          FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms,
+        SfcSemanticProjection.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
+          SfcSemanticProjection.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms,
       )
 
     result.trace.executedFlows.govSpending shouldBe emittedGovSpending
@@ -242,8 +242,8 @@ class FlowSimulationStepSpec extends AnyFlatSpec with Matchers:
     val expectedGovSpending =
       mechanismsTotal(
         result.flows,
-        FlowSimulation.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
-          FlowSimulation.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms,
+        SfcSemanticProjection.ExecutedFlowEvidence.CentralGovernmentSpendingMechanisms ++
+          SfcSemanticProjection.ExecutedFlowEvidence.SocialFundGovSubventionMechanisms,
       )
 
     result.trace.executedFlows.govSpending shouldBe expectedGovSpending

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/InvestmentDepositSettlementFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/InvestmentDepositSettlementFlowsSpec.scala
@@ -28,7 +28,7 @@ class InvestmentDepositSettlementFlowsSpec extends AnyFlatSpec with Matchers:
     batch.to shouldBe EntitySector.Firms
     totalTransferred(batches) shouldBe PLN(250000)
 
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
     evidence.investNetDepositFlow shouldBe PLN(250000)
   }
 
@@ -43,7 +43,7 @@ class InvestmentDepositSettlementFlowsSpec extends AnyFlatSpec with Matchers:
     batch.to shouldBe EntitySector.Banks
     totalTransferred(batches) shouldBe PLN(125000)
 
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
     evidence.investNetDepositFlow shouldBe PLN(-125000)
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NbfiFlowsSpec.scala
@@ -63,7 +63,7 @@ class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
     batch.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].banks.aggregate)
     totalTransferred(batches) shouldBe PLN(125000)
 
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
     evidence.nbfiDepositDrain shouldBe PLN(-125000)
   }
 
@@ -79,7 +79,7 @@ class NbfiFlowsSpec extends AnyFlatSpec with Matchers:
     batch.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].households.investors)
     totalTransferred(batches) shouldBe PLN(80000)
 
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
     evidence.nbfiDepositDrain shouldBe PLN(80000)
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/QuasiFiscalFlowsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/QuasiFiscalFlowsSpec.scala
@@ -100,7 +100,7 @@ class QuasiFiscalFlowsSpec extends AnyFlatSpec with Matchers:
     repaymentDeposit.targetIndices.toVector shouldBe Vector(summon[RuntimeLedgerTopology].banks.aggregate)
     repaymentDeposit.asset shouldBe AssetType.DemandDeposit
 
-    val evidence = FlowSimulation.ExecutedFlowEvidence.from(batches)
+    val evidence = SfcSemanticProjection.ExecutedFlowEvidence.from(batches)
     evidence.quasiFiscalBondIssuance shouldBe input.bankBondIssuance + input.nbpBondAbsorption
     evidence.quasiFiscalBondAmortization shouldBe input.bankBondAmortization + input.nbpBondAmortization
     evidence.quasiFiscalNbpAbsorption shouldBe input.nbpBondAbsorption


### PR DESCRIPTION
Refs #622.

Summary:
- extracts MonthlyCalculus -> runtime batch translation into MonthFlowEmitter
- extracts executed-flow evidence, SFC semantic-flow projection, and SFC validation into SfcSemanticProjection
- keeps FlowSimulation.step as the public month boundary and leaves thin compatibility delegates for emitAllBatches / ExecutedFlowEvidence
- updates flow/evidence tests to target the new modules directly
- updates engine README flow-boundary docs

Note:
- #655 remains the separate same-month calculus runner follow-up.

Validation:
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec com.boombustgroup.amorfati.engine.flows.QuasiFiscalFlowsSpec com.boombustgroup.amorfati.engine.flows.InvestmentDepositSettlementFlowsSpec com.boombustgroup.amorfati.engine.flows.NbfiFlowsSpec com.boombustgroup.amorfati.engine.flows.RuntimeFlowExecutorSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationRuntimeProjectionSpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.assembly.SignalTimingRegressionSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal flow simulation architecture for improved code clarity and maintainability. The system now uses a dedicated component to translate simulation calculus into runtime batches and another to handle semantic flow validation. All existing functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->