### PR TITLE
Standardize economics StepOutput names

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -95,10 +95,9 @@ emitting monetary flows. `MonthCalculusRunner` wires them together.
 | `OpenEconEconomics.scala` | BoP/forex, GVC trade, Taylor rule, bond yields, interbank, corporate bonds, insurance, NBFI |
 | `BankingEconomics.scala` | Bank P&L, provisioning, CAR, multi-bank resolution, bail-in, interbank, BFG levy, monetary aggregates (M1/M2/M3) |
 
-Each module exposes a `StepOutput` boundary type. Stages that historically named
-their payload `Output` keep `type StepOutput = Output` aliases, so pipeline
-boundaries can use one semantic naming convention without forcing a noisy
-case-class rename.
+Each module exposes a `StepOutput` boundary type. Modules that historically
+named their payload `Output` keep `type Output = StepOutput` aliases for
+transitional type references, but new engine code should refer to `StepOutput`.
 
 ## assembly/
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/DemandEconomics.scala
@@ -24,7 +24,7 @@ object DemandEconomics:
   private val PressureSignalSmoothing = Share.decimal(65, 2)      // persistent sector order-book pressure; avoids startup repricing spikes
   private val HiringSignalSmoothing   = Share.decimal(65, 2)      // persistence in sector hiring plans; avoids month-to-month whipsaw
 
