### PR TITLE
Add nightly diagnostics health summary

### DIFF
--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -155,6 +155,7 @@ jobs:
           ARTIFACT_NAME: ${{ steps.meta.outputs.artifact_name }}
           RETENTION_DAYS: ${{ steps.meta.outputs.retention_days }}
           MANIFEST_PATH: ${{ steps.meta.outputs.run_root }}/run-manifest.json
+          HEALTH_PATH: ${{ steps.meta.outputs.run_root }}/health-summary.json
           BUILD_LOG_PATH: target/nightly-diagnostics/build.log
           LOG_PATH: target/nightly-diagnostics/diagnostics.log
         run: |
@@ -175,12 +176,15 @@ jobs:
           artifact_name = os.environ.get("ARTIFACT_NAME") or "not-created"
           retention_days = os.environ.get("RETENTION_DAYS") or "not-configured"
           manifest_path = Path(os.environ.get("MANIFEST_PATH", ""))
+          health_path = Path(os.environ.get("HEALTH_PATH", ""))
           build_log_path = Path(os.environ.get("BUILD_LOG_PATH", ""))
           log_path = Path(os.environ.get("LOG_PATH", ""))
 
           status = "MISSING_MANIFEST"
           reason = ""
           failed_step = ""
+          health_status = "MISSING_HEALTH_SUMMARY"
+          failed_health_metrics = []
           if build_exit_code not in ("0", "not-run"):
               status = "BUILD_FAILED"
               if build_log_path.is_file():
@@ -203,6 +207,18 @@ jobs:
               lines = log_path.read_text(errors="replace").splitlines()
               reason = "\n".join(lines[-20:])
 
+          if health_path.is_file():
+              try:
+                  health = json.loads(health_path.read_text())
+                  health_status = health.get("status", "UNKNOWN")
+                  failed_health_metrics = [
+                      metric.get("id", "")
+                      for metric in health.get("metrics", [])
+                      if metric.get("status") == "FAIL" and metric.get("hard") is True
+                  ]
+              except Exception as exc:
+                  health_status = f"MALFORMED_HEALTH_SUMMARY:{type(exc).__name__}"
+
           summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
           with summary.open("a", encoding="utf-8") as out:
               out.write("\n")
@@ -216,10 +232,13 @@ jobs:
               out.write(f"- Diagnostics exit code: `{diagnostics_exit_code}`\n")
               out.write(f"- Diagnostics runtime seconds: `{diagnostics_duration}`\n")
               out.write(f"- Manifest: `{manifest_path}`\n")
+              out.write(f"- Health summary: `{health_status}` (`{health_path}`)\n")
               out.write(f"- Artifact: `{artifact_name}`\n")
               out.write(f"- Artifact retention days: `{retention_days}`\n")
               if failed_step:
                   out.write(f"- Failed step: `{failed_step}`\n")
+              if failed_health_metrics:
+                  out.write(f"- Failed health metrics: `{', '.join(failed_health_metrics[:8])}`\n")
               if reason:
                   out.write("\n#### Failure Reason\n\n")
                   out.write("```text\n")

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -57,6 +57,12 @@ Every run should include a manifest with at least:
 - start and end timestamps
 - Nix, Java, sbt, and project versions where practical
 
+Every non-dry-run profile should also include compact health summaries:
+
+- `health-summary.json`: machine-readable profile verdict, thresholded metrics,
+  and hard-failure counts
+- `health-summary.md`: reviewer-facing table with the same verdict and metrics
+
 ## Jar / Nix Execution
 
 Build the assembled jar from the project Nix environment:
@@ -103,12 +109,33 @@ The runner writes:
 
 ```text
 target/nightly-diagnostics/<profile>/<run-id>/run-manifest.json
+target/nightly-diagnostics/<profile>/<run-id>/health-summary.json
+target/nightly-diagnostics/<profile>/<run-id>/health-summary.md
 ```
 
 The manifest records the profile, resolved git ref, dirty-tree status, jar path
 and SHA-256 when available, command line, tool versions, step seed/month
 settings, step output directories, artifact paths, timestamps, and final
 status.
+
+The health summary reuses artifacts emitted by the configured diagnostics. It
+does not launch additional simulations. The first threshold layer reads the
+baseline Monte Carlo seed CSVs and manifest step statuses to produce a stable
+normal-path verdict over:
+
+- diagnostic completion by step classification
+- baseline artifact completeness (`seeds × months` monthly rows)
+- normal-path bank failures and bank-resolution invariant counters
+- positive GDP proxy direction, with terminal decline reported as a warning
+- total credit to GDP blow-up bounds
+- default/NPL ratio bounds
+- bank-capital and flow-of-funds residual guards relative to annualized GDP
+- household negative-deposit diagnostic counts as warnings
+
+Hard threshold breaches in normal-validation evidence fail the runner after the
+summary files have been written. Exploratory and stress steps remain visible in
+completion metrics, but their economic outcomes are not reclassified as
+scheduled normal-path failures.
 
 ## Scheduled Workflow
 
