### PR TITLE
Narrow semantic flow projection inputs

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/MonthSemantics.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.engine
 
-import com.boombustgroup.amorfati.engine.flows.FlowSimulation.{ClosedMonthBoundary, SemanticFlowInputs, SignalBoundaryInputs}
+import com.boombustgroup.amorfati.engine.flows.FlowSimulation.{ClosedMonthBoundary, SemanticFlowInputs, SignalBoundaryInputs, StepEvidenceInputs}
 import com.boombustgroup.amorfati.engine.flows.MonthlyCalculus
 
 /** Tiny type-level timeline for one monthly engine step.
@@ -98,26 +98,34 @@ object MonthSemantics:
     wrap[SemanticFlowInputs, SameMonth](inputs)
 
   extension (semanticProjection: SemanticProjection)
-    private[engine] inline def labor =
-      unwrap(semanticProjection).labor
+    private[engine] inline def firmCredit =
+      unwrap(semanticProjection).firmCredit
 
-    private[engine] inline def hhIncome =
-      unwrap(semanticProjection).hhIncome
-
-    private[engine] inline def firms =
-      unwrap(semanticProjection).firms
-
-    private[engine] inline def hhFinancial =
-      unwrap(semanticProjection).hhFinancial
-
-    private[engine] inline def prices =
-      unwrap(semanticProjection).prices
-
-    private[engine] inline def openEcon =
-      unwrap(semanticProjection).openEcon
+    private[engine] inline def external =
+      unwrap(semanticProjection).external
 
     private[engine] inline def banking =
       unwrap(semanticProjection).banking
+
+  /** Same-month diagnostic/export evidence carried to `StepOutput`.
+    *
+    * This stays separate from [[SemanticProjection]] so SFC validation cannot
+    * accidentally depend on full economics-stage payloads.
+    */
+  type StepEvidence = At[StepEvidenceInputs, SameMonth]
+
+  private[engine] inline def stepEvidence(inputs: StepEvidenceInputs): StepEvidence =
+    wrap[StepEvidenceInputs, SameMonth](inputs)
+
+  extension (stepEvidence: StepEvidence)
+    private[engine] inline def firmDecisionTraces =
+      unwrap(stepEvidence).firmDecisionTraces
+
+    private[engine] inline def householdSnapshotState =
+      unwrap(stepEvidence).householdSnapshotState
+
+    private[engine] inline def householdMonthlyFlows =
+      unwrap(stepEvidence).householdMonthlyFlows
 
   /** Realized closed-month boundary before extracting the next seed. */
   type ClosedMonth = At[ClosedMonthBoundary, Post]

--- a/src/main/scala/com/boombustgroup/amorfati/engine/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/README.md
@@ -78,7 +78,7 @@ Read it as a month transition:
 
 - `stateIn.world.seedIn` is the persisted `pre` input surface.
 - `randomness` is the explicit month-level randomness surface; fixing `stateIn` and `randomness.rootSeed` fixes replay for one step.
