### PR TITLE
Introduce structured engine failure categories

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/DiagnosticIo.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/DiagnosticIo.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.diagnostics
 
-import zio.{Runtime, Unsafe, ZIO}
+import com.boombustgroup.amorfati.engine.EngineFailure
+import zio.{Cause, Runtime, Unsafe, ZIO}
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -13,7 +14,7 @@ private[diagnostics] object DiagnosticIo:
       Runtime.default.unsafe
         .run:
           effect.foldCause(
-            cause => Left(cause.failureOption.getOrElse(s"Diagnostic crashed: ${cause.prettyPrint}")),
+            cause => Left(renderCause(cause)),
             value => Right(value),
           )
         .getOrThrowFiberFailure()
@@ -28,3 +29,10 @@ private[diagnostics] object DiagnosticIo:
 
   def outputFailure(operation: String, path: Path, err: Throwable): String =
     s"Output failure during $operation at $path: ${Option(err.getMessage).filter(_.nonEmpty).getOrElse(err.getClass.getSimpleName)}"
+
+  private def renderCause(cause: Cause[String]): String =
+    cause.failureOption.getOrElse:
+      EngineFailure
+        .firstIn(cause.defects)
+        .map(failure => s"Diagnostic crashed: ${failure.diagnosticMessage}")
+        .getOrElse(s"Diagnostic crashed: ${cause.prettyPrint}")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/EngineFailure.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/EngineFailure.scala
@@ -1,0 +1,67 @@
+package com.boombustgroup.amorfati.engine
+
+/** Stable engine failure taxonomy for central runtime boundaries.
+  *
+  * The engine remains fail-fast, but failures that cross simulation,
+  * diagnostics, or Monte Carlo boundaries should carry a machine-readable
+  * category instead of requiring callers to parse exception strings.
+  */
+enum EngineFailureCategory(val code: String):
+  case InvariantViolation            extends EngineFailureCategory("invariant_violation")
+  case RuntimeLedgerExecutionFailure extends EngineFailureCategory("runtime_ledger_execution_failure")
+  case CalibrationInvalidity         extends EngineFailureCategory("calibration_invalidity")
+  case ScenarioInvalidity            extends EngineFailureCategory("scenario_invalidity")
+  case UnsupportedTopology           extends EngineFailureCategory("unsupported_topology")
+  case OwnershipContractViolation    extends EngineFailureCategory("ownership_contract_violation")
+
+/** Fail-fast exception carrying a structured engine failure category. */
+final case class EngineFailure(
+    category: EngineFailureCategory,
+    boundary: String,
+    details: String,
+    cause: Option[Throwable] = None,
+) extends RuntimeException(EngineFailure.message(category, boundary, details), cause.orNull):
+
+  def categoryCode: String =
+    category.code
+
+  def diagnosticMessage: String =
+    s"Engine failure category=${category.code} boundary=$boundary: $details"
+
+object EngineFailure:
+
+  def invariantViolation(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.InvariantViolation, boundary, details)
+
+  def runtimeLedgerExecution(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.RuntimeLedgerExecutionFailure, boundary, details)
+
+  def calibrationInvalidity(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.CalibrationInvalidity, boundary, details)
+
+  def scenarioInvalidity(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.ScenarioInvalidity, boundary, details)
+
+  def unsupportedTopology(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.UnsupportedTopology, boundary, details)
+
+  def ownershipContractViolation(boundary: String, details: String): EngineFailure =
+    EngineFailure(EngineFailureCategory.OwnershipContractViolation, boundary, details)
+
+  def ensure(condition: Boolean, category: EngineFailureCategory, boundary: String, details: => String): Unit =
+    if !condition then throw EngineFailure(category, boundary, details)
+
+  def fromThrowable(error: Throwable): Option[EngineFailure] =
+    if error == null then None
+    else
+      error match
+        case failure: EngineFailure                                      => Some(failure)
+        case other if other.getCause != null && other.getCause.ne(other) =>
+          fromThrowable(other.getCause)
+        case _                                                           => None
+
+  def firstIn(errors: IterableOnce[Throwable]): Option[EngineFailure] =
+    errors.iterator.flatMap(fromThrowable).nextOption
+
+  private def message(category: EngineFailureCategory, boundary: String, details: String): String =
+    s"[${category.code}] $boundary: $details"

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthDriver.scala
@@ -11,8 +11,10 @@ import com.boombustgroup.amorfati.engine.flows.FlowSimulation
   */
 object MonthDriver:
 
