### PR TITLE
Capture nightly diagnostics performance telemetry

### DIFF
--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -53,9 +53,12 @@ Every run should include a manifest with at least:
 - month horizon
 - logical diagnostic steps
 - per-step semantic classification and failure policy
+- per-step runtime telemetry: duration, normalized seed-month throughput where
+  applicable, artifact sizes, CSV row counts, and memory/GC observations
 - output paths
 - start and end timestamps
 - Nix, Java, sbt, and project versions where practical
+- JVM and OS runtime metadata where practical
 
 Every non-dry-run profile should also include compact health summaries:
 
@@ -115,8 +118,16 @@ target/nightly-diagnostics/<profile>/<run-id>/health-summary.md
 
 The manifest records the profile, resolved git ref, dirty-tree status, jar path
 and SHA-256 when available, command line, tool versions, step seed/month
-settings, step output directories, artifact paths, timestamps, and final
-status.
+settings, step output directories, artifact paths, timestamps, lightweight
+performance telemetry, JVM/OS runtime metadata, and final status.
+
+Per-step telemetry is intentionally orchestration-level evidence, not a
+correctness test. It records elapsed step time, `seeds × months` throughput when
+both dimensions are meaningful, emitted artifact file counts and bytes, CSV row
+counts where available, and before/after memory plus GC deltas when the JVM
+exposes them. Missing or partial telemetry is represented in the manifest rather
+than launching duplicate simulations or adding assertions inside diagnostic
+exporters.
 
 The health summary reuses artifacts emitted by the configured diagnostics. It
 does not launch additional simulations. The first threshold layer reads the

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -32,6 +32,7 @@ duplicating those layers.
 | Coverage upload | PR and push | `.github/workflows/ci.yml` `test` job | `codecov/codecov-action` | Publish non-heavy unit coverage | Non-blocking upload; CI does not fail if Codecov upload fails |
 | Nightly diagnostics | Scheduled daily on `main`; manual dispatch | `.github/workflows/nightly-diagnostics.yml` | Build `sbt assembly` under Nix, then run `NightlyDiagnosticsProfileRunner` from the jar | Long validation and diagnostics artifacts over `smoke`, `nightly`, and `extended` profiles | Hard fail on runner/build failure and hard invariants; economic outcomes are interpreted by profile classification |
 | Nightly health summary | After a non-dry-run diagnostics profile completes | `NightlyHealthSummary` via `NightlyDiagnosticsProfileRunner` | Reuse `run-manifest.json` and baseline Monte Carlo seed CSVs to write `health-summary.json` and `health-summary.md` | Compact machine/human verdict answering whether `main` stayed normal-path healthy overnight | Hard fail on normal-validation threshold breaches; warn/report for soft research signals; do not turn stress/exploratory outcomes into normal-path failures |
+| Nightly performance telemetry | Every diagnostics profile step | `NightlyDiagnosticsProfileRunner` manifest telemetry | Per-step duration, seed-month throughput, artifact size/row counts, and JVM memory/GC observations in `run-manifest.json` | Lightweight regression visibility before heavier profilers exist | Report-only initially; hard performance budgets belong to later baseline/regression work |
 | Manual diagnostics | Local or workflow dispatch | Maintainer | `nix develop --command java -cp target/scala-3.8.2/amor-fati.jar com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner ...` | Reproduce or inspect profile outputs outside PR CI | Evidence only unless explicitly promoted to a CI/nightly gate |
 | Future profiling | Manual or weekly | #687 / #688 | To be added under Nix | Hot-path timing/allocation visibility for FlowSimulation, banking, firms, households, runtime ledger execution, SFC projection, and diagnostics exports | Initially warning/report-only; hard budgets require low-noise baseline evidence |
 
@@ -50,9 +51,9 @@ invariant gate.
 ## Nightly Profile Ownership
 
 The nightly workflow is the owner for long-running diagnostics, research health
-evidence, and the compact health verdict derived from those artifacts. It runs
-from the assembled jar under the Nix environment, not from ad hoc local
-classpaths.
+evidence, lightweight performance telemetry, and the compact health verdict
+derived from those artifacts. It runs from the assembled jar under the Nix
+environment, not from ad hoc local classpaths.
 
 | Profile | Trigger | Current intent | Typical interpretation |
 | --- | --- | --- | --- |

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -2,9 +2,10 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.config.RobustnessScenarios.ScenarioSet
 import com.boombustgroup.amorfati.config.{ScenarioRegistry, SimParams}
+import com.boombustgroup.amorfati.engine.EngineFailure
 import com.boombustgroup.amorfati.montecarlo.{McRunConfig, McRunner}
 import com.boombustgroup.amorfati.util.BuildInfo
-import zio.{Clock, Ref, ZIO}
+import zio.{Cause, Clock, Exit, Ref, ZIO}
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
@@ -363,33 +364,37 @@ object NightlyDiagnosticsProfileRunner:
           for
             started   <- Clock.instant
             before    <- ZIO.succeed(StepRuntimeCounters.capture())
-            outcome   <- step.run(ctx).either
+            outcome   <- step.run(ctx).exit
             finished  <- Clock.instant
             after     <- ZIO.succeed(StepRuntimeCounters.capture())
-            paths      = outcome.toOption.getOrElse(Vector.empty)
+            paths      = outcome match
+              case Exit.Success(paths) => paths
+              case Exit.Failure(_)     => Vector.empty
             telemetry <- collectStepTelemetry(ctx, step, started, finished, before, after, paths)
             _         <- outcome match
