### PR TITLE
Sharpen same-month flow plan source boundaries

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -161,7 +161,8 @@ exactness, each month.
 | `MonthlyCalculus.scala` | Same-month flow-plan contract consumed by `MonthFlowEmitter`; economics outputs are projected here before runtime ledger batches are emitted. |
 | `MonthCalculusRunner.scala` | Orchestrates ordered same-month economics through `MonthWorkflow` and returns the month-`t` boundary views consumed by flow emission, signal timing, month closing, and SFC projection. |
 | `SameMonthEconomicsDsl.scala` | Identity-monad DSL for the same-month economics order: fiscal -> labor-pre -> household income -> demand -> firm -> labor reconciliation -> household finance -> prices -> open economy -> banking. |
-| `MonthFlowPlanBuilder.scala` | Projects `MonthExecution` plus opening ledgers into `MonthlyCalculus`; this is translation glue, not economics execution. |
+| `SameMonthFlowPlanSource.scala` | Named source surfaces for flow-plan translation: opening financial state, execution transcript, labor/payroll opening facts, and firm-demography facts. |
+| `MonthFlowPlanBuilder.scala` | Projects `SameMonthFlowPlanSource` into `MonthlyCalculus`; this is translation glue, not economics execution. |
 | `MonthFlowEmitter.scala` | Translates `MonthlyCalculus` into named runtime ledger batches without doing economics or validation. |
 | `SfcSemanticProjection.scala` | Converts executed runtime batches plus narrow semantic views into `Sfc.SemanticFlows` and runs the SFC validation boundary. |
 | `MonthTraceBuilder.scala` | Builds the month audit trace from explicit step boundaries: start/end snapshots, seed transition, timing envelopes, executed SFC flows, and validation results. |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
@@ -15,11 +15,11 @@ private[flows] object MonthCalculusRunner:
   import FlowSimulation.{SameMonthBoundaryViews, SemanticFlowInputs, SignalBoundaryInputs, StepInput}
 
   def run(input: StepInput)(using p: SimParams): SameMonthBoundaryViews =
-    val stages   = runEconomicsStages(input)
-    val flowPlan = MonthFlowPlanBuilder.build(stages)
-    buildBoundaryViews(stages.execution, flowPlan)
+    val flowPlanSource = runEconomicsStages(input)
+    val flowPlan       = MonthFlowPlanBuilder.build(flowPlanSource)
+    buildBoundaryViews(flowPlanSource.execution, flowPlan)
 
-  private def runEconomicsStages(input: StepInput)(using p: SimParams): SameMonthStageRun =
+  private def runEconomicsStages(input: StepInput)(using p: SimParams): SameMonthFlowPlanSource =
     MonthWorkflow.run:
       for
         pre                <- SameMonthEconomicsDsl.pre(input)
@@ -37,14 +37,21 @@ private[flows] object MonthCalculusRunner:
         openEconomy        <- SameMonthEconomicsDsl.openEconomy(pre, fiscal, labor, householdIncome, demand, firm, householdFinancial, priceEquity)
         banking            <- SameMonthEconomicsDsl.banking(pre, fiscal, labor, householdIncome, demand, firm, householdFinancial, priceEquity, openEconomy)
         execution          <- SameMonthEconomicsDsl.execution(pre, fiscal, labor, householdIncome, demand, firm, householdFinancial, priceEquity, openEconomy, banking)