-  case class Output(
+  case class StepOutput(
       govPurchases: PLN,                        // total government purchases this month
       sectorMults: Vector[Multiplier],          // per-sector demand multiplier (0 = no demand, 1 = full capacity)
       sectorDemandPressure: Vector[Multiplier], // persistent demand/capacity pressure used for hiring and pricing
@@ -35,7 +35,10 @@ object DemandEconomics:
       fiscalRuleStatus: FiscalRules.RuleStatus, // fiscal rule compliance diagnostics
   )
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   def compute(
       w: World,
@@ -56,7 +59,7 @@ object DemandEconomics:
     val sectorHiringSignal = smoothHiringSignal(seedIn.sectorHiringSignal, sectorPressure)
     val sectorMults        = applySpillover(rawPressure, sectorCapReal, w.priceLevel)
     val avgDemandMult      = computeAvgDemandMult(sectorMults, sectorCapReal, w)
-    Output(govPurchases, sectorMults, sectorPressure, sectorHiringSignal, avgDemandMult, sectorCapReal, laggedInvestDemand, fiscalResult.status)
+    StepOutput(govPurchases, sectorMults, sectorPressure, sectorHiringSignal, avgDemandMult, sectorCapReal, laggedInvestDemand, fiscalResult.status)
 
   /** Government purchases: base spending x price level plus a small automatic
     * stabilizer tied to labor-market slack. Revenue windfalls are not

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/FiscalConstraintEconomics.scala
@@ -18,7 +18,7 @@ object FiscalConstraintEconomics:
 
   private val ExpectationsBlendWeight = Share.decimal(5, 1)
 
-  case class Output(
+  case class StepOutput(
       month: ExecutionMonth,
       baseMinWage: PLN,
       updatedMinWagePriceLevel: PriceIndex,
@@ -27,7 +27,10 @@ object FiscalConstraintEconomics:
   ):
     def m: ExecutionMonth = month
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   def compute(w: World, banks: Vector[Banking.BankState], ledgerFinancialState: LedgerFinancialState, month: ExecutionMonth)(using p: SimParams): StepOutput =
     val bankAgg = Banking.aggregateFromBankStocks(banks, ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks))
@@ -59,4 +62,4 @@ object FiscalConstraintEconomics:
     val lendingBaseRate =
       rawLendingBaseRate * ExpectationsBlendWeight + w.mechanisms.expectations.expectedRate * (Share.One - ExpectationsBlendWeight)
 
-    Output(month, baseMinWage, updatedMinWagePriceLevel, resWage, lendingBaseRate)
+    StepOutput(month, baseMinWage, updatedMinWagePriceLevel, resWage, lendingBaseRate)

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala
@@ -25,7 +25,7 @@ object HouseholdFinancialEconomics:
   private def trendFactor(annualGrowth: Rate, elapsedMonths: Int): Multiplier =
     annualGrowth.monthly.growthMultiplier.pow(Scalar(elapsedMonths))
 
-  case class Output(
+  case class StepOutput(
       depositInterestPaid: PLN,         // total deposit interest paid to households
       remittanceOutflow: PLN,           // total household remittance outflow
       diasporaInflow: PLN,              // diaspora remittance inflow (NBP BoP)
@@ -41,7 +41,10 @@ object HouseholdFinancialEconomics:
       consumerPrincipal: PLN,           // consumer loan principal repayment
   )
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   def compute(
       w: World,
@@ -93,7 +96,7 @@ object HouseholdFinancialEconomics:
     val consumerNplLoss             = consumerLoanDefaultAmt * (Share.One - p.household.ccNplRecovery)
     val consumerPrincipal           = hhAgg.totalConsumerPrincipal
 
-    Output(
+    StepOutput(
       depositInterestPaid,
       remittanceOutflow,
       diasporaInflow,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdIncomeEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdIncomeEconomics.scala
@@ -25,7 +25,7 @@ object HouseholdIncomeEconomics:
   // ---- Calibration constants ----
   private val ImportErElasticity = Coefficient.decimal(5, 1) // exchange rate elasticity of import propensity
 
-  case class Output(
+  case class StepOutput(
       totalIncome: PLN,                                     // aggregate household income (wages + benefits + transfers)
       consumption: PLN,                                     // aggregate household consumption spending
       importCons: PLN,                                      // import component of household consumption (forex demand)
@@ -40,7 +40,10 @@ object HouseholdIncomeEconomics:
       ledgerFinancialState: LedgerFinancialState,           // ledger after household financial stock updates
   )
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   def compute(
       w: World,
@@ -113,7 +116,7 @@ object HouseholdIncomeEconomics:
         )
       else agg
 
-    Output(
+    StepOutput(
       aggWithPensions.totalIncome,
       aggWithPensions.consumption,
       aggWithPensions.importConsumption,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
@@ -46,7 +46,7 @@ object LaborEconomics:
       val unemploymentRate = Share.fraction(unemployed, laborForcePopulation)
       (p.monetary.nairu - unemploymentRate).max(Share.Zero).toCoefficient * p.labor.tightLaborWageSensitivity
 
-  case class Output(
+  case class StepOutput(
       newWage: PLN,
       employed: Int,
       laborDemand: Int,
@@ -64,7 +64,10 @@ object LaborEconomics:
       regionalWages: Map[Region, PLN],
   )
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   def compute(
       w: World,
@@ -103,7 +106,7 @@ object LaborEconomics:
       newDemographics.retirees,
     )
 
-    Output(
+    StepOutput(
       newWage = cleared.wage,
       employed = cleared.employed,
       laborDemand = laborDemand,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/PriceEquityEconomics.scala
@@ -19,7 +19,7 @@ import com.boombustgroup.amorfati.types.*
   */
 object PriceEquityEconomics:
 
-  case class Output(
+  case class StepOutput(
       autoR: Share,
       hybR: Share,
       aggInventoryStock: PLN,
@@ -45,7 +45,10 @@ object PriceEquityEconomics:
       aggInventoryChange: PLN,
   )
 
-  type StepOutput = Output
+  /** Compatibility alias for older type references; new code should use
+    * [[StepOutput]].
+    */
+  type Output = StepOutput
 
   // ---------------------------------------------------------------------------
   // Sigma dynamics — Arthur-style increasing returns / learning-by-doing
@@ -235,7 +238,7 @@ object PriceEquityEconomics:
     val dividendTax            = dividends.tax
     val stateOwnedGovDividends = dividends.gov
 
-    Output(
+    StepOutput(
       autoR,
       hybR,
       aggInventoryStock,

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomicsSpec.scala
@@ -21,7 +21,7 @@ class LaborEconomicsSpec extends AnyFlatSpec with Matchers:
   private val firms      = initResult.firms
   private val households = initResult.households
 
-  private val s1 = FiscalConstraintEconomics.Output(
+  private val s1 = FiscalConstraintEconomics.StepOutput(
     month = ExecutionMonth.First,
     lendingBaseRate = world.nbp.referenceRate,
     resWage = world.householdMarket.reservationWage,


### PR DESCRIPTION
## Summary
- rename remaining economics payload case classes from Output to StepOutput
- retain Output type aliases for transitional type references
- update internal constructors, the LaborEconomics fixture, and engine README guidance

Closes #653

## Validation
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.*"
- sbt "testOnly com.boombustgroup.amorfati.engine.assembly.SignalTimingRegressionSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized output type naming conventions across economic engine modules for consistency
  * Maintained backward compatibility through type aliases, ensuring existing code references continue to work

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->