### PR TITLE
Narrow month closing execution boundary

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthClosing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthClosing.scala
@@ -1,6 +1,7 @@
 package com.boombustgroup.amorfati.engine
 
 import com.boombustgroup.amorfati.agents.*
+import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.mechanisms.{InformalEconomy, PopulationLifecycleTransitions}
 import com.boombustgroup.amorfati.types.*
@@ -8,15 +9,49 @@ import com.boombustgroup.amorfati.types.*
 /** Same-month input consumed by the month-closing phase.
   *
   * Unlike [[MonthExecution]], this is not the whole execution transcript. It is
-  * the closing contract: execution plus the derived mechanism, diagnostic, and
-  * agent-lifecycle inputs required to materialize the realized month-`t` state.
+  * the closing contract: a narrowed closing-state view plus the derived
+  * mechanism, diagnostic, and agent-lifecycle inputs required to materialize
+  * the realized month-`t` state.
   */
 final case class MonthClosingInput(
-    execution: MonthExecution,
+    closingState: MonthClosingStateInput,
     mechanisms: MonthClosingMechanisms,
     diagnostics: MonthClosingDiagnostics,
     agentLifecycle: PopulationLifecycleTransitions.Input,
 )
+
+/** Same-month state surface needed to materialize the realized closed month.
+  *
+  * `MonthExecution` remains the full economics transcript. This type is the
+  * narrower closing view consumed by `closedmonth` assemblers.
+  */
+final case class MonthClosingStateInput(
+    openingWorld: World,
+    fiscal: FiscalConstraintEconomics.StepOutput,
+    labor: LaborEconomics.StepOutput,
+    householdIncome: HouseholdIncomeEconomics.StepOutput,
+    demand: DemandEconomics.StepOutput,
+    firm: FirmEconomics.StepOutput,
+    householdFinancial: HouseholdFinancialEconomics.StepOutput,
+    priceEquity: PriceEquityEconomics.StepOutput,
+    openEconomy: OpenEconEconomics.StepOutput,
+    banking: BankingEconomics.StepOutput,
+)
+
+object MonthClosingStateInput:
+  def fromExecution(execution: MonthExecution): MonthClosingStateInput =
+    MonthClosingStateInput(
+      openingWorld = execution.openingWorld,
+      fiscal = execution.fiscal,
+      labor = execution.labor,
+      householdIncome = execution.householdIncome,
+      demand = execution.demand,
+      firm = execution.firm,
+      householdFinancial = execution.householdFinancial,
+      priceEquity = execution.priceEquity,
+      openEconomy = execution.openEconomy,
+      banking = execution.banking,
+    )
 
 final case class MonthClosingMechanisms(
     informalEconomy: InformalEconomy.Result,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthExecution.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthExecution.scala
@@ -5,8 +5,9 @@ import com.boombustgroup.amorfati.engine.economics.*
 /** Same-month result of executing the ordered economics pipeline for month `t`.
   *
   * This is not an opening state and not a next-month output. It is the
-  * month-`t` execution surface consumed by flow emission, semantic projection,
-  * and month closing.
+  * month-`t` execution surface consumed by flow emission and semantic
+  * projection. Month closing receives a narrowed [[MonthClosingStateInput]]
+  * derived from this transcript.
   */
 final case class MonthExecution(
     openingWorld: World,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -39,8 +39,8 @@ engine/
 | `ledger/RuntimeFlowProjection.scala` | Typed projection from executed runtime `deltaLedger` into the currently materialized persisted ledger slice. |
 | `ledger/BankReserveDiagnostics.scala` | Ledger-backed reserve diagnostics for active bank deposit-facility usage. |
 | `MonthSemantics.scala` | Tiny typed phase markers for the internal month step: pre-seed, same-month operational state, closed-month state, and next pre-seed extraction. |
-| `MonthExecution.scala` | Same-month result of the ordered economics pipeline; consumed by flow planning, semantic projection, and month closing. |
-| `MonthClosing.scala` | Explicit closing input/result contracts: derived mechanisms, diagnostics, agent lifecycle input, and realized month-`t` closing state. |
+| `MonthExecution.scala` | Same-month result of the ordered economics pipeline; retained as an execution transcript and adapted into narrower downstream boundary views. |
+| `MonthClosing.scala` | Explicit closing input/result contracts: narrowed closing-state view, derived mechanisms, diagnostics, agent lifecycle input, and realized month-`t` closing state. |
 | `MonthWorkflow.scala` | Minimal identity-monad DSL used to express the deterministic month transition as a typed `for`-comprehension without adding runtime effects. |
 | `MonthRandomness.scala` | Explicit month-step randomness contract: one root seed split into named stage and closing streams for deterministic replay and auditability. |
 | `MonthDriver.scala` | Shared month-by-month unfold driver over the explicit `FlowSimulation.step` boundary. |

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowOfFundsDiagnostics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowOfFundsDiagnostics.scala
@@ -1,28 +1,47 @@
 package com.boombustgroup.amorfati.engine.closedmonth
 
+import com.boombustgroup.amorfati.agents.Firm
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.MonthExecution
+import com.boombustgroup.amorfati.engine.MonthClosingStateInput
 import com.boombustgroup.amorfati.engine.economics.GdpAccounting
 import com.boombustgroup.amorfati.types.*
 
 /** Flow-of-funds diagnostics derived at the month-closing boundary. */
 object FlowOfFundsDiagnostics:
 
-  def residual(in: MonthExecution)(using p: SimParams): PLN =
+  final case class Input(
+      priceLevel: PriceIndex,
+      productivityIndex: Multiplier,
+      livingFirms: Vector[Firm.State],
+      sectorCapReal: Vector[PLN],
+      sectorMults: Vector[Multiplier],
+  )
+
+  object Input:
+    def fromClosingState(state: MonthClosingStateInput): Input =
+      Input(
+        priceLevel = state.openingWorld.priceLevel,
+        productivityIndex = state.openingWorld.real.productivityIndex,
+        livingFirms = state.labor.living,
+        sectorCapReal = state.demand.sectorCapReal,
+        sectorMults = state.demand.sectorMults,
+      )
+
+  def residual(in: Input)(using p: SimParams): PLN =
     val realizedOutput    = GdpAccounting
       .realizedSectorOutputs(
-        priceLevel = in.openingWorld.priceLevel,
+        priceLevel = in.priceLevel,
         sectorCount = p.sectorDefs.length,
-        firms = in.labor.living,
-        sectorMultiplier = s => in.demand.sectorMults(s),
-        capacityBoost = in.openingWorld.real.productivityIndex,
+        firms = in.livingFirms,
+        sectorMultiplier = s => in.sectorMults(s),
+        capacityBoost = in.productivityIndex,
       )
       .sumPln
     val demandStageOutput = GdpAccounting
       .capacityWeightedSectorOutputs(
-        priceLevel = in.openingWorld.priceLevel,
-        sectorCapReal = in.demand.sectorCapReal,
-        sectorMultiplier = s => in.demand.sectorMults(s),
+        priceLevel = in.priceLevel,
+        sectorCapReal = in.sectorCapReal,
+        sectorMultiplier = s => in.sectorMults(s),
       )
       .sumPln
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowStateAssembler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/FlowStateAssembler.scala
@@ -10,7 +10,7 @@ object FlowStateAssembler:
       closingInput: MonthClosingInput,
       lifecycle: PopulationLifecycleTransitions.Result,
   ): FlowState =
-    val in       = closingInput.execution
+    val in       = closingInput.closingState
     val informal = closingInput.mechanisms.informalEconomy
     FlowState(
       monthlyGdpProxy = in.priceEquity.gdp,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosing.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/MonthClosing.scala
@@ -14,15 +14,18 @@ import com.boombustgroup.amorfati.engine.mechanisms.{FirmEntry, InformalEconomy,
 object MonthClosing:
 
   def prepareInput(execution: MonthExecution)(using p: SimParams): MonthClosingInput =
+    prepareInput(MonthClosingStateInput.fromExecution(execution))
+
+  def prepareInput(state: MonthClosingStateInput)(using p: SimParams): MonthClosingInput =
     MonthClosingInput(
-      execution = execution,
+      closingState = state,
       mechanisms = MonthClosingMechanisms(
-        informalEconomy = InformalEconomy.compute(informalInput(execution)),
+        informalEconomy = InformalEconomy.compute(informalInput(state)),
       ),
       diagnostics = MonthClosingDiagnostics(
-        flowOfFundsResidual = FlowOfFundsDiagnostics.residual(execution),
+        flowOfFundsResidual = FlowOfFundsDiagnostics.residual(FlowOfFundsDiagnostics.Input.fromClosingState(state)),
       ),
-      agentLifecycle = populationLifecycleInput(execution),
+      agentLifecycle = populationLifecycleInput(state),
     )
 
   def closeExecution(
@@ -35,7 +38,7 @@ object MonthClosing:
       closingInput: MonthClosingInput,
       randomness: MonthRandomness.ClosingStreams,
   )(using p: SimParams): MonthClosingResult =
-    val execution   = closingInput.execution
+    val state       = closingInput.closingState
     val lifecycle   = PopulationLifecycleTransitions.run(
       closingInput.agentLifecycle,
       fdiMaRng = randomness.fdiMa,
@@ -44,10 +47,10 @@ object MonthClosing:
       regionalMigrationRng = randomness.regionalMigration,
     )
     val finalWorld  = WorldStateAssembler.assemble(closingInput, lifecycle)
-    val finalLedger = execution.banking.ledgerFinancialState.copy(
+    val finalLedger = state.banking.ledgerFinancialState.copy(
       firms = LedgerFinancialState.refreshFirmPopulationBalances(
         lifecycle.firmFinancialStocks,
-        execution.banking.ledgerFinancialState.firms,
+        state.banking.ledgerFinancialState.firms,
         lifecycle.newFirmIds,
       ),
     )
@@ -56,51 +59,51 @@ object MonthClosing:
       world = finalWorld,
       firms = lifecycle.firms,
       households = lifecycle.households,
-      banks = execution.banking.banks,
+      banks = state.banking.banks,
       householdAggregates = lifecycle.householdAggregates,
       ledgerFinancialState = finalLedger,
       startupAbsorptionRate = lifecycle.startupAbsorptionRate,
     )
 
-  private def informalInput(execution: MonthExecution): InformalEconomy.Input =
+  private def informalInput(state: MonthClosingStateInput): InformalEconomy.Input =
     InformalEconomy.Input(
-      citEvasion = execution.firm.sumCitEvasion,
-      vatBeforeEvasion = execution.banking.vat,
-      vatAfterEvasion = execution.banking.vatAfterEvasion,
-      pitBeforeEvasion = execution.householdIncome.pitRevenue,
-      pitAfterEvasion = execution.banking.pitAfterEvasion,
-      exciseBeforeEvasion = execution.banking.exciseRevenue,
-      exciseAfterEvasion = execution.banking.exciseAfterEvasion,
-      realizedTaxShadowShare = execution.banking.realizedTaxShadowShare,
-      employed = execution.labor.employed,
-      workingAgePopulation = execution.labor.newDemographics.workingAgePop,
-      previousCyclicalAdjustment = execution.openingWorld.mechanisms.informalCyclicalAdj,
+      citEvasion = state.firm.sumCitEvasion,
+      vatBeforeEvasion = state.banking.vat,
+      vatAfterEvasion = state.banking.vatAfterEvasion,
+      pitBeforeEvasion = state.householdIncome.pitRevenue,
+      pitAfterEvasion = state.banking.pitAfterEvasion,
+      exciseBeforeEvasion = state.banking.exciseRevenue,
+      exciseAfterEvasion = state.banking.exciseAfterEvasion,
+      realizedTaxShadowShare = state.banking.realizedTaxShadowShare,
+      employed = state.labor.employed,
+      workingAgePopulation = state.labor.newDemographics.workingAgePop,
+      previousCyclicalAdjustment = state.openingWorld.mechanisms.informalCyclicalAdj,
     )
 
-  private def populationLifecycleInput(execution: MonthExecution): PopulationLifecycleTransitions.Input =
+  private def populationLifecycleInput(state: MonthClosingStateInput): PopulationLifecycleTransitions.Input =
     PopulationLifecycleTransitions.Input(
       stocks = PopulationLifecycleTransitions.AgentStocks(
-        firms = execution.banking.reassignedFirms,
-        firmFinancialBalances = execution.banking.ledgerFinancialState.firms,
-        households = execution.banking.reassignedHouseholds,
-        householdFinancialBalances = execution.banking.ledgerFinancialState.households,
+        firms = state.banking.reassignedFirms,
+        firmFinancialBalances = state.banking.ledgerFinancialState.firms,
+        households = state.banking.reassignedHouseholds,
+        householdFinancialBalances = state.banking.ledgerFinancialState.households,
       ),
       entry = PopulationLifecycleTransitions.EntryContext(
-        automationRatio = execution.priceEquity.autoR,
-        hybridRatio = execution.priceEquity.hybR,
-        laggedEntrySignals = FirmEntry.LaggedEntrySignals.fromDecisionSignals(execution.openingWorld.seedIn),
+        automationRatio = state.priceEquity.autoR,
+        hybridRatio = state.priceEquity.hybR,
+        laggedEntrySignals = FirmEntry.LaggedEntrySignals.fromDecisionSignals(state.openingWorld.seedIn),
       ),
       startupStaffing = PopulationLifecycleTransitions.StartupStaffingContext(
-        marketWage = execution.labor.newWage,
-        reservationWage = execution.fiscal.resWage,
-        importAdjustment = execution.householdIncome.importAdj,
-        regionalWages = execution.labor.regionalWages,
-        remainingHireCapacity = execution.firm.postFirmHireCapacity - execution.firm.postFirmHires,
-        retrainingAttempts = execution.householdIncome.hhAgg.retrainingAttempts,
-        retrainingSuccesses = execution.householdIncome.hhAgg.retrainingSuccesses,
-        householdFlowTotals = execution.banking.finalHhAgg,
+        marketWage = state.labor.newWage,
+        reservationWage = state.fiscal.resWage,
+        importAdjustment = state.householdIncome.importAdj,
+        regionalWages = state.labor.regionalWages,
+        remainingHireCapacity = state.firm.postFirmHireCapacity - state.firm.postFirmHires,
+        retrainingAttempts = state.householdIncome.hhAgg.retrainingAttempts,
+        retrainingSuccesses = state.householdIncome.hhAgg.retrainingSuccesses,
+        householdFlowTotals = state.banking.finalHhAgg,
       ),
       regionalMigration = PopulationLifecycleTransitions.RegionalMigrationContext(
-        regionalWages = execution.labor.regionalWages,
+        regionalWages = state.labor.regionalWages,
       ),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/WorldStateAssembler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/closedmonth/WorldStateAssembler.scala
@@ -2,6 +2,7 @@ package com.boombustgroup.amorfati.engine.closedmonth
 
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.*
+import com.boombustgroup.amorfati.engine.economics.PriceEquityEconomics
 import com.boombustgroup.amorfati.engine.ledger.BankReserveDiagnostics
 import com.boombustgroup.amorfati.engine.markets.EquityMarket
 import com.boombustgroup.amorfati.engine.mechanisms.{ClimatePolicy, PopulationLifecycleTransitions, SectoralMobility, TourismSeasonality}
@@ -16,7 +17,7 @@ object WorldStateAssembler:
       closingInput: MonthClosingInput,
       lifecycle: PopulationLifecycleTransitions.Result,
   )(using p: SimParams): World =
-    val in                    = closingInput.execution
+    val in                    = closingInput.closingState
     val informal              = closingInput.mechanisms.informalEconomy
     val diagnostics           = closingInput.diagnostics
     val elapsedMonths         = in.fiscal.m.previousCompleted.toInt
@@ -49,7 +50,7 @@ object WorldStateAssembler:
       householdMarket = HouseholdMarketState.fromAggregates(in.banking.finalHhAgg),
       social = social,
       financialMarkets = FinancialMarketsState(
-        equity = finalizeEquity(in),
+        equity = finalizeEquity(in.priceEquity),
         corporateBonds = in.openEconomy.corpBonds.newCorpBonds,
         insurance = in.banking.finalInsurance,
         nbfi = in.banking.finalNbfi,
@@ -98,10 +99,10 @@ object WorldStateAssembler:
       regionalWages = in.labor.regionalWages,
     )
 
-  private def finalizeEquity(in: MonthExecution): EquityMarket.State =
-    in.priceEquity.equityAfterForeignStock.copy(
+  private def finalizeEquity(priceEquity: PriceEquityEconomics.StepOutput): EquityMarket.State =
+    priceEquity.equityAfterForeignStock.copy(
       lastWealthEffect = PLN.Zero,
-      lastDomesticDividends = in.priceEquity.netDomesticDividends,
-      lastForeignDividends = in.priceEquity.foreignDividendOutflow,
-      lastDividendTax = in.priceEquity.dividendTax,
+      lastDomesticDividends = priceEquity.netDomesticDividends,
+      lastForeignDividends = priceEquity.foreignDividendOutflow,
+      lastDividendTax = priceEquity.dividendTax,
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.engine.flows
 
 import com.boombustgroup.amorfati.config.SimParams
-import com.boombustgroup.amorfati.engine.{MonthExecution, MonthWorkflow}
+import com.boombustgroup.amorfati.engine.{MonthClosingStateInput, MonthExecution, MonthWorkflow}
 import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 
 /** Runs the deterministic same-month economics boundary.
@@ -55,13 +55,14 @@ private[flows] object MonthCalculusRunner:
       )
 
   private def buildBoundaryViews(execution: MonthExecution, flowPlan: MonthlyCalculus)(using p: SimParams): SameMonthBoundaryViews =
+    val closingState = MonthClosingStateInput.fromExecution(execution)
     SameMonthBoundaryViews(
       flowPlan = flowPlan,
       signals = SignalBoundaryInputs(
         labor = execution.labor,
         demand = execution.demand,
       ),
-      closing = MonthClosing.prepareInput(execution),
+      closing = MonthClosing.prepareInput(closingState),
       semanticProjection = SemanticFlowInputs(
         labor = execution.labor,
         hhIncome = execution.householdIncome,


### PR DESCRIPTION
Fixes #679

Summary:
- Add `MonthClosingStateInput` as the explicit closed-month state boundary derived from `MonthExecution`.
- Make month closing, flow-of-funds diagnostics, and closed-month assemblers consume the narrowed closing view instead of the full execution transcript.
- Keep `MonthClosing.closeExecution` / `prepareInput(MonthExecution)` as adapters for tests and diagnostic entry points.
- Update engine docs to distinguish the execution transcript from downstream boundary inputs.

Validation:
- `sbt scalafmtAll`
- `sbt Test/compile`
- `sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec com.boombustgroup.amorfati.engine.closedmonth.MonthClosingSpec com.boombustgroup.amorfati.engine.closedmonth.SignalTimingRegressionSpec"`