@@ -147,12 +174,13 @@ required during CET months. A single cron is intentional because it avoids
 duplicate scheduled workflow runs in the Actions UI.
 
 The job summary reports the profile, commit SHA, run id, runtime, manifest path,
-terminal status, build/runtime exit codes, and failure reason when either the
-build or diagnostics runner produces one. The workflow also uploads a GitHub
-Actions artifact named `amor-fati-diagnostics-<run-id>` containing the profile
-run directory, `build.log`, and `diagnostics.log` when those files exist. Failed
-runs still upload partial logs and manifests when the build has progressed far
-enough to create them.
+health-summary status, terminal status, build/runtime exit codes, and failure
+reason when either the build or diagnostics runner produces one. The workflow
+also uploads a GitHub Actions artifact named
+`amor-fati-diagnostics-<run-id>` containing the profile run directory,
+`build.log`, and `diagnostics.log` when those files exist. Failed runs still
+upload partial logs, manifests, and health summaries when the build has
+progressed far enough to create them.
 
 Artifact retention is profile-specific:
 
@@ -254,6 +282,7 @@ Primary artifacts:
 - HH-bank lead-lag outputs
 - loan-origination quality outputs
 - profile manifest and logs
+- health-summary JSON and Markdown verdicts
 
 ## Extended Profile
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -276,15 +276,26 @@ object NightlyDiagnosticsProfileRunner:
               finished  <- Clock.instant
               completed <- completedRef.get
               failed    <- failedRef.get
-              manifest  <- writeManifest(ctx, mergeSteps(steps, completed, failed, ctx), "FAILED", Some(finished), Some(err))
+              terminal   = mergeSteps(steps, completed, failed, ctx)
+              _         <- NightlyHealthSummary.write(ctx, terminal)
+              manifest  <- writeManifest(ctx, terminal, "FAILED", Some(finished), Some(err))
               _         <- ZIO.fail(err)
             yield RunResult(manifest, ctx.runRoot, "FAILED"),
           _ =>
             for
-              finished  <- Clock.instant
               completed <- completedRef.get
