### PR TITLE
Classify nightly diagnostics profile steps

### DIFF
--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -52,6 +52,7 @@ Every run should include a manifest with at least:
 - seed policy and seed range
 - month horizon
 - logical diagnostic steps
+- per-step semantic classification and failure policy
 - output paths
 - start and end timestamps
 - Nix, Java, sbt, and project versions where practical
@@ -161,11 +162,26 @@ Artifact retention is profile-specific:
 
 ## Profile Matrix
 
-| Profile | Intended Trigger | Horizon | Purpose |
-| --- | --- | --- | --- |
-| `smoke` | local, manual, possibly PR if runtime stays acceptable | 12 months | Fast sanity check and invariant validation |
-| `nightly` | scheduled daily on `main`, plus manual dispatch | 60 months | Daily research validation over the standard five-year horizon |
-| `extended` | weekly or manual | 60 months | Wider seed, scenario, and diagnostic coverage over the same five-year horizon |
+| Profile | Intended Trigger | Horizon | Primary Semantics | Purpose |
+| --- | --- | --- | --- | --- |
+| `smoke` | local, manual, possibly PR if runtime stays acceptable | 12 months | normal validation plus benchmark/exploratory evidence | Fast sanity check and invariant validation without stress-only assumptions |
+| `nightly` | scheduled daily on `main`, plus manual dispatch | 60 months | normal validation plus benchmark/exploratory evidence | Daily research validation over the standard five-year horizon without stress-only assumptions |
+| `extended` | weekly or manual | 60 months | exploratory and stress validation | Wider seed, scenario, and diagnostic coverage over the same five-year horizon |
+
+## Step Classification
+
+Each manifest step carries a `classification` and `failure_policy`:
+
+| Classification | Meaning | Failure Policy |
+| --- | --- | --- |
+| `normal_validation` | Intended baseline-path evidence for the model's current operational horizon | Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms |
+| `stress_validation` | Deliberately adverse assumptions used to exercise stress channels | Hard accounting/runtime failures fail; expected stress outcomes are interpreted through stress-channel semantics |
+| `exploratory` | Research probes or comparison surfaces without stable thresholds | Hard accounting/runtime failures fail; economic metrics are report-only until thresholds are explicitly promoted |
+| `benchmark` | Opening balance-sheet or snapshot evidence for review/calibration | Malformed output and hard accounting errors fail; economic deltas require explicit benchmark thresholds |
+
+Scheduled `nightly` evidence must not silently include stress-only assumptions.
+Stress-channel diagnostics such as bank-failure ablations belong to manual
+`extended` evidence until a dedicated stress workflow/profile is introduced.
 
 ## Smoke Profile
 
@@ -182,12 +198,13 @@ Recommended steps:
 - robustness smoke: `--scenario-set smoke`, 1 seed, 6 months
 - bank balance-sheet benchmark: 2 seeds
 - household credit-stress calibration: 1 seed, 12 months
-- bank failure ablations: 1 seed, 12 months
 
 Comparison mode:
 
 - hard-fail only on invariants and malformed output
 - report research metrics without tight thresholds
+- no stress-only assumptions; bank-failure ablations are excluded from this
+  normal-validation smoke profile
 
 Primary artifacts:
 
@@ -212,7 +229,6 @@ Recommended steps:
 - robustness report: `--scenario-set core`, 2 seeds, 24 months
 - bank balance-sheet benchmark: 10 seeds
 - household credit-stress calibration: 5 seeds, 60 months
-- bank failure ablations: 5 seeds, 60 months
 - HH-bank lead-lag diagnostics: 5 seeds, 60 months, lag max 6
 - loan-origination quality diagnostics: 2 seeds, 60 months, outcome window 12
 
@@ -224,6 +240,8 @@ Comparison mode:
   total credit to GDP, debt to GDP, current account to GDP, bank failures,
   credit losses, household bankruptcies, credit rejection rates, and approval
   stochasticity
+- no stress-only assumptions; expected stress-channel failures are not part of
+  scheduled normal-validation evidence
 
 Primary artifacts:
 
@@ -233,7 +251,6 @@ Primary artifacts:
 - robustness envelope and sensitivity reports
 - household credit-stress outputs
 - bank balance-sheet benchmark outputs