-- `MonthOutcome` is built through the `MonthWorkflow` identity DSL as `pre -> same-month boundary views -> closed month -> seedOut/next-pre`; the same-month views are `SignalView`, `FlowPlan`, `ClosingInput`, and `SemanticProjection`.
+- `MonthOutcome` is built through the `MonthWorkflow` identity DSL as `pre -> same-month boundary views -> closed month -> seedOut/next-pre`; the same-month views are `SignalView`, `FlowPlan`, `ClosingInput`, `SemanticProjection`, and `StepEvidence`.
 - `operationalSignals` is the explicit same-month surface created inside the step.
 - `signalExtraction` is the dedicated `closed -> next-pre` boundary.
 - `trace` is the emitted audit artifact for month `t`.

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala
@@ -8,6 +8,7 @@ import com.boombustgroup.amorfati.engine.SimulationMonth.{CompletedMonth, Execut
 import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
 import com.boombustgroup.amorfati.engine.economics.*
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
+import com.boombustgroup.amorfati.types.*
 import com.boombustgroup.ledger.*
 
 /** New flow-based simulation pipeline.
@@ -92,16 +93,83 @@ object FlowSimulation:
   )
 
   /** Same-month payload narrowed for executed-batch -> SFC semantic projection.
+    *
+    * Each field is a non-batch identity term needed by `Sfc.SemanticFlows`.
+    * Runtime-covered cash legs stay sourced from executed batch evidence.
     */
   private[engine] case class SemanticFlowInputs(
-      labor: LaborEconomics.StepOutput,
-      hhIncome: HouseholdIncomeEconomics.StepOutput,
-      firms: FirmEconomics.StepOutput,
-      hhFinancial: HouseholdFinancialEconomics.StepOutput,
-      prices: PriceEquityEconomics.StepOutput,
-      openEcon: OpenEconEconomics.StepOutput,
-      banking: BankingEconomics.StepOutput,
+      firmCredit: SemanticFlowInputs.FirmCreditEvidence,
+      external: SemanticFlowInputs.ExternalBalanceEvidence,
+      banking: SemanticFlowInputs.BankingBalanceSheetEvidence,
   )
+
+  private[engine] object SemanticFlowInputs:
+
+    /** Firm-credit stock movement that is validated by SFC outside runtime
+      * batch execution.
+      */
+    case class FirmCreditEvidence(
+        newNonPerformingLoans: PLN,
+    )
+
+    /** External-account stock-flow facts that currently enter SFC as same-month
+      * semantic terms rather than emitted runtime batches.
+      */
+    case class ExternalBalanceEvidence(
+        currentAccount: PLN,
+        valuationEffect: PLN,
+    )
+
+    /** Bank balance-sheet identity terms not represented as first-class runtime
+      * transfer batches.
+      */
+    case class BankingBalanceSheetEvidence(
+        netGovernmentBondChange: PLN,
+        capitalDestruction: PLN,
+        interbankContagionLoss: PLN,
+        htmRealizedLoss: PLN,
+        eclProvisionChange: PLN,
+    )
+
+    def fromExecution(execution: MonthExecution): SemanticFlowInputs =
+      SemanticFlowInputs(
+        firmCredit = FirmCreditEvidence(
+          newNonPerformingLoans = execution.firm.nplNew,
+        ),
+        external = ExternalBalanceEvidence(
+          currentAccount = execution.openEconomy.external.newBop.currentAccount,
+          valuationEffect = execution.openEconomy.external.oeValuationEffect,
+        ),
+        banking = BankingBalanceSheetEvidence(
+          netGovernmentBondChange = execution.banking.actualBondChange,
+          capitalDestruction = execution.banking.multiCapDestruction,
+          interbankContagionLoss = execution.banking.interbankContagionLoss,
+          htmRealizedLoss = execution.banking.htmRealizedLoss,
+          eclProvisionChange = execution.banking.eclProvisionChange,
+        ),
+      )
+
+  /** Same-month evidence needed by `StepOutput` diagnostics and exports.
+    *
+    * This is deliberately separate from SFC semantic projection so trace and
+    * snapshot payloads do not widen the accounting validation boundary.
+    */
+  private[engine] case class StepEvidenceInputs(
+      firmDecisionTraces: Vector[Firm.DecisionTrace],
+      householdSnapshotState: HouseholdSnapshotState,
+      householdMonthlyFlows: Vector[Household.MonthlyFlow],
+  )
+
+  private[engine] object StepEvidenceInputs:
+    def fromExecution(execution: MonthExecution): StepEvidenceInputs =
+      StepEvidenceInputs(
+        firmDecisionTraces = execution.firm.decisionTraces,
+        householdSnapshotState = HouseholdSnapshotState(
+          households = execution.householdIncome.updatedHouseholds,
+          ledgerFinancialState = execution.householdIncome.ledgerFinancialState,
+        ),
+        householdMonthlyFlows = execution.householdIncome.householdMonthlyFlows,
+      )
 
   /** Downstream-specific same-month boundary views derived from one economics
     * execution.
@@ -111,6 +179,7 @@ object FlowSimulation:
       signals: SignalBoundaryInputs,
       closing: MonthClosingInput,
       semanticProjection: SemanticFlowInputs,
+      stepEvidence: StepEvidenceInputs,
   )
 
   /** Realized month-`t` closing boundary plus the narrow payload needed to
@@ -129,6 +198,7 @@ object FlowSimulation:
       operational: MonthSemantics.Operational,
       flowPlan: MonthSemantics.FlowPlan,
       semanticProjection: MonthSemantics.SemanticProjection,
+      stepEvidence: MonthSemantics.StepEvidence,
       closed: MonthSemantics.ClosedMonth,
       seedOut: MonthSemantics.SeedOut,
       traceCore: MonthTraceCore,
@@ -154,6 +224,9 @@ object FlowSimulation:
 
     def semanticProjection(boundaries: SameMonthBoundaryViews): Program[MonthSemantics.SemanticProjection] =
       MonthWorkflow.pure(MonthSemantics.semanticProjection(boundaries.semanticProjection))
+
+    def stepEvidence(boundaries: SameMonthBoundaryViews): Program[MonthSemantics.StepEvidence] =
+      MonthWorkflow.pure(MonthSemantics.stepEvidence(boundaries.stepEvidence))
 
     def operational(signalView: MonthSemantics.SignalView): Program[MonthSemantics.Operational] =
       MonthWorkflow.pure(buildOperationalSignals(signalView))
@@ -252,12 +325,9 @@ object FlowSimulation:
       semanticFlows = sfcFlows,
       sfcResult,
       trace = monthTrace,
-      firmDecisionTraces = outcome.semanticProjection.firms.decisionTraces,
-      householdSnapshotState = HouseholdSnapshotState(
-        households = outcome.semanticProjection.hhIncome.updatedHouseholds,
-        ledgerFinancialState = outcome.semanticProjection.hhIncome.ledgerFinancialState,
-      ),
-      householdMonthlyFlows = outcome.semanticProjection.hhIncome.householdMonthlyFlows,
+      firmDecisionTraces = outcome.stepEvidence.firmDecisionTraces,
+      householdSnapshotState = outcome.stepEvidence.householdSnapshotState,
+      householdMonthlyFlows = outcome.stepEvidence.householdMonthlyFlows,
       nextState = nextState,
     )
 
@@ -354,6 +424,7 @@ object FlowSimulation:
         flowPlan           <- MonthStepDsl.flowPlan(sameMonth)
         closingInput       <- MonthStepDsl.closingInput(sameMonth)
         semanticProjection <- MonthStepDsl.semanticProjection(sameMonth)
+        stepEvidence       <- MonthStepDsl.stepEvidence(sameMonth)
         operational        <- MonthStepDsl.operational(signalView)
         closed             <- MonthStepDsl.closedMonth(pre, closingInput, signalView)
         seedOut            <- MonthStepDsl.seedOut(signalView, closed)
@@ -362,6 +433,7 @@ object FlowSimulation:
         operational = operational,
         flowPlan = flowPlan,
         semanticProjection = semanticProjection,
+        stepEvidence = stepEvidence,
         closed = closed,
         seedOut = seedOut,
         traceCore = traceCore,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthCalculusRunner.scala
@@ -12,7 +12,7 @@ import com.boombustgroup.amorfati.engine.closedmonth.MonthClosing
   * seed extraction remain outside this runner.
   */
 private[flows] object MonthCalculusRunner:
-  import FlowSimulation.{SameMonthBoundaryViews, SemanticFlowInputs, SignalBoundaryInputs, StepInput}
+  import FlowSimulation.{SameMonthBoundaryViews, SemanticFlowInputs, SignalBoundaryInputs, StepEvidenceInputs, StepInput}
 
   def run(input: StepInput)(using p: SimParams): SameMonthBoundaryViews =
     val flowPlanSource = runEconomicsStages(input)
@@ -63,13 +63,6 @@ private[flows] object MonthCalculusRunner:
         demand = execution.demand,
       ),
       closing = MonthClosing.prepareInput(closingState),