-              manifest  <- writeManifest(ctx, mergeSteps(steps, completed, None, ctx), "SUCCEEDED", Some(finished), None)
-            yield RunResult(manifest, ctx.runRoot, "SUCCEEDED"),
+              terminal   = mergeSteps(steps, completed, None, ctx)
+              health    <- NightlyHealthSummary.write(ctx, terminal)
+              finished  <- Clock.instant
+              result    <- health.status match
+                case NightlyHealthSummary.HealthStatus.Failed =>
+                  val err = health.hardFailureMessage
+                  writeManifest(ctx, terminal, "FAILED", Some(finished), Some(err)) *>
+                    ZIO.fail(err)
+                case _                                        =>
+                  writeManifest(ctx, terminal, "SUCCEEDED", Some(finished), None)
+              status     = if health.status == NightlyHealthSummary.HealthStatus.Failed then "FAILED" else "SUCCEEDED"
+            yield RunResult(result, ctx.runRoot, status),
         )
     yield stepResult
 

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyHealthSummary.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyHealthSummary.scala
@@ -1,0 +1,517 @@
+package com.boombustgroup.amorfati.diagnostics
+
+import com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner.{DiagnosticClass, ManifestStep, RunContext}
+import zio.{Clock, ZIO}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.time.format.DateTimeFormatter
+import java.time.Instant
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+/** Builds a compact nightly health verdict from artifacts already emitted by
+  * the diagnostics profile.
+  *
+  * This layer is intentionally post-processing only: it reads the manifest
+  * steps and baseline Monte Carlo seed CSVs, applies documented threshold
+  * semantics, and writes machine/human summaries without launching more
+  * simulations.
+  */
+private[diagnostics] object NightlyHealthSummary:
+
+  private val HealthJsonName = "health-summary.json"
+  private val HealthMdName   = "health-summary.md"
+
+  private val BaselineStepId              = "baseline-monte-carlo"
+  private val NormalCreditToGdpLowerBound = BigDecimal(0)
+  private val NormalCreditToGdpUpperBound = BigDecimal(10)
+  private val ResidualToGdpUpperBound     = BigDecimal("0.001")
+  private val RatioLowerBound             = BigDecimal(0)
+  private val RatioUpperBound             = BigDecimal(1)
+
+  private val RequiredBaselineColumns: Vector[String] = Vector(
+    "Month",
+    "MonthlyGdpProxy",
+    "AnnualizedGdpProxy",
+    "TotalCreditToGdp",
+    "BankFailures",
+    "BankResolution_NewFailures",
+    "BankResolution_AllFailedFallback",
+    "BankResolution_InvalidActiveBankInvariant",
+    "BankCapital_WaterfallResidual",
+    "BankCapital_ReconciliationResidual",
+    "FofResidual",
+    "BankCreditLoss_FirmDefaultRate",
+    "BankCreditLoss_MortgageDefaultRate",
+    "BankCreditLoss_ConsumerLoanDefaultRate",
+    "BankCreditLoss_CorpBondDefaultRate",
+    "ConsumerCredit_NplRatioGross",
+    "HouseholdLiquidity_NegativeDepositCount",
+    "HouseholdLiquidity_NegativeDepositShare",
+  )
+
+  private val LossRateColumns: Vector[String] = Vector(
+    "BankCreditLoss_FirmDefaultRate",
+    "BankCreditLoss_MortgageDefaultRate",
+    "BankCreditLoss_ConsumerLoanDefaultRate",
+    "BankCreditLoss_CorpBondDefaultRate",
+    "ConsumerCredit_NplRatioGross",
+  )
+
+  private[diagnostics] enum HealthStatus(val id: String):
+    case Passed  extends HealthStatus("PASSED")
+    case Warning extends HealthStatus("WARNING")
+    case Failed  extends HealthStatus("FAILED")
+
+  private[diagnostics] enum MetricStatus(val id: String):
+    case Pass extends MetricStatus("PASS")
+    case Warn extends MetricStatus("WARN")
+    case Fail extends MetricStatus("FAIL")
+    case Info extends MetricStatus("INFO")
+
+  private[diagnostics] final case class Metric(
+      id: String,
+      label: String,
+      classification: String,
+      status: MetricStatus,
+      hard: Boolean,
+      observed: String,
+      threshold: String,
+      source: String,
+      details: String,
+  )
+
+  private[diagnostics] final case class Summary(
+      profile: String,
+      runId: String,
+      generatedAt: Instant,
+      status: HealthStatus,
+      hardFailureCount: Int,
+      warningCount: Int,
+      metrics: Vector[Metric],
+  )
+
+  private[diagnostics] final case class Result(summary: Summary, jsonPath: Path, markdownPath: Path):
+    def status: HealthStatus       = summary.status
+    def hardFailureCount: Int      = summary.hardFailureCount
+    def hardFailureMessage: String =
+      val failedIds = summary.metrics.filter(metric => metric.hard && metric.status == MetricStatus.Fail).map(_.id)
+      val rendered  = failedIds.take(6).mkString(", ")
+      val suffix    = if failedIds.length > 6 then s", +${failedIds.length - 6} more" else ""
+      s"Nightly health summary failed ${summary.hardFailureCount} hard metric(s): $rendered$suffix"
+
+  def write(ctx: RunContext, steps: Vector[ManifestStep]): ZIO[Any, String, Result] =
+    for
+      generated <- Clock.instant
+      summary   <- ZIO.attemptBlocking(build(ctx, steps, generated)).mapError(err => s"Failed to build nightly health summary: ${message(err)}")
+      jsonPath  <- DiagnosticIo.writeText(ctx.runRoot.resolve(HealthJsonName), renderJson(summary))
+      mdPath    <- DiagnosticIo.writeText(ctx.runRoot.resolve(HealthMdName), renderMarkdown(summary))
+    yield Result(summary, jsonPath, mdPath)
+
+  private[diagnostics] def build(ctx: RunContext, steps: Vector[ManifestStep], generatedAt: Instant): Summary =
+    val metrics          = completionMetrics(steps) ++ baselineMetrics(steps)
+    val hardFailureCount = metrics.count(metric => metric.hard && metric.status == MetricStatus.Fail)
+    val warningCount     = metrics.count(_.status == MetricStatus.Warn)
+    val status           =
+      if hardFailureCount > 0 then HealthStatus.Failed
+      else if warningCount > 0 then HealthStatus.Warning
+      else HealthStatus.Passed
+
+    Summary(
+      profile = ctx.profile.id,
+      runId = ctx.runId,
+      generatedAt = generatedAt,
+      status = status,
+      hardFailureCount = hardFailureCount,
+      warningCount = warningCount,
+      metrics = metrics,
+    )
+
+  private def completionMetrics(steps: Vector[ManifestStep]): Vector[Metric] =
+    DiagnosticClass.values.toVector.flatMap: classification =>
+      val classSteps = steps.filter(_.classification == classification)
+      Option.when(classSteps.nonEmpty):
+        val failed = classSteps.filter(step => step.status != "SUCCEEDED")
+        val status = if failed.nonEmpty then MetricStatus.Fail else MetricStatus.Pass
+        Metric(
+          id = s"diagnostic_completion.${classification.id}",
+          label = s"${classification.id} step completion",
+          classification = classification.id,
+          status = status,
+          hard = true,
+          observed =
+            if failed.isEmpty then s"${classSteps.length}/${classSteps.length} succeeded"
+            else failed.map(step => s"${step.id}:${step.status}").mkString("; "),
+          threshold = "All configured steps must complete successfully.",
+          source = "run-manifest.json",
+          details = classification.failurePolicy,
+        )
+
+  private def baselineMetrics(steps: Vector[ManifestStep]): Vector[Metric] =
+    steps.find(_.id == BaselineStepId) match
+      case None       =>
+        Vector(
+          metric(
+            id = "normal.baseline_artifacts",
+            label = "Baseline Monte Carlo artifacts",
+            status = MetricStatus.Fail,
+            hard = true,
+            observed = "baseline-monte-carlo step missing",
+            threshold = "Baseline normal-validation evidence must be present.",
+            source = "run-manifest.json",
+            details = "The health summary cannot evaluate normal-path economic thresholds without baseline seed CSVs.",
+          ),
+        )
+      case Some(step) =>
+        loadBaseline(step) match
+          case Left(err)     =>
+            Vector(
+              metric(
+                id = "normal.baseline_artifacts",
+                label = "Baseline Monte Carlo artifacts",
+                status = MetricStatus.Fail,
+                hard = true,
+                observed = err,
+                threshold = "Baseline seed CSVs must be present, well-formed, and contain required health columns.",
+                source = step.outputDir.toString,
+                details = "This is an artifact/readiness failure, not an economic finding.",
+              ),
+            )
+          case Right(series) =>
+            baselineArtifactMetric(series, step) +:
+              Vector(
+                bankFailureMetric(series),
+                gdpMetric(series),
+                creditToGdpMetric(series),
+                lossRatesMetric(series),
+                residualMetric(series),
+                negativeStockMetric(series),
+              )
+
+  private def baselineArtifactMetric(series: BaselineSeries, step: ManifestStep): Metric =
+    val expectedRows = for
+      seeds  <- step.seeds
+      months <- step.months
+    yield seeds * months
+    val rowCountOk   = expectedRows.forall(_ == series.rowCount)
+    metric(
+      id = "normal.baseline_artifacts",
+      label = "Baseline Monte Carlo artifacts",
+      status = if rowCountOk then MetricStatus.Pass else MetricStatus.Fail,
+      hard = true,
+      observed = s"${series.files.length} seed CSV(s), ${series.rowCount} monthly row(s)",
+      threshold = expectedRows.fold("At least one non-empty baseline seed CSV with all required health columns.")(rows =>
+        s"Exactly $rows monthly row(s), derived from baseline seeds=${step.seeds.getOrElse("?")} and months=${step.months.getOrElse("?")}.",
+      ),
+      source = series.files.map(_.getFileName.toString).mkString(", "),
+      details = "Seed CSVs are reused from the baseline Monte Carlo step.",
+    )
+
+  private def bankFailureMetric(series: BaselineSeries): Metric =
+    val maxFailures       = series.max("BankFailures")
+    val cumulativeNew     = series.sum("BankResolution_NewFailures")
+    val allFailedFallback = series.sum("BankResolution_AllFailedFallback")
+    val invalidInvariant  = series.sum("BankResolution_InvalidActiveBankInvariant")
+    val failed            = maxFailures > 0 || cumulativeNew > 0 || allFailedFallback > 0 || invalidInvariant > 0
+    metric(
+      id = "normal.bank_failures",
+      label = "Normal-path bank failures",
+      status = if failed then MetricStatus.Fail else MetricStatus.Pass,
+      hard = true,
+      observed =
+        s"max_bank_failures=$maxFailures; cumulative_new_failures=$cumulativeNew; all_failed_fallback=$allFailedFallback; invalid_active_bank_invariant=$invalidInvariant",
+      threshold = "All bank-failure and bank-resolution failure counters must remain 0 on normal baseline paths.",
+      source = "baseline Monte Carlo seed CSVs",
+      details = "Stress-channel bank failures are not evaluated here; this metric only reads the normal baseline Monte Carlo step.",
+    )
+
+  private def gdpMetric(series: BaselineSeries): Metric =
+    val nonPositiveRows = series.countWhere("MonthlyGdpProxy")(_ <= 0)
+    val terminalDrop    = series
+      .seedSeries("MonthlyGdpProxy")
+      .count: values =>
+        values.nonEmpty && values.last < values.head
+    val status          =
+      if nonPositiveRows > 0 then MetricStatus.Fail
+      else if terminalDrop > 0 then MetricStatus.Warn
+      else MetricStatus.Pass
+    metric(
+      id = "normal.gdp_direction",
+      label = "GDP proxy direction",
+      status = status,
+      hard = nonPositiveRows > 0,
+      observed = s"min_monthly_gdp=${series.min("MonthlyGdpProxy")}; terminal_below_opening_seed_count=$terminalDrop/${series.files.length}",
+      threshold = "MonthlyGdpProxy must stay positive; terminal-below-opening seeds are warnings until calibrated as hard trend thresholds.",
+      source = "baseline Monte Carlo seed CSVs",
+      details = "The five-year profile validates operational sanity, not long-horizon cycle claims.",
+    )
+
+  private def creditToGdpMetric(series: BaselineSeries): Metric =
+    val minValue = series.min("TotalCreditToGdp")
+    val maxValue = series.max("TotalCreditToGdp")
+    val failed   = minValue < NormalCreditToGdpLowerBound || maxValue > NormalCreditToGdpUpperBound
+    metric(
+      id = "normal.total_credit_to_gdp",
+      label = "Total credit to GDP bound",
+      status = if failed then MetricStatus.Fail else MetricStatus.Pass,
+      hard = true,
+      observed = s"min=$minValue; max=$maxValue",
+      threshold = s"$NormalCreditToGdpLowerBound <= TotalCreditToGdp <= $NormalCreditToGdpUpperBound",
+      source = "baseline Monte Carlo seed CSVs",
+      details = "This is a blow-up guard shared with the baseline invariant integration gate, not a calibration target.",
+    )
+
+  private def lossRatesMetric(series: BaselineSeries): Metric =
+    val extrema = LossRateColumns.map(column => column -> (series.min(column), series.max(column)))
+    val failed  = extrema.exists((_, bounds) => bounds._1 < RatioLowerBound || bounds._2 > RatioUpperBound)
+    metric(
+      id = "normal.default_loss_rates",
+      label = "Default and loss-rate bounds",
+      status = if failed then MetricStatus.Fail else MetricStatus.Pass,
+      hard = true,
+      observed = extrema.map((column, bounds) => s"$column=[${bounds._1},${bounds._2}]").mkString("; "),
+      threshold = s"All monitored default/NPL ratios must satisfy $RatioLowerBound <= value <= $RatioUpperBound.",
+      source = "baseline Monte Carlo seed CSVs",
+      details = "Positive defaults are allowed; impossible negative or above-100% rates are not.",
+    )
+
+  private def residualMetric(series: BaselineSeries): Metric =
+    val waterfallMax = series.maxAbs("BankCapital_WaterfallResidual")
+    val reconMax     = series.maxAbs("BankCapital_ReconciliationResidual")
+    val fofMax       = series.maxAbs("FofResidual")
+    val waterfallGdp = series.maxAbsRatio("BankCapital_WaterfallResidual", "AnnualizedGdpProxy")
+    val reconGdp     = series.maxAbsRatio("BankCapital_ReconciliationResidual", "AnnualizedGdpProxy")
+    val fofGdp       = series.maxAbsRatio("FofResidual", "AnnualizedGdpProxy")
+    val failed       = waterfallGdp > ResidualToGdpUpperBound || reconGdp > ResidualToGdpUpperBound || fofGdp > ResidualToGdpUpperBound
+    metric(
+      id = "normal.accounting_residuals",
+      label = "SFC/accounting residual guard",
+      status = if failed then MetricStatus.Fail else MetricStatus.Pass,
+      hard = true,
+      observed =
+        s"bank_capital_waterfall_abs_max=$waterfallMax; bank_capital_waterfall_to_gdp_max=$waterfallGdp; bank_reconciliation_abs_max=$reconMax; bank_reconciliation_to_gdp_max=$reconGdp; fof_abs_max=$fofMax; fof_to_gdp_max=$fofGdp",
+      threshold = s"Runtime SFC exactness must complete; exported residuals must remain <= $ResidualToGdpUpperBound of annualized GDP.",
+      source = "baseline Monte Carlo seed CSVs and runtime SFC completion",
+      details = "Runtime SFC exactness failures stop the baseline step; exported residual columns catch material accounting drift at macro scale.",
+    )
+
+  private def negativeStockMetric(series: BaselineSeries): Metric =
+    val maxCount = series.max("HouseholdLiquidity_NegativeDepositCount")
+    val maxShare = series.max("HouseholdLiquidity_NegativeDepositShare")
+    metric(
+      id = "normal.negative_stock_counts",
+      label = "Negative stock diagnostics",
+      status = if maxCount > 0 then MetricStatus.Warn else MetricStatus.Pass,
+      hard = false,
+      observed = s"household_negative_deposit_count_max=$maxCount; household_negative_deposit_share_max=$maxShare",
+      threshold = "Reported as warning when household negative deposit diagnostics are non-zero.",
+      source = "baseline Monte Carlo seed CSVs",
+      details =
+        "Bank/firm hard non-negative stock invariants are enforced by runtime and integration tests; household negative deposits remain a diagnostic signal.",
+    )
+
+  private def metric(
+      id: String,
+      label: String,
+      status: MetricStatus,
+      hard: Boolean,
+      observed: String,
+      threshold: String,
+      source: String,
+      details: String,
+      classification: DiagnosticClass = DiagnosticClass.NormalValidation,
+  ): Metric =
+    Metric(
+      id = id,
+      label = label,
+      classification = classification.id,
+      status = status,
+      hard = hard,
+      observed = observed,
+      threshold = threshold,
+      source = source,
+      details = details,
+    )
+
+  private final case class BaselineSeries(files: Vector[Path], rows: Vector[BaselineRow]):
+    val rowCount: Int = rows.length
+
+    def values(column: String): Vector[BigDecimal] =
+      rows.map(_.decimal(column))
+
+    def seedSeries(column: String): Vector[Vector[BigDecimal]] =
+      rows
+        .groupBy(_.file)
+        .toVector
+        .sortBy((file, _) => file.toString)
+        .map((_, fileRows) => fileRows.sortBy(_.rowNumber).map(_.decimal(column)))
+
+    def min(column: String): BigDecimal =
+      values(column).min
+
+    def max(column: String): BigDecimal =
+      values(column).max
+
+    def maxAbs(column: String): BigDecimal =
+      values(column).map(_.abs).max
+
+    def maxAbsRatio(numerator: String, denominator: String): BigDecimal =
+      rows
+        .map: row =>
+          val den = row.decimal(denominator).abs
+          if den > 0 then row.decimal(numerator).abs / den else BigDecimal(0)
+        .max
+
+    def sum(column: String): BigDecimal =
+      values(column).foldLeft(BigDecimal(0))(_ + _)
+
+    def countWhere(column: String)(predicate: BigDecimal => Boolean): Int =
+      values(column).count(predicate)
+
+  private final case class BaselineRow(file: Path, rowNumber: Int, values: Map[String, BigDecimal]):
+    def decimal(column: String): BigDecimal =
+      values.getOrElse(column, throw IllegalStateException(s"Missing parsed column '$column' in ${file.getFileName}:$rowNumber"))
+
+  private def loadBaseline(step: ManifestStep): Either[String, BaselineSeries] =
+    for
+      files <- seedCsvFiles(step.outputDir)
+      rows  <- readSeedRows(files)
+    yield BaselineSeries(files, rows)
+
+  private def seedCsvFiles(outputDir: Path): Either[String, Vector[Path]] =
+    if !Files.isDirectory(outputDir) then Left(s"baseline output directory is missing: $outputDir")
+    else
+      Using.resource(Files.list(outputDir)): stream =>
+        val files = stream
+          .iterator()
+          .asScala
+          .filter(path => Files.isRegularFile(path))
+          .filter(path => path.getFileName.toString.endsWith(".csv"))
+          .filter(path => path.getFileName.toString.contains("_seed"))
+          .toVector
+          .sortBy(_.toString)
+        Either.cond(files.nonEmpty, files, s"baseline seed CSV files are missing under $outputDir")
+
+  private def readSeedRows(files: Vector[Path]): Either[String, Vector[BaselineRow]] =
+    val parsed = files.foldLeft[Either[String, Vector[BaselineRow]]](Right(Vector.empty)): (acc, file) =>
+      acc.flatMap(rows => readSeedRows(file).map(rows ++ _))
+    parsed.flatMap: rows =>
+      Either.cond(rows.nonEmpty, rows, s"baseline seed CSV files contain no monthly rows: ${files.mkString(", ")}")
+
+  private def readSeedRows(file: Path): Either[String, Vector[BaselineRow]] =
+    val lines = Files.readAllLines(file, StandardCharsets.UTF_8).asScala.toVector.filter(_.trim.nonEmpty)
+    if lines.isEmpty then Left(s"empty seed CSV: $file")
+    else
+      val header  = lines.head.split(";", -1).toVector
+      val missing = RequiredBaselineColumns.filterNot(header.contains)
+      if missing.nonEmpty then Left(s"${file.getFileName} is missing required health columns: ${missing.mkString(", ")}")
+      else
+        val index = header.zipWithIndex.toMap
+        lines.tail.zipWithIndex.foldLeft[Either[String, Vector[BaselineRow]]](Right(Vector.empty)): (acc, rowWithIndex) =>
+          acc.flatMap: rows =>
+            val (line, zeroBasedIndex) = rowWithIndex
+            val rowNumber              = zeroBasedIndex + 2
+            val parts                  = line.split(";", -1)
+            if parts.length < header.length then Left(s"${file.getFileName}:$rowNumber has ${parts.length} cells, expected ${header.length}")
+            else parseRequiredValues(file, rowNumber, parts, index).map(parsed => rows :+ BaselineRow(file, rowNumber, parsed))
+
+  private def parseRequiredValues(file: Path, rowNumber: Int, parts: Array[String], index: Map[String, Int]): Either[String, Map[String, BigDecimal]] =
+    RequiredBaselineColumns.foldLeft[Either[String, Map[String, BigDecimal]]](Right(Map.empty)): (acc, column) =>
+      acc.flatMap: parsed =>
+        parseDecimal(parts(index(column)))
+          .map(value => parsed.updated(column, value))
+          .left
+          .map: err =>
+            s"${file.getFileName}:$rowNumber column $column is not numeric: $err"
+
+  private def parseDecimal(value: String): Either[String, BigDecimal] =
+    val clean = value.trim.replace(',', '.')
+    if clean.isEmpty then Left("empty value")
+    else
+      try Right(BigDecimal(clean))
+      catch case err: NumberFormatException => Left(err.getMessage)
+
+  private[diagnostics] def renderJson(summary: Summary): String =
+    val fields = Vector(
+      "profile"            -> json(summary.profile),
+      "run_id"             -> json(summary.runId),
+      "generated_at"       -> json(instant(summary.generatedAt)),
+      "status"             -> json(summary.status.id),
+      "hard_failure_count" -> summary.hardFailureCount.toString,
+      "warning_count"      -> summary.warningCount.toString,
+      "metrics"            -> renderArray(summary.metrics.map(renderMetricJson)),
+    )
+    renderObject(fields) + "\n"
+
+  private def renderMetricJson(metric: Metric): String =
+    renderObject(
+      Vector(
+        "id"             -> json(metric.id),
+        "label"          -> json(metric.label),
+        "classification" -> json(metric.classification),
+        "status"         -> json(metric.status.id),
+        "hard"           -> metric.hard.toString,
+        "observed"       -> json(metric.observed),
+        "threshold"      -> json(metric.threshold),
+        "source"         -> json(metric.source),
+        "details"        -> json(metric.details),
+      ),
+    )
+
+  private[diagnostics] def renderMarkdown(summary: Summary): String =
+    val rows = summary.metrics.map: metric =>
+      Vector(
+        metric.id,
+        metric.classification,
+        metric.status.id,
+        if metric.hard then "yes" else "no",
+        metric.observed,
+        metric.threshold,
+      ).map(markdownCell).mkString("| ", " | ", " |")
+
+    (Vector(
+      "# Nightly Health Summary",
+      "",
+      s"- Profile: `${summary.profile}`",
+      s"- Run id: `${summary.runId}`",
+      s"- Generated at: `${instant(summary.generatedAt)}`",
+      s"- Status: `${summary.status.id}`",
+      s"- Hard failures: `${summary.hardFailureCount}`",
+      s"- Warnings: `${summary.warningCount}`",
+      "",
+      "| Metric | Classification | Status | Hard | Observed | Threshold |",
+      "| --- | --- | --- | --- | --- | --- |",
+    ) ++ rows).mkString("\n") + "\n"
+
+  private def markdownCell(value: String): String =
+    value.replace("|", "\\|").replace("\n", " ").trim
+
+  private def renderObject(fields: Vector[(String, String)]): String =
+    fields.map((key, value) => s"${json(key)}:$value").mkString("{", ",", "}")
+
+  private def renderArray(values: Vector[String]): String =
+    values.mkString("[", ",", "]")
+
+  private def json(value: String): String =
+    value
+      .flatMap:
+        case '"'                => "\\\""
+        case '\\'               => "\\\\"
+        case '\b'               => "\\b"
+        case '\f'               => "\\f"
+        case '\n'               => "\\n"
+        case '\r'               => "\\r"
+        case '\t'               => "\\t"
+        case ch if ch.isControl => "\\u%04x".format(ch.toInt)
+        case ch                 => ch.toString
+      .prepended('"')
+      .appended('"')
+
+  private def instant(value: Instant): String =
+    DateTimeFormatter.ISO_INSTANT.format(value)
+
+  private def message(err: Throwable): String =
+    Option(err.getMessage).filter(_.trim.nonEmpty).getOrElse(err.getClass.getSimpleName)
+
+end NightlyHealthSummary

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.OptionValues.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import java.time.Instant
 
 class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
