### PR TITLE
Split diagnostics workflows by profile

### DIFF
--- a/.github/workflows/diagnostics-extended.yml
+++ b/.github/workflows/diagnostics-extended.yml
@@ -1,0 +1,17 @@
+name: Diagnostics Extended
+
+on:
+  schedule:
+    # GitHub cron is UTC; this runs weekly at 03:00 Warsaw during CEST.
+    - cron: "0 1 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  extended:
+    uses: ./.github/workflows/diagnostics-reusable.yml
+    with:
+      profile: extended
+      run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}

--- a/.github/workflows/diagnostics-nightly.yml
+++ b/.github/workflows/diagnostics-nightly.yml
@@ -1,0 +1,17 @@
+name: Diagnostics Nightly
+
+on:
+  schedule:
+    # GitHub cron is UTC; this runs daily at 02:00 Warsaw during CEST.
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/diagnostics-reusable.yml
+    with:
+      profile: nightly
+      run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}

--- a/.github/workflows/diagnostics-reusable.yml
+++ b/.github/workflows/diagnostics-reusable.yml
@@ -1,36 +1,30 @@
-name: Nightly Diagnostics
+name: Diagnostics Reusable
 
 on:
-  schedule:
-    # GitHub cron is UTC; this runs at 02:00 Warsaw during CEST.
-    # A single cron avoids duplicate scheduled workflow runs in the Actions UI.
-    - cron: "0 0 * * *"
-  workflow_dispatch:
+  workflow_call:
     inputs:
       profile:
-        description: "Diagnostics profile to run from the assembled jar"
         required: true
-        default: nightly
-        type: choice
-        options:
-          - smoke
-          - nightly
-          - extended
+        type: string
+      run_kind:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: nightly-diagnostics-${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }}
+  group: diagnostics-${{ inputs.profile }}
   cancel-in-progress: false
 
 jobs:
   diagnostics:
-    name: Run ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }} diagnostics
+    name: Run ${{ inputs.profile }} diagnostics
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      PROFILE: ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'nightly' }}
+      PROFILE: ${{ inputs.profile }}
+      RUN_KIND: ${{ inputs.run_kind }}
       OUT_DIR: target/nightly-diagnostics
       JAR_PATH: target/scala-3.8.2/amor-fati.jar
     steps:
@@ -53,7 +47,7 @@ jobs:
           sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short HEAD)"
           warsaw_time="$(TZ=Europe/Warsaw date '+%Y-%m-%d %H:%M:%S %Z')"
-          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+          if [[ "${RUN_KIND}" == "scheduled" ]]; then
             run_id="${PROFILE}-$(date -u +%Y%m%d)-${short_sha}"
           else
             run_id="${PROFILE}-manual-$(date -u +%Y%m%d-%H%M)-${short_sha}"

--- a/.github/workflows/diagnostics-smoke.yml
+++ b/.github/workflows/diagnostics-smoke.yml
@@ -1,0 +1,17 @@
+name: Diagnostics Smoke
+
+on:
+  schedule:
+    # GitHub cron is UTC; this runs daily at 01:00 Warsaw during CEST.
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    uses: ./.github/workflows/diagnostics-reusable.yml
+    with:
+      profile: smoke
+      run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@
 
 ### Operational Diagnostics
 