-      semanticProjection = SemanticFlowInputs(
-        labor = execution.labor,
-        hhIncome = execution.householdIncome,
-        firms = execution.firm,
-        hhFinancial = execution.householdFinancial,
-        prices = execution.priceEquity,
-        openEcon = execution.openEconomy,
-        banking = execution.banking,
-      ),
+      semanticProjection = SemanticFlowInputs.fromExecution(execution),
+      stepEvidence = StepEvidenceInputs.fromExecution(execution),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SfcSemanticProjection.scala
@@ -19,10 +19,10 @@ object SfcSemanticProjection:
       batches: Vector[BatchedFlow],
       fofResidual: PLN,
   )(using p: SimParams): Sfc.SemanticFlows =
-    val firms    = semanticProjection.firms
-    val openEcon = semanticProjection.openEcon
-    val banking  = semanticProjection.banking
-    val evidence = ExecutedFlowEvidence.from(batches)
+    val firmCredit = semanticProjection.firmCredit
+    val external   = semanticProjection.external
+    val banking    = semanticProjection.banking
+    val evidence   = ExecutedFlowEvidence.from(batches)
     // Runtime-covered legs are sourced from executed flow evidence. Remaining
     // month-semantics reads are diagnostics or stock projections without a
     // first-class emitted mechanism yet.