@@ -136,14 +136,58 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "nightly-manual-20260526-1234-abcdef0"
   }
 
-  private def context(profileId: String): NightlyDiagnosticsProfileRunner.RunContext =
+  "NightlyHealthSummary" should "pass when baseline CSVs satisfy normal-path thresholds" in {
+    val ctx = context("smoke", tempOut("health-pass"), runId = "health-pass")
+    writeBaselineSeedCsv(ctx, seed = 1, rows = healthyRows(months = 12))
+
+    val result = DiagnosticIo.unsafeRun(NightlyHealthSummary.write(ctx, succeededSteps(ctx))).value
+
+    result.status shouldBe NightlyHealthSummary.HealthStatus.Passed
+    result.hardFailureCount shouldBe 0
+    Files.readString(result.jsonPath) should include(""""id":"normal.bank_failures"""")
+    Files.readString(result.markdownPath) should include("Nightly Health Summary")
+  }
+
+  it should "fail on normal-path bank failures from baseline CSVs" in {
+    val ctx = context("smoke", tempOut("health-bank-fail"), runId = "health-bank-fail")
+    writeBaselineSeedCsv(ctx, seed = 1, rows = healthyRows(months = 12).updated(5, healthyRow(month = 6, bankFailures = 1, newFailures = 1)))
+
+    val result = DiagnosticIo.unsafeRun(NightlyHealthSummary.write(ctx, succeededSteps(ctx))).value
+
+    result.status shouldBe NightlyHealthSummary.HealthStatus.Failed
+    result.hardFailureCount should be > 0
+    Files.readString(result.jsonPath) should include(""""id":"normal.bank_failures"""")
+    Files.readString(result.jsonPath) should include(""""status":"FAIL"""")
+  }
+
+  it should "warn without hard-failing on household negative-deposit diagnostics" in {
+    val ctx = context("smoke", tempOut("health-warning"), runId = "health-warning")
+    writeBaselineSeedCsv(
+      ctx,
+      seed = 1,
+      rows = healthyRows(months = 12).updated(2, healthyRow(month = 3, negativeDepositCount = 2, negativeDepositShare = "0.004")),
+    )
+
+    val result = DiagnosticIo.unsafeRun(NightlyHealthSummary.write(ctx, succeededSteps(ctx))).value
+
+    result.status shouldBe NightlyHealthSummary.HealthStatus.Warning
+    result.hardFailureCount shouldBe 0
+    Files.readString(result.jsonPath) should include(""""id":"normal.negative_stock_counts"""")
+    Files.readString(result.jsonPath) should include(""""status":"WARN"""")
+  }
+
+  private def context(
+      profileId: String,
+      out: Path = Path.of("target/nightly-diagnostics"),
+      runId: String = "run-1",
+  ): NightlyDiagnosticsProfileRunner.RunContext =
     val profile = NightlyDiagnosticsProfileRunner.profileById(profileId).value
-    val config  = NightlyDiagnosticsProfileRunner.Config(profile = profileId, out = Path.of("target/nightly-diagnostics"), runId = Some("run-1"))
+    val config  = NightlyDiagnosticsProfileRunner.Config(profile = profileId, out = out, runId = Some(runId))
     NightlyDiagnosticsProfileRunner.RunContext(
       config = config,
       profile = profile,
-      runId = "run-1",
-      runRoot = config.out.resolve(profileId).resolve("run-1"),
+      runId = runId,
+      runRoot = config.out.resolve(profileId).resolve(runId),
       metadata = NightlyDiagnosticsProfileRunner.RuntimeMetadata(
         commit = "abcdef0123456789",
         shortCommit = "abcdef0",
@@ -161,3 +205,81 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       ),
       startedAt = Instant.parse("2026-05-26T00:00:00Z"),
     )
+
+  private def succeededSteps(ctx: NightlyDiagnosticsProfileRunner.RunContext): Vector[NightlyDiagnosticsProfileRunner.ManifestStep] =
+    ctx.profile
+      .steps(ctx)
+      .map: step =>
+        step.completed(
+          ctx,
+          startedAt = Instant.parse("2026-05-26T00:00:01Z"),
+          finishedAt = Instant.parse("2026-05-26T00:00:02Z"),
+          artifacts = Vector(step.outputDir(ctx)),
+        )
+
+  private def tempOut(name: String): Path =
+    val path = Path.of("target", "nightly-health-summary-spec", s"$name-${System.nanoTime()}")
+    Files.createDirectories(path)
+    path
+
+  private def writeBaselineSeedCsv(ctx: NightlyDiagnosticsProfileRunner.RunContext, seed: Int, rows: Vector[String]): Path =
+    val baselineStep = ctx.profile.steps(ctx).find(_.id == "baseline-monte-carlo").value
+    val months       = baselineStep.months.value
+    val dir          = baselineStep.outputDir(ctx)
+    Files.createDirectories(dir)
+    val path         = dir.resolve(f"baseline_${ctx.runId}_${months}m_seed$seed%03d.csv")
+    Files.writeString(path, (HealthCsvHeader +: rows).mkString("\n") + "\n")
+    path
+
+  private def healthyRows(months: Int): Vector[String] =
+    (1 to months).toVector.map(month => healthyRow(month))
+
+  private def healthyRow(
+      month: Int,
+      bankFailures: Int = 0,
+      newFailures: Int = 0,
+      negativeDepositCount: Int = 0,
+      negativeDepositShare: String = "0",
+  ): String =
+    Vector(
+      month.toString,
+      (100 + month).toString,
+      ((100 + month) * 12).toString,
+      "0.55",
+      bankFailures.toString,
+      newFailures.toString,
+      "0",
+      "0",
+      "0",
+      "0",
+      "0",
+      "0.01",
+      "0.02",
+      "0.03",
+      "0.04",
+      "0.05",
+      negativeDepositCount.toString,
+      negativeDepositShare,
+    ).mkString(";")
+
+  private val HealthCsvHeader: String =
+    Vector(
+      "Month",
+      "MonthlyGdpProxy",
+      "AnnualizedGdpProxy",
+      "TotalCreditToGdp",
+      "BankFailures",
+      "BankResolution_NewFailures",
+      "BankResolution_AllFailedFallback",
+      "BankResolution_InvalidActiveBankInvariant",
+      "BankCapital_WaterfallResidual",
+      "BankCapital_ReconciliationResidual",
+      "FofResidual",
+      "BankCreditLoss_FirmDefaultRate",
+      "BankCreditLoss_MortgageDefaultRate",
+      "BankCreditLoss_ConsumerLoanDefaultRate",
+      "BankCreditLoss_CorpBondDefaultRate",
+      "ConsumerCredit_NplRatioGross",
+      "HouseholdLiquidity_NegativeDepositCount",
+      "HouseholdLiquidity_NegativeDepositShare",
+    ).mkString(";")


### PR DESCRIPTION
## Summary
- add `NightlyHealthSummary` to write `health-summary.json` and `health-summary.md` from existing manifest + baseline Monte Carlo seed CSV artifacts
- fail the runner on normal-path hard threshold breaches: diagnostic completion, baseline row completeness, bank failures, credit/GDP bounds, default/loss ratio bounds, and accounting residual-to-GDP guard
- keep GDP direction and household negative-deposit diagnostics as report/warning signals, and expose the health verdict in the GitHub Actions summary/docs

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunnerSpec"`
- `sbt Test/compile`
- `bash scripts/check-generated-outputs.sh`
- `sbt "runMain com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner --profile smoke --out target/nightly-health-summary-smoke --run-id health-smoke-local-2 --jar-path target/scala-3.8.2/amor-fati.jar --allow-dirty"` -> health summary `PASSED`

Closes #685