### PR TITLE
Extract same-month calculus runner

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -43,20 +43,20 @@ Those CSV outputs are the primary numeric evidence surface for these rules.
 
 ## Timing Contract
 
-One model month follows the deterministic economics pipeline below, then emits
-runtime ledger flows and validates SFC identities.
+One model month follows the deterministic same-month economics pipeline below,
+then emits runtime ledger flows and validates SFC identities.
 
-| Stage | Module | Rule surface |
-| --- | --- | --- |
-| s1 | `engine/economics/FiscalConstraintEconomics.scala` | minimum wage, reservation wage, lending base rate |
-| s2 | `engine/economics/LaborEconomics.scala` | wage clearing, employment, immigration, demographics |
-| s3 | `engine/economics/HouseholdIncomeEconomics.scala` and `agents/Household.scala` | household income, consumption, saving, credit, retraining, bankruptcy |
-| s4 | `engine/economics/DemandEconomics.scala` | sector demand, government purchases, fiscal-rule constraint |
-| s5 | `engine/economics/FirmEconomics.scala` and `agents/Firm.scala` | production, pricing markup contribution, technology, labor, investment, defaults, entry |
-| s6 | `engine/economics/HouseholdFinancialEconomics.scala` | mortgages, deposit interest, remittances, tourism, consumer credit aggregation |
-| s7 | `engine/economics/PriceEquityEconomics.scala` | GDP proxy, inflation, equity, macroprudential, EU funds |
-| s8 | `engine/economics/OpenEconEconomics.scala` | external sector, NBP rate, bond yield, QE, insurance, NBFI |
-| s9 | `engine/economics/BankingEconomics.scala` and `agents/Banking.scala` | bank P&L, rates, interbank, bond waterfall, failure and resolution |
+| Module | Rule surface |
+| --- | --- |
+| `engine/economics/FiscalConstraintEconomics.scala` | minimum wage, reservation wage, lending base rate |
+| `engine/economics/LaborEconomics.scala` | wage clearing, employment, immigration, demographics |
+| `engine/economics/HouseholdIncomeEconomics.scala` and `agents/Household.scala` | household income, consumption, saving, credit, retraining, bankruptcy |
+| `engine/economics/DemandEconomics.scala` | sector demand, government purchases, fiscal-rule constraint |
+| `engine/economics/FirmEconomics.scala` and `agents/Firm.scala` | production, pricing markup contribution, technology, labor, investment, defaults, entry |
+| `engine/economics/HouseholdFinancialEconomics.scala` | mortgages, deposit interest, remittances, tourism, consumer credit aggregation |
+| `engine/economics/PriceEquityEconomics.scala` | GDP proxy, inflation, equity, macroprudential, EU funds |
+| `engine/economics/OpenEconEconomics.scala` | external sector, NBP rate, bond yield, QE, insurance, NBFI |
+| `engine/economics/BankingEconomics.scala` and `agents/Banking.scala` | bank P&L, rates, interbank, bond waterfall, failure and resolution |
 
 ## Rule-To-Output Map
 

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -178,20 +178,20 @@ The high-level order is fixed:
 
 ### Economics Pipeline
 
-The monthly calculus stages are:
+The monthly calculus boundary is:
 
-| Stage | Module | Domain |
-| --- | --- | --- |
-| s1 | `FiscalConstraintEconomics` | minimum wage indexation, reservation wage, lending base rate |
-| s2 | `LaborEconomics` | labor market, wages, employment, demographics, immigration, payroll base |
-| s3 | `HouseholdIncomeEconomics` | household income, consumption, saving, portfolios, separations, mobility |
-| s4 | `DemandEconomics` | demand allocation across consumption, government purchases, investment, exports |
-| s5 | `FirmEconomics` | production, I-O intermediate market, capex, financing, labor, NPL detection |
-| s6 | `HouseholdFinancialEconomics` | mortgages, deposit interest, remittances, tourism, consumer credit |
-| s7 | `PriceEquityEconomics` | inflation, equity market, GDP proxy, macroprudential, EU funds |
-| s8 | `OpenEconEconomics` | BoP, forex, GVC, Taylor rule, bond yields, insurance, NBFI |
-| s9 | `BankingEconomics` | bank P&L, provisioning, CAR, resolution, interbank, BFG levy, M1/M2/M3 |
-| final | `MonthClosing` | aggregation, informal economy, lifecycle transitions, SFC status, next state |
+| Module | Domain |
+| --- | --- |
+| `FiscalConstraintEconomics` | minimum wage indexation, reservation wage, lending base rate |
+| `LaborEconomics` | labor market, wages, employment, demographics, immigration, payroll base |
+| `HouseholdIncomeEconomics` | household income, consumption, saving, portfolios, separations, mobility |
+| `DemandEconomics` | demand allocation across consumption, government purchases, investment, exports |
+| `FirmEconomics` | production, I-O intermediate market, capex, financing, labor, NPL detection |
+| `HouseholdFinancialEconomics` | mortgages, deposit interest, remittances, tourism, consumer credit |
+| `PriceEquityEconomics` | inflation, equity market, GDP proxy, macroprudential, EU funds |
+| `OpenEconEconomics` | BoP, forex, GVC, Taylor rule, bond yields, insurance, NBFI |
+| `BankingEconomics` | bank P&L, provisioning, CAR, resolution, interbank, BFG levy, M1/M2/M3 |
+| `MonthClosing` | aggregation, informal economy, lifecycle transitions, SFC status, next state |
 
 ### Flow Emission And Accounting Boundary
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -3,7 +3,7 @@
 The engine package orchestrates the monthly simulation loop. The month
 boundary is `FlowSimulation.SimState`, which carries `World` macro state,
 agent populations, household aggregates, and `LedgerFinancialState`.