-| Nightly diagnostics | Profiling smoke | Profiling nightly | Profiling extended | Diagnostic profiles |
-| --- | --- | --- | --- | --- |
-| [![Nightly Diagnostics](https://github.com/boombustgroup/amor-fati/actions/workflows/nightly-diagnostics.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/nightly-diagnostics.yml) | [![Hot-Path Profiling Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml) | [![Hot-Path Profiling Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml) | [![Hot-Path Profiling Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml) | [![Diagnostics profiles](https://img.shields.io/badge/diagnostics-smoke_%7C_nightly_%7C_extended-8A2BE2.svg)](docs/nightly-diagnostics.md) |
+| Diagnostics smoke | Diagnostics nightly | Diagnostics extended | Diagnostic profiles |
+| --- | --- | --- | --- |
+| [![Diagnostics Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml) | [![Diagnostics Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml) | [![Diagnostics Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml) | [![Diagnostics profiles](https://img.shields.io/badge/diagnostics-smoke_%7C_nightly_%7C_extended-8A2BE2.svg)](docs/nightly-diagnostics.md) |
+
+| Profiling smoke | Profiling nightly | Profiling extended |
+| --- | --- | --- |
+| [![Hot-Path Profiling Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml) | [![Hot-Path Profiling Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml) | [![Hot-Path Profiling Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 
 ### Operational Diagnostics
 
-| Diagnostics smoke | Diagnostics nightly | Diagnostics extended | Diagnostic profiles |
-| --- | --- | --- | --- |
-| [![Diagnostics Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml) | [![Diagnostics Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml) | [![Diagnostics Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml) | [![Diagnostics profiles](https://img.shields.io/badge/diagnostics-smoke_%7C_nightly_%7C_extended-8A2BE2.svg)](docs/nightly-diagnostics.md) |
+| Diagnostics smoke | Diagnostics nightly | Diagnostics extended |
+| --- | --- | --- |
+| [![Diagnostics Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml) | [![Diagnostics Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml) | [![Diagnostics Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml) |
 
 | Profiling smoke | Profiling nightly | Profiling extended |
 | --- | --- | --- |

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -148,19 +148,34 @@ summary files have been written. Exploratory and stress steps remain visible in
 completion metrics, but their economic outcomes are not reclassified as
 scheduled normal-path failures.
 
-## Scheduled Workflow
+## Scheduled Workflows
 
-The GitHub Actions workflow `.github/workflows/nightly-diagnostics.yml` runs the
-same jar/Nix path. It is intentionally not attached to `pull_request`, so long
-diagnostics do not block normal PR feedback.
+The GitHub Actions workflows below run the same jar/Nix path:
+
+```text
+.github/workflows/diagnostics-smoke.yml
+.github/workflows/diagnostics-nightly.yml
+.github/workflows/diagnostics-extended.yml
+```
+
+They delegate to:
+
+```text
+.github/workflows/diagnostics-reusable.yml
+```
+
+This keeps the Actions UI and README badges profile-specific without copying
+the build/run/upload implementation. These workflows are intentionally not
+attached to `pull_request`, so long diagnostics do not block normal PR
+feedback.
 
 Triggers:
 
-- `schedule`: runs the `nightly` profile against `HEAD` of `main`
-- `workflow_dispatch`: lets maintainers manually select `smoke`, `nightly`, or
-  `extended`
+- `schedule`: runs each fixed profile against `HEAD` of `main`
+- `workflow_dispatch`: lets maintainers manually launch the selected fixed
+  profile
 
-The workflow checks out `main`, builds the assembled jar with:
+Each workflow checks out `main`, builds the assembled jar with:
 
 ```bash
 nix develop --command sbt assembly
@@ -178,11 +193,18 @@ nix develop --command java -cp target/scala-3.8.2/amor-fati.jar \
   --require-main
 ```
 
-The scheduled workflow uses a single GitHub cron, `0 0 * * *` UTC. During CEST
-this runs at 02:00 Europe/Warsaw. GitHub cron does not track local daylight
-saving time, so maintainers should adjust the cron if exact 02:00 local time is
-required during CET months. A single cron is intentional because it avoids
-duplicate scheduled workflow runs in the Actions UI.
+Scheduled workflows use profile-specific crons:
+
+| Profile | Workflow | Schedule |
+| --- | --- | --- |
+| `smoke` | `diagnostics-smoke.yml` | daily `23:00` UTC |
+| `nightly` | `diagnostics-nightly.yml` | daily `00:00` UTC |
+| `extended` | `diagnostics-extended.yml` | weekly, Saturday `01:00` UTC |
+
+During CEST, these correspond to 01:00, 02:00, and 03:00 Europe/Warsaw
+respectively. GitHub cron does not track local daylight saving time, so
+maintainers should adjust the cron if exact local wall-clock timing is required
+during CET months.
 
 The job summary reports the profile, commit SHA, run id, runtime, manifest path,
 health-summary status, terminal status, build/runtime exit codes, and failure

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -30,7 +30,7 @@ duplicating those layers.
 | Heavy unit tests | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt -DamorFati.includeHeavyTests=true "root / Test / testOnly * -- -n com.boombustgroup.amorfati.tags.Heavy"` | Selected expensive unit/property checks that should not run under coverage | Hard fail on broken heavy invariant |
 | Integration smoke | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt "integrationTests / Test / test"` | End-to-end smoke over the root project and integration-test project | Hard fail on integration-level regression |
 | Coverage upload | PR and push | `.github/workflows/ci.yml` `test` job | `codecov/codecov-action` | Publish non-heavy unit coverage | Non-blocking upload; CI does not fail if Codecov upload fails |
-| Nightly diagnostics | Scheduled daily on `main`; manual dispatch | `.github/workflows/nightly-diagnostics.yml` | Build `sbt assembly` under Nix, then run `NightlyDiagnosticsProfileRunner` from the jar | Long validation and diagnostics artifacts over `smoke`, `nightly`, and `extended` profiles | Hard fail on runner/build failure and hard invariants; economic outcomes are interpreted by profile classification |
+| Nightly diagnostics | Scheduled on `main`; manual dispatch | `.github/workflows/diagnostics-{smoke,nightly,extended}.yml` via reusable diagnostics workflow | Build `sbt assembly` under Nix, then run `NightlyDiagnosticsProfileRunner` from the jar | Long validation and diagnostics artifacts over `smoke`, `nightly`, and `extended` profiles | Hard fail on runner/build failure and hard invariants; economic outcomes are interpreted by profile classification |
 | Nightly health summary | After a non-dry-run diagnostics profile completes | `NightlyHealthSummary` via `NightlyDiagnosticsProfileRunner` | Reuse `run-manifest.json` and baseline Monte Carlo seed CSVs to write `health-summary.json` and `health-summary.md` | Compact machine/human verdict answering whether `main` stayed normal-path healthy overnight | Hard fail on normal-validation threshold breaches; warn/report for soft research signals; do not turn stress/exploratory outcomes into normal-path failures |
 | Nightly performance telemetry | Every diagnostics profile step | `NightlyDiagnosticsProfileRunner` manifest telemetry | Per-step duration, seed-month throughput, artifact size/row counts, and JVM memory/GC observations in `run-manifest.json` | Lightweight regression visibility before heavier profilers exist | Report-only initially; hard performance budgets belong to later baseline/regression work |
 | Manual diagnostics | Local or workflow dispatch | Maintainer | `nix develop --command java -cp target/scala-3.8.2/amor-fati.jar com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner ...` | Reproduce or inspect profile outputs outside PR CI | Evidence only unless explicitly promoted to a CI/nightly gate |
@@ -57,9 +57,9 @@ environment, not from ad hoc local classpaths.
 
 | Profile | Trigger | Current intent | Typical interpretation |
 | --- | --- | --- | --- |
-| `smoke` | Manual dispatch, local reproduction | Fast profile contract and artifact sanity | Hard invariants only; research metrics are informational |
+| `smoke` | Scheduled daily on `main`, manual dispatch, local reproduction | Fast profile contract and artifact sanity | Hard invariants only; research metrics are informational |
 | `nightly` | Scheduled daily on `main`, manual dispatch | Standard 60-month validation horizon | Hard invariants fail; soft calibration guardrails warn unless promoted |
-| `extended` | Manual dispatch, future weekly use | Wider seed/scenario/diagnostic surface at the current 60-month horizon | Same hard invariants; broader research envelope reporting |
+| `extended` | Scheduled weekly on `main`, manual dispatch | Wider seed/scenario/diagnostic surface at the current 60-month horizon | Same hard invariants; broader research envelope reporting |
 
 The profile definitions and per-step semantic classifications live in
 `NightlyDiagnosticsProfileRunner.Profiles` and are documented in


### PR DESCRIPTION
## Summary
- replace the single diagnostics workflow with profile-specific smoke, nightly, and extended workflows
- keep build/run/upload logic in a reusable diagnostics workflow
- add separate README badges for diagnostics smoke/nightly/extended
- update nightly diagnostics and validation-matrix docs

## Validation
- ruby YAML parse for all diagnostics workflows
- git diff --check
- bash scripts/check-generated-outputs.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate scheduled diagnostic workflows for smoke (daily), nightly (daily), and extended (weekly) profiles.
  * All workflows support manual dispatch in addition to automatic scheduling.

* **Documentation**
  * Updated operational diagnostics documentation with new workflow structure and schedule details.
  * Clarified UTC-to-local time mappings and profile-specific triggers.
  * Reorganized README badges for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boombustgroup/amor-fati/pull/716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->