-- bank failure ablation outputs
 - HH-bank lead-lag outputs
 - loan-origination quality outputs
 - profile manifest and logs
@@ -253,7 +270,8 @@ Recommended steps:
 - robustness report: `--scenario-set core`, 5 seeds, 60 months
 - bank balance-sheet benchmark: 10 seeds
 - household credit-stress calibration: 10 seeds, 60 months
-- bank failure ablations: 10 seeds, 60 months
+- bank failure ablations: 10 seeds, 60 months, classified as
+  `stress_validation`
 - HH-bank lead-lag diagnostics: 10 seeds, 60 months, lag max 12
 - loan-origination quality diagnostics: 5 seeds, 60 months, outcome window 12
 
@@ -261,6 +279,8 @@ Comparison mode:
 
 - same hard invariants as `nightly`
 - wider research comparison envelope over a larger seed and scenario surface
+- stress-channel findings are interpreted by `stress_validation` semantics and
+  do not define scheduled normal-path health
 - no long-horizon cycle or regime interpretation
 
 Primary artifacts:

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -174,10 +174,10 @@ Each manifest step carries a `classification` and `failure_policy`:
 
 | Classification | Meaning | Failure Policy |
 | --- | --- | --- |
-| `normal_validation` | Intended baseline-path evidence for the model's current operational horizon | Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms |
-| `stress_validation` | Deliberately adverse assumptions used to exercise stress channels | Hard accounting/runtime failures fail; expected stress outcomes are interpreted through stress-channel semantics |
-| `exploratory` | Research probes or comparison surfaces without stable thresholds | Hard accounting/runtime failures fail; economic metrics are report-only until thresholds are explicitly promoted |
-| `benchmark` | Opening balance-sheet or snapshot evidence for review/calibration | Malformed output and hard accounting errors fail; economic deltas require explicit benchmark thresholds |
+| `normal_validation` | Intended baseline-path evidence for the model's current operational horizon | Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms. |
+| `stress_validation` | Deliberately adverse assumptions used to exercise stress channels | Hard accounting/runtime failures fail; expected stress outcomes are interpreted through stress-channel semantics. |
+| `exploratory` | Research probes or comparison surfaces without stable thresholds | Hard accounting/runtime failures fail; economic metrics are report-only until thresholds are explicitly promoted. |
+| `benchmark` | Opening balance-sheet or snapshot evidence for review/calibration | Malformed output and hard accounting errors fail; economic deltas require explicit benchmark thresholds. |
 
 Scheduled `nightly` evidence must not silently include stress-only assumptions.
 Stress-channel diagnostics such as bank-failure ablations belong to manual

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -58,9 +58,10 @@ from ad hoc local classpaths.
 | `nightly` | Scheduled daily on `main`, manual dispatch | Standard 60-month validation horizon | Hard invariants fail; soft calibration guardrails warn unless promoted |
 | `extended` | Manual dispatch, future weekly use | Wider seed/scenario/diagnostic surface at the current 60-month horizon | Same hard invariants; broader research envelope reporting |
 
-The profile definitions live in
+The profile definitions and per-step semantic classifications live in
 `NightlyDiagnosticsProfileRunner.Profiles` and are documented in
-[nightly-diagnostics.md](nightly-diagnostics.md). Comparison semantics live in
+[nightly-diagnostics.md](nightly-diagnostics.md). Every nightly manifest records
+each step's classification and failure policy. Comparison semantics live in
 [nightly-baseline-comparison.md](nightly-baseline-comparison.md).
 
 ## Normal, Stress, Exploratory, And Benchmark Semantics
@@ -75,9 +76,11 @@ Validation results must be interpreted by profile class:
 | Benchmark | Snapshot or balance-sheet evidence used for review/calibration | Fail malformed output or hard accounting errors; economic deltas require explicit thresholds |
 | Profiling | Runtime and allocation observability | Start as report/warn; fail only after a stable baseline and budget are defined |
 
-#684 owns the explicit classification of existing nightly steps into these
-classes. Until that lands, reviewers should not interpret every nightly
-diagnostic failure as a normal-path calibration failure.
+Existing nightly steps are explicitly classified into these classes in the
+runner manifest. Scheduled `nightly` evidence excludes stress-only diagnostics;
+manual `extended` evidence may include stress-validation steps, which must be
+interpreted by their stress semantics rather than as normal-path calibration
+failures.
 
 ## Where New Validation Belongs
 
