### PR TITLE
Add household step DSL

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -87,6 +87,8 @@ carry behavioral state, operational diagnostics, and legacy unsupported metrics.
 | `household/HouseholdPerBankFlowAggregation.scala` | Per-bank household-flow aggregation |
 | `household/HouseholdDistributionStats.scala` | Distribution statistics, Gini, poverty-search helper, and sector-mobility metric |
 | `household/HouseholdAggregateComputation.scala` | Household aggregate accounting from state, stocks, and monthly flow totals |
+| `household/HouseholdStepSemantics.scala` | Zero-cost phase tags for the household monthly batch timeline |
+| `household/HouseholdStepDsl.scala` | Identity DSL wiring the household step as opening → prepare → process → aggregate → validate → close |
 | `household/HouseholdStepRunner.scala` | Month-step orchestration preserving the public `Household.step` facade |
 | `household/HouseholdMortgageSchedule.scala` | Mortgage amortization helpers for household financial stocks |
 | `household/HouseholdParameters.scala` | Shared household constants used across init, monthly execution, and aggregates |

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
@@ -133,17 +133,72 @@ private[household] object HouseholdStepDsl:
 
   /** Checks monthly diagnostics against aggregate accounting before closing. */
   def validate(aggregated: AggregatedHouseholds): Program[ValidatedHouseholds] =
-    val rows             = aggregated.rows
-    val monthlyRows      = rows.monthly
-    val agg              = rows.aggregates
-    var monthlyLiquidity = PLN.Zero
-    var j                = 0
+    val rows                       = aggregated.rows
+    val monthlyRows                = rows.monthly
+    val agg                        = rows.aggregates
+    var monthlyLiquidity           = PLN.Zero
+    var monthlyDefault             = PLN.Zero
+    var monthlyLoanDef             = PLN.Zero
+    var monthlyBridge              = PLN.Zero
+    var monthlyConsGap             = PLN.Zero
+    var monthlyRentGap             = PLN.Zero
+    var monthlyMtgGap              = PLN.Zero
+    var monthlyDebtGap             = PLN.Zero
+    var monthlyOverdraft           = PLN.Zero
+    var j                          = 0
     while j < monthlyRows.length do
-      monthlyLiquidity = monthlyLiquidity + monthlyRows(j).liquidityShortfallFinancing
+      val row = monthlyRows(j)
+      monthlyLiquidity = monthlyLiquidity + row.liquidityShortfallFinancing
+      monthlyDefault = monthlyDefault + row.consumerDefault
+      monthlyLoanDef = monthlyLoanDef + row.consumerLoanDefault
+      monthlyBridge = monthlyBridge + row.liquidityBridgeChargeOff
+      monthlyConsGap = monthlyConsGap + row.consumptionShortfall
+      monthlyRentGap = monthlyRentGap + row.rentArrears
+      monthlyMtgGap = monthlyMtgGap + row.mortgageArrears
+      monthlyDebtGap = monthlyDebtGap + row.consumerDebtArrears
+      monthlyOverdraft = monthlyOverdraft + row.temporaryOverdraft
       j += 1