-Domain logic is split across **economics** (9-stage computation pipeline),
+Domain logic is split across **economics** (same-month calculus pipeline),
 **assembly** (month-closing state projection), **flows** (SFC-verified monetary
 flow emission via ledger), **ledger** (financial ownership contracts and
 projections), **markets** (clearing mechanisms), and **mechanisms** (domain
@@ -12,7 +12,7 @@ rules that modify agent state outside market clearing).
 ```
 engine/
 ├── World.scala             # Immutable macro/runtime state container (9 nested types)
-├── economics/              # 9-stage computation pipeline (calculus, no flows)
+├── economics/              # Same-month calculus pipeline, no monetary flow emission
 ├── assembly/               # Month-closing World/agent/ledger projection
 ├── flows/                  # SFC flow emission via verified ledger
 ├── ledger/                 # Ledger-owned financial state, ownership contracts, projections
@@ -79,23 +79,23 @@ Read it as a month transition:
 
 ## economics/
 
-The 9-stage computation pipeline, executed in fixed order each month. Each
-module is a pure function producing calculus (quantities, rates, decisions)
-without emitting monetary flows. `FlowSimulation` wires them together.
+The same-month calculus pipeline is executed in fixed order each month. Each
+module is a pure function producing quantities, rates, and decisions without
+emitting monetary flows. `MonthCalculusRunner` wires them together.
 
-| File | Stage | Domain                                                                                                                                        |
-|------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `FiscalConstraintEconomics.scala` | s1 | Minimum wage indexation, reservation wage, lending base rate                                                                                  |
-| `LaborEconomics.scala` | s2 | Phillips curve + expectations + union rigidity wages, employment, demographics, immigration                                                   |
-| `HouseholdIncomeEconomics.scala` | s3 | Individual HH income, consumption, saving, portfolio; labor separations, wage updates, bank-specific rates, equity returns, sectoral mobility |
-| `DemandEconomics.scala` | s4 | Sector demand allocation: HH consumption, government purchases, investment, exports; capacity constraints and spillover                       |
-| `FirmEconomics.scala` | s5 | Production, I-O intermediate market, CAPEX, financing splits (equity/bonds/loans), labor matching, NPL detection                              |
-| `HouseholdFinancialEconomics.scala` | s6 | Mortgage debt service, deposit interest, diaspora remittances, tourism, consumer credit aggregation                                           |
-| `PriceEquityEconomics.scala` | s7 | Inflation, GPW equity, sigma dynamics, GDP, macroprudential, EU funds                                                                        |
-| `OpenEconEconomics.scala` | s8 | BoP/forex, GVC trade, Taylor rule, bond yields, interbank, corporate bonds, insurance, NBFI                                                   |
-| `BankingEconomics.scala` | s9 | Bank P&L, provisioning, CAR, multi-bank resolution, bail-in, interbank, BFG levy, monetary aggregates (M1/M2/M3)                              |
+| File | Domain |
+|------|--------|
+| `FiscalConstraintEconomics.scala` | Minimum wage indexation, reservation wage, lending base rate |
+| `LaborEconomics.scala` | Phillips curve + expectations + union rigidity wages, employment, demographics, immigration |
+| `HouseholdIncomeEconomics.scala` | Individual HH income, consumption, saving, portfolio; labor separations, wage updates, bank-specific rates, equity returns, sectoral mobility |
+| `DemandEconomics.scala` | Sector demand allocation: HH consumption, government purchases, investment, exports; capacity constraints and spillover |
+| `FirmEconomics.scala` | Production, I-O intermediate market, CAPEX, financing splits (equity/bonds/loans), labor matching, NPL detection |
+| `HouseholdFinancialEconomics.scala` | Mortgage debt service, deposit interest, diaspora remittances, tourism, consumer credit aggregation |
+| `PriceEquityEconomics.scala` | Inflation, GPW equity, sigma dynamics, GDP, macroprudential, EU funds |
+| `OpenEconEconomics.scala` | BoP/forex, GVC trade, Taylor rule, bond yields, interbank, corporate bonds, insurance, NBFI |
+| `BankingEconomics.scala` | Bank P&L, provisioning, CAR, multi-bank resolution, bail-in, interbank, BFG levy, monetary aggregates (M1/M2/M3) |
 
-Each stage exposes a `StepOutput` boundary type. Stages that historically named
+Each module exposes a `StepOutput` boundary type. Stages that historically named
 their payload `Output` keep `type StepOutput = Output` aliases, so pipeline
 boundaries can use one semantic naming convention without forcing a noisy
 case-class rename.
@@ -123,7 +123,8 @@ exactness, each month.
 
 | File | Responsibility |
 |------|----------------|
-| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it computes narrow same-month groups for flow emission, signal timing, month closing, and SFC projection, assembles `MonthOutcome`, delegates flow emission, runtime execution, SFC projection, next-state advancement, and trace construction, and returns typed `nextState` for month `t+1`. |
+| `FlowSimulation.scala` | Sole pipeline entry point for one month. `step(state, randomness)` is the explicit month boundary: it assembles `MonthOutcome`, delegates same-month calculus, flow emission, runtime execution, SFC projection, next-state advancement, and trace construction, and returns typed `nextState` for month `t+1`. |
+| `MonthCalculusRunner.scala` | Runs ordered same-month economics and builds the narrow month-`t` boundary views consumed by flow emission, signal timing, month closing, and SFC projection. |
 | `MonthFlowEmitter.scala` | Translates `MonthlyCalculus` into named runtime ledger batches without doing economics or validation. |
 | `SfcSemanticProjection.scala` | Converts executed runtime batches plus narrow semantic views into `Sfc.SemanticFlows` and runs the SFC validation boundary. |
 | `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |
@@ -209,7 +210,7 @@ economics-stage market-clearing pipeline.
 **Adding a new market** (e.g., derivatives, crypto):
 1. Create `markets/NewMarket.scala` with a `step(...)` or `update(...)` function.
 2. Add state to `World.scala` if the market carries state across months.
-3. Wire the call into the appropriate economics stage (usually s5–s8).
+3. Wire the call into the appropriate economics boundary, usually firm, price/equity, or open-economy execution.
 4. If flows affect bank capital, deposits, or government — add a `FlowMechanism` entry and corresponding `*Flows.scala`.
 
 **Adding a new mechanism** (e.g., carbon tax, capital controls):

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -7,12 +7,9 @@ import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
 import com.boombustgroup.amorfati.engine.assembly.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
-import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit, LedgerFinancialState}
-import com.boombustgroup.amorfati.engine.markets.CorporateBondMarket
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
-
-import scala.IArray
 
 /** New flow-based simulation pipeline.
   *
@@ -242,7 +239,7 @@ object FlowSimulation:
   /** Downstream-specific same-month boundary views derived from one economics
     * execution.
     */