@@ -113,7 +116,7 @@ Observatory:
 
 - #683 adds the missing PR-level non-CSV normal-path integration gate.
 - #684 separates normal-validation diagnostics from stress and exploratory
-  profiles.
+  profile semantics.
 - #685 adds thresholded nightly health summaries from existing artifacts.
 - #686 captures performance telemetry in nightly manifests.
 - #687 adds a manual or weekly hot-path profiling workflow under Nix.

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -77,6 +77,7 @@ object NightlyDiagnosticsProfileRunner:
   private[diagnostics] final case class ManifestStep(
       id: String,
       label: String,
+      classification: DiagnosticClass,
       entrypoint: String,
       seedStart: Option[Long],
       seeds: Option[Int],
@@ -111,6 +112,36 @@ object NightlyDiagnosticsProfileRunner:
       steps: RunContext => Vector[DiagnosticStep],
   )
 
+  /** Semantic interpretation class for a diagnostic step.
+    *
+    * The runner still fails on runtime errors, malformed artifacts, SFC
+    * violations, and impossible accounting states. This class tells reviewers
+    * whether an economic outcome such as bank failure should be read as a
+    * normal-path alarm, an expected stress-channel signal, or research
+    * evidence.
+    */
+  private[diagnostics] enum DiagnosticClass(val id: String, val failurePolicy: String):
+    case NormalValidation
+        extends DiagnosticClass(
+          "normal_validation",
+          "Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms.",
+        )
+    case StressValidation
+        extends DiagnosticClass(
+          "stress_validation",
+          "Hard accounting/runtime failures fail; expected stress outcomes are interpreted through stress-channel semantics.",
+        )
+    case Exploratory
+        extends DiagnosticClass(
+          "exploratory",
+          "Hard accounting/runtime failures fail; economic metrics are report-only until thresholds are explicitly promoted.",
+        )
+    case Benchmark
+        extends DiagnosticClass(
+          "benchmark",
+          "Malformed output and hard accounting errors fail; economic deltas require explicit benchmark thresholds.",
+        )
+
   /** Thin adapter around an existing diagnostic export. The step owns no model
     * logic; it only maps a profile contract to that export's Config and output
     * directory.
@@ -118,6 +149,7 @@ object NightlyDiagnosticsProfileRunner:
   private[diagnostics] final case class DiagnosticStep(
       id: String,
       label: String,
+      classification: DiagnosticClass,
       entrypoint: String,
       seedStart: Option[Long],
       seeds: Option[Int],
@@ -130,6 +162,7 @@ object NightlyDiagnosticsProfileRunner:
       ManifestStep(
         id = id,
         label = label,
+        classification = classification,
         entrypoint = entrypoint,
         seedStart = seedStart,
         seeds = seeds,
@@ -339,7 +372,6 @@ object NightlyDiagnosticsProfileRunner:
             robustnessReport(scenarioSet = ScenarioSet.Smoke, seeds = 1, months = 6),
             bankBalanceSheetBenchmark(seeds = 2),
             householdCreditStress(seeds = 1, months = 12),
-            bankFailureAblations(seeds = 1, months = 12),
           ),
       ),
       ProfileSpec(
@@ -354,7 +386,6 @@ object NightlyDiagnosticsProfileRunner:
             robustnessReport(scenarioSet = ScenarioSet.Core, seeds = 2, months = 24),
             bankBalanceSheetBenchmark(seeds = 10),
             householdCreditStress(seeds = 5, months = 60),
-            bankFailureAblations(seeds = 5, months = 60),
             hhBankLeadLag(seeds = 5, months = 60, lagMax = 6),
             loanOriginationQuality(seeds = 2, months = 60, outcomeWindow = 12),
           ),
@@ -381,6 +412,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "baseline-monte-carlo",
       label = "Baseline Monte Carlo",
+      classification = DiagnosticClass.NormalValidation,
       entrypoint = "com.boombustgroup.amorfati.montecarlo.McRunner",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -397,6 +429,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "sfc-matrix",
       label = "SFC Matrix Evidence",
+      classification = DiagnosticClass.NormalValidation,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.SfcMatrixExport",
       seedStart = Some(seed),
       seeds = Some(1),
@@ -413,6 +446,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "scenario-run",
       label = "Scenario Registry Run",
+      classification = scenarioClassification(selection),
       entrypoint = "com.boombustgroup.amorfati.diagnostics.ScenarioRunExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -439,6 +473,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "robustness-report",
       label = "Sensitivity Robustness Report",
+      classification = DiagnosticClass.Exploratory,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.SensitivityRobustnessExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -463,6 +498,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "empirical-validation",
       label = "Empirical Validation Snapshot",
+      classification = DiagnosticClass.NormalValidation,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.EmpiricalValidationExport",
       seedStart = Some(1L),
       seeds = Some(baselineSeeds),
@@ -494,6 +530,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "bank-balance-sheet-benchmark",
       label = "Bank Balance-Sheet Benchmark",
+      classification = DiagnosticClass.Benchmark,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -515,6 +552,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "household-credit-stress",
       label = "Household Credit-Stress Calibration",
+      classification = DiagnosticClass.Exploratory,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.HouseholdCreditStressCalibrationExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -539,6 +577,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "bank-failure-ablations",
       label = "Bank Failure Ablations",
+      classification = DiagnosticClass.StressValidation,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.BankFailureAblationExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -563,6 +602,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "hh-bank-lead-lag",
       label = "HH-Bank Lead-Lag Diagnostics",
+      classification = DiagnosticClass.Exploratory,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.HhBankLeadLagDiagnosticsExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -588,6 +628,7 @@ object NightlyDiagnosticsProfileRunner:
     DiagnosticStep(
       id = "loan-origination-quality",
       label = "Loan Origination Quality",
+      classification = DiagnosticClass.Exploratory,
       entrypoint = "com.boombustgroup.amorfati.diagnostics.LoanOriginationQualityExport",
       seedStart = Some(1L),
       seeds = Some(seeds),
@@ -613,6 +654,15 @@ object NightlyDiagnosticsProfileRunner:
 
   private def baselineMonteCarloDir(ctx: RunContext): Path =
     ctx.runRoot.resolve("baseline-monte-carlo").resolve(ctx.runId)
+
+  private def scenarioClassification(selection: String): DiagnosticClass =
+    val includesStress = resolveScenarios(selection).toOption.exists(_.exists(isStressScenario))
+    if includesStress then DiagnosticClass.StressValidation
+    else if selection.trim == "baseline" then DiagnosticClass.NormalValidation
+    else DiagnosticClass.Exploratory
+
+  private def isStressScenario(scenario: ScenarioRegistry.ScenarioSpec): Boolean =
+    scenario.deltas.exists(_.provenance.classification == ScenarioRegistry.ProvenanceClassification.HistoricalAnalogue)
 
   private def resolveScenarios(selection: String): Either[String, Vector[ScenarioRegistry.ScenarioSpec]] =
     selection match
@@ -730,19 +780,21 @@ object NightlyDiagnosticsProfileRunner:
   private def renderStep(step: ManifestStep): String =
     renderObject(
       Vector(
-        "id"          -> json(step.id),
-        "label"       -> json(step.label),
-        "entrypoint"  -> json(step.entrypoint),
-        "seed_start"  -> step.seedStart.fold("null")(_.toString),
-        "seeds"       -> step.seeds.fold("null")(_.toString),
-        "months"      -> step.months.fold("null")(_.toString),
-        "output_dir"  -> json(step.outputDir.toString),
-        "details"     -> renderObject(step.details.map((key, value) => key -> json(value))),
-        "status"      -> json(step.status),
-        "started_at"  -> step.startedAt.fold("null")(value => json(instant(value))),
-        "finished_at" -> step.finishedAt.fold("null")(value => json(instant(value))),
-        "artifacts"   -> renderArray(step.artifacts.map(path => json(path.toString))),
-        "error"       -> step.error.fold("null")(json),
+        "id"             -> json(step.id),
+        "label"          -> json(step.label),
+        "classification" -> json(step.classification.id),
+        "failure_policy" -> json(step.classification.failurePolicy),
+        "entrypoint"     -> json(step.entrypoint),
+        "seed_start"     -> step.seedStart.fold("null")(_.toString),
+        "seeds"          -> step.seeds.fold("null")(_.toString),
+        "months"         -> step.months.fold("null")(_.toString),
+        "output_dir"     -> json(step.outputDir.toString),
+        "details"        -> renderObject(step.details.map((key, value) => key -> json(value))),
+        "status"         -> json(step.status),
+        "started_at"     -> step.startedAt.fold("null")(value => json(instant(value))),
+        "finished_at"    -> step.finishedAt.fold("null")(value => json(instant(value))),
+        "artifacts"      -> renderArray(step.artifacts.map(path => json(path.toString))),
+        "error"          -> step.error.fold("null")(json),
       ),
     )
 

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -51,11 +51,11 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "robustness-report",
       "bank-balance-sheet-benchmark",
       "household-credit-stress",
-      "bank-failure-ablations",
     )
     steps.find(_.id == "baseline-monte-carlo").value.seeds shouldBe Some(1)
     steps.find(_.id == "baseline-monte-carlo").value.months shouldBe Some(12)
     steps.find(_.id == "robustness-report").value.months shouldBe Some(6)
+    steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
   }
 
   it should "encode the five-year nightly profile without 120 month diagnostics" in {
@@ -69,13 +69,13 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "robustness-report",
       "bank-balance-sheet-benchmark",
       "household-credit-stress",
-      "bank-failure-ablations",
       "hh-bank-lead-lag",
       "loan-origination-quality",
     )
     steps.flatMap(_.months).max shouldBe 60
     steps.find(_.id == "hh-bank-lead-lag").value.details should contain("lag_max" -> "6")
     steps.find(_.id == "loan-origination-quality").value.details should contain("outcome_window" -> "12")
+    steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
   }
 
   it should "encode the extended profile lag window and all-scenario selector" in {
@@ -83,9 +83,23 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     val steps = ctx.profile.steps(ctx)
 
     steps.find(_.id == "scenario-run").value.details should contain("scenario_selection" -> "all")
+    steps.find(_.id == "scenario-run").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
+    steps.find(_.id == "bank-failure-ablations").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
     steps.find(_.id == "hh-bank-lead-lag").value.details should contain("lag_max" -> "12")
     steps.find(_.id == "loan-origination-quality").value.seeds shouldBe Some(5)
     steps.flatMap(_.months).max shouldBe 60
+  }
+
+  it should "classify baseline evidence, benchmarks, and research diagnostics explicitly" in {
+    val ctx   = context("nightly")
+    val steps = ctx.profile.steps(ctx)
+
+    steps.find(_.id == "baseline-monte-carlo").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.NormalValidation
+    steps.find(_.id == "empirical-validation").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.NormalValidation
+    steps.find(_.id == "bank-balance-sheet-benchmark").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.Benchmark
+    steps.find(_.id == "household-credit-stress").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.Exploratory
+    steps.find(_.id == "hh-bank-lead-lag").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.Exploratory
+    steps.find(_.id == "loan-origination-quality").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.Exploratory
   }
 
   "NightlyDiagnosticsProfileRunner.renderManifest" should "emit machine-readable run metadata" in {
@@ -111,6 +125,10 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     rendered should include(""""jar":{"path":"target/scala-3.8.2/amor-fati.jar"""")
     rendered should include(""""steps":[""")
     rendered should include(""""id":"baseline-monte-carlo"""")
+    rendered should include(""""classification":"normal_validation"""")
+    rendered should include(
+      """"failure_policy":"Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms."""",
+    )
   }
 
   it should "derive manual UTC run ids from profile and short commit" in {


### PR DESCRIPTION
## Summary
- add per-step diagnostics classifications and failure policies to the nightly profile manifest
- keep smoke/nightly free of stress-only bank-failure ablation diagnostics
- mark stress/all-scenario and bank-failure ablation coverage with stress semantics in extended/manual evidence
- update docs and tests for normal, stress, exploratory, and benchmark interpretation

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunnerSpec"
- sbt Test/compile
- bash scripts/check-generated-outputs.sh

Fixes #684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagnostic profile documentation with explicit semantic classifications and failure policy specifications for all profiles.

* **Improvements**
  * Diagnostic manifests now include per-step semantic classifications (normal, stress, exploratory, benchmark) and associated failure policies.
  * Enhanced clarity on smoke, nightly, and extended profile semantics and behavior.

* **Tests**
  * Extended test coverage for diagnostic step classification validation and manifest rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->