### PR TITLE
Document validation matrix and ownership boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ replication, calibration, validation, and publication work:
 | [Calibration register](docs/calibration-register.md) | Key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and searchable gaps. |
 | [Data bridge to national and financial accounts](docs/data-bridge-national-financial-accounts.md) | Official Polish, EU, and financial-account sources mapped to initialization stocks, calibrated parameters, scenario inputs, validation targets, transformations, and prioritized empirical gaps. |
 | [Empirical validation report](docs/empirical-validation-report.md) | Workflow for the empirical-validation snapshot: the curated source manifest is the editable input, while generated baseline artifacts live under `docs/empirical-validation/`. |
+| [Validation matrix and ownership boundaries](docs/validation-matrix.md) | CI, integration-test, generated-output, nightly, stress, and profiling ownership rules so new validation work lands in the right layer. |
 | [Sensitivity and robustness workflow](docs/sensitivity-robustness-workflow.md) | Seed envelopes and one-at-a-time parameter-sensitivity artifacts generated from the Monte Carlo runner. |
 | [Reproducible scenario registry](docs/scenario-registry.md) | Named policy and shock scenarios with exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path. |
 

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -139,15 +139,11 @@ nix develop --command java -cp target/scala-3.8.2/amor-fati.jar \
   --require-main
 ```
 
-The scheduled workflow targets 02:00 Europe/Warsaw. GitHub cron only supports
-UTC, so the workflow registers both `0 0 * * *` and `0 1 * * *` UTC and then
-uses a lightweight gate step to continue only for the intended local-time
-occurrence. In ordinary CEST this is `0 0 * * *`; in ordinary CET this is
-`0 1 * * *`. On the autumn DST transition, where local 02:00 occurs twice, the
-workflow keeps the second occurrence in CET and skips the first one. On the
-spring DST transition, where local 02:00 does not exist, the workflow runs at
-the first valid post-transition slot, 03:00 CEST. The gate runs before checkout
-or Nix setup, so skipped scheduled events are cheap.
+The scheduled workflow uses a single GitHub cron, `0 0 * * *` UTC. During CEST
+this runs at 02:00 Europe/Warsaw. GitHub cron does not track local daylight
+saving time, so maintainers should adjust the cron if exact 02:00 local time is
+required during CET months. A single cron is intentional because it avoids
+duplicate scheduled workflow runs in the Actions UI.
 
 The job summary reports the profile, commit SHA, run id, runtime, manifest path,
 terminal status, build/runtime exit codes, and failure reason when either the

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -1,0 +1,122 @@
+# Validation Matrix and Ownership Boundaries
+
+This document is the ownership map for engine validation. It describes the
+checks that already exist and the layer each one owns. It is intentionally not a
+replacement for CI, integration tests, generated-output checks, or nightly
+diagnostics; it is the routing rule that keeps future validation work from
+duplicating those layers.
+
+## Principles
+
+- PR feedback should stay fast enough for normal development.
+- Accounting and runtime-execution failures are hard correctness failures.
+- Macro-financial research metrics are health signals until a threshold is
+  explicitly justified.
+- Normal-validation profiles and stress/exploratory profiles must be interpreted
+  separately.
+- Long diagnostics should reuse the existing jar/Nix nightly runner and its
+  artifacts instead of adding duplicate long simulations.
+- Generated repository outputs are committed evidence; if regeneration changes
+  them, the diff must be reviewed and committed.
+
+## Current Matrix
+
+| Layer | Trigger | Owner | Command / workflow | Primary purpose | Failure semantics |
+| --- | --- | --- | --- | --- | --- |
+| Generated outputs | PR and push | `.github/workflows/ci.yml` `generated-outputs` job | `nix develop --command bash scripts/check-generated-outputs.sh` | Prove generated docs/resources match checked-in sources | Hard fail on stale or missing generated output |
+| Nix environment | PR and push | `.github/workflows/ci.yml` `test` job | `nix flake check --print-build-logs`; dev-shell version checks | Ensure the reproducible build shell works | Hard fail on broken Nix flake or missing toolchain |
+| Formatting | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt scalafmtCheckAll` | Keep Scala formatting deterministic | Hard fail on formatting drift |
+| Non-heavy unit tests | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt coverage "root / Test / test" coverageReport` | Fast correctness for mechanisms, economics boundaries, flows, SFC, ledger projection, diagnostics helpers, and schemas | Hard fail on broken local invariant or regression |
+| Heavy unit tests | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"` | Selected expensive unit/property checks that should not run under coverage | Hard fail on broken heavy invariant |
+| Integration smoke | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt "integrationTests / Test / test"` | End-to-end smoke over the root project and integration-test project | Hard fail on integration-level regression |
+| Coverage upload | PR and push | `.github/workflows/ci.yml` `test` job | `codecov/codecov-action` | Publish non-heavy unit coverage | Non-blocking upload; CI does not fail if Codecov upload fails |
+| Nightly diagnostics | Scheduled daily on `main`; manual dispatch | `.github/workflows/nightly-diagnostics.yml` | Build `sbt assembly` under Nix, then run `NightlyDiagnosticsProfileRunner` from the jar | Long validation and diagnostics artifacts over `smoke`, `nightly`, and `extended` profiles | Hard fail on runner/build failure and hard invariants; research metrics are interpreted by profile policy |
+| Manual diagnostics | Local or workflow dispatch | Maintainer | `nix develop --command java -cp target/scala-3.8.2/amor-fati.jar com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner ...` | Reproduce or inspect profile outputs outside PR CI | Evidence only unless explicitly promoted to a CI/nightly gate |
+| Future profiling | Manual or weekly | #687 / #688 | To be added under Nix | Hot-path timing/allocation visibility for FlowSimulation, banking, firms, households, runtime ledger execution, SFC projection, and diagnostics exports | Initially warning/report-only; hard budgets require low-noise baseline evidence |
+
+## Existing Integration Ownership
+
+The current integration suite is intentionally small. Its main existing test is
+`McRunnerCsvIntegrationSpec`, which validates deterministic Monte Carlo CSV
+output, schema headers, snapshot files, and bank-capital waterfall accounting on
+a short run. It is not the owner of every macro-financial sanity condition.
+
+New PR-level normal-path engine-health checks belong in integration tests only
+when they need a short multi-month engine run and cannot be expressed as a
+focused unit or property test. #683 extends this layer with a non-CSV baseline
+invariant gate.
+
+## Nightly Profile Ownership
+
+The nightly workflow is the owner for long-running diagnostics and research
+health evidence. It runs from the assembled jar under the Nix environment, not
+from ad hoc local classpaths.
+
+| Profile | Trigger | Current intent | Typical interpretation |
+| --- | --- | --- | --- |
+| `smoke` | Manual dispatch, local reproduction | Fast profile contract and artifact sanity | Hard invariants only; research metrics are informational |
+| `nightly` | Scheduled daily on `main`, manual dispatch | Standard 60-month validation horizon | Hard invariants fail; soft calibration guardrails warn unless promoted |
+| `extended` | Manual dispatch, future weekly use | Wider seed/scenario/diagnostic surface at the current 60-month horizon | Same hard invariants; broader research envelope reporting |
+
+The profile definitions live in
+`NightlyDiagnosticsProfileRunner.Profiles` and are documented in
+[nightly-diagnostics.md](nightly-diagnostics.md). Comparison semantics live in
+[nightly-baseline-comparison.md](nightly-baseline-comparison.md).
+
+## Normal, Stress, Exploratory, And Benchmark Semantics
+
+Validation results must be interpreted by profile class:
+
+| Class | Meaning | Failure policy |
+| --- | --- | --- |
+| Normal validation | Intended baseline path for the model's current operational horizon | Hard accounting/runtime failures fail; normal-path bank failure or impossible stock states should fail once encoded |
+| Stress validation | Deliberately adverse assumptions used to test failure channels | Accounting/runtime failures fail; expected economic stress outcomes are reported with stress semantics |
+| Exploratory diagnostics | Research probes without stable thresholds | Report-only unless a hard invariant is breached |
+| Benchmark | Snapshot or balance-sheet evidence used for review/calibration | Fail malformed output or hard accounting errors; economic deltas require explicit thresholds |
+| Profiling | Runtime and allocation observability | Start as report/warn; fail only after a stable baseline and budget are defined |
+
+#684 owns the explicit classification of existing nightly steps into these
+classes. Until that lands, reviewers should not interpret every nightly
+diagnostic failure as a normal-path calibration failure.
+
+## Where New Validation Belongs
+
+Use this routing rule before adding a new check:
+
+| New check type | Put it in | Do not put it in |
+| --- | --- | --- |
+| Local mechanism invariant, algebraic identity, schema rule, parser behavior | Root unit/property tests | Nightly diagnostics |
+| Slow but focused mechanism/property test | Heavy-tagged root test | Integration tests unless it needs end-to-end state |
+| Short multi-month normal-path engine health | `integrationTests / Test / test` | CSV determinism tests |
+| Generated docs/resources consistency | Existing generated-output script | Unit tests |
+| Long Monte Carlo, scenario, robustness, diagnostic export validation | Nightly diagnostics profile | PR unit tests |
+| Stress/failure-channel experiments | Stress/exploratory nightly class | Normal-validation gate |
+| Hot-path timing or allocation visibility | Profiling workflow/telemetry artifacts | Correctness unit tests |
+| Thresholded nightly health summary | Nightly comparison/health layer | Diagnostic exporters themselves |
+
+## Promotion Policy
+
+A check can become a hard gate only when the contract is clear:
+
+- accounting exactness, ledger conservation, malformed output, missing required
+  artifacts, and impossible stock states are hard failures by default;
+- calibration and research metrics require a written threshold rationale before
+  they can fail CI;
+- stress-profile findings must not mask normal-profile health;
+- profiling budgets should start as warnings and become hard gates only for
+  low-noise metrics tied to commit/profile metadata.
+
+## Relationship To Milestone #28
+
+This matrix is the base layer for the rest of Engine Validation & Performance
+Observatory:
+
+- #683 adds the missing PR-level non-CSV normal-path integration gate.
+- #684 separates normal-validation diagnostics from stress and exploratory
+  profiles.
+- #685 adds thresholded nightly health summaries from existing artifacts.
+- #686 captures performance telemetry in nightly manifests.
+- #687 adds a manual or weekly hot-path profiling workflow under Nix.
+- #688 introduces performance baselines and regression budgets.
+- #689 creates the canonical invariants and economic-semantics index.
+- #690 maps `FlowMechanism` semantics to ledger legs, SFC identities, and tests.


### PR DESCRIPTION
Fixes #682

Summary:
- Add `docs/validation-matrix.md` as the reviewer-facing ownership map for CI, generated-output checks, unit/heavy tests, integration smoke, nightly diagnostics, manual diagnostics, and future profiling.
- Define routing rules for new validation work so PR checks, integration tests, nightly profiles, stress diagnostics, and profiling do not duplicate each other.
- Link the validation matrix from the main README model documentation table.
- Update `docs/nightly-diagnostics.md` to match the current single-cron workflow schedule.

Validation:
- `git diff --check`

Notes:
- Documentation-only change; no Scala tests were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced validation matrix documentation defining ownership boundaries for engine validation across CI triggers and test layers.
  * Clarified nightly diagnostic workflow scheduling and daylight saving time handling.
  * Updated model documentation index with new validation matrix reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->