+    val monthlyShortfallComponents =
+      monthlyConsGap + monthlyRentGap + monthlyMtgGap + monthlyDebtGap + monthlyOverdraft
     require(
       monthlyLiquidity == agg.totalLiquidityShortfallFinancing,
       "Household.step monthly flow diagnostics must reconcile to aggregate liquidity shortfall financing",
+    )
+    require(
+      monthlyDefault == agg.totalConsumerDefault,
+      "Household.step monthly flow diagnostics must reconcile to aggregate consumer default",
+    )
+    require(
+      monthlyLoanDef == agg.totalConsumerLoanDefault,
+      "Household.step monthly flow diagnostics must reconcile to aggregate consumer-loan default",
+    )
+    require(
+      monthlyBridge == agg.totalLiquidityBridgeChargeOff,
+      "Household.step monthly flow diagnostics must reconcile to aggregate liquidity bridge charge-off",
+    )
+    require(
+      monthlyConsGap == agg.totalConsumptionShortfall,
+      "Household.step monthly flow diagnostics must reconcile to aggregate consumption shortfall",
+    )
+    require(
+      monthlyRentGap == agg.totalRentArrears,
+      "Household.step monthly flow diagnostics must reconcile to aggregate rent arrears",
+    )
+    require(
+      monthlyMtgGap == agg.totalMortgageArrears,
+      "Household.step monthly flow diagnostics must reconcile to aggregate mortgage arrears",
+    )
+    require(
+      monthlyDebtGap == agg.totalConsumerDebtArrears,
+      "Household.step monthly flow diagnostics must reconcile to aggregate consumer-debt arrears",
+    )
+    require(
+      monthlyOverdraft == agg.totalTemporaryOverdraft,
+      "Household.step monthly flow diagnostics must reconcile to aggregate temporary overdraft",
+    )
+    require(
+      monthlyShortfallComponents == agg.totalLiquidityShortfallComponents,
+      "Household.step monthly flow diagnostics must reconcile to aggregate liquidity shortfall components",
     )
     require(
       agg.totalLiquidityShortfallComponents == agg.totalLiquidityShortfallFinancing,

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
@@ -1,0 +1,171 @@
+package com.boombustgroup.amorfati.agents.household
+
+import com.boombustgroup.amorfati.agents.{HhFinancialDistressState, HhStatus, Household}
+import com.boombustgroup.amorfati.agents.household.HouseholdStepAccumulator.StepTotals
+import com.boombustgroup.amorfati.agents.household.HouseholdStepSemantics.*
+import com.boombustgroup.amorfati.agents.household.HouseholdStepTypes.*
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.MonthWorkflow
+import com.boombustgroup.amorfati.engine.MonthWorkflow.Program
+import com.boombustgroup.amorfati.types.*
+
+/** Identity-DSL for the household monthly batch step.
+  *
+  * Each method names one temporal boundary around the existing data-oriented
+  * implementation: validate opening rows, execute households, aggregate public
+  * totals, validate diagnostics, and close into the public result.
+  */
+private[agents] object HouseholdStepDsl:
+
+  /** Opens one household batch from the public `Household.step` argument
+    * surface.
+    */
+  def open(input: Input): Program[OpeningInput] =
+    MonthWorkflow.pure(HouseholdStepSemantics.opening(input))
+
+  /** Validates aligned opening rows and derives shared month context. */
+  def prepare(opening: OpeningInput): Program[PreparedInput] =
+    val input           = opening.input
+    val households      = input.opening.households
+    val financialStocks = input.opening.financialStocks
+    require(
+      households.length == financialStocks.length,
+      s"Household.step requires aligned households and financialStocks, got ${households.length} households and ${financialStocks.length} stock rows",
+    )
+    var stockCheck      = 0
+    while stockCheck < financialStocks.length do
+      require(
+        financialStocks(stockCheck).demandDeposit >= PLN.Zero,
+        "Household.step requires non-negative opening demandDeposit balances; liquidity shortfalls must enter as consumer-loan stocks",
+      )
+      stockCheck += 1
+
+    MonthWorkflow.pure(
+      HouseholdStepSemantics.preparedMonth(
+        PreparedMonth(
+          input = input,
+          distressedIds = HouseholdDistressMachine.buildDistressedSet(households),
+          laborContext = HouseholdLaborTransitionContext.fromOptions(input.market.sectorWages, input.market.sectorVacancies),
+        ),
+      ),
+    )
+
+  /** Executes every household row while preserving array-backed hot paths. */
+  def process(prepared: PreparedInput)(using SimParams): Program[ProcessedHouseholds] =
+    val context         = prepared.month
+    val input           = context.input
+    val households      = input.opening.households
+    val financialStocks = input.opening.financialStocks
+    val updatedRows     = new Array[Household.State](households.length)
+    val stockRows       = new Array[Household.FinancialStocks](financialStocks.length)
+    val monthlyRows     = new Array[Household.MonthlyFlow](households.length)
+    val flowBuilder     = Vector.newBuilder[BankedMonthlyResult]
+    val totals          = StepTotals()
+
+    var i = 0
+    while i < households.length do
+      val hh     = households(i)
+      val stocks = financialStocks(i)
+      if hh.status == HhStatus.Bankrupt then
+        val bankruptHh = hh.copy(financialDistressState = HhFinancialDistressState.Bankruptcy)
+        updatedRows(i) = bankruptHh
+        stockRows(i) = stocks
+        monthlyRows(i) = Household.MonthlyFlow.inactive(hh.id, stocks)
+      else
+        val result = HouseholdMonthlyFlowConstruction.processHousehold(
+          hh,
+          stocks,
+          input.opening.world,
+          input.stochastic.rng,
+          input.credit.bankRates,
+          input.market.equityIndexReturn,
+          context.laborContext,
+          context.distressedIds,
+          input.credit.consumerCreditGate,
+        )
+        flowBuilder += ((hh.bankId, result))
+        totals.add(result)
+        updatedRows(i) = result.newState
+        stockRows(i) = result.financialStocks
+        monthlyRows(i) = HouseholdMonthlyFlowConstruction.monthlyFlow(hh, stocks, result)
+      i += 1
+
+    MonthWorkflow.pure(
+      HouseholdStepSemantics.processedHouseholds(
+        ProcessedRows(
+          input = input,
+          updatedRows = updatedRows,
+          stockRows = stockRows,
+          monthlyRows = monthlyRows,
+          bankedFlows = flowBuilder.result(),
+          totals = totals,
+        ),
+      ),
+    )
+
+  /** Converts row buffers into immutable public aggregates and per-bank flows.
+    */
+  def aggregate(processed: ProcessedHouseholds)(using SimParams): Program[AggregatedHouseholds] =
+    val rows    = processed.rows
+    val input   = rows.input
+    val market  = input.market
+    val credit  = input.credit
+    val updated = rows.updatedRows.toVector
+    val stocks  = rows.stockRows.toVector
+    val monthly = rows.monthlyRows.toVector
+    val agg     =
+      HouseholdAggregateComputation.computeAggregates(updated, stocks, market.marketWage, market.reservationWage, market.importAdj, rows.totals)
+    val pbf     =
+      if credit.bankRates.isDefined then Some(HouseholdPerBankFlowAggregation.buildPerBankFlows(rows.bankedFlows, credit.nBanks))
+      else None
+
+    MonthWorkflow.pure(
+      HouseholdStepSemantics.aggregatedHouseholds(
+        AggregatedRows(
+          updated = updated,
+          stocks = stocks,
+          monthly = monthly,
+          aggregates = agg,
+          perBankFlows = pbf,
+        ),
+      ),
+    )
+
+  /** Checks monthly diagnostics against aggregate accounting before closing. */
+  def validate(aggregated: AggregatedHouseholds): Program[ValidatedHouseholds] =
+    val rows             = aggregated.rows
+    val monthlyRows      = rows.monthly
+    val agg              = rows.aggregates
+    var monthlyLiquidity = PLN.Zero
+    var j                = 0
+    while j < monthlyRows.length do
+      monthlyLiquidity = monthlyLiquidity + monthlyRows(j).liquidityShortfallFinancing
+      j += 1
+    require(
+      monthlyLiquidity == agg.totalLiquidityShortfallFinancing,
+      "Household.step monthly flow diagnostics must reconcile to aggregate liquidity shortfall financing",
+    )
+    require(
+      agg.totalLiquidityShortfallComponents == agg.totalLiquidityShortfallFinancing,
+      "Household.step shortfall components must reconcile to aggregate liquidity shortfall financing",
+    )
+    require(
+      agg.totalConsumerLoanDefault + agg.totalLiquidityBridgeChargeOff == agg.totalConsumerDefault,
+      "Household.step consumer default components must reconcile to aggregate consumer default",
+    )
+    MonthWorkflow.pure(HouseholdStepSemantics.validatedHouseholds(rows))
+
+  /** Closes the household batch into the public `Household.StepResult`. */
+  def close(validated: ValidatedHouseholds): Program[ClosedResult] =
+    val rows = validated.validatedRows
+    MonthWorkflow.pure(
+      HouseholdStepSemantics.closedResult(
+        Household.StepResult(
+          households = rows.updated,
+          aggregates = rows.aggregates,
+          perBankFlows = rows.perBankFlows,
+          financialStocks = rows.stocks,
+          monthlyFlows = rows.monthly,
+        ),
+      ),
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepDsl.scala
@@ -15,7 +15,7 @@ import com.boombustgroup.amorfati.types.*
   * implementation: validate opening rows, execute households, aggregate public
   * totals, validate diagnostics, and close into the public result.
   */
-private[agents] object HouseholdStepDsl:
+private[household] object HouseholdStepDsl:
 
   /** Opens one household batch from the public `Household.step` argument
     * surface.

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepRunner.scala
@@ -1,10 +1,9 @@
 package com.boombustgroup.amorfati.agents.household
 
-import com.boombustgroup.amorfati.agents.{BankRates, HhFinancialDistressState, HhStatus, Household, PerBankFlow}
-import com.boombustgroup.amorfati.agents.household.HouseholdStepAccumulator.StepTotals
-import com.boombustgroup.amorfati.agents.household.HouseholdStepTypes.*
+import com.boombustgroup.amorfati.agents.{BankRates, Household}
+import com.boombustgroup.amorfati.agents.household.HouseholdStepSemantics.*
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.engine.{MonthWorkflow, World}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
 
@@ -31,77 +30,33 @@ private[agents] object HouseholdStepRunner:
       sectorVacancies: Option[Vector[Int]] = None,
       consumerCreditGate: Option[Household.ConsumerCreditGate] = None,
   )(using p: SimParams): Household.StepResult =
-    require(
-      households.length == financialStocks.length,
-      s"Household.step requires aligned households and financialStocks, got ${households.length} households and ${financialStocks.length} stock rows",
+    val stepInput = Input(
+      opening = OpeningState(
+        households = households,
+        financialStocks = financialStocks,
+        world = world,
+      ),
+      market = MarketSurface(
+        marketWage = marketWage,
+        reservationWage = reservationWage,
+        importAdj = importAdj,
+        equityIndexReturn = equityIndexReturn,
+        sectorWages = sectorWages,
+        sectorVacancies = sectorVacancies,
+      ),
+      credit = CreditSurface(
+        nBanks = nBanks,
+        bankRates = bankRates,
+        consumerCreditGate = consumerCreditGate,
+      ),
+      stochastic = StochasticSurface(rng),
     )
-    var stockCheck = 0
-    while stockCheck < financialStocks.length do
-      require(
-        financialStocks(stockCheck).demandDeposit >= PLN.Zero,
-        "Household.step requires non-negative opening demandDeposit balances; liquidity shortfalls must enter as consumer-loan stocks",
-      )
-      stockCheck += 1
-
-    val distressedIds = HouseholdDistressMachine.buildDistressedSet(households)
-    val laborContext  = HouseholdLaborTransitionContext.fromOptions(sectorWages, sectorVacancies)
-    val updatedRows   = new Array[Household.State](households.length)
-    val stockRows     = new Array[Household.FinancialStocks](financialStocks.length)
-    val monthlyRows   = new Array[Household.MonthlyFlow](households.length)
-    val flowBuilder   = Vector.newBuilder[BankedMonthlyResult]
-    val totals        = StepTotals()
-
-    var i = 0
-    while i < households.length do
-      val hh     = households(i)
-      val stocks = financialStocks(i)
-      if hh.status == HhStatus.Bankrupt then
-        val bankruptHh = hh.copy(financialDistressState = HhFinancialDistressState.Bankruptcy)
-        updatedRows(i) = bankruptHh
-        stockRows(i) = stocks
-        monthlyRows(i) = Household.MonthlyFlow.inactive(hh.id, stocks)
-      else
-        val result = HouseholdMonthlyFlowConstruction.processHousehold(
-          hh,
-          stocks,
-          world,
-          rng,
-          bankRates,
-          equityIndexReturn,
-          laborContext,
-          distressedIds,
-          consumerCreditGate,
-        )
-        flowBuilder += ((hh.bankId, result))
-        totals.add(result)
-        updatedRows(i) = result.newState
-        stockRows(i) = result.financialStocks
-        monthlyRows(i) = HouseholdMonthlyFlowConstruction.monthlyFlow(hh, stocks, result)
-      i += 1
-
-    val updated                          = updatedRows.toVector
-    val stocks                           = stockRows.toVector
-    val flows                            = flowBuilder.result()
-    val monthly                          = monthlyRows.toVector
-    val agg                              = HouseholdAggregateComputation.computeAggregates(updated, stocks, marketWage, reservationWage, importAdj, totals)
-    val pbf: Option[Vector[PerBankFlow]] =
-      if bankRates.isDefined then Some(HouseholdPerBankFlowAggregation.buildPerBankFlows(flows, nBanks)) else None
-
-    var monthlyLiquidity = PLN.Zero
-    var j                = 0
-    while j < monthlyRows.length do
-      monthlyLiquidity = monthlyLiquidity + monthlyRows(j).liquidityShortfallFinancing
-      j += 1
-    require(
-      monthlyLiquidity == agg.totalLiquidityShortfallFinancing,
-      "Household.step monthly flow diagnostics must reconcile to aggregate liquidity shortfall financing",
-    )
-    require(
-      agg.totalLiquidityShortfallComponents == agg.totalLiquidityShortfallFinancing,
-      "Household.step shortfall components must reconcile to aggregate liquidity shortfall financing",
-    )
-    require(
-      agg.totalConsumerLoanDefault + agg.totalLiquidityBridgeChargeOff == agg.totalConsumerDefault,
-      "Household.step consumer default components must reconcile to aggregate consumer default",
-    )
-    Household.StepResult(updated, agg, pbf, stocks, monthly)
+    MonthWorkflow.run:
+      for
+        opening    <- HouseholdStepDsl.open(stepInput)
+        prepared   <- HouseholdStepDsl.prepare(opening)
+        processed  <- HouseholdStepDsl.process(prepared)
+        aggregated <- HouseholdStepDsl.aggregate(processed)
+        validated  <- HouseholdStepDsl.validate(aggregated)
+        closed     <- HouseholdStepDsl.close(validated)
+      yield closed.result

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepSemantics.scala
@@ -1,0 +1,154 @@
+package com.boombustgroup.amorfati.agents.household
+
+import com.boombustgroup.amorfati.agents.{BankRates, Household, PerBankFlow}
+import com.boombustgroup.amorfati.agents.household.HouseholdStepAccumulator.StepTotals
+import com.boombustgroup.amorfati.agents.household.HouseholdStepTypes.*
+import com.boombustgroup.amorfati.engine.World
+import com.boombustgroup.amorfati.random.RandomStream
+import com.boombustgroup.amorfati.types.*
+
+/** Zero-cost timeline for the household monthly batch step.
+  *
+  * `At[A, P]` is only a compile-time phase tag. It makes household execution
+  * order explicit while preserving the same runtime representation as the
+  * wrapped value.
+  */
+private[agents] object HouseholdStepSemantics:
+
+  sealed trait Phase
+  sealed trait Opening       extends Phase
+  sealed trait Prepared      extends Phase
+  sealed trait RowsProcessed extends Phase
+  sealed trait Aggregated    extends Phase
+  sealed trait Validated     extends Phase
+  sealed trait Closed        extends Phase
+
+  opaque type At[+A, P <: Phase] = A
+
+  private inline def wrap[A, P <: Phase](value: A): At[A, P] = value
+
+  private inline def unwrap[A, P <: Phase](staged: At[A, P]): A = staged
+
+  /** Household state, financial stocks, and same-month world visible at
+    * opening.
+    */
+  final case class OpeningState(
+      households: Vector[Household.State],
+      financialStocks: Vector[Household.FinancialStocks],
+      world: World,
+  )
+
+  /** Wage, consumption-import, equity-return, and labor-market boundary used by
+    * the household month.
+    */
+  final case class MarketSurface(
+      marketWage: PLN,
+      reservationWage: PLN,
+      importAdj: Share,
+      equityIndexReturn: Rate,
+      sectorWages: Option[Vector[PLN]],
+      sectorVacancies: Option[Vector[Int]],
+  )
+
+  /** Bank-rate and consumer-credit underwriting boundary. */
+  final case class CreditSurface(
+      nBanks: Int,
+      bankRates: Option[BankRates],
+      consumerCreditGate: Option[Household.ConsumerCreditGate],
+  )
+
+  /** Stochastic boundary consumed by household labor and credit transitions. */
+  final case class StochasticSurface(rng: RandomStream)
+
+  /** Complete opening boundary for processing one household batch during one
+    * execution month.
+    */
+  final case class Input(
+      opening: OpeningState,
+      market: MarketSurface,
+      credit: CreditSurface,
+      stochastic: StochasticSurface,
+  )
+
+  /** Validated opening plus derived context shared by all rows. */
+  final case class PreparedMonth(
+      input: Input,
+      distressedIds: java.util.BitSet,
+      laborContext: Option[HouseholdLaborTransitionContext],
+  )
+
+  /** Aligned row buffers and exact flow totals after per-household execution.
+    */
+  final case class ProcessedRows(
+      input: Input,
+      updatedRows: Array[Household.State],
+      stockRows: Array[Household.FinancialStocks],
+      monthlyRows: Array[Household.MonthlyFlow],
+      bankedFlows: Vector[BankedMonthlyResult],
+      totals: StepTotals,
+  )
+
+  /** Public household aggregates and diagnostics after row buffers are closed
+    * into immutable vectors.
+    */
+  final case class AggregatedRows(
+      updated: Vector[Household.State],
+      stocks: Vector[Household.FinancialStocks],
+      monthly: Vector[Household.MonthlyFlow],
+      aggregates: Household.Aggregates,
+      perBankFlows: Option[Vector[PerBankFlow]],
+  )
+
+  type OpeningInput = At[Input, Opening]
+
+  inline def opening(input: Input): OpeningInput =
+    wrap[Input, Opening](input)
+
+  extension (opening: OpeningInput)
+    inline def input: Input =
+      unwrap(opening)
+
+  type PreparedInput = At[PreparedMonth, Prepared]
+
+  inline def preparedMonth(prepared: PreparedMonth): PreparedInput =
+    wrap[PreparedMonth, Prepared](prepared)
+
+  extension (prepared: PreparedInput)
+    inline def month: PreparedMonth =
+      unwrap(prepared)
+
+  type ProcessedHouseholds = At[ProcessedRows, RowsProcessed]
+
+  inline def processedHouseholds(processed: ProcessedRows): ProcessedHouseholds =
+    wrap[ProcessedRows, RowsProcessed](processed)
+
+  extension (processed: ProcessedHouseholds)
+    inline def rows: ProcessedRows =
+      unwrap(processed)
+
+  type AggregatedHouseholds = At[AggregatedRows, Aggregated]
+
+  inline def aggregatedHouseholds(aggregated: AggregatedRows): AggregatedHouseholds =
+    wrap[AggregatedRows, Aggregated](aggregated)
+
+  extension (aggregated: AggregatedHouseholds)
+    inline def rows: AggregatedRows =
+      unwrap(aggregated)
+
+  type ValidatedHouseholds = At[AggregatedRows, Validated]
+
+  inline def validatedHouseholds(aggregated: AggregatedRows): ValidatedHouseholds =
+    wrap[AggregatedRows, Validated](aggregated)
+
+  extension (validated: ValidatedHouseholds)
+    inline def validatedRows: AggregatedRows =
+      unwrap(validated)
+
+  type ClosedResult = At[Household.StepResult, Closed]
+
+  inline def closedResult(result: Household.StepResult): ClosedResult =
+    wrap[Household.StepResult, Closed](result)
+
+  extension (closed: ClosedResult)
+    inline def result: Household.StepResult =
+      unwrap(closed)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/household/HouseholdStepSemantics.scala
@@ -13,7 +13,7 @@ import com.boombustgroup.amorfati.types.*
   * order explicit while preserving the same runtime representation as the
   * wrapped value.
   */
-private[agents] object HouseholdStepSemantics:
+private[household] object HouseholdStepSemantics:
 
   sealed trait Phase
   sealed trait Opening       extends Phase


### PR DESCRIPTION
Summary: Add zero-cost phase tags and an identity DSL around Household.step, mirroring the firm step structure while keeping row processing array-backed. Narrow the new DSL visibility to the household package so mutable phase buffers cannot escape to the wider agents package. Update the agents README with the new household modules. Validation: sbt scalafmtAll; sbt Test/compile; focused household testOnly suite (133 passed); git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated household modules documentation in reference materials.

* **Refactor**
  * Improved internal household batch processing architecture for better maintainability and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->