-  type SimState   = FlowSimulation.SimState
-  type StepOutput = FlowSimulation.StepOutput
+  type SimState                     = FlowSimulation.SimState
+  type StepOutput                   = FlowSimulation.StepOutput
+  type StepResult                   = Either[EngineFailure, StepOutput]
+  private[engine] type StepBoundary = (SimState, MonthRandomness.Contract, Boolean) => StepResult
 
   /** Caller-owned month schedule for the engine unfold.
     *
@@ -22,7 +24,27 @@ object MonthDriver:
   type RandomnessSchedule = SimState => Option[MonthRandomness.Contract]
 
   def unfoldSteps(initialState: SimState, traceFirmDecisions: Boolean = false)(schedule: RandomnessSchedule)(using p: SimParams): Iterator[StepOutput] =
-    Iterator.unfold(initialState): state =>
-      schedule(state).map: randomness =>
-        val output = FlowSimulation.step(state, randomness, traceFirmDecisions = traceFirmDecisions)
-        (output, output.nextState)
+    unfoldStepResults(initialState, traceFirmDecisions = traceFirmDecisions)(schedule).map:
+      case Right(output) => output
+      case Left(failure) => throw failure
+
+  /** Engine unfold that keeps central month-step failures in their structured
+    * form for diagnostics and Monte Carlo orchestration.
+    */
+  def unfoldStepResults(initialState: SimState, traceFirmDecisions: Boolean = false)(schedule: RandomnessSchedule)(using
+      p: SimParams,
+  ): Iterator[StepResult] =
+    unfoldStepResultsWithBoundary(initialState, traceFirmDecisions = traceFirmDecisions)(schedule): (state, randomness, trace) =>
+      FlowSimulation.stepEither(state, randomness, traceFirmDecisions = trace)
+
+  private[engine] def unfoldStepResultsWithBoundary(initialState: SimState, traceFirmDecisions: Boolean = false)(schedule: RandomnessSchedule)(
+      stepBoundary: StepBoundary,
+  ): Iterator[StepResult] =
+    Iterator.unfold((initialState, false)):
+      case (_, true)      =>
+        None
+      case (state, false) =>
+        schedule(state).map: randomness =>
+          stepBoundary(state, randomness, traceFirmDecisions) match
+            case Right(output) => (Right(output), (output.nextState, false))
+            case Left(failure) => (Left(failure), (state, true))

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -394,6 +394,17 @@ object FlowSimulation:
       nextState = nextState,
     )
 
+  /** Typed month-step boundary for callers that need classifiable fail-fast
+    * errors, such as diagnostics and Monte Carlo orchestration.
+    */
+  def stepEither(
+      stateIn: SimState,
+      randomness: MonthRandomness.Contract,
+      traceFirmDecisions: Boolean = false,
+  )(using p: SimParams): Either[EngineFailure, StepOutput] =
+    try Right(step(stateIn, randomness, traceFirmDecisions = traceFirmDecisions))
+    catch case failure: EngineFailure => Left(failure)
+
   /** Public API: compute calculus only (for tests that need MonthlyCalculus).
     */
   def computeCalculus(state: SimState, randomness: MonthRandomness.Contract)(using p: SimParams): MonthlyCalculus =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancer.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