-  private case class SameMonthBoundaryViews(
+  private[flows] case class SameMonthBoundaryViews(
       flowPlan: MonthlyCalculus,
       signals: SignalBoundaryInputs,
       closing: MonthClosingInput,
@@ -277,7 +274,7 @@ object FlowSimulation:
       MonthWorkflow.pure(input)
 
     def sameMonth(input: StepInput)(using SimParams): Program[SameMonthBoundaryViews] =
-      MonthWorkflow.pure(computeSameMonthBoundaryViews(input))
+      MonthWorkflow.pure(MonthCalculusRunner.run(input))
 
     def signalView(boundaries: SameMonthBoundaryViews): Program[MonthSemantics.SignalView] =
       MonthWorkflow.pure(MonthSemantics.signalView(boundaries.signals))
@@ -400,7 +397,7 @@ object FlowSimulation:
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
   def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =
-    computeSameMonthBoundaryViews(stepInput(state, randomness, traceFirmDecisions = false)).flowPlan
+    MonthCalculusRunner.run(stepInput(state, randomness, traceFirmDecisions = false)).flowPlan
 
   private def stepInput(
       stateIn: SimState,
@@ -415,334 +412,6 @@ object FlowSimulation:
       boundaryIn = MonthBoundarySnapshot.capture(stateIn.world, stateIn.firms, stateIn.households, stateIn.banks, stateIn.ledgerFinancialState),
       traceFirmDecisions = traceFirmDecisions,
     )
-
-  /** Computes the same-month execution by chaining all Economics. Uses old
-    * pipeline steps for HH/Demand/Firm/PriceEquity (pure calculus). Uses
-    * self-contained OpenEconEconomics for monetary/external. Runs
-    * BankingEconomics exactly once, then narrows the result into flow, signal,
-    * closing, and SFC projection views so later boundaries do not depend on one
-    * broad transport bag.
-    */
-  private def computeSameMonthBoundaryViews(input: StepInput)(using p: SimParams): SameMonthBoundaryViews =
-    val randomness        = input.randomness.stages
-    val stateIn           = input.stateIn
-    val ledger            = stateIn.ledgerFinancialState
-    val w                 = stateIn.world
-    val firms             = stateIn.firms
-    val households        = stateIn.households
-    val banks             = stateIn.banks
-    val s1                = FiscalConstraintEconomics.compute(w, banks, ledger, input.executionMonth)
-    val s2Pre             = LaborEconomics.compute(w, firms, households, s1)
-    val payroll           = SocialSecurity.payrollBase(households)
-    val payrollZus        = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
-    val s3                = HouseholdIncomeEconomics.compute(
-      w,
-      firms,
-      households,
-      banks,
-      ledger,
-      s1.lendingBaseRate,
-      s1.resWage,
-      s2Pre.newWage,
-      randomness.householdIncomeEconomics.newStream(),
-      pensionIncome = payrollZus.pensionPayments,
-    )
-    val s4                = DemandEconomics.compute(w, s2Pre.employed, s2Pre.living, s3.domesticCons)
-    val s5                = FirmEconomics.runStep(
-      w,
-      firms,
-      households,
-      banks,
-      ledger,
-      s1,
-      s2Pre,
-      s3,
-      s4,
-      randomness.firmEconomics.newStream(),
-      traceDecisions = input.traceFirmDecisions,
-    )
-    val postLivingFirms   = s5.ioFirms.filter(Firm.isAlive)
-    val nBankruptFirms    = s5.firmDeaths
-    val avgFirmWorkers    = if s2Pre.living.nonEmpty then s2Pre.employed / s2Pre.living.length else 0
-    val payrollNfz        = SocialSecurity.nfzStep(payroll, s2Pre.newDemographics.workingAgePop, s2Pre.newDemographics.retirees)
-    val payrollPpk        = SocialSecurity.ppkStep(payroll)
-    val payrollEarmarked  = EarmarkedFunds.step(payroll, s3.hhAgg.totalUnempBenefits, nBankruptFirms, avgFirmWorkers)
-    val s2Reconciled      = LaborEconomics.reconcilePostFirmStep(w, s1, s2Pre, postLivingFirms, s5.households)
-    // Labor reconciliation refreshes employment/wage state after the firm step,
-    // but social funds are pinned to the opening-boundary payroll for month t.
-    val s2                = s2Reconciled.copy(
-      newZus = payrollZus,
-      newNfz = payrollNfz,
-      newPpk = payrollPpk,
-      newEarmarked = payrollEarmarked,
-    )
-    val s6                = HouseholdFinancialEconomics.compute(w, s1.m, s2.employed, s3.hhAgg, randomness.householdFinancialEconomics.newStream())
-    val s7                = PriceEquityEconomics.compute(
-      w = w,
-      month = s1.m,
-      wageGrowth = s2.wageGrowth,
-      avgDemandMult = s4.avgDemandMult,
-      sectorMults = s4.sectorMults,
-      totalSystemLoans = ledger.banks.map(_.firmLoan).sumPln,
-      firmStep = s5,
-      ledgerFinancialState = ledger,
-    )
-    val s8                = OpenEconEconomics.runStep(
-      OpenEconEconomics.StepInput(
-        w,
-        ledger,
-        s1,
-        s2,
-        s3,
-        s4,
-        s5,
-        s6,
-        s7,
-        banks,
-        randomness.openEconEconomics.newStream(),
-      ),
-    )
-    val bankingDepositRng = randomness.bankingEconomics.newStream()
-    val s9                = BankingEconomics.runStep(
-      BankingEconomics.StepInput(
-        w,
-        ledger,
-        s1,
-        s2,
-        s3,
-        s4,
-        s5,
-        s6,
-        s7,
-        s8,
-        banks,
-        bankingDepositRng,
-      ),
-    )
-    val prevBankAgg       = Banking.aggregateFromBankStocks(
-      banks,
-      ledger.banks.map(LedgerFinancialState.projectBankFinancialStocks),
-      bankId => CorporateBondOwnership.bankHolderFor(ledger, bankId),
-    )
-    val agg               = s3.hhAgg
-    val h                 = s9.housingAfterFlows
-    val externalFlowBop   = s8.external.flowBop
-    val openingCorpBonds  = CorporateBondOwnership.stockStateFromLedger(ledger)
-    val corpBondCoupon    = CorporateBondMarket.computeCoupon(w.financialMarkets.corporateBonds, openingCorpBonds)
-    val corpBondIssuance  = CorporateBondMarket.processIssuance(CorporateBondMarket.StockState.zero, s5.actualBondIssuance)
-    val laborForce        = s2.newDemographics.workingAgePop.max(1)
-    val unemploymentRate  = Share.One - Share.fraction(Math.max(0, Math.min(s2.employed, laborForce)), laborForce)
-    val equityRevaluation = equityRevaluationInput(ledger, s9.ledgerFinancialState)
-    val calc              = MonthlyCalculus(
-      month = s1.month,
-      resWage = s1.resWage,
-      lendingBaseRate = s1.lendingBaseRate,
-      baseMinWage = s1.baseMinWage,
-      minWagePriceLevel = s1.updatedMinWagePriceLevel,
-      wage = s2.newWage,
-      employed = s2.employed,
-      payroll = payroll,
-      zus = s2.newZus,
-      ppk = s2.newPpk,
-      earmarked = s2.newEarmarked,
-      unemploymentRate = unemploymentRate,
-      laborDemand = s2.laborDemand,
-      livingFirms = s5.ioFirms.count(Firm.isAlive),
-      retirees = s2Pre.newDemographics.retirees,
-      workingAgePop = s2Pre.newDemographics.workingAgePop,
-      nfz = s2.newNfz,
-      nBankruptFirms = nBankruptFirms,
-      avgFirmWorkers = avgFirmWorkers,
-      totalIncome = s3.totalIncome,
-      consumption = agg.consumption,
-      domesticConsumption = s3.domesticCons,
-      importConsumption = s3.importCons,
-      totalRent = agg.totalRent,
-      pitRevenue = s9.pitAfterEvasion,
-      totalDepositInterest = agg.totalDepositInterest,
-      totalRemittances = agg.totalRemittances,
-      totalUnempBenefits = agg.totalUnempBenefits,
-      totalSocialTransfers = agg.totalSocialTransfers,
-      totalCcOrigination = agg.totalConsumerOrigination,
-      approvedCcOrigination = agg.totalConsumerApprovedOrigination,
-      liquidityShortfallFinancing = agg.totalLiquidityShortfallFinancing,
-      totalCcDebtService = agg.totalConsumerDebtService,
-      totalCcPrincipal = agg.totalConsumerPrincipal,
-      totalCcDefault = agg.totalConsumerDefault,
-      govCurrentSpend = s9.newGovWithYield.govCurrentSpend,
-      firmTax = s5.sumTax,
-      firmNewLoans = s5.sumNewLoans,
-      firmPrincipal = s5.sumFirmPrincipal,
-      firmInterestIncome = s5.intIncome,
-      firmCapex = s5.sumCapex,
-      firmEquityIssuance = s5.sumEquityIssuance,
-      firmIoPayments = s5.totalIoPaid,
-      firmNplLoss = s5.nplLoss,
-      firmProfitShifting = s5.sumProfitShifting,
-      firmFdiRepatriation = s5.sumFdiRepatriation,
-      firmGrossInvestment = s5.sumGrossInvestment,
-      investNetDepositFlow = s9.investNetDepositFlow,
-      gdp = s7.gdp,
-      inflation = s7.newInfl,
-      equityDomDividends = s7.netDomesticDividends,
-      equityForDividends = s7.foreignDividendOutflow,
-      equityDivTax = s7.dividendTax,
-      equityGovDividends = s7.stateOwnedGovDividends,
-      equityReturn = s7.equityAfterForeignStock.monthlyReturn,
-      exports = externalFlowBop.exports,
-      totalImports = externalFlowBop.totalImports,
-      tourismExport = s6.tourismExport,
-      tourismImport = s6.tourismImport,
-      fdi = externalFlowBop.fdi,
-      portfolioFlows = externalFlowBop.portfolioFlows,
-      carryTradeFlow = externalFlowBop.carryTradeFlow,
-      capitalFlightOutflow = externalFlowBop.capitalFlightOutflow,
-      primaryIncome = externalFlowBop.primaryIncome,
-      euFunds = externalFlowBop.euFundsMonthly,
-      diasporaInflow = s6.diasporaInflow,
-      corpBondCoupon = s8.corpBonds.corpBondCoupon,
-      corpBondDefaultAmount = s5.totalBondDefault,
-      corpBondIssuance = s5.actualBondIssuance,
-      corpBondAmortization = s8.corpBonds.corpBondAmort,
-      corpBondCouponRecipients = corpBondCouponRecipients(corpBondCoupon),
-      corpBondDefaultRecipients = allocateCorpBondReduction(s5.totalBondDefault, openingCorpBonds),
-      corpBondIssuanceRecipients = corpBondStockRecipients(corpBondIssuance),
-      corpBondAmortizationRecipients = allocateCorpBondReduction(s8.corpBonds.corpBondAmort, openingCorpBonds),
-      mortgageOrigination = h.lastOrigination,
-      mortgageRepayment = h.lastRepayment,
-      mortgageInterest = h.mortgageInterestIncome,
-      mortgageDefault = h.lastDefault,
-      bankGovBondIncome = prevBankAgg.govBondHoldings * s8.monetary.newBondYield.monthly,
-      bankReserveInterest = s8.banking.totalReserveInterest,
-      bankStandingFacility = s8.banking.totalStandingFacilityIncome,
-      bankStandingFacilityBackstop = s9.standingFacilityBackstop,
-      bankInterbankInterest = s8.banking.totalInterbankInterest,
-      bankCorpBondCoupon = s8.corpBonds.corpBondBankCoupon,
-      bankCorpBondLoss = s8.corpBonds.corpBondBankDefaultLoss,
-      bankFxReserveSettlement = s8.monetary.fxPlnInjection,
-      bankBfgLevy = s9.bfgLevy,
-      bankUnrealizedLoss = s9.unrealizedBondLoss,
-      bankBailIn = s9.bailInLoss,
-      bankNbpRemittance = s8.banking.nbpRemittance,
-      equityRevaluation = equityRevaluation,
-      nbfiDepositDrain = s8.nonBank.nbfiDepositDrain,
-      nbfiOrigination = s9.finalNbfi.lastNbfiOrigination,
-      nbfiRepayment = s9.finalNbfi.lastNbfiRepayment,
-      nbfiDefaultAmount = s9.finalNbfi.lastNbfiDefaultAmount,
-      qfBankBondIssuance = s9.newQuasiFiscal.monthlyBankBondIssuance,
-      qfNbpBondAbsorption = s9.newQuasiFiscal.monthlyNbpBondAbsorption,
-      qfBankBondAmortization = s9.newQuasiFiscal.monthlyBankBondAmortization,
-      qfNbpBondAmortization = s9.newQuasiFiscal.monthlyNbpBondAmortization,
-      qfLending = s9.newQuasiFiscal.monthlyLending,
-      qfRepayment = s9.newQuasiFiscal.monthlyLoanRepayment,
-      govVatRevenue = s9.vatAfterEvasion,
-      govExciseRevenue = s9.exciseAfterEvasion,
-      govCustomsDutyRevenue = s9.customsDutyRevenue,
-      govDebtService = s8.banking.monthlyDebtService,
-      govDebtServiceRecipients = GovBudgetFlows.DebtServiceRecipients.fromCircuit(GovernmentBondCircuit.from(ledger), s8.banking.monthlyDebtService),
-      govBondRuntimeMovements = s9.govBondRuntimeMovements,
-      govEuCofinancing = s9.newGovWithYield.euCofinancing,
-      govCapitalSpend = s9.newGovWithYield.govCapitalSpend,
-      insuranceCurrentLifeReserves = ledger.insurance.lifeReserve,
-      insuranceCurrentNonLifeReserves = ledger.insurance.nonLifeReserve,
-      insurancePrevGovBonds = ledger.insurance.govBondHoldings,
-      insurancePrevCorpBonds = ledger.insurance.corpBondHoldings,
-      insuranceCorpBondDefaultLoss = s8.corpBonds.corpBondInsuranceDefaultLoss,
-      insurancePrevEquity = ledger.insurance.equityHoldings,
-      govBondYield = s8.monetary.newBondYield,
-      corpBondYield = s8.corpBonds.newCorpBonds.corpBondYield,
-    )
-    val execution         = MonthExecution(
-      openingWorld = w,
-      fiscal = s1,
-      labor = s2,
-      householdIncome = s3,
-      demand = s4,
-      firm = s5,
-      householdFinancial = s6,
-      priceEquity = s7,
-      openEconomy = s8,
-      banking = s9,
-    )
-    SameMonthBoundaryViews(
-      flowPlan = calc,
-      signals = SignalBoundaryInputs(
-        labor = s2,
-        demand = s4,
-      ),
-      closing = MonthClosing.prepareInput(execution),
-      semanticProjection = SemanticFlowInputs(
-        labor = s2,
-        hhIncome = s3,
-        firms = s5,
-        hhFinancial = s6,
-        prices = s7,
-        openEcon = s8,
-        banking = s9,
-      ),
-    )
-
-  private def corpBondCouponRecipients(coupon: CorporateBondMarket.CouponResult): CorpBondFlows.HolderBreakdown =
-    CorpBondFlows.HolderBreakdown(
-      banks = coupon.bank,
-      ppk = coupon.ppk,
-      other = coupon.other,
-      insurance = coupon.insurance,
-      nbfi = coupon.nbfi,
-    )
-
-  private def corpBondStockRecipients(stock: CorporateBondMarket.StockState): CorpBondFlows.HolderBreakdown =
-    CorpBondFlows.HolderBreakdown(
-      banks = stock.bankHoldings,
-      ppk = stock.ppkHoldings,
-      other = stock.otherHoldings,
-      insurance = stock.insuranceHoldings,
-      nbfi = stock.nbfiHoldings,
-    )
-
-  private def equityRevaluationInput(
-      opening: LedgerFinancialState,
-      closing: LedgerFinancialState,
-  ): EquityFlows.RevaluationInput =
-    val householdDeltas = Array.fill(opening.households.length)(PLN.Zero)
-    var i               = 0
-    while i < opening.households.length do
-      val closingEquity = if i < closing.households.length then closing.households(i).equity else PLN.Zero
-      householdDeltas(i) = closingEquity - opening.households(i).equity
-      i += 1
-
-    EquityFlows.RevaluationInput(
-      // Runtime topology is keyed to opening households; entrants become
-      // holder-addressable at the next month boundary.
-      householdDeltas = IArray.unsafeFromArray(householdDeltas),
-      insuranceDelta = closing.insurance.equityHoldings - opening.insurance.equityHoldings,
-      fundsDelta = closing.funds.nbfi.equityHoldings - opening.funds.nbfi.equityHoldings,
-      foreignDelta = closing.foreign.equityHoldings - opening.foreign.equityHoldings,
-    )
-
-  private def allocateCorpBondReduction(
-      amount: PLN,
-      opening: CorporateBondMarket.StockState,
-  ): CorpBondFlows.HolderBreakdown =
-    if amount <= PLN.Zero then CorpBondFlows.HolderBreakdown.zero
-    else
-      val weights = Array(
-        opening.bankHoldings.distributeRaw,
-        opening.ppkHoldings.distributeRaw,
-        opening.otherHoldings.distributeRaw,
-        opening.insuranceHoldings.distributeRaw,
-        opening.nbfiHoldings.distributeRaw,
-      )
-      if weights.forall(_ <= 0L) then CorpBondFlows.HolderBreakdown.copyToOther(amount)
-      else
-        val allocated = Distribute.distribute(amount.distributeRaw, weights)
-        CorpBondFlows.HolderBreakdown(
-          banks = PLN.fromRaw(allocated(0)),
-          ppk = PLN.fromRaw(allocated(1)),
-          other = PLN.fromRaw(allocated(2)),
-          insurance = PLN.fromRaw(allocated(3)),
-          nbfi = PLN.fromRaw(allocated(4)),
-        )
 
   private def operationalSignals(
       labor: LaborEconomics.StepOutput,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
@@ -1,0 +1,388 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.agents.*
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthExecution
+import com.boombustgroup.amorfati.engine.assembly.MonthClosing
+import com.boombustgroup.amorfati.engine.economics.*
+import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit, LedgerFinancialState}
+import com.boombustgroup.amorfati.engine.markets.CorporateBondMarket
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.*
+
+import scala.IArray
+
+/** Runs the deterministic same-month economics boundary.
+  *
+  * This is the one insertion point for the ordered same-month economics
+  * boundary. It returns only month-`t` views: flow plan, operational signals,
+  * closing input, and SFC semantic projection. Closed-month state and next-pre
+  * seed extraction remain outside this runner.
+  */
+private[flows] object MonthCalculusRunner:
+  import FlowSimulation.{MonthlyCalculus, SameMonthBoundaryViews, SemanticFlowInputs, SignalBoundaryInputs, StepInput}
+
+  private final case class StageRun(
+      openingLedger: LedgerFinancialState,
+      openingBanks: Vector[Banking.BankState],
+      execution: MonthExecution,
+      laborPre: LaborEconomics.StepOutput,
+      payroll: SocialSecurity.PayrollBase,
+      nBankruptFirms: Int,
+      avgFirmWorkers: Int,
+  )
+
+  def run(input: StepInput)(using p: SimParams): SameMonthBoundaryViews =
+    val stages   = runEconomicsStages(input)
+    val flowPlan = buildFlowPlan(stages)
+    buildBoundaryViews(stages.execution, flowPlan)
+
+  private def runEconomicsStages(input: StepInput)(using p: SimParams): StageRun =
+    val randomness         = input.randomness.stages
+    val stateIn            = input.stateIn
+    val ledger             = stateIn.ledgerFinancialState
+    val w                  = stateIn.world
+    val firms              = stateIn.firms
+    val households         = stateIn.households
+    val banks              = stateIn.banks
+    val fiscal             = FiscalConstraintEconomics.compute(w, banks, ledger, input.executionMonth)
+    val laborPre           = LaborEconomics.compute(w, firms, households, fiscal)
+    val payroll            = SocialSecurity.payrollBase(households)
+    val payrollZus         = SocialSecurity.zusStep(payroll, laborPre.newDemographics.retirees)
+    val householdIncome    = HouseholdIncomeEconomics.compute(
+      w,
+      firms,
+      households,
+      banks,
+      ledger,
+      fiscal.lendingBaseRate,
+      fiscal.resWage,
+      laborPre.newWage,
+      randomness.householdIncomeEconomics.newStream(),
+      pensionIncome = payrollZus.pensionPayments,
+    )
+    val demand             = DemandEconomics.compute(w, laborPre.employed, laborPre.living, householdIncome.domesticCons)
+    val firm               = FirmEconomics.runStep(
+      w,
+      firms,
+      households,
+      banks,
+      ledger,
+      fiscal,
+      laborPre,
+      householdIncome,
+      demand,
+      randomness.firmEconomics.newStream(),
+      traceDecisions = input.traceFirmDecisions,
+    )
+    val postLivingFirms    = firm.ioFirms.filter(Firm.isAlive)
+    val nBankruptFirms     = firm.firmDeaths
+    val avgFirmWorkers     = if laborPre.living.nonEmpty then laborPre.employed / laborPre.living.length else 0
+    val payrollNfz         = SocialSecurity.nfzStep(payroll, laborPre.newDemographics.workingAgePop, laborPre.newDemographics.retirees)
+    val payrollPpk         = SocialSecurity.ppkStep(payroll)
+    val payrollEarmarked   = EarmarkedFunds.step(payroll, householdIncome.hhAgg.totalUnempBenefits, nBankruptFirms, avgFirmWorkers)
+    val laborReconciled    = LaborEconomics.reconcilePostFirmStep(w, fiscal, laborPre, postLivingFirms, firm.households)
+    // Labor reconciliation refreshes employment/wage state after the firm step,
+    // but social funds are pinned to the opening-boundary payroll for month t.
+    val labor              = laborReconciled.copy(
+      newZus = payrollZus,
+      newNfz = payrollNfz,
+      newPpk = payrollPpk,
+      newEarmarked = payrollEarmarked,
+    )
+    val householdFinancial =
+      HouseholdFinancialEconomics.compute(w, fiscal.m, labor.employed, householdIncome.hhAgg, randomness.householdFinancialEconomics.newStream())
+    val priceEquity        = PriceEquityEconomics.compute(
+      w = w,
+      month = fiscal.m,
+      wageGrowth = labor.wageGrowth,
+      avgDemandMult = demand.avgDemandMult,
+      sectorMults = demand.sectorMults,
+      totalSystemLoans = ledger.banks.map(_.firmLoan).sumPln,
+      firmStep = firm,
+      ledgerFinancialState = ledger,
+    )
+    val openEconomy        = OpenEconEconomics.runStep(
+      OpenEconEconomics.StepInput(
+        w,
+        ledger,
+        fiscal,
+        labor,
+        householdIncome,
+        demand,
+        firm,
+        householdFinancial,
+        priceEquity,
+        banks,
+        randomness.openEconEconomics.newStream(),
+      ),
+    )
+    val bankingDepositRng  = randomness.bankingEconomics.newStream()
+    val banking            = BankingEconomics.runStep(
+      BankingEconomics.StepInput(
+        w,
+        ledger,
+        fiscal,
+        labor,
+        householdIncome,
+        demand,
+        firm,
+        householdFinancial,
+        priceEquity,
+        openEconomy,
+        banks,
+        bankingDepositRng,
+      ),
+    )
+    val execution          = MonthExecution(
+      openingWorld = w,
+      fiscal = fiscal,
+      labor = labor,
+      householdIncome = householdIncome,
+      demand = demand,
+      firm = firm,
+      householdFinancial = householdFinancial,
+      priceEquity = priceEquity,
+      openEconomy = openEconomy,
+      banking = banking,
+    )
+
+    StageRun(
+      openingLedger = ledger,
+      openingBanks = banks,
+      execution = execution,
+      laborPre = laborPre,
+      payroll = payroll,
+      nBankruptFirms = nBankruptFirms,
+      avgFirmWorkers = avgFirmWorkers,
+    )
+
+  private def buildFlowPlan(stages: StageRun)(using p: SimParams): MonthlyCalculus =
+    val ledger             = stages.openingLedger
+    val banks              = stages.openingBanks
+    val execution          = stages.execution
+    val w                  = execution.openingWorld
+    val fiscal             = execution.fiscal
+    val laborPre           = stages.laborPre
+    val labor              = execution.labor
+    val householdIncome    = execution.householdIncome
+    val firm               = execution.firm
+    val householdFinancial = execution.householdFinancial
+    val priceEquity        = execution.priceEquity
+    val openEconomy        = execution.openEconomy
+    val banking            = execution.banking
+    val prevBankAgg        = Banking.aggregateFromBankStocks(
+      banks,
+      ledger.banks.map(LedgerFinancialState.projectBankFinancialStocks),
+      bankId => CorporateBondOwnership.bankHolderFor(ledger, bankId),
+    )
+    val agg                = householdIncome.hhAgg
+    val h                  = banking.housingAfterFlows
+    val externalFlowBop    = openEconomy.external.flowBop
+    val openingCorpBonds   = CorporateBondOwnership.stockStateFromLedger(ledger)
+    val corpBondCoupon     = CorporateBondMarket.computeCoupon(w.financialMarkets.corporateBonds, openingCorpBonds)
+    val corpBondIssuance   = CorporateBondMarket.processIssuance(CorporateBondMarket.StockState.zero, firm.actualBondIssuance)
+    val laborForce         = labor.newDemographics.workingAgePop.max(1)
+    val unemploymentRate   = Share.One - Share.fraction(Math.max(0, Math.min(labor.employed, laborForce)), laborForce)
+    val equityRevaluation  = equityRevaluationInput(ledger, banking.ledgerFinancialState)
+
+    MonthlyCalculus(
+      month = fiscal.month,
+      resWage = fiscal.resWage,
+      lendingBaseRate = fiscal.lendingBaseRate,
+      baseMinWage = fiscal.baseMinWage,
+      minWagePriceLevel = fiscal.updatedMinWagePriceLevel,
+      wage = labor.newWage,
+      employed = labor.employed,
+      payroll = stages.payroll,
+      zus = labor.newZus,
+      ppk = labor.newPpk,
+      earmarked = labor.newEarmarked,
+      unemploymentRate = unemploymentRate,
+      laborDemand = labor.laborDemand,
+      livingFirms = firm.ioFirms.count(Firm.isAlive),
+      retirees = laborPre.newDemographics.retirees,
+      workingAgePop = laborPre.newDemographics.workingAgePop,
+      nfz = labor.newNfz,
+      nBankruptFirms = stages.nBankruptFirms,
+      avgFirmWorkers = stages.avgFirmWorkers,
+      totalIncome = householdIncome.totalIncome,
+      consumption = agg.consumption,
+      domesticConsumption = householdIncome.domesticCons,
+      importConsumption = householdIncome.importCons,
+      totalRent = agg.totalRent,
+      pitRevenue = banking.pitAfterEvasion,
+      totalDepositInterest = agg.totalDepositInterest,
+      totalRemittances = agg.totalRemittances,
+      totalUnempBenefits = agg.totalUnempBenefits,
+      totalSocialTransfers = agg.totalSocialTransfers,
+      totalCcOrigination = agg.totalConsumerOrigination,
+      approvedCcOrigination = agg.totalConsumerApprovedOrigination,
+      liquidityShortfallFinancing = agg.totalLiquidityShortfallFinancing,
+      totalCcDebtService = agg.totalConsumerDebtService,
+      totalCcPrincipal = agg.totalConsumerPrincipal,
+      totalCcDefault = agg.totalConsumerDefault,
+      govCurrentSpend = banking.newGovWithYield.govCurrentSpend,
+      firmTax = firm.sumTax,
+      firmNewLoans = firm.sumNewLoans,
+      firmPrincipal = firm.sumFirmPrincipal,
+      firmInterestIncome = firm.intIncome,
+      firmCapex = firm.sumCapex,
+      firmEquityIssuance = firm.sumEquityIssuance,
+      firmIoPayments = firm.totalIoPaid,
+      firmNplLoss = firm.nplLoss,
+      firmProfitShifting = firm.sumProfitShifting,
+      firmFdiRepatriation = firm.sumFdiRepatriation,
+      firmGrossInvestment = firm.sumGrossInvestment,
+      investNetDepositFlow = banking.investNetDepositFlow,
+      gdp = priceEquity.gdp,
+      inflation = priceEquity.newInfl,
+      equityDomDividends = priceEquity.netDomesticDividends,
+      equityForDividends = priceEquity.foreignDividendOutflow,
+      equityDivTax = priceEquity.dividendTax,
+      equityGovDividends = priceEquity.stateOwnedGovDividends,
+      equityReturn = priceEquity.equityAfterForeignStock.monthlyReturn,
+      exports = externalFlowBop.exports,
+      totalImports = externalFlowBop.totalImports,
+      tourismExport = householdFinancial.tourismExport,
+      tourismImport = householdFinancial.tourismImport,
+      fdi = externalFlowBop.fdi,
+      portfolioFlows = externalFlowBop.portfolioFlows,
+      carryTradeFlow = externalFlowBop.carryTradeFlow,
+      capitalFlightOutflow = externalFlowBop.capitalFlightOutflow,
+      primaryIncome = externalFlowBop.primaryIncome,
+      euFunds = externalFlowBop.euFundsMonthly,
+      diasporaInflow = householdFinancial.diasporaInflow,
+      corpBondCoupon = openEconomy.corpBonds.corpBondCoupon,
+      corpBondDefaultAmount = firm.totalBondDefault,
+      corpBondIssuance = firm.actualBondIssuance,
+      corpBondAmortization = openEconomy.corpBonds.corpBondAmort,
+      corpBondCouponRecipients = corpBondCouponRecipients(corpBondCoupon),
+      corpBondDefaultRecipients = allocateCorpBondReduction(firm.totalBondDefault, openingCorpBonds),
+      corpBondIssuanceRecipients = corpBondStockRecipients(corpBondIssuance),
+      corpBondAmortizationRecipients = allocateCorpBondReduction(openEconomy.corpBonds.corpBondAmort, openingCorpBonds),
+      mortgageOrigination = h.lastOrigination,
+      mortgageRepayment = h.lastRepayment,
+      mortgageInterest = h.mortgageInterestIncome,
+      mortgageDefault = h.lastDefault,
+      bankGovBondIncome = prevBankAgg.govBondHoldings * openEconomy.monetary.newBondYield.monthly,
+      bankReserveInterest = openEconomy.banking.totalReserveInterest,
+      bankStandingFacility = openEconomy.banking.totalStandingFacilityIncome,
+      bankStandingFacilityBackstop = banking.standingFacilityBackstop,
+      bankInterbankInterest = openEconomy.banking.totalInterbankInterest,
+      bankCorpBondCoupon = openEconomy.corpBonds.corpBondBankCoupon,
+      bankCorpBondLoss = openEconomy.corpBonds.corpBondBankDefaultLoss,
+      bankFxReserveSettlement = openEconomy.monetary.fxPlnInjection,
+      bankBfgLevy = banking.bfgLevy,
+      bankUnrealizedLoss = banking.unrealizedBondLoss,
+      bankBailIn = banking.bailInLoss,
+      bankNbpRemittance = openEconomy.banking.nbpRemittance,
+      equityRevaluation = equityRevaluation,
+      nbfiDepositDrain = openEconomy.nonBank.nbfiDepositDrain,
+      nbfiOrigination = banking.finalNbfi.lastNbfiOrigination,
+      nbfiRepayment = banking.finalNbfi.lastNbfiRepayment,
+      nbfiDefaultAmount = banking.finalNbfi.lastNbfiDefaultAmount,
+      qfBankBondIssuance = banking.newQuasiFiscal.monthlyBankBondIssuance,
+      qfNbpBondAbsorption = banking.newQuasiFiscal.monthlyNbpBondAbsorption,
+      qfBankBondAmortization = banking.newQuasiFiscal.monthlyBankBondAmortization,
+      qfNbpBondAmortization = banking.newQuasiFiscal.monthlyNbpBondAmortization,
+      qfLending = banking.newQuasiFiscal.monthlyLending,
+      qfRepayment = banking.newQuasiFiscal.monthlyLoanRepayment,
+      govVatRevenue = banking.vatAfterEvasion,
+      govExciseRevenue = banking.exciseAfterEvasion,
+      govCustomsDutyRevenue = banking.customsDutyRevenue,
+      govDebtService = openEconomy.banking.monthlyDebtService,
+      govDebtServiceRecipients = GovBudgetFlows.DebtServiceRecipients.fromCircuit(GovernmentBondCircuit.from(ledger), openEconomy.banking.monthlyDebtService),
+      govBondRuntimeMovements = banking.govBondRuntimeMovements,
+      govEuCofinancing = banking.newGovWithYield.euCofinancing,
+      govCapitalSpend = banking.newGovWithYield.govCapitalSpend,
+      insuranceCurrentLifeReserves = ledger.insurance.lifeReserve,
+      insuranceCurrentNonLifeReserves = ledger.insurance.nonLifeReserve,
+      insurancePrevGovBonds = ledger.insurance.govBondHoldings,
+      insurancePrevCorpBonds = ledger.insurance.corpBondHoldings,
+      insuranceCorpBondDefaultLoss = openEconomy.corpBonds.corpBondInsuranceDefaultLoss,
+      insurancePrevEquity = ledger.insurance.equityHoldings,
+      govBondYield = openEconomy.monetary.newBondYield,
+      corpBondYield = openEconomy.corpBonds.newCorpBonds.corpBondYield,
+    )
+
+  private def buildBoundaryViews(execution: MonthExecution, flowPlan: MonthlyCalculus)(using p: SimParams): SameMonthBoundaryViews =
+    SameMonthBoundaryViews(
+      flowPlan = flowPlan,
+      signals = SignalBoundaryInputs(
+        labor = execution.labor,
+        demand = execution.demand,
+      ),
+      closing = MonthClosing.prepareInput(execution),
+      semanticProjection = SemanticFlowInputs(
+        labor = execution.labor,
+        hhIncome = execution.householdIncome,
+        firms = execution.firm,
+        hhFinancial = execution.householdFinancial,
+        prices = execution.priceEquity,
+        openEcon = execution.openEconomy,
+        banking = execution.banking,
+      ),
+    )
+
+  private def corpBondCouponRecipients(coupon: CorporateBondMarket.CouponResult): CorpBondFlows.HolderBreakdown =
+    CorpBondFlows.HolderBreakdown(
+      banks = coupon.bank,
+      ppk = coupon.ppk,
+      other = coupon.other,
+      insurance = coupon.insurance,
+      nbfi = coupon.nbfi,
+    )
+
+  private def corpBondStockRecipients(stock: CorporateBondMarket.StockState): CorpBondFlows.HolderBreakdown =
+    CorpBondFlows.HolderBreakdown(
+      banks = stock.bankHoldings,
+      ppk = stock.ppkHoldings,
+      other = stock.otherHoldings,
+      insurance = stock.insuranceHoldings,
+      nbfi = stock.nbfiHoldings,
+    )
+
+  private def equityRevaluationInput(
+      opening: LedgerFinancialState,
+      closing: LedgerFinancialState,
+  ): EquityFlows.RevaluationInput =
+    val householdDeltas = Array.fill(opening.households.length)(PLN.Zero)
+    var i               = 0
+    while i < opening.households.length do
+      val closingEquity = if i < closing.households.length then closing.households(i).equity else PLN.Zero
+      householdDeltas(i) = closingEquity - opening.households(i).equity
+      i += 1
+
+    EquityFlows.RevaluationInput(
+      // Runtime topology is keyed to opening households; entrants become
+      // holder-addressable at the next month boundary.
+      householdDeltas = IArray.unsafeFromArray(householdDeltas),
+      insuranceDelta = closing.insurance.equityHoldings - opening.insurance.equityHoldings,
+      fundsDelta = closing.funds.nbfi.equityHoldings - opening.funds.nbfi.equityHoldings,
+      foreignDelta = closing.foreign.equityHoldings - opening.foreign.equityHoldings,
+    )
+
+  private def allocateCorpBondReduction(
+      amount: PLN,
+      opening: CorporateBondMarket.StockState,
+  ): CorpBondFlows.HolderBreakdown =
+    if amount <= PLN.Zero then CorpBondFlows.HolderBreakdown.zero
+    else
+      val weights = Array(
+        opening.bankHoldings.distributeRaw,
+        opening.ppkHoldings.distributeRaw,
+        opening.otherHoldings.distributeRaw,
+        opening.insuranceHoldings.distributeRaw,
+        opening.nbfiHoldings.distributeRaw,
+      )
+      if weights.forall(_ <= 0L) then CorpBondFlows.HolderBreakdown.copyToOther(amount)
+      else
+        val allocated = Distribute.distribute(amount.distributeRaw, weights)
+        CorpBondFlows.HolderBreakdown(
+          banks = PLN.fromRaw(allocated(0)),
+          ppk = PLN.fromRaw(allocated(1)),
+          other = PLN.fromRaw(allocated(2)),
+          insurance = PLN.fromRaw(allocated(3)),
+          nbfi = PLN.fromRaw(allocated(4)),
+        )


### PR DESCRIPTION
## Summary
- extract ordered s1-s9 same-month economics from FlowSimulation into MonthCalculusRunner
- keep FlowSimulation focused on the month workflow DSL and runtime boundaries
- update engine README ownership for the economics runner

Closes #655

## Validation
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.assembly.SignalTimingRegressionSpec"
- sbt -DamorFati.includeHeavyTests=true "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated simulation engine package layout documentation to clarify month-step boundaries and economics pipeline components.

* **Refactor**
  * Restructured same-month economics computation by extracting the calculation logic into a dedicated runner module, improving code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->