### PR TITLE
Rename month assembly package to closedmonth

### DIFF
--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -191,7 +191,7 @@ The monthly calculus boundary is:
 | `PriceEquityEconomics` | inflation, equity market, GDP proxy, macroprudential, EU funds |
 | `OpenEconEconomics` | BoP, forex, GVC, Taylor rule, bond yields, insurance, NBFI |
 | `BankingEconomics` | bank P&L, provisioning, CAR, resolution, interbank, BFG levy, M1/M2/M3 |
-| `MonthClosing` | aggregation, informal economy, lifecycle transitions, SFC status, next state |
+| `closedmonth/MonthClosing` | aggregation, informal economy, lifecycle transitions, SFC status, next state |
 
 ### Flow Emission And Accounting Boundary
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{MonthExecution, MonthRandomness, SignalExtraction}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.World
-import com.boombustgroup.amorfati.engine.assembly.MonthClosing
+import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.markets.{PriceLevel, RegionalClearing}
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{MonthExecution, MonthRandomness, OperationalSignals, SignalExtraction, World}
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
-import com.boombustgroup.amorfati.engine.assembly.MonthClosing
+import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -4,7 +4,7 @@ The engine package orchestrates the monthly simulation loop. The month
 boundary is `FlowSimulation.SimState`, which carries `World` macro state,
 agent populations, household aggregates, and `LedgerFinancialState`.
 Domain logic is split across **economics** (same-month calculus pipeline),
-**assembly** (month-closing state projection), **flows** (SFC-verified monetary
+**closedmonth** (closed-month state projection), **flows** (SFC-verified monetary
 flow emission via ledger), **ledger** (financial ownership contracts and
 projections), **markets** (clearing mechanisms), and **mechanisms** (domain
 rules that modify agent state outside market clearing).
@@ -13,7 +13,7 @@ rules that modify agent state outside market clearing).
 engine/
 ├── World.scala             # Immutable macro/runtime state container (9 nested types)
 ├── economics/              # Same-month calculus pipeline, no monetary flow emission
-├── assembly/               # Month-closing World/agent/ledger projection
+├── closedmonth/            # Closed-month World/agent/ledger projection
 ├── flows/                  # SFC flow emission via verified ledger
 ├── ledger/                 # Ledger-owned financial state, ownership contracts, projections
 ├── markets/                # Market clearing & price formation
@@ -39,7 +39,7 @@ engine/
 | `OperationalSignals.scala` | Explicit same-month signal surface for month-`t` operational execution, kept distinct from persisted start-of-month `DecisionSignals`. |
 | `SignalExtraction.scala` | Explicit closed-to-next-pre boundary: derives next-month `DecisionSignals` and typed seed provenance from realized month-`t` outcomes. |
 | `MonthTrace.scala` | Boundary-focused audit artifact with a stable month core (`boundary`, `seedTransition`, `randomness`, validations) plus extensible typed timing envelopes. |
-| `assembly/MonthClosing.scala` | Explicit month-closing boundary. Consumes `MonthClosingInput` and closing randomness, then returns the realized month-`t` closing state before next seed extraction. |
+| `closedmonth/MonthClosing.scala` | Explicit month-closing boundary. Consumes `MonthClosingInput` and closing randomness, then returns the realized month-`t` closed state before next seed extraction. |
 
 ## Month Step Boundary
 
@@ -101,12 +101,12 @@ Each module exposes a `StepOutput` boundary type. Modules that historically
 named their payload `Output` keep `type Output = StepOutput` aliases for
 transitional type references, but new engine code should refer to `StepOutput`.
 
-## assembly/
+## closedmonth/
 
-Month-closing state projection. This package is intentionally separate from
+Closed-month state projection. This package is intentionally separate from
 `economics`: it does not decide market behavior or emit monetary flows. It
 takes the already-computed stage outputs, invokes domain transition mechanisms,
-and materializes the month-`t+1` engine boundary.
+and materializes the realized month-`t` state consumed by next-month seed extraction.
 
 | File | Responsibility |
 |------|----------------|

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowOfFundsDiagnostics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowOfFundsDiagnostics.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.MonthExecution

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowStateAssembler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowStateAssembler.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.engine.{FlowState, MonthClosingInput}
 import com.boombustgroup.amorfati.engine.mechanisms.PopulationLifecycleTransitions
@@ -6,7 +6,7 @@ import com.boombustgroup.amorfati.engine.mechanisms.PopulationLifecycleTransitio
 /** Maps month-closing inputs into the diagnostic flow-state surface. */
 object FlowStateAssembler:
 
-  private[assembly] def build(
+  private[closedmonth] def build(
       closingInput: MonthClosingInput,
       lifecycle: PopulationLifecycleTransitions.Result,
   ): FlowState =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosing.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/WorldStateAssembler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/WorldStateAssembler.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
@@ -12,7 +12,7 @@ import com.boombustgroup.amorfati.types.*
   */
 object WorldStateAssembler:
 
-  private[assembly] def assemble(
+  private[closedmonth] def assemble(
       closingInput: MonthClosingInput,
       lifecycle: PopulationLifecycleTransitions.Result,
   )(using p: SimParams): World =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -5,7 +5,7 @@ import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
 import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, ExecutionMonth}
-import com.boombustgroup.amorfati.engine.assembly.MonthClosing
+import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.types.*

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
@@ -3,7 +3,7 @@ package com.boombustgroup.amorfati.engine.flows
 import com.boombustgroup.amorfati.agents.*
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.{MonthExecution, MonthRandomness, MonthWorkflow, World}
-import com.boombustgroup.amorfati.engine.assembly.MonthClosing
+import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, GovernmentBondCircuit, LedgerFinancialState}
 import com.boombustgroup.amorfati.engine.markets.CorporateBondMarket

--- a/src/test/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosingSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosingSpec.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.config.SimParams

--- a/src/test/scala/com/boombustgroup/amorfati/engine/closedmonth/SignalTimingRegressionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/closedmonth/SignalTimingRegressionSpec.scala
@@ -1,4 +1,4 @@
-package com.boombustgroup.amorfati.engine.assembly
+package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
 import com.boombustgroup.amorfati.agents.*


### PR DESCRIPTION
## Summary
- rename the stale month-closing implementation package from engine.assembly to engine.closedmonth
- update imports, test package names, and engine documentation references
- keep public MonthClosing contracts and runtime behavior unchanged

## Validation
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.closedmonth.MonthClosingSpec com.boombustgroup.amorfati.engine.closedmonth.SignalTimingRegressionSpec"
- git diff --check

Closes #648