-              case Right(paths) =>
+              case Exit.Success(paths) =>
                 val done = step.completed(ctx, started, finished, paths, Some(telemetry))
                 for
                   _       <- completedRef.update(_ :+ done)
                   current <- completedRef.get
                   _       <- writeManifest(ctx, mergeSteps(steps, current, None, ctx), "RUNNING", None, None)
                 yield ()
-              case Left(err)    =>
+              case Exit.Failure(cause) =>
+                val err = renderCause(step.id, cause)
                 failedRef.set(Some(step.failed(ctx, started, finished, err, Some(telemetry)))) *>
-                  ZIO.fail(err)
+                  ZIO.failCause(cause)
           yield ()
-        .foldZIO(
-          err =>
+        .foldCauseZIO(
+          cause =>
             for
               finished  <- Clock.instant
               completed <- completedRef.get
               failed    <- failedRef.get
+              err        = renderCause("Nightly diagnostics profile", cause)
               terminal   = mergeSteps(steps, completed, failed, ctx)
               _         <- NightlyHealthSummary.write(ctx, terminal)
               manifest  <- writeManifest(ctx, terminal, "FAILED", Some(finished), Some(err))
-              _         <- ZIO.fail(err)
+              _         <- ZIO.failCause(cause)
             yield RunResult(manifest, ctx.runRoot, "FAILED"),
           _ =>
             for
@@ -1140,6 +1145,13 @@ object NightlyDiagnosticsProfileRunner:
 
   private def knownFlag(flag: String): Boolean =
     flag == "--profile" || flag == "--out" || flag == "--run-id" || flag == "--jar-path" || flag == "--jar"
+
+  private[diagnostics] def renderCause(context: String, cause: Cause[String]): String =
+    cause.failureOption.getOrElse:
+      EngineFailure
+        .firstIn(cause.defects)
+        .map(failure => s"$context crashed: ${failure.diagnosticMessage}")
+        .getOrElse(s"$context crashed: ${cause.prettyPrint}")
 
   private def message(err: Throwable): String =
     Option(err.getMessage).filter(_.trim.nonEmpty).getOrElse(err.getClass.getSimpleName)

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -12,7 +12,7 @@ import java.nio.file.{Files, Path}
 import java.security.MessageDigest
 import java.lang.management.ManagementFactory
 import java.time.format.DateTimeFormatter
-import java.time.{Duration, Instant, ZoneOffset}
+import java.time.{Instant, ZoneOffset}
 import java.util.Locale
 import scala.jdk.CollectionConverters.*
 import scala.util.{Try, Using}
@@ -362,16 +362,22 @@ object NightlyDiagnosticsProfileRunner:
       stepResult   <- ZIO
         .foreachDiscard(steps): step =>
           for
-            started   <- Clock.instant
-            before    <- ZIO.succeed(StepRuntimeCounters.capture())
-            outcome   <- step.run(ctx).exit
-            finished  <- Clock.instant
-            after     <- ZIO.succeed(StepRuntimeCounters.capture())
-            paths      = outcome match
+            started     <- Clock.instant
+            startNano   <- ZIO.succeed(System.nanoTime())
+            before      <- ZIO.succeed(StepRuntimeCounters.capture())
+            outcome     <- step.run(ctx).exit
+            endNano     <- ZIO.succeed(System.nanoTime())
+            finished    <- Clock.instant
+            after       <- ZIO.succeed(StepRuntimeCounters.capture())
+            elapsedNanos = math.max(0L, endNano - startNano)
+            paths        = outcome match
               case Exit.Success(paths) => paths
               case Exit.Failure(_)     => Vector.empty
-            telemetry <- collectStepTelemetry(ctx, step, started, finished, before, after, paths)
-            _         <- outcome match
+            stepError    = outcome match
+              case Exit.Success(_)     => None
+              case Exit.Failure(cause) => Some(renderCause(step.id, cause))
+            telemetry   <- collectStepTelemetry(ctx, step, elapsedNanos, before, after, paths, stepError)
+            _           <- outcome match
               case Exit.Success(paths) =>
                 val done = step.completed(ctx, started, finished, paths, Some(telemetry))
                 for
@@ -380,7 +386,7 @@ object NightlyDiagnosticsProfileRunner:
                   _       <- writeManifest(ctx, mergeSteps(steps, current, None, ctx), "RUNNING", None, None)
                 yield ()
               case Exit.Failure(cause) =>
-                val err = renderCause(step.id, cause)
+                val err = stepError.getOrElse(renderCause(step.id, cause))
                 failedRef.set(Some(step.failed(ctx, started, finished, err, Some(telemetry)))) *>
                   ZIO.failCause(cause)
           yield ()
@@ -423,36 +429,32 @@ object NightlyDiagnosticsProfileRunner:
   private def collectStepTelemetry(
       ctx: RunContext,
       step: DiagnosticStep,
-      startedAt: Instant,
-      finishedAt: Instant,
+      elapsedNanos: Long,
       before: StepRuntimeCounters,
       after: StepRuntimeCounters,
       artifacts: Vector[Path],
+      stepError: Option[String],
   ): ZIO[Any, Nothing, StepTelemetry] =
     ZIO
-      .attemptBlocking(collectStepTelemetryBlocking(ctx, step, startedAt, finishedAt, before, after, artifacts))
+      .attemptBlocking(collectStepTelemetryBlocking(ctx, step, elapsedNanos, before, after, artifacts, stepError))
       .catchAll: err =>
-        ZIO.succeed(fallbackStepTelemetry(step, startedAt, finishedAt, before, after, Some(message(err))))
+        ZIO.succeed(fallbackStepTelemetry(step, elapsedNanos, before, after, combineCollectionErrors(stepError, Some(message(err)))))
 
   private def collectStepTelemetryBlocking(
       ctx: RunContext,
       step: DiagnosticStep,
-      startedAt: Instant,
-      finishedAt: Instant,
+      elapsedNanos: Long,
       before: StepRuntimeCounters,
       after: StepRuntimeCounters,
       artifacts: Vector[Path],
+      stepError: Option[String],
   ): StepTelemetry =
-    val durationMillis       = math.max(0L, Duration.between(startedAt, finishedAt).toMillis)
+    val durationMillis       = durationMillisFromNanos(elapsedNanos)
     val seedMonths           = for
       seeds  <- step.seeds
       months <- step.months
     yield seeds.toLong * months.toLong
-    val seedMonthsPerSecond  =
-      seedMonths
-        .filter(_ > 0)
-        .flatMap: value =>
-          Option.when(durationMillis > 0)(round6(BigDecimal(value) * BigDecimal(1000) / BigDecimal(durationMillis)))
+    val seedMonthsPerSecond  = throughputPerSecond(seedMonths, elapsedNanos)
     val artifactPaths        = (artifacts :+ step.outputDir(ctx)).distinct
     val artifactTelemetry    = collectArtifactTelemetry(artifactPaths)
     val (artifactStats, err) = artifactTelemetry match
@@ -467,18 +469,17 @@ object NightlyDiagnosticsProfileRunner:
       memoryBefore = before.memory,
       memoryAfter = after.memory,
       gc = gcDelta(before.gc, after.gc),
-      collectionError = err,
+      collectionError = combineCollectionErrors(stepError, err),
     )
 
   private def fallbackStepTelemetry(
       step: DiagnosticStep,
-      startedAt: Instant,
-      finishedAt: Instant,
+      elapsedNanos: Long,
       before: StepRuntimeCounters,
       after: StepRuntimeCounters,
       collectionError: Option[String],
   ): StepTelemetry =
-    val durationMillis = math.max(0L, Duration.between(startedAt, finishedAt).toMillis)
+    val durationMillis = durationMillisFromNanos(elapsedNanos)
     val seedMonths     = for
       seeds  <- step.seeds
       months <- step.months
@@ -486,7 +487,7 @@ object NightlyDiagnosticsProfileRunner:
     StepTelemetry(
       durationMillis = durationMillis,
       seedMonths = seedMonths,
-      seedMonthsPerSecond = seedMonths.filter(_ > 0).flatMap(value => Option.when(durationMillis > 0)(round6(BigDecimal(value) * 1000 / durationMillis))),
+      seedMonthsPerSecond = throughputPerSecond(seedMonths, elapsedNanos),
       artifacts = ArtifactTelemetry(fileCount = 0L, bytes = 0L, csvFileCount = 0L, csvRowCount = 0L),
       memoryBefore = before.memory,
       memoryAfter = after.memory,
@@ -1143,6 +1144,20 @@ object NightlyDiagnosticsProfileRunner:
   private def round6(value: BigDecimal): BigDecimal =
     value.setScale(6, BigDecimal.RoundingMode.HALF_UP)
 
+  private def durationMillisFromNanos(elapsedNanos: Long): Long =
+    math.max(0L, elapsedNanos) / NanosPerMillisecond
+
+  private def throughputPerSecond(seedMonths: Option[Long], elapsedNanos: Long): Option[BigDecimal] =
+    val safeElapsedNanos = math.max(0L, elapsedNanos)
+    seedMonths
+      .filter(_ > 0)
+      .flatMap: value =>
+        Option.when(safeElapsedNanos > 0L)(round6(BigDecimal(value) * NanosPerSecond / BigDecimal(safeElapsedNanos)))
+
+  private def combineCollectionErrors(first: Option[String], second: Option[String]): Option[String] =
+    val messages = Vector(first, second).flatten.map(_.trim).filter(_.nonEmpty)
+    Option.when(messages.nonEmpty)(messages.mkString("; "))
+
   private def knownFlag(flag: String): Boolean =
     flag == "--profile" || flag == "--out" || flag == "--run-id" || flag == "--jar-path" || flag == "--jar"
 
@@ -1155,6 +1170,9 @@ object NightlyDiagnosticsProfileRunner:
 
   private def message(err: Throwable): String =
     Option(err.getMessage).filter(_.trim.nonEmpty).getOrElse(err.getClass.getSimpleName)
+
+  private val NanosPerSecond: BigDecimal = BigDecimal(1000000000L)
+  private val NanosPerMillisecond: Long  = 1000000L
 
   private val usage: String =
     """Usage: NightlyDiagnosticsProfileRunner [--profile smoke|nightly|extended] [--out DIR] [--run-id ID] [--jar-path PATH] [--dry-run] [--allow-dirty] [--require-main]

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -9,11 +9,12 @@ import zio.{Clock, Ref, ZIO}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.security.MessageDigest
+import java.lang.management.ManagementFactory
 import java.time.format.DateTimeFormatter
-import java.time.{Instant, ZoneOffset}
+import java.time.{Duration, Instant, ZoneOffset}
 import java.util.Locale
 import scala.jdk.CollectionConverters.*
-import scala.util.Try
+import scala.util.{Try, Using}
 
 /** Jar-runnable profile orchestrator for the nightly diagnostics milestone.
   *
@@ -59,7 +60,106 @@ object NightlyDiagnosticsProfileRunner:
       nixVersion: Option[String],
       sbtVersion: Option[String],
       buildCommit: String,
+      runtime: RuntimeTelemetry,
   )
+
+  /** JVM/runtime facts captured once per diagnostics invocation. */
+  private[diagnostics] final case class RuntimeTelemetry(
+      availableProcessors: Int,
+      maxMemoryBytes: Long,
+      totalMemoryBytes: Long,
+      freeMemoryBytes: Long,
+      usedMemoryBytes: Long,
+      jvmName: String,
+      jvmVendor: String,
+      jvmVersion: String,
+      osName: String,
+      osArch: String,
+      osVersion: String,
+  )
+
+  /** Heap/non-heap sample around a single diagnostic step. */
+  private[diagnostics] final case class MemoryTelemetry(
+      heapUsedBytes: Long,
+      heapCommittedBytes: Long,
+      heapMaxBytes: Long,
+      nonHeapUsedBytes: Long,
+      nonHeapCommittedBytes: Long,
+      nonHeapMaxBytes: Long,
+  )
+
+  /** Best-effort GC delta observed around a single diagnostic step. */
+  private[diagnostics] final case class GcTelemetry(name: String, collectionCountDelta: Option[Long], collectionTimeMillisDelta: Option[Long])
+
+  /** File-system facts collected from a step's emitted artifacts. */
+  private[diagnostics] final case class ArtifactTelemetry(
+      fileCount: Long,
+      bytes: Long,
+      csvFileCount: Long,
+      csvRowCount: Long,
+  )
+
+  /** Lightweight per-step performance telemetry for the nightly manifest. */
+  private[diagnostics] final case class StepTelemetry(
+      durationMillis: Long,
+      seedMonths: Option[Long],
+      seedMonthsPerSecond: Option[BigDecimal],
+      artifacts: ArtifactTelemetry,
+      memoryBefore: MemoryTelemetry,
+      memoryAfter: MemoryTelemetry,
+      gc: Vector[GcTelemetry],
+      collectionError: Option[String],
+  )
+
+  private[diagnostics] object RuntimeTelemetry:
+    def capture(): RuntimeTelemetry =
+      val runtime = Runtime.getRuntime
+      val vm      = ManagementFactory.getRuntimeMXBean
+      val os      = ManagementFactory.getOperatingSystemMXBean
+      RuntimeTelemetry(
+        availableProcessors = runtime.availableProcessors(),
+        maxMemoryBytes = runtime.maxMemory(),
+        totalMemoryBytes = runtime.totalMemory(),
+        freeMemoryBytes = runtime.freeMemory(),
+        usedMemoryBytes = runtime.totalMemory() - runtime.freeMemory(),
+        jvmName = vm.getVmName,
+        jvmVendor = vm.getVmVendor,
+        jvmVersion = vm.getVmVersion,
+        osName = os.getName,
+        osArch = os.getArch,
+        osVersion = os.getVersion,
+      )
+
+  private[diagnostics] object MemoryTelemetry:
+    def capture(): MemoryTelemetry =
+      val memory  = ManagementFactory.getMemoryMXBean
+      val heap    = memory.getHeapMemoryUsage
+      val nonHeap = memory.getNonHeapMemoryUsage
+      MemoryTelemetry(
+        heapUsedBytes = heap.getUsed,
+        heapCommittedBytes = heap.getCommitted,
+        heapMaxBytes = heap.getMax,
+        nonHeapUsedBytes = nonHeap.getUsed,
+        nonHeapCommittedBytes = nonHeap.getCommitted,
+        nonHeapMaxBytes = nonHeap.getMax,
+      )
+
+  private final case class GcCounter(collectionCount: Option[Long], collectionTimeMillis: Option[Long])
+
+  private final case class StepRuntimeCounters(memory: MemoryTelemetry, gc: Map[String, GcCounter])
+
+  private object StepRuntimeCounters:
+    def capture(): StepRuntimeCounters =
+      StepRuntimeCounters(
+        memory = MemoryTelemetry.capture(),
+        gc = ManagementFactory.getGarbageCollectorMXBeans.asScala
+          .map: bean =>
+            bean.getName -> GcCounter(nonNegative(bean.getCollectionCount), nonNegative(bean.getCollectionTime))
+          .toMap,
+      )
+
+    private def nonNegative(value: Long): Option[Long] =
+      Option.when(value >= 0L)(value)
 
   private[diagnostics] final case class RunContext(
       config: Config,
@@ -88,6 +188,7 @@ object NightlyDiagnosticsProfileRunner:
       startedAt: Option[Instant],
       finishedAt: Option[Instant],
       artifacts: Vector[Path],
+      telemetry: Option[StepTelemetry],
       error: Option[String],
   )
 
@@ -173,14 +274,15 @@ object NightlyDiagnosticsProfileRunner:
         startedAt = None,
         finishedAt = None,
         artifacts = Vector.empty,
+        telemetry = None,
         error = None,
       )
 
-    def completed(ctx: RunContext, startedAt: Instant, finishedAt: Instant, artifacts: Vector[Path]): ManifestStep =
-      planned(ctx).copy(status = "SUCCEEDED", startedAt = Some(startedAt), finishedAt = Some(finishedAt), artifacts = artifacts)
+    def completed(ctx: RunContext, startedAt: Instant, finishedAt: Instant, artifacts: Vector[Path], telemetry: Option[StepTelemetry] = None): ManifestStep =
+      planned(ctx).copy(status = "SUCCEEDED", startedAt = Some(startedAt), finishedAt = Some(finishedAt), artifacts = artifacts, telemetry = telemetry)
 
-    def failed(ctx: RunContext, startedAt: Instant, finishedAt: Instant, error: String): ManifestStep =
-      planned(ctx).copy(status = "FAILED", startedAt = Some(startedAt), finishedAt = Some(finishedAt), error = Some(error))
+    def failed(ctx: RunContext, startedAt: Instant, finishedAt: Instant, error: String, telemetry: Option[StepTelemetry] = None): ManifestStep =
+      planned(ctx).copy(status = "FAILED", startedAt = Some(startedAt), finishedAt = Some(finishedAt), error = Some(error), telemetry = telemetry)
 
   def main(args: Array[String]): Unit =
     parseArgs(args.toVector) match
@@ -259,16 +361,24 @@ object NightlyDiagnosticsProfileRunner:
       stepResult   <- ZIO
         .foreachDiscard(steps): step =>
           for
-            started  <- Clock.instant
-            paths    <- step
-              .run(ctx)
-              .tapError: err =>
-                Clock.instant.flatMap(finished => failedRef.set(Some(step.failed(ctx, started, finished, err))))
-            finished <- Clock.instant
-            done      = step.completed(ctx, started, finished, paths)
-            _        <- completedRef.update(_ :+ done)
-            current  <- completedRef.get
-            _        <- writeManifest(ctx, mergeSteps(steps, current, None, ctx), "RUNNING", None, None)
+            started   <- Clock.instant
+            before    <- ZIO.succeed(StepRuntimeCounters.capture())
+            outcome   <- step.run(ctx).either
+            finished  <- Clock.instant
+            after     <- ZIO.succeed(StepRuntimeCounters.capture())
+            paths      = outcome.toOption.getOrElse(Vector.empty)
+            telemetry <- collectStepTelemetry(ctx, step, started, finished, before, after, paths)
+            _         <- outcome match
+              case Right(paths) =>
+                val done = step.completed(ctx, started, finished, paths, Some(telemetry))
+                for
+                  _       <- completedRef.update(_ :+ done)
+                  current <- completedRef.get
+                  _       <- writeManifest(ctx, mergeSteps(steps, current, None, ctx), "RUNNING", None, None)
+                yield ()
+              case Left(err)    =>
+                failedRef.set(Some(step.failed(ctx, started, finished, err, Some(telemetry)))) *>
+                  ZIO.fail(err)
           yield ()
         .foldZIO(
           err =>
@@ -304,6 +414,122 @@ object NightlyDiagnosticsProfileRunner:
       finished <- Clock.instant
       manifest <- writeManifest(ctx, steps.map(_.planned(ctx)), "DRY_RUN", Some(finished), None)
     yield RunResult(manifest, ctx.runRoot, "DRY_RUN")
+
+  private def collectStepTelemetry(
+      ctx: RunContext,
+      step: DiagnosticStep,
+      startedAt: Instant,
+      finishedAt: Instant,
+      before: StepRuntimeCounters,
+      after: StepRuntimeCounters,
+      artifacts: Vector[Path],
+  ): ZIO[Any, Nothing, StepTelemetry] =
+    ZIO
+      .attemptBlocking(collectStepTelemetryBlocking(ctx, step, startedAt, finishedAt, before, after, artifacts))
+      .orElseSucceed:
+        fallbackStepTelemetry(step, startedAt, finishedAt, before, after, Some("telemetry collection crashed"))
+
+  private def collectStepTelemetryBlocking(
+      ctx: RunContext,
+      step: DiagnosticStep,
+      startedAt: Instant,
+      finishedAt: Instant,
+      before: StepRuntimeCounters,
+      after: StepRuntimeCounters,
+      artifacts: Vector[Path],
+  ): StepTelemetry =
+    val durationMillis       = math.max(0L, Duration.between(startedAt, finishedAt).toMillis)
+    val seedMonths           = for
+      seeds  <- step.seeds
+      months <- step.months
+    yield seeds.toLong * months.toLong
+    val seedMonthsPerSecond  =
+      seedMonths
+        .filter(_ > 0)
+        .flatMap: value =>
+          Option.when(durationMillis > 0)(round6(BigDecimal(value) * BigDecimal(1000) / BigDecimal(durationMillis)))
+    val artifactPaths        = (artifacts :+ step.outputDir(ctx)).distinct
+    val artifactTelemetry    = collectArtifactTelemetry(artifactPaths)
+    val (artifactStats, err) = artifactTelemetry match
+      case Right(stats)  => stats                                                                              -> None
+      case Left(message) => ArtifactTelemetry(fileCount = 0L, bytes = 0L, csvFileCount = 0L, csvRowCount = 0L) -> Some(message)
+
+    StepTelemetry(
+      durationMillis = durationMillis,
+      seedMonths = seedMonths,
+      seedMonthsPerSecond = seedMonthsPerSecond,
+      artifacts = artifactStats,
+      memoryBefore = before.memory,
+      memoryAfter = after.memory,
+      gc = gcDelta(before.gc, after.gc),
+      collectionError = err,
+    )
+
+  private def fallbackStepTelemetry(
+      step: DiagnosticStep,
+      startedAt: Instant,
+      finishedAt: Instant,
+      before: StepRuntimeCounters,
+      after: StepRuntimeCounters,
+      collectionError: Option[String],
+  ): StepTelemetry =
+    val durationMillis = math.max(0L, Duration.between(startedAt, finishedAt).toMillis)
+    val seedMonths     = for
+      seeds  <- step.seeds
+      months <- step.months
+    yield seeds.toLong * months.toLong
+    StepTelemetry(
+      durationMillis = durationMillis,
+      seedMonths = seedMonths,
+      seedMonthsPerSecond = seedMonths.filter(_ > 0).flatMap(value => Option.when(durationMillis > 0)(round6(BigDecimal(value) * 1000 / durationMillis))),
+      artifacts = ArtifactTelemetry(fileCount = 0L, bytes = 0L, csvFileCount = 0L, csvRowCount = 0L),
+      memoryBefore = before.memory,
+      memoryAfter = after.memory,
+      gc = gcDelta(before.gc, after.gc),
+      collectionError = collectionError,
+    )
+
+  private def collectArtifactTelemetry(paths: Vector[Path]): Either[String, ArtifactTelemetry] =
+    Try:
+      val files    = paths
+        .flatMap(filesForArtifact)
+        .distinctBy(path => path.toAbsolutePath.normalize.toString)
+      val csvFiles = files.filter(path => path.getFileName.toString.toLowerCase(Locale.ROOT).endsWith(".csv"))
+      ArtifactTelemetry(
+        fileCount = files.length.toLong,
+        bytes = files.foldLeft(0L)((acc, path) => acc + Files.size(path)),
+        csvFileCount = csvFiles.length.toLong,
+        csvRowCount = csvFiles.foldLeft(0L)((acc, path) => acc + csvDataRows(path)),
+      )
+    .toEither.left.map(err => s"artifact telemetry unavailable: ${message(err)}")
+
+  private def filesForArtifact(path: Path): Vector[Path] =
+    if Files.isRegularFile(path) then Vector(path)
+    else if Files.isDirectory(path) then
+      Using.resource(Files.walk(path)): stream =>
+        stream.iterator().asScala.filter(candidate => Files.isRegularFile(candidate)).toVector
+    else Vector.empty
+
+  private def csvDataRows(path: Path): Long =
+    val lineCount = Using.resource(Files.lines(path, StandardCharsets.UTF_8))(_.count())
+    math.max(0L, lineCount - 1L)
+
+  private def gcDelta(before: Map[String, GcCounter], after: Map[String, GcCounter]): Vector[GcTelemetry] =
+    after.toVector
+      .sortBy((name, _) => name)
+      .map: (name, afterCounter) =>
+        val beforeCounter = before.getOrElse(name, GcCounter(None, None))
+        GcTelemetry(
+          name = name,
+          collectionCountDelta = delta(beforeCounter.collectionCount, afterCounter.collectionCount),
+          collectionTimeMillisDelta = delta(beforeCounter.collectionTimeMillis, afterCounter.collectionTimeMillis),
+        )
+
+  private def delta(before: Option[Long], after: Option[Long]): Option[Long] =
+    for
+      start <- before
+      end   <- after
+    yield math.max(0L, end - start)
 
   private def writeManifest(
       ctx: RunContext,
@@ -709,6 +935,7 @@ object NightlyDiagnosticsProfileRunner:
           nixVersion = command(Vector("nix", "--version")),
           sbtVersion = command(Vector("sbt", "--script-version")),
           buildCommit = BuildInfo.gitCommit,
+          runtime = RuntimeTelemetry.capture(),
         )
       .mapError(err => s"Failed to capture runtime metadata: ${message(err)}")
 
@@ -783,6 +1010,7 @@ object NightlyDiagnosticsProfileRunner:
           "sbt"   -> metadata.sbtVersion.fold("null")(json),
         ),
       ),
+      "runtime"       -> renderRuntimeTelemetry(metadata.runtime),
       "steps"         -> renderArray(manifest.steps.map(renderStep)),
       "error"         -> manifest.error.fold("null")(json),
     )
@@ -805,7 +1033,75 @@ object NightlyDiagnosticsProfileRunner:
         "started_at"     -> step.startedAt.fold("null")(value => json(instant(value))),
         "finished_at"    -> step.finishedAt.fold("null")(value => json(instant(value))),
         "artifacts"      -> renderArray(step.artifacts.map(path => json(path.toString))),
+        "telemetry"      -> step.telemetry.fold("null")(renderStepTelemetry),
         "error"          -> step.error.fold("null")(json),
+      ),
+    )
+
+  private def renderRuntimeTelemetry(runtime: RuntimeTelemetry): String =
+    renderObject(
+      Vector(
+        "available_processors" -> runtime.availableProcessors.toString,
+        "max_memory_bytes"     -> runtime.maxMemoryBytes.toString,
+        "total_memory_bytes"   -> runtime.totalMemoryBytes.toString,
+        "free_memory_bytes"    -> runtime.freeMemoryBytes.toString,
+        "used_memory_bytes"    -> runtime.usedMemoryBytes.toString,
+        "jvm_name"             -> json(runtime.jvmName),
+        "jvm_vendor"           -> json(runtime.jvmVendor),
+        "jvm_version"          -> json(runtime.jvmVersion),
+        "os_name"              -> json(runtime.osName),
+        "os_arch"              -> json(runtime.osArch),
+        "os_version"           -> json(runtime.osVersion),
+      ),
+    )
+
+  private def renderStepTelemetry(telemetry: StepTelemetry): String =
+    renderObject(
+      Vector(
+        "duration_ms"            -> telemetry.durationMillis.toString,
+        "duration_seconds"       -> decimalSeconds(telemetry.durationMillis),
+        "seed_months"            -> telemetry.seedMonths.fold("null")(_.toString),
+        "seed_months_per_second" -> telemetry.seedMonthsPerSecond.fold("null")(decimal),
+        "artifacts"              -> renderArtifactTelemetry(telemetry.artifacts),
+        "memory"                 -> renderObject(
+          Vector(
+            "before" -> renderMemoryTelemetry(telemetry.memoryBefore),
+            "after"  -> renderMemoryTelemetry(telemetry.memoryAfter),
+          ),
+        ),
+        "gc"                     -> renderArray(telemetry.gc.map(renderGcTelemetry)),
+        "collection_error"       -> telemetry.collectionError.fold("null")(json),
+      ),
+    )
+
+  private def renderArtifactTelemetry(telemetry: ArtifactTelemetry): String =
+    renderObject(
+      Vector(
+        "file_count"     -> telemetry.fileCount.toString,
+        "bytes"          -> telemetry.bytes.toString,
+        "csv_file_count" -> telemetry.csvFileCount.toString,
+        "csv_row_count"  -> telemetry.csvRowCount.toString,
+      ),
+    )
+
+  private def renderMemoryTelemetry(telemetry: MemoryTelemetry): String =
+    renderObject(
+      Vector(
+        "heap_used_bytes"          -> telemetry.heapUsedBytes.toString,
+        "heap_committed_bytes"     -> telemetry.heapCommittedBytes.toString,
+        "heap_max_bytes"           -> telemetry.heapMaxBytes.toString,
+        "non_heap_used_bytes"      -> telemetry.nonHeapUsedBytes.toString,
+        "non_heap_committed_bytes" -> telemetry.nonHeapCommittedBytes.toString,
+        "non_heap_max_bytes"       -> telemetry.nonHeapMaxBytes.toString,
+      ),
+    )
+
+  private def renderGcTelemetry(telemetry: GcTelemetry): String =
+    renderObject(
+      Vector(
+        "name"                         -> json(telemetry.name),
+        "collection_count_delta"       -> telemetry.collectionCountDelta.fold("null")(_.toString),
+        "collection_time_millis_delta" -> telemetry.collectionTimeMillisDelta.fold("null")(_.toString),
       ),
     )
 
@@ -832,6 +1128,15 @@ object NightlyDiagnosticsProfileRunner:
 
   private def instant(value: Instant): String =
     DateTimeFormatter.ISO_INSTANT.format(value)
+
+  private def decimalSeconds(durationMillis: Long): String =
+    decimal(round6(BigDecimal(durationMillis) / BigDecimal(1000)))
+
+  private def decimal(value: BigDecimal): String =
+    value.bigDecimal.stripTrailingZeros.toPlainString
+
+  private def round6(value: BigDecimal): BigDecimal =
+    value.setScale(6, BigDecimal.RoundingMode.HALF_UP)
 
   private def knownFlag(flag: String): Boolean =
     flag == "--profile" || flag == "--out" || flag == "--run-id" || flag == "--jar-path" || flag == "--jar"

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -431,8 +431,8 @@ object NightlyDiagnosticsProfileRunner:
   ): ZIO[Any, Nothing, StepTelemetry] =
     ZIO
       .attemptBlocking(collectStepTelemetryBlocking(ctx, step, startedAt, finishedAt, before, after, artifacts))
-      .orElseSucceed:
-        fallbackStepTelemetry(step, startedAt, finishedAt, before, after, Some("telemetry collection crashed"))
+      .catchAll: err =>
+        ZIO.succeed(fallbackStepTelemetry(step, startedAt, finishedAt, before, after, Some(message(err))))
 
   private def collectStepTelemetryBlocking(
       ctx: RunContext,

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.EitherValues.*
 import org.scalatest.OptionValues.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import zio.Cause
 
 import java.nio.file.{Files, Path}
 import java.time.Instant
@@ -174,6 +175,11 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
   it should "derive manual UTC run ids from profile and short commit" in {
     NightlyDiagnosticsProfileRunner.autoRunId("nightly", "abcdef0", Instant.parse("2026-05-26T12:34:00Z")) shouldBe
       "nightly-manual-20260526-1234-abcdef0"
+  }
+
+  it should "render typed and defect causes for manifest failure fields" in {
+    NightlyDiagnosticsProfileRunner.renderCause("step-x", Cause.fail("typed failure")) shouldBe "typed failure"
+    NightlyDiagnosticsProfileRunner.renderCause("step-x", Cause.die(RuntimeException("boom"))) should include("step-x crashed")
   }
 
   "NightlyHealthSummary" should "pass when baseline CSVs satisfy normal-path thresholds" in {

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -123,12 +123,52 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     rendered should include(""""profile":"smoke"""")
     rendered should include(""""status":"DRY_RUN"""")
     rendered should include(""""jar":{"path":"target/scala-3.8.2/amor-fati.jar"""")
+    rendered should include(""""runtime":{"available_processors":8""")
     rendered should include(""""steps":[""")
     rendered should include(""""id":"baseline-monte-carlo"""")
     rendered should include(""""classification":"normal_validation"""")
+    rendered should include(""""telemetry":null""")
     rendered should include(
       """"failure_policy":"Hard accounting/runtime failures fail; economic failures are interpreted as normal-path engine or calibration alarms."""",
     )
+  }
+
+  it should "render per-step performance telemetry" in {
+    val ctx      = context("smoke")
+    val step     = ctx.profile
+      .steps(ctx)
+      .head
+      .completed(
+        ctx,
+        startedAt = Instant.parse("2026-05-26T00:00:00Z"),
+        finishedAt = Instant.parse("2026-05-26T00:00:01Z"),
+        artifacts = Vector(ctx.runRoot.resolve("baseline-monte-carlo")),
+        telemetry = Some(sampleStepTelemetry),
+      )
+    val manifest = NightlyDiagnosticsProfileRunner.Manifest(
+      profileId = "smoke",
+      runId = "smoke-manual-20260526-abcdef0",
+      status = "RUNNING",
+      dryRun = false,
+      startedAt = Instant.parse("2026-05-26T00:00:00Z"),
+      finishedAt = None,
+      runRoot = ctx.runRoot,
+      outRoot = ctx.config.out,
+      metadata = ctx.metadata,
+      steps = Vector(step),
+      error = None,
+    )
+    val rendered = NightlyDiagnosticsProfileRunner.renderManifest(manifest)
+
+    rendered should include(""""telemetry":{""")
+    rendered should include(""""duration_ms":1500""")
+    rendered should include(""""duration_seconds":1.5""")
+    rendered should include(""""seed_months":12""")
+    rendered should include(""""seed_months_per_second":8""")
+    rendered should include(""""csv_row_count":36""")
+    rendered should include(""""heap_used_bytes":1000""")
+    rendered should include(""""collection_count_delta":2""")
+    rendered should include(""""collection_error":null""")
   }
 
   it should "derive manual UTC run ids from profile and short commit" in {
@@ -202,8 +242,52 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
         nixVersion = Some("nix test"),
         sbtVersion = Some("sbt test"),
         buildCommit = "abcdef0",
+        runtime = NightlyDiagnosticsProfileRunner.RuntimeTelemetry(
+          availableProcessors = 8,
+          maxMemoryBytes = 4096,
+          totalMemoryBytes = 2048,
+          freeMemoryBytes = 1024,
+          usedMemoryBytes = 1024,
+          jvmName = "test-vm",
+          jvmVendor = "test-vendor",
+          jvmVersion = "test-vm-version",
+          osName = "test-os",
+          osArch = "test-arch",
+          osVersion = "test-os-version",
+        ),
       ),
       startedAt = Instant.parse("2026-05-26T00:00:00Z"),
+    )
+
+  private def sampleStepTelemetry: NightlyDiagnosticsProfileRunner.StepTelemetry =
+    NightlyDiagnosticsProfileRunner.StepTelemetry(
+      durationMillis = 1500L,
+      seedMonths = Some(12L),
+      seedMonthsPerSecond = Some(BigDecimal(8)),
+      artifacts = NightlyDiagnosticsProfileRunner.ArtifactTelemetry(
+        fileCount = 4L,
+        bytes = 8192L,
+        csvFileCount = 3L,
+        csvRowCount = 36L,
+      ),
+      memoryBefore = NightlyDiagnosticsProfileRunner.MemoryTelemetry(
+        heapUsedBytes = 1000L,
+        heapCommittedBytes = 2000L,
+        heapMaxBytes = 4000L,
+        nonHeapUsedBytes = 300L,
+        nonHeapCommittedBytes = 600L,
+        nonHeapMaxBytes = 900L,
+      ),
+      memoryAfter = NightlyDiagnosticsProfileRunner.MemoryTelemetry(
+        heapUsedBytes = 1200L,
+        heapCommittedBytes = 2200L,
+        heapMaxBytes = 4000L,
+        nonHeapUsedBytes = 350L,
+        nonHeapCommittedBytes = 650L,
+        nonHeapMaxBytes = 900L,
+      ),
+      gc = Vector(NightlyDiagnosticsProfileRunner.GcTelemetry("test-gc", collectionCountDelta = Some(2L), collectionTimeMillisDelta = Some(11L))),
+      collectionError = None,
     )
 
   private def succeededSteps(ctx: NightlyDiagnosticsProfileRunner.RunContext): Vector[NightlyDiagnosticsProfileRunner.ManifestStep] =


### PR DESCRIPTION
## Summary
- extend `run-manifest.json` with JVM/OS runtime metadata and per-step telemetry
- record step duration, normalized seed-month throughput, artifact file/byte counts, CSV row counts, memory snapshots, and GC deltas
- keep telemetry at the orchestration layer and report collection errors in the manifest instead of failing correctness paths
- document the new manifest contract in nightly diagnostics and validation matrix docs

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunnerSpec"`
- `sbt Test/compile`
- `bash scripts/check-generated-outputs.sh`
- `sbt "runMain com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner --profile smoke --out target/nightly-telemetry-smoke --run-id telemetry-smoke-local --jar-path target/scala-3.8.2/amor-fati.jar --allow-dirty"` -> manifest contains completed-step telemetry and health summary `PASSED`

Closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly diagnostics now capture and record per-step performance telemetry including execution duration, throughput metrics, memory usage, garbage collection statistics, and artifact details in run manifests.

* **Documentation**
  * Updated nightly diagnostics documentation to specify telemetry recording requirements and manifest contract expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->