-      yield SameMonthStageRun(
-        openingLedger = pre.ledger,
-        openingBanks = pre.banks,
+      yield SameMonthFlowPlanSource(
+        openingFinancial = SameMonthFlowPlanSource.OpeningFinancialBoundary(
+          ledger = pre.ledger,
+          banks = pre.banks,
+        ),
         execution = execution,
-        laborPre = laborPre,
-        payroll = payroll.payroll,
-        nBankruptFirms = postFirm.nBankruptFirms,
-        avgFirmWorkers = postFirm.avgFirmWorkers,
+        laborOpening = SameMonthFlowPlanSource.LaborOpeningBoundary(
+          payroll = payroll.payroll,
+          retirees = laborPre.newDemographics.retirees,
+          workingAgePopulation = laborPre.newDemographics.workingAgePop,
+        ),
+        firmDemography = SameMonthFlowPlanSource.FirmDemographyBoundary(
+          bankruptFirms = postFirm.nBankruptFirms,
+          averageFirmWorkers = postFirm.avgFirmWorkers,
+        ),
       )
 
   private def buildBoundaryViews(execution: MonthExecution, flowPlan: MonthlyCalculus)(using p: SimParams): SameMonthBoundaryViews =

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthFlowPlanBuilder.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthFlowPlanBuilder.scala
@@ -12,13 +12,15 @@ import scala.IArray
 /** Projects same-month economics outputs into the flow-emission contract. */
 private[flows] object MonthFlowPlanBuilder:
 
-  def build(stages: SameMonthStageRun)(using p: SimParams): MonthlyCalculus =
-    val ledger             = stages.openingLedger
-    val banks              = stages.openingBanks
-    val execution          = stages.execution
+  def build(source: SameMonthFlowPlanSource)(using p: SimParams): MonthlyCalculus =
+    val openingFinancial   = source.openingFinancial
+    val laborOpening       = source.laborOpening
+    val firmDemography     = source.firmDemography
+    val ledger             = openingFinancial.ledger
+    val banks              = openingFinancial.banks
+    val execution          = source.execution
     val w                  = execution.openingWorld
     val fiscal             = execution.fiscal
-    val laborPre           = stages.laborPre
     val labor              = execution.labor
     val householdIncome    = execution.householdIncome
     val firm               = execution.firm
@@ -52,18 +54,18 @@ private[flows] object MonthFlowPlanBuilder:
       labor = MonthlyCalculus.LaborAndSocial(
         wage = labor.newWage,
         employed = labor.employed,
-        payroll = stages.payroll,
+        payroll = laborOpening.payroll,
         zus = labor.newZus,
         ppk = labor.newPpk,
         earmarked = labor.newEarmarked,
         unemploymentRate = unemploymentRate,
         laborDemand = labor.laborDemand,
         livingFirms = firm.ioFirms.count(Firm.isAlive),
-        retirees = laborPre.newDemographics.retirees,
-        workingAgePop = laborPre.newDemographics.workingAgePop,
+        retirees = laborOpening.retirees,
+        workingAgePop = laborOpening.workingAgePopulation,
         nfz = labor.newNfz,
-        nBankruptFirms = stages.nBankruptFirms,
-        avgFirmWorkers = stages.avgFirmWorkers,
+        nBankruptFirms = firmDemography.bankruptFirms,
+        avgFirmWorkers = firmDemography.averageFirmWorkers,
       ),
       household = MonthlyCalculus.HouseholdFlows(
         totalIncome = householdIncome.totalIncome,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthEconomicsDsl.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthEconomicsDsl.scala
@@ -7,16 +7,6 @@ import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.types.*
 
-private[flows] final case class SameMonthStageRun(
-    openingLedger: LedgerFinancialState,
-    openingBanks: Vector[Banking.BankState],
-    execution: MonthExecution,
-    laborPre: LaborEconomics.StepOutput,
-    payroll: SocialSecurity.PayrollBase,
-    nBankruptFirms: Int,
-    avgFirmWorkers: Int,
-)
-
 private[flows] final case class SameMonthEconomicsPre(
     input: FlowSimulation.StepInput,
     randomness: MonthRandomness.StageSeeds,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthFlowPlanSource.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthFlowPlanSource.scala
@@ -1,0 +1,39 @@
+package com.boombustgroup.amorfati.engine.flows
+
+import com.boombustgroup.amorfati.agents.{Banking, SocialSecurity}
+import com.boombustgroup.amorfati.engine.MonthExecution
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+
+/** Named same-month source surfaces used to build the runtime flow plan.
+  *
+  * `MonthExecution` remains the economics transcript. The other fields are
+  * deliberately narrow opening-boundary facts needed only for translating that
+  * transcript into `MonthlyCalculus`.
+  */
+private[flows] final case class SameMonthFlowPlanSource(
+    openingFinancial: SameMonthFlowPlanSource.OpeningFinancialBoundary,
+    execution: MonthExecution,
+    laborOpening: SameMonthFlowPlanSource.LaborOpeningBoundary,
+    firmDemography: SameMonthFlowPlanSource.FirmDemographyBoundary,
+)
+
+private[flows] object SameMonthFlowPlanSource:
+
+  /** Opening ledger-owned financial state and operational bank rows. */
+  final case class OpeningFinancialBoundary(
+      ledger: LedgerFinancialState,
+      banks: Vector[Banking.BankState],
+  )
+
+  /** Opening labor/payroll facts pinned to the month-t flow boundary. */
+  final case class LaborOpeningBoundary(
+      payroll: SocialSecurity.PayrollBase,
+      retirees: Int,
+      workingAgePopulation: Int,
+  )
+
+  /** Firm-demography facts produced by same-month firm processing. */
+  final case class FirmDemographyBoundary(
+      bankruptFirms: Int,
+      averageFirmWorkers: Int,
+  )


### PR DESCRIPTION
## Summary
- replace the mixed `SameMonthStageRun` glue object with `SameMonthFlowPlanSource` and named source groups
- narrow the labor/payroll flow-plan source to the facts needed by `MonthlyCalculus`
- update `MonthFlowPlanBuilder` and engine README to use the sharper boundary

## Validation
- `sbt scalafmtAll`
- `sbt Test/compile`
- `sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec"`

Fixes #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated flow documentation to reflect changes in same-month translation process.

* **Refactor**
  * Reorganized internal flow plan construction components for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->