@@ -34,12 +34,12 @@ object SfcSemanticProjection:
       totalIncome = evidence.amount(FlowMechanism.HhTotalIncome),
       totalConsumption = evidence.amount(FlowMechanism.HhConsumption),
       newLoans = evidence.amount(FlowMechanism.FirmNewLoan),
-      nplRecovery = firms.nplNew * p.banking.loanRecovery,
-      currentAccount = openEcon.external.newBop.currentAccount,
-      valuationEffect = openEcon.external.oeValuationEffect,
+      nplRecovery = firmCredit.newNonPerformingLoans * p.banking.loanRecovery,
+      currentAccount = external.currentAccount,
+      valuationEffect = external.valuationEffect,
       bankBondIncome = evidence.amount(FlowMechanism.BankGovBondIncome),
       qePurchase = evidence.amount(FlowMechanism.NbpQeGovBondPurchase),
-      newBondIssuance = banking.actualBondChange,
+      newBondIssuance = banking.netGovernmentBondChange,
       depositInterestPaid = evidence.amount(FlowMechanism.HhDepositInterest),
       reserveInterest = evidence.amount(FlowMechanism.BankReserveInterest),
       standingFacilityIncome = evidence.signedAmount(FlowMechanism.BankStandingFacility),
@@ -86,7 +86,7 @@ object SfcSemanticProjection:
       tourismImport = evidence.amount(FlowMechanism.TourismImport),
       bfgLevy = evidence.amount(FlowMechanism.BankBfgLevy),
       bailInLoss = evidence.amount(FlowMechanism.BankBailIn),
-      bankCapitalDestruction = banking.multiCapDestruction,
+      bankCapitalDestruction = banking.capitalDestruction,
       interbankContagionLoss = banking.interbankContagionLoss,
       investNetDepositFlow = evidence.investNetDepositFlow,
       firmPrincipalRepaid = evidence.amount(FlowMechanism.FirmLoanRepayment),


### PR DESCRIPTION
Fixes #680

Summary:
- Replace broad `SemanticFlowInputs` stage outputs with a minimal SFC-facing projection input grouped into firm-credit, external-balance, and banking balance-sheet evidence.
- Keep `SfcSemanticProjection` dependent only on the exact non-batch facts it validates plus executed batch evidence.
- Move `StepOutput` trace/snapshot payloads into a separate `StepEvidenceInputs` boundary so diagnostics/exports do not widen SFC projection.
- Update `MonthSemantics` and `MonthCalculusRunner` to carry the new explicit same-month views.

Validation:
- `sbt scalafmtAll`
- `sbt Test/compile`
- `sbt "testOnly com.boombustgroup.amorfati.engine.flows.FlowSimulationSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationStepSpec com.boombustgroup.amorfati.engine.flows.FlowSimulationExecutedEvidenceSpec"`