-import com.boombustgroup.amorfati.engine.{MonthSemantics, SimulationMonth}
+import com.boombustgroup.amorfati.engine.{EngineFailure, EngineFailureCategory, MonthSemantics, SimulationMonth}
 import com.boombustgroup.amorfati.engine.ledger.RuntimeFlowProjection
 
 /** Advances a realized closed month into the next pre-month simulation state.
@@ -42,13 +42,30 @@ object NextStateAdvancer:
 
     // This is the only legal closed-month -> next-pre transition: the closed
     // month still sees the old seed, while the next boundary applies SeedOut.
-    require(
+    EngineFailure.ensure(
       input.executionMonth == expectedExecutionMonth,
+      EngineFailureCategory.InvariantViolation,
+      "NextStateAdvancer.advanceSemanticState",
       s"NextStateAdvancer input.executionMonth ${input.executionMonth.toInt} must equal input.stateIn.completedMonth.next ${expectedExecutionMonth.toInt} before constructing FlowSimulation.SimState",
     )
-    require(currentSeed == input.stateIn.world.seedIn, "StepInput seedIn must match stateIn.world.seedIn")
-    require(closing.world.seedIn == currentSeed, "ClosedMonth world must remain on the pre-step seed until NextStateAdvancer runs")
-    require(nextWorld.seedIn == nextSeed, "NextStateAdvancer must be the transition that applies SeedOut to the next boundary")
+    EngineFailure.ensure(
+      currentSeed == input.stateIn.world.seedIn,
+      EngineFailureCategory.InvariantViolation,
+      "NextStateAdvancer.advanceSemanticState",
+      "StepInput seedIn must match stateIn.world.seedIn",
+    )
+    EngineFailure.ensure(
+      closing.world.seedIn == currentSeed,
+      EngineFailureCategory.InvariantViolation,
+      "NextStateAdvancer.advanceSemanticState",
+      "ClosedMonth world must remain on the pre-step seed until NextStateAdvancer runs",
+    )
+    EngineFailure.ensure(
+      nextWorld.seedIn == nextSeed,
+      EngineFailureCategory.InvariantViolation,
+      "NextStateAdvancer.advanceSemanticState",
+      "NextStateAdvancer must be the transition that applies SeedOut to the next boundary",
+    )
 
     FlowSimulation.SimState(
       completedMonth = input.executionMonth.completed,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.EngineFailure
 import com.boombustgroup.ledger.*
 
 /** Executes runtime ledger batches against the explicit month topology.
@@ -21,10 +22,12 @@ object RuntimeFlowExecutor:
       netDelta: Long,
   )
 
-  def execute(flows: Vector[BatchedFlow])(using topology: RuntimeLedgerTopology): Either[String, Result] =
+  def execute(flows: Vector[BatchedFlow])(using topology: RuntimeLedgerTopology): Either[EngineFailure, Result] =
     val state = topology.emptyExecutionState()
     ImperativeInterpreter
       .planAndApplyAll(state, flows)
+      .left
+      .map(executionFailure)
       .map: _ =>
         val deltaLedger = state.snapshot
         Result(
@@ -34,7 +37,7 @@ object RuntimeFlowExecutor:
         )
 
   def executeOrThrow(flows: Vector[BatchedFlow])(using RuntimeLedgerTopology): Result =
-    execute(flows).fold(err => throw executionFailure(err), identity)
+    execute(flows).fold(err => throw err, identity)
 
-  def executionFailure(error: String): IllegalStateException =
-    IllegalStateException(s"Ledger batch execution failed: $error")
+  def executionFailure(error: String): EngineFailure =
+    EngineFailure.runtimeLedgerExecution("RuntimeFlowExecutor.execute", s"Ledger batch execution failed: $error")

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeLedgerTopology.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeLedgerTopology.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.{EngineFailure, EngineFailureCategory}
 import com.boombustgroup.amorfati.engine.ledger.FundRuntimeIndex
 import com.boombustgroup.ledger.*
 
@@ -72,20 +73,26 @@ final case class RuntimeLedgerTopology(
       sectorSize: Int,
       index: Int,
   ): Unit =
-    require(
+    EngineFailure.ensure(
       index >= 0 && index < sectorSize,
+      EngineFailureCategory.UnsupportedTopology,
+      "RuntimeLedgerTopology.toFlatFlows",
       s"$batchKind $position index $index is out of bounds for $sector (size=$sectorSize).",
     )
 
   private def validateScatter(scatter: BatchedFlow.Scatter): Unit =
     val sourceSize = sectorSizes(scatter.from)
     val targetSize = sectorSizes(scatter.to)
-    require(
+    EngineFailure.ensure(
       scatter.amounts.length == scatter.targetIndices.length,
+      EngineFailureCategory.UnsupportedTopology,
+      "RuntimeLedgerTopology.validateScatter",
       s"Scatter ${scatter.mechanism} has amounts.length=${scatter.amounts.length} but targetIndices.length=${scatter.targetIndices.length}.",
     )
-    require(
+    EngineFailure.ensure(
       scatter.amounts.length == sourceSize,
+      EngineFailureCategory.UnsupportedTopology,
+      "RuntimeLedgerTopology.validateScatter",
       s"Scatter ${scatter.mechanism} has amounts.length=${scatter.amounts.length} but source sector ${scatter.from} has size=$sourceSize.",
     )
     scatter.targetIndices.zipWithIndex.foreach:
@@ -101,8 +108,10 @@ final case class RuntimeLedgerTopology(
   private def validateBroadcast(broadcast: BatchedFlow.Broadcast): Unit =
     val sourceSize = sectorSizes(broadcast.from)
     val targetSize = sectorSizes(broadcast.to)
-    require(
+    EngineFailure.ensure(
       broadcast.amounts.length == broadcast.targetIndices.length,
+      EngineFailureCategory.UnsupportedTopology,
+      "RuntimeLedgerTopology.validateBroadcast",
       s"Broadcast ${broadcast.mechanism} has amounts.length=${broadcast.amounts.length} but targetIndices.length=${broadcast.targetIndices.length}.",
     )
     requireBoundedIndex(

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
@@ -2,7 +2,7 @@ package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.accounting.Sfc
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.MonthSemantics
+import com.boombustgroup.amorfati.engine.{EngineFailure, MonthSemantics}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
@@ -228,39 +228,25 @@ object SfcSemanticProjection:
                     case (EntitySector.NBP, EntitySector.Banks) => amount
                     case (EntitySector.Banks, EntitySector.NBP) => -amount
                     case _                                      =>
-                      throw new IllegalArgumentException(
-                        s"${bankIncomeMechanismLabel(mechanism)} batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
+                      throw unsupportedDirection(bankIncomeMechanismLabel(mechanism), batch)
                 case FlowMechanism.InvestmentDepositSettlement                                              =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Firms) => amount
                     case (EntitySector.Firms, EntitySector.Banks) => -amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"InvestmentDepositSettlement batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
+                    case _                                        => throw unsupportedDirection("InvestmentDepositSettlement", batch)
                 case FlowMechanism.TfiDepositDrain                                                          =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Households) => amount
                     case (EntitySector.Households, EntitySector.Banks) => -amount
-                    case _                                             =>
-                      throw new IllegalArgumentException(
-                        s"TfiDepositDrain batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
+                    case _                                             => throw unsupportedDirection("TfiDepositDrain", batch)
                 case FlowMechanism.QuasiFiscalLendingDeposit                                                =>
                   (batch.from, batch.to) match
                     case (EntitySector.Banks, EntitySector.Firms) => amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"QuasiFiscalLendingDeposit batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
+                    case _                                        => throw unsupportedDirection("QuasiFiscalLendingDeposit", batch)
                 case FlowMechanism.QuasiFiscalRepaymentDeposit                                              =>
                   (batch.from, batch.to) match
                     case (EntitySector.Firms, EntitySector.Banks) => -amount
-                    case _                                        =>
-                      throw new IllegalArgumentException(
-                        s"QuasiFiscalRepaymentDeposit batch has unsupported direction ${batch.from}->${batch.to}",
-                      )
+                    case _                                        => throw unsupportedDirection("QuasiFiscalRepaymentDeposit", batch)
                 case _                                                                                      => amount
 
             (
@@ -273,3 +259,9 @@ object SfcSemanticProjection:
     private def bankIncomeMechanismLabel(mechanism: MechanismId): String =
       if mechanism == FlowMechanism.BankInterbankInterest then "FlowMechanism.BankInterbankInterest"
       else "FlowMechanism.BankStandingFacility"
+
+    private def unsupportedDirection(mechanismLabel: String, batch: BatchedFlow): EngineFailure =
+      EngineFailure.unsupportedTopology(
+        "SfcSemanticProjection.ExecutedFlowEvidence.from",
+        s"$mechanismLabel batch has unsupported direction ${batch.from}->${batch.to}",
+      )

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunner.scala
@@ -1,7 +1,8 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.config.SimParams
-import zio.ZIO
+import com.boombustgroup.amorfati.engine.EngineFailure
+import zio.{Cause, ZIO}
 import zio.stream.ZStream
 
 private[amorfati] object McDiagnosticRunner:
@@ -90,14 +91,12 @@ private[amorfati] object McDiagnosticRunner:
         given SimParams  = params
         val monthsStream = McRunner
           .seedMonths(job.seed, months, traceFirmDecisions)
-          .mapError(_.toString)
+          .mapError(renderSimError)
         reduce(job.scenario, job.seed, monthsStream)
           .catchAll(err => ZIO.fail(s"$context failed: $err"))
 
     effect.catchAllCause: cause =>
-      cause.failureOption match
-        case Some(err) => ZIO.fail(err)
-        case None      => ZIO.fail(s"$context crashed: ${cause.prettyPrint}")
+      ZIO.fail(renderCause(context, cause))
 
   private def runJobStream[Scenario, A](
       job: Job[Scenario],
@@ -113,11 +112,21 @@ private[amorfati] object McDiagnosticRunner:
           given SimParams  = params
           val monthsStream = McRunner
             .seedMonths(job.seed, months, traceFirmDecisions)
-            .mapError(_.toString)
+            .mapError(renderSimError)
           ZIO.succeed:
             rows(job.scenario, job.seed, monthsStream)
               .mapError(err => s"$context failed: $err")
       .catchAllCause: cause =>
-        cause.failureOption match
-          case Some(err) => ZStream.fail(err)
-          case None      => ZStream.fail(s"$context crashed: ${cause.prettyPrint}")
+        ZStream.fail(renderCause(context, cause))
+
+  private def renderSimError(error: SimError): String =
+    error match
+      case SimError.Engine(failure) => failure.diagnosticMessage
+      case other                    => other.toString
+
+  private def renderCause(context: String, cause: Cause[String]): String =
+    cause.failureOption.getOrElse:
+      EngineFailure
+        .firstIn(cause.defects)
+        .map(failure => s"$context crashed: ${failure.diagnosticMessage}")
+        .getOrElse(s"$context crashed: ${cause.prettyPrint}")

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McRunner.scala
@@ -90,7 +90,9 @@ object McRunner:
       .unfold(steps): iterator =>
         if iterator.hasNext then Some((iterator.next(), iterator))
         else None
-      .mapZIO(result => ZIO.fromEither(stepSnapshot(result)))
+      .mapZIO:
+        case Left(failure) => ZIO.fail(SimError.Engine(failure))
+        case Right(result) => ZIO.fromEither(stepSnapshot(result))
 
   private def initSeed(seed: Long)(using p: SimParams) =
     val init      = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
@@ -102,8 +104,8 @@ object McRunner:
 
   private def runtimeSteps(seed: Long, initState: FlowSimulation.SimState, traceFirmDecisions: Boolean)(using
       p: SimParams,
-  ): Iterator[FlowSimulation.StepOutput] =
-    MonthDriver.unfoldSteps(initState, traceFirmDecisions = traceFirmDecisions): state =>
+  ): Iterator[MonthDriver.StepResult] =
+    MonthDriver.unfoldStepResults(initState, traceFirmDecisions = traceFirmDecisions): state =>
       Some(MonthRandomness.Contract.fromSeed(runtimeRootSeed(seed, state)))
 
   private def runtimeRootSeed(seed: Long, state: FlowSimulation.SimState): Long =
@@ -138,19 +140,22 @@ object McRunner:
 
   private def materializeRun(
       initState: FlowSimulation.SimState,
-      steps: Iterator[FlowSimulation.StepOutput],
+      steps: Iterator[MonthDriver.StepResult],
   )(using p: SimParams): Either[SimError, RunResult] =
     val monthSeries = Vector.newBuilder[Array[MetricValue]]
 
     @scala.annotation.tailrec
-    def collect(remaining: Iterator[FlowSimulation.StepOutput], terminal: FlowSimulation.SimState): Either[SimError, RunResult] =
+    def collect(remaining: Iterator[MonthDriver.StepResult], terminal: FlowSimulation.SimState): Either[SimError, RunResult] =
       if !remaining.hasNext then Right(RunResult(TimeSeries.wrap(monthSeries.result().toArray), terminal))
       else
-        stepSnapshot(remaining.next()) match
-          case Left(err)       => Left(err)
-          case Right(snapshot) =>
-            monthSeries += snapshot.monthData
-            collect(remaining, snapshot.state)
+        remaining.next() match
+          case Left(failure) => Left(SimError.Engine(failure))
+          case Right(result) =>
+            stepSnapshot(result) match
+              case Left(err)       => Left(err)
+              case Right(snapshot) =>
+                monthSeries += snapshot.monthData
+                collect(remaining, snapshot.state)
 
     collect(steps, initState)
 

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McTypes.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.montecarlo
 
 import com.boombustgroup.amorfati.accounting.{InitCheck, Sfc}
+import com.boombustgroup.amorfati.engine.EngineFailure
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.FlowSimulation
 import com.boombustgroup.amorfati.montecarlo.McTimeseriesSchema.Col
@@ -21,6 +22,10 @@ object SimError:
   case class RuntimeFailure(operation: String, details: String) extends SimError:
     override def toString: String =
       s"Runtime failure during $operation: $details"
+
+  case class Engine(failure: EngineFailure) extends SimError:
+    override def toString: String =
+      failure.diagnosticMessage
 
   case class OutputFailure(operation: String, path: String, details: String) extends SimError:
     override def toString: String =

--- a/src/test/scala/com/boombustgroup/amorfati/engine/MonthDriverSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/MonthDriverSpec.scala
@@ -1,0 +1,26 @@
+package com.boombustgroup.amorfati.engine
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.flows.RuntimeFlowsTestSupport.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MonthDriverSpec extends AnyFlatSpec with Matchers:
+
+  private given SimParams = SimParams.defaults
+
+  "MonthDriver" should "emit a structured step failure once and stop typed unfolding" in {
+    val state   = stateFromSeed()
+    val failure = EngineFailure.invariantViolation("MonthDriverSpec.stepBoundary", "synthetic typed failure")
+    var calls   = 0
+
+    val results = MonthDriver
+      .unfoldStepResultsWithBoundary(state)(_ => Some(monthRandomness(42L))) { (_, _, _) =>
+        calls += 1
+        Left(failure)
+      }
+      .toVector
+
+    results shouldBe Vector(Left(failure))
+    calls shouldBe 1
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulationExecutedEvidenceSpec.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.{EngineFailure, EngineFailureCategory}
 import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.{AssetType, BatchedFlow, EntitySector}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -108,9 +109,10 @@ class FlowSimulationExecutedEvidenceSpec extends AnyFlatSpec with Matchers:
       mechanism = FlowMechanism.BankInterbankInterest,
     )
 
-    val err = intercept[IllegalArgumentException]:
+    val err = intercept[EngineFailure]:
       SfcSemanticProjection.ExecutedFlowEvidence.from(Vector(batch))
 
+    err.category.shouldBe(EngineFailureCategory.UnsupportedTopology)
     err.getMessage.should(include("FlowMechanism.BankInterbankInterest"))
     err.getMessage.should(include("unsupported direction"))
     err.getMessage.should(include("Government->Banks"))

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/NextStateAdvancerSpec.scala
@@ -3,6 +3,8 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{
   DecisionSignals,
+  EngineFailure,
+  EngineFailureCategory,
   MonthBoundarySnapshot,
   MonthClosingResult,
   MonthSemantics,
@@ -41,9 +43,10 @@ class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
     val nextSeed = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
     val badSeed  = state.world.seedIn.copy(laggedHiringSlack = Share.Zero)
 
-    val err = intercept[IllegalArgumentException]:
+    val err = intercept[EngineFailure]:
       NextStateAdvancer.advance(input(state, nextSeed, seedIn = Some(MonthSemantics.seedIn(badSeed))))
 
+    err.category.shouldBe(EngineFailureCategory.InvariantViolation)
     err.getMessage.should(include("StepInput seedIn"))
   }
 
@@ -51,9 +54,10 @@ class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
     val state    = stateFromSeed()
     val nextSeed = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
 
-    val err = intercept[IllegalArgumentException]:
+    val err = intercept[EngineFailure]:
       NextStateAdvancer.advance(input(state, nextSeed, executionMonth = Some(state.completedMonth.next.next)))
 
+    err.category.shouldBe(EngineFailureCategory.InvariantViolation)
     err.getMessage.should(include("input.executionMonth"))
     err.getMessage.should(include("input.stateIn.completedMonth.next"))
     err.getMessage.should(include("FlowSimulation.SimState"))
@@ -64,9 +68,10 @@ class NextStateAdvancerSpec extends AnyFlatSpec with Matchers:
     val nextSeed    = state.world.seedIn.copy(laggedHiringSlack = Share.decimal(42, 2))
     val seededWorld = state.world.copy(pipeline = state.world.pipeline.withDecisionSignals(nextSeed))
 
-    val err = intercept[IllegalArgumentException]:
+    val err = intercept[EngineFailure]:
       NextStateAdvancer.advance(input(state, nextSeed, closed = Some(closedMonth(state, world = Some(seededWorld)))))
 
+    err.category.shouldBe(EngineFailureCategory.InvariantViolation)
     err.getMessage.should(include("ClosedMonth world must remain on the pre-step seed"))
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutorSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutorSpec.scala
@@ -1,5 +1,6 @@
 package com.boombustgroup.amorfati.engine.flows
 
+import com.boombustgroup.amorfati.engine.{EngineFailure, EngineFailureCategory}
 import com.boombustgroup.ledger.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,7 +25,7 @@ class RuntimeFlowExecutorSpec extends AnyFlatSpec with Matchers:
     val topology = summon[RuntimeLedgerTopology]
     val result   = RuntimeFlowExecutor.execute(Vector(validTransfer(100L))) match
       case Right(value) => value
-      case Left(error)  => fail(error)
+      case Left(error)  => fail(error.diagnosticMessage)
 
     result.topology shouldBe topology
     result.netDelta shouldBe 0L
@@ -34,14 +35,18 @@ class RuntimeFlowExecutorSpec extends AnyFlatSpec with Matchers:
 
   it should "return interpreter validation failures without throwing" in {
     RuntimeFlowExecutor.execute(Vector(validTransfer(-1L))) match
-      case Left(error)  => error should include("negative")
+      case Left(error)  =>
+        error.category shouldBe EngineFailureCategory.RuntimeLedgerExecutionFailure
+        error.boundary shouldBe "RuntimeFlowExecutor.execute"
+        error.details should include("negative")
       case Right(value) => fail(s"Expected runtime execution failure, got $value")
   }
 
   it should "map execution failures through one exception path for month-step callers" in {
-    val err = intercept[IllegalStateException]:
+    val err = intercept[EngineFailure]:
       RuntimeFlowExecutor.executeOrThrow(Vector(validTransfer(-1L)))
 
+    err.category shouldBe EngineFailureCategory.RuntimeLedgerExecutionFailure
     err.getMessage should include("Ledger batch execution failed")
     err.getMessage should include("negative")
   }

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McDiagnosticRunnerSpec.scala
@@ -1,0 +1,46 @@
+package com.boombustgroup.amorfati.montecarlo
+
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.engine.{EngineFailure, EngineFailureCategory}
+import org.scalatest.EitherValues.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.{Runtime, Unsafe, ZIO}
+
+class McDiagnosticRunnerSpec extends AnyFlatSpec with Matchers:
+
+  "McDiagnosticRunner" should "render EngineFailure defects with category and boundary" in {
+    val failure = EngineFailure.unsupportedTopology("McDiagnosticRunnerSpec.step", "synthetic topology failure")
+
+    val result = unsafeRun:
+      McDiagnosticRunner
+        .runScenarioSeeds[String, Nothing](
+          scenarios = Vector("synthetic"),
+          seeds = Vector(1L),
+          months = 1,
+          scenarioId = identity,
+          params = _ => SimParams.defaults,
+          parallelism = Some(1),
+        ) { (_, _, _) =>
+          ZIO.die(failure)
+        }
+        .runCollect
+
+    val rendered = result.left.value
+    rendered should include("Scenario synthetic seed 1 crashed")
+    rendered should include("category=unsupported_topology")
+    rendered should include("boundary=McDiagnosticRunnerSpec.step")
+    rendered should include("synthetic topology failure")
+  }
+
+  it should "preserve EngineFailure category in SimError rendering" in {
+    val failure = EngineFailure.runtimeLedgerExecution("RuntimeFlowExecutor.execute", "synthetic ledger failure")
+
+    SimError.Engine(failure).toString should include(s"category=${EngineFailureCategory.RuntimeLedgerExecutionFailure.code}")
+    SimError.Engine(failure).toString should include("boundary=RuntimeFlowExecutor.execute")
+  }
+
+  private def unsafeRun[E, A](effect: ZIO[Any, E, A]): Either[E, A] =
+    Unsafe.unsafe: unsafe =>
+      given Unsafe = unsafe
+      Runtime.default.unsafe.run(effect.either).getOrThrowFiberFailure()


### PR DESCRIPTION
## Summary
- add EngineFailure and EngineFailureCategory as the structured engine failure taxonomy
- thread typed engine failures through FlowSimulation, MonthDriver, McRunner, diagnostics, and MC diagnostic rendering
- migrate central runtime ledger, topology, next-state, and SFC route guards to typed fail-fast failures
- add tests for typed MonthDriver stop behavior and diagnostic rendering

## Validation
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.MonthDriverSpec com.boombustgroup.amorfati.montecarlo.McDiagnosticRunnerSpec com.boombustgroup.amorfati.engine.flows.RuntimeFlowExecutorSpec com.boombustgroup.amorfati.engine.flows.NextStateAdvancerSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec"
- git diff --check

Closes #654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Structured engine failure categorization with machine-readable codes for invariant violations, calibration issues, topology problems, and execution failures
  * Enhanced diagnostic error messages throughout the simulation pipeline

* **Tests**
  * Added comprehensive tests validating engine failure categorization and error rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->