### PR TITLE
Add soft performance regression budgets

### DIFF
--- a/.github/workflows/diagnostics-extended.yml
+++ b/.github/workflows/diagnostics-extended.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   extended:

--- a/.github/workflows/diagnostics-extended.yml
+++ b/.github/workflows/diagnostics-extended.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 1 * * 6"
   workflow_dispatch:
 
+# Performance baseline selection queries the Actions API and downloads artifacts
+# from previous runs, so artifact access requires actions: read.
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/diagnostics-extended.yml
+++ b/.github/workflows/diagnostics-extended.yml
@@ -16,3 +16,5 @@ jobs:
     with:
       profile: extended
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/diagnostics-nightly.yml
+++ b/.github/workflows/diagnostics-nightly.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   nightly:

--- a/.github/workflows/diagnostics-nightly.yml
+++ b/.github/workflows/diagnostics-nightly.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+# Performance baseline selection queries the Actions API and downloads artifacts
+# from previous runs, so artifact access requires actions: read.
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/diagnostics-nightly.yml
+++ b/.github/workflows/diagnostics-nightly.yml
@@ -16,3 +16,5 @@ jobs:
     with:
       profile: nightly
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/diagnostics-reusable.yml
+++ b/.github/workflows/diagnostics-reusable.yml
@@ -301,7 +301,7 @@ jobs:
           CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
           BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
           BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
-          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}
+          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until issue 718 resolves all-failed bank stress semantics.' || '' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/diagnostics-reusable.yml
+++ b/.github/workflows/diagnostics-reusable.yml
@@ -9,6 +9,12 @@ on:
       run_kind:
         required: true
         type: string
+      checkout_ref:
+        required: true
+        type: string
+      require_main:
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -26,13 +32,15 @@ jobs:
     env:
       PROFILE: ${{ inputs.profile }}
       RUN_KIND: ${{ inputs.run_kind }}
+      CHECKOUT_REF: ${{ inputs.checkout_ref }}
+      REQUIRE_MAIN: ${{ inputs.require_main }}
       OUT_DIR: target/nightly-diagnostics
       JAR_PATH: target/scala-3.8.2/amor-fati.jar
     steps:
-      - name: Check out HEAD of main
+      - name: Check out diagnostics ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: main
+          ref: ${{ inputs.checkout_ref }}
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
@@ -77,6 +85,8 @@ jobs:
             echo
             echo "- Profile: \`${PROFILE}\`"
             echo "- Commit: \`${sha}\`"
+            echo "- Checkout ref: \`${CHECKOUT_REF}\`"
+            echo "- Require main: \`${REQUIRE_MAIN}\`"
             echo "- Run id: \`${run_id}\`"
             echo "- Output root: \`${run_root}\`"
             echo "- Artifact: \`${artifact_name}\`"
@@ -113,18 +123,23 @@ jobs:
           set -euo pipefail
 
           mkdir -p "${OUT_DIR}"
-          export GITHUB_REF_NAME=main
+          export GITHUB_REF_NAME="${CHECKOUT_REF}"
           export GITHUB_SHA="${{ steps.meta.outputs.sha }}"
+
+          runner_args=(
+            com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner
+            --profile "${PROFILE}"
+            --out "${OUT_DIR}"
+            --run-id "${{ steps.meta.outputs.run_id }}"
+            --jar-path "${JAR_PATH}"
+          )
+          if [[ "${REQUIRE_MAIN}" == "true" ]]; then
+            runner_args+=(--require-main)
+          fi
 
           start_seconds="$(date +%s)"
           set +e
-          nix develop --command java -cp "${JAR_PATH}" \
-            com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner \
-            --profile "${PROFILE}" \
-            --out "${OUT_DIR}" \
-            --run-id "${{ steps.meta.outputs.run_id }}" \
-            --jar-path "${JAR_PATH}" \
-            --require-main 2>&1 | tee "${OUT_DIR}/diagnostics.log"
+          nix develop --command java -cp "${JAR_PATH}" "${runner_args[@]}" 2>&1 | tee "${OUT_DIR}/diagnostics.log"
           exit_code="${PIPESTATUS[0]}"
           set -e
           end_seconds="$(date +%s)"

--- a/.github/workflows/diagnostics-reusable.yml
+++ b/.github/workflows/diagnostics-reusable.yml
@@ -301,7 +301,7 @@ jobs:
           CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
           BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
           BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
-          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until issue 718 resolves all-failed bank stress semantics.' || '' }}
+          SKIP_REASON: "${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/diagnostics-reusable.yml
+++ b/.github/workflows/diagnostics-reusable.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: diagnostics-${{ inputs.profile }}
@@ -246,6 +247,71 @@ jobs:
           if [[ "${DIAGNOSTICS_EXIT_CODE:-}" =~ ^[0-9]+$ ]] && [[ "${DIAGNOSTICS_EXIT_CODE}" != "0" ]]; then
             exit "${DIAGNOSTICS_EXIT_CODE}"
           fi
+
+      - name: Download performance baseline artifact
+        if: ${{ always() && inputs.profile != 'extended' }}
+        id: performance_baseline
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_PREFIX: amor-fati-diagnostics-${{ inputs.profile }}-
+          BASELINE_DIR: target/performance-baseline/diagnostics-${{ inputs.profile }}
+        run: |
+          set -euo pipefail
+
+          selection_json="${BASELINE_DIR}/selection.json"
+          python3 scripts/select-performance-baseline.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --artifact-prefix "${ARTIFACT_PREFIX}" \
+            --out-json "${selection_json}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+          artifact_name="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("artifact_name", ""))' "${selection_json}")"
+          run_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("run_id", ""))' "${selection_json}")"
+          if [[ -n "${artifact_name}" && -n "${run_id}" ]]; then
+            artifact_dir="${BASELINE_DIR}/artifact"
+            rm -rf "${artifact_dir}"
+            mkdir -p "${artifact_dir}"
+            timeout 120s gh run download "${run_id}" --name "${artifact_name}" --dir "${artifact_dir}" || true
+            manifest="$(find "${artifact_dir}" -name run-manifest.json -print -quit)"
+            echo "manifest=${manifest}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Write performance regression report
+        if: ${{ always() }}
+        shell: bash
+        env:
+          RUN_ROOT: ${{ steps.meta.outputs.run_root }}
+          CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
+          BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
+          BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
+          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}
+        run: |
+          set -euo pipefail
+
+          report_dir="${RUN_ROOT}/performance"
+          mkdir -p "${report_dir}"
+          args=(
+            --current "${CURRENT_MANIFEST}"
+            --out-json "${report_dir}/performance-regression-report.json"
+            --out-md "${report_dir}/performance-regression-report.md"
+            --profile "${PROFILE}"
+            --source "diagnostics"
+            --baseline-artifact "${BASELINE_ARTIFACT:-}"
+          )
+          if [[ -n "${BASELINE_MANIFEST:-}" ]]; then
+            args+=(--baseline "${BASELINE_MANIFEST}")
+          fi
+          if [[ -n "${SKIP_REASON:-}" ]]; then
+            args+=(--skip-reason "${SKIP_REASON}")
+          fi
+
+          python3 scripts/performance-regression-report.py "${args[@]}"
+          {
+            echo
+            cat "${report_dir}/performance-regression-report.md"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload diagnostics artifacts
         if: ${{ always() && steps.meta.outputs.artifact_name != '' }}

--- a/.github/workflows/diagnostics-smoke.yml
+++ b/.github/workflows/diagnostics-smoke.yml
@@ -16,3 +16,5 @@ jobs:
     with:
       profile: smoke
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/diagnostics-smoke.yml
+++ b/.github/workflows/diagnostics-smoke.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   smoke:

--- a/.github/workflows/hot-path-profiling-extended.yml
+++ b/.github/workflows/hot-path-profiling-extended.yml
@@ -26,3 +26,5 @@ jobs:
       profile: extended
       jfr_settings: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jfr_settings || 'profile' }}
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/hot-path-profiling-extended.yml
+++ b/.github/workflows/hot-path-profiling-extended.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   extended:

--- a/.github/workflows/hot-path-profiling-nightly.yml
+++ b/.github/workflows/hot-path-profiling-nightly.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   nightly:

--- a/.github/workflows/hot-path-profiling-nightly.yml
+++ b/.github/workflows/hot-path-profiling-nightly.yml
@@ -26,3 +26,5 @@ jobs:
       profile: nightly
       jfr_settings: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jfr_settings || 'profile' }}
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/hot-path-profiling-reusable.yml
+++ b/.github/workflows/hot-path-profiling-reusable.yml
@@ -350,7 +350,7 @@ jobs:
           CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
           BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
           BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
-          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}
+          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until issue 718 resolves all-failed bank stress semantics.' || '' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/hot-path-profiling-reusable.yml
+++ b/.github/workflows/hot-path-profiling-reusable.yml
@@ -350,7 +350,7 @@ jobs:
           CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
           BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
           BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
-          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until issue 718 resolves all-failed bank stress semantics.' || '' }}
+          SKIP_REASON: "${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/hot-path-profiling-reusable.yml
+++ b/.github/workflows/hot-path-profiling-reusable.yml
@@ -13,6 +13,12 @@ on:
       run_kind:
         required: true
         type: string
+      checkout_ref:
+        required: true
+        type: string
+      require_main:
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -31,13 +37,15 @@ jobs:
       PROFILE: ${{ inputs.profile }}
       JFR_SETTINGS: ${{ inputs.jfr_settings }}
       RUN_KIND: ${{ inputs.run_kind }}
+      CHECKOUT_REF: ${{ inputs.checkout_ref }}
+      REQUIRE_MAIN: ${{ inputs.require_main }}
       OUT_DIR: target/hot-path-profiling
       JAR_PATH: target/scala-3.8.2/amor-fati.jar
     steps:
-      - name: Check out HEAD of main
+      - name: Check out profiling ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: main
+          ref: ${{ inputs.checkout_ref }}
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
@@ -90,6 +98,8 @@ jobs:
             echo "- Profile: \`${PROFILE}\`"
             echo "- JFR settings: \`${JFR_SETTINGS}\`"
             echo "- Commit: \`${sha}\`"
+            echo "- Checkout ref: \`${CHECKOUT_REF}\`"
+            echo "- Require main: \`${REQUIRE_MAIN}\`"
             echo "- Run id: \`${run_id}\`"
             echo "- Output root: \`${run_root}\`"
             echo "- JFR: \`${jfr_path}\`"
@@ -132,20 +142,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          export GITHUB_REF_NAME=main
+          export GITHUB_REF_NAME="${CHECKOUT_REF}"
           export GITHUB_SHA="${COMMIT_SHA}"
+
+          runner_args=(
+            com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner
+            --profile "${PROFILE}"
+            --out "${OUT_DIR}"
+            --run-id "${RUN_ID}"
+            --jar-path "${JAR_PATH}"
+          )
+          if [[ "${REQUIRE_MAIN}" == "true" ]]; then
+            runner_args+=(--require-main)
+          fi
 
           start_seconds="$(date +%s)"
           set +e
           nix develop --command java \
             "-XX:StartFlightRecording=filename=${JFR_PATH},settings=${JFR_SETTINGS},dumponexit=true,disk=true" \
             -cp "${JAR_PATH}" \
-            com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner \
-            --profile "${PROFILE}" \
-            --out "${OUT_DIR}" \
-            --run-id "${RUN_ID}" \
-            --jar-path "${JAR_PATH}" \
-            --require-main 2>&1 | tee "${PROFILING_LOG_PATH}"
+            "${runner_args[@]}" 2>&1 | tee "${PROFILING_LOG_PATH}"
           exit_code="${PIPESTATUS[0]}"
           set -e
           end_seconds="$(date +%s)"
@@ -252,6 +268,8 @@ jobs:
               "workload_duration_seconds": os.environ.get("WORKLOAD_DURATION_SECONDS") or "not-recorded",
               "artifact_name": os.environ.get("ARTIFACT_NAME", "not-created"),
               "retention_days": os.environ.get("RETENTION_DAYS", "not-configured"),
+              "checkout_ref": os.environ.get("CHECKOUT_REF", "unknown"),
+              "require_main": os.environ.get("REQUIRE_MAIN", "false").lower() == "true",
               "warsaw_time": os.environ.get("WARSAW_TIME", "unknown"),
               "created_at_utc": datetime.now(timezone.utc).isoformat(),
               "workflow": "hot-path-profiling",
@@ -270,7 +288,8 @@ jobs:
                   " -cp target/scala-3.8.2/amor-fati.jar "
                   "com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner "
                   f"--profile {os.environ.get('PROFILE', 'nightly')} --out target/hot-path-profiling "
-                  f"--run-id {os.environ.get('RUN_ID', '')} --jar-path target/scala-3.8.2/amor-fati.jar --require-main"
+                  f"--run-id {os.environ.get('RUN_ID', '')} --jar-path target/scala-3.8.2/amor-fati.jar"
+                  + (" --require-main" if os.environ.get("REQUIRE_MAIN", "false").lower() == "true" else "")
               ),
           }
 

--- a/.github/workflows/hot-path-profiling-reusable.yml
+++ b/.github/workflows/hot-path-profiling-reusable.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: hot-path-profiling-${{ inputs.profile }}
@@ -291,6 +292,71 @@ jobs:
               out.write(f"- Health summary present: `{health_path.is_file()}`\n")
               out.write(f"- Artifact: `{metadata['artifact_name']}`\n")
           PY
+
+      - name: Download performance baseline artifact
+        if: ${{ always() && inputs.profile != 'extended' }}
+        id: performance_baseline
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_PREFIX: amor-fati-hot-path-profiling-hotpath-${{ inputs.profile }}-
+          BASELINE_DIR: target/performance-baseline/hot-path-profiling-${{ inputs.profile }}
+        run: |
+          set -euo pipefail
+
+          selection_json="${BASELINE_DIR}/selection.json"
+          python3 scripts/select-performance-baseline.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --artifact-prefix "${ARTIFACT_PREFIX}" \
+            --out-json "${selection_json}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+          artifact_name="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("artifact_name", ""))' "${selection_json}")"
+          run_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("run_id", ""))' "${selection_json}")"
+          if [[ -n "${artifact_name}" && -n "${run_id}" ]]; then
+            artifact_dir="${BASELINE_DIR}/artifact"
+            rm -rf "${artifact_dir}"
+            mkdir -p "${artifact_dir}"
+            timeout 120s gh run download "${run_id}" --name "${artifact_name}" --dir "${artifact_dir}" || true
+            manifest="$(find "${artifact_dir}" -name run-manifest.json -print -quit)"
+            echo "manifest=${manifest}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Write performance regression report
+        if: ${{ always() }}
+        shell: bash
+        env:
+          RUN_ROOT: ${{ steps.meta.outputs.run_root }}
+          CURRENT_MANIFEST: ${{ steps.meta.outputs.run_root }}/run-manifest.json
+          BASELINE_MANIFEST: ${{ steps.performance_baseline.outputs.manifest }}
+          BASELINE_ARTIFACT: ${{ steps.performance_baseline.outputs.artifact_name }}
+          SKIP_REASON: ${{ inputs.profile == 'extended' && 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.' || '' }}
+        run: |
+          set -euo pipefail
+
+          report_dir="${RUN_ROOT}/performance"
+          mkdir -p "${report_dir}"
+          args=(
+            --current "${CURRENT_MANIFEST}"
+            --out-json "${report_dir}/performance-regression-report.json"
+            --out-md "${report_dir}/performance-regression-report.md"
+            --profile "${PROFILE}"
+            --source "hot-path-profiling"
+            --baseline-artifact "${BASELINE_ARTIFACT:-}"
+          )
+          if [[ -n "${BASELINE_MANIFEST:-}" ]]; then
+            args+=(--baseline "${BASELINE_MANIFEST}")
+          fi
+          if [[ -n "${SKIP_REASON:-}" ]]; then
+            args+=(--skip-reason "${SKIP_REASON}")
+          fi
+
+          python3 scripts/performance-regression-report.py "${args[@]}"
+          {
+            echo
+            cat "${report_dir}/performance-regression-report.md"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload profiling artifacts
         if: ${{ always() && steps.meta.outputs.artifact_name != '' }}

--- a/.github/workflows/hot-path-profiling-smoke.yml
+++ b/.github/workflows/hot-path-profiling-smoke.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   smoke:

--- a/.github/workflows/hot-path-profiling-smoke.yml
+++ b/.github/workflows/hot-path-profiling-smoke.yml
@@ -26,3 +26,5 @@ jobs:
       profile: smoke
       jfr_settings: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jfr_settings || 'profile' }}
       run_kind: ${{ github.event_name == 'schedule' && 'scheduled' || 'manual' }}
+      checkout_ref: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
+      require_main: ${{ github.event_name == 'schedule' }}

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ replication, calibration, validation, and publication work:
 | [Empirical validation report](docs/empirical-validation-report.md) | Workflow for the empirical-validation snapshot: the curated source manifest is the editable input, while generated baseline artifacts live under `docs/empirical-validation/`. |
 | [Engine invariants and economic semantics](docs/engine-invariants-and-semantics.md) | Canonical reviewer-facing index of hard invariants, normal-path expectations, stress/exploratory diagnostics, calibration warnings, known limitations, enforcement points, and coverage. |
 | [Validation matrix and ownership boundaries](docs/validation-matrix.md) | CI, integration-test, generated-output, nightly, stress, and profiling ownership rules so new validation work lands in the right layer. |
+| [Performance regression budgets](docs/performance-regression-budgets.md) | Soft baseline comparisons for diagnostics and profiling telemetry, using existing run manifests without adding duplicate simulations. |
 | [Sensitivity and robustness workflow](docs/sensitivity-robustness-workflow.md) | Seed envelopes and one-at-a-time parameter-sensitivity artifacts generated from the Monte Carlo runner. |
 | [Reproducible scenario registry](docs/scenario-registry.md) | Named policy and shock scenarios with exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path. |
 

--- a/docs/engine-invariants-and-semantics.md
+++ b/docs/engine-invariants-and-semantics.md
@@ -58,7 +58,7 @@ known-limitation tracking.
 | Informal economy and tax evasion | `normal_path_expectation` plus `stress_or_exploratory_diagnostic` | Informal-sector adjustments and tax-evasion flows affect PIT/VAT/CIT/excise and employment diagnostics; they are bounded model channels, not residual balancing rows. | [behavioral equations](behavioral-equations-and-decision-rules.md), `engine/mechanisms/InformalEconomy.scala` | `engine/mechanisms/InformalEconomy.scala`, firm/household/public-finance stages | `InformalEconomySpec`, tax-flow diagnostics in timeseries | Hard fail for impossible bounded share logic; report/warn for calibration |
 | Scenario and robustness semantics | `stress_or_exploratory_diagnostic` | Named scenarios are executable economic stories with provenance; sensitivity runs are one-at-a-time local checks, not normal-path verdicts. | [scenario registry](scenario-registry.md), [sensitivity and robustness workflow](sensitivity-robustness-workflow.md), [validation matrix](validation-matrix.md) | `config/ScenarioRegistry.scala`, `diagnostics/ScenarioRunExport.scala`, `diagnostics/SensitivityRobustnessExport.scala` | scenario run exports, robustness reports, nightly step classification | Report only unless a hard accounting/runtime invariant fails |
 | Empirical validation and source bridges | `calibration_warning` plus `known_limitation` | External data bridges define initialization, calibration, scenario, and validation targets; incomplete source rows are explicit publication-readiness gaps. | [data bridge](data-bridge-national-financial-accounts.md), [empirical validation report](empirical-validation-report.md), [calibration register](calibration-register.md) | `diagnostics/EmpiricalValidationExport.scala`, `config/CalibrationProvenance.scala`, committed source manifests | `EmpiricalValidationManifestSpec`, `EmpiricalValidationExportSpec`, generated-output guard | Warning/report unless a required generated output is stale or malformed |
-| Performance and profiling evidence | `stress_or_exploratory_diagnostic` | Runtime telemetry and JFR artifacts show where the engine spends time and allocates; they are observability evidence before stable budgets exist. | [hot-path profiling](hot-path-profiling.md), [validation matrix](validation-matrix.md), #688 | `diagnostics/NightlyDiagnosticsProfileRunner.scala`, hot-path profiling workflows | profiling artifacts, runner telemetry specs | Report only until selected low-noise budgets are promoted |
+| Performance and profiling evidence | `stress_or_exploratory_diagnostic` | Runtime telemetry, soft regression-budget reports, and JFR artifacts show where the engine spends time and allocates; they are observability evidence before stable hard budgets exist. | [hot-path profiling](hot-path-profiling.md), [performance regression budgets](performance-regression-budgets.md), [validation matrix](validation-matrix.md) | `diagnostics/NightlyDiagnosticsProfileRunner.scala`, diagnostics/profiling workflows, `scripts/performance-regression-report.py` | profiling artifacts, runner telemetry specs, performance-regression reports | Soft warnings until selected low-noise budgets are promoted |
 
 ## Minimal Hard-Fail Set
 
@@ -104,8 +104,8 @@ rationale in the comparison or diagnostics contract.
 - Empirical source extraction is not yet fully manifest-backed for several
   domains, especially household microdata, firm demography, holder-resolved
   financial accounts, and scenario-specific shocks.
-- Performance budgets are not yet hard gates; profiling evidence is currently
-  observational.
+- Performance budgets are soft warning reports; hard gates require documented
+  promotion after comparable `main` runs.
 
 ## Maintenance Rule
 

--- a/docs/hot-path-profiling.md
+++ b/docs/hot-path-profiling.md
@@ -11,8 +11,9 @@ Profiling answers where the engine spends time, allocates memory, blocks,
 compiles hot methods, or triggers GC while running representative workloads.
 
 The workflow exists to produce reproducible artifacts after large refactors and
-before introducing performance budgets. Initial results are report-only. Hard
-performance gates belong to a later baseline and regression-budget workflow.
+to feed the soft [performance regression budget](performance-regression-budgets.md)
+reports. Initial results remain report-only. Hard performance gates require a
+documented promotion step.
 
 ## Workflow
 
@@ -112,6 +113,9 @@ The uploaded artifact contains the profile run directory, including:
 - `profiling/profiling.log`: profiled workload stdout/stderr
 - `profiling/profiling-metadata.json`: commit, command, profile, runtime, and
   artifact metadata
+- `performance/performance-regression-report.json` and
+  `performance/performance-regression-report.md`: soft comparison against the
+  newest same-profile baseline artifact on `main`, when available
 - `run-manifest.json`, `health-summary.json`, and `health-summary.md` when the
   diagnostics runner reaches the point where it can write them
 
@@ -142,8 +146,12 @@ Profiling evidence is initially report-only:
 - It does not mean performance is good.
 - It does not mean the economic path is calibrated.
 
-Performance budgets should be introduced only after several comparable runs
-exist for the same profile, commit metadata, JVM, and machine class.
+Soft performance-budget reports compare the current manifest to the newest
+same-profile baseline artifact on `main`. They warn about large step-level
+changes in duration, seed-month throughput, post-step heap use, and GC time.
+They do not fail the workflow. Hard gates can be introduced only after several
+comparable runs exist for the same profile, commit metadata, JVM, and machine
+class.
 
 ## Relationship To Other Validation Layers
 
@@ -153,3 +161,6 @@ exist for the same profile, commit metadata, JVM, and machine class.
 - Nightly per-step telemetry owns lightweight step-level runtime visibility.
 - Hot-path profiling owns low-frequency JFR evidence for runtime and allocation
   investigation.
+- [Performance regression budgets](performance-regression-budgets.md) own the
+  soft manifest-to-manifest comparison policy and the criteria for promoting a
+  metric to a hard gate.

--- a/docs/hot-path-profiling.md
+++ b/docs/hot-path-profiling.md
@@ -28,7 +28,9 @@ GitHub Actions workflows:
 Triggers:
 
 - `workflow_dispatch`: maintainers can profile the selected workflow's fixed
-  profile with `profile` or `default` JFR settings.
+  profile with `profile` or `default` JFR settings. Dispatching with `--ref`
+  checks out that branch so profiling workflow changes can be validated before
+  merge.
 - `schedule`: each profile runs weekly against `HEAD` of `main`, staggered by
   profile.
 

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -66,6 +66,12 @@ Every non-dry-run profile should also include compact health summaries:
   and hard-failure counts
 - `health-summary.md`: reviewer-facing table with the same verdict and metrics
 
+GitHub Actions diagnostics runs additionally write soft performance-budget
+reports under `performance/`. These reports compare the current manifest to the
+newest same-profile baseline artifact on `main` when one is available. The
+policy is documented in
+[performance-regression-budgets.md](performance-regression-budgets.md).
+
 ## Jar / Nix Execution
 
 Build the assembled jar from the project Nix environment:
@@ -114,6 +120,8 @@ The runner writes:
 target/nightly-diagnostics/<profile>/<run-id>/run-manifest.json
 target/nightly-diagnostics/<profile>/<run-id>/health-summary.json
 target/nightly-diagnostics/<profile>/<run-id>/health-summary.md
+target/nightly-diagnostics/<profile>/<run-id>/performance/performance-regression-report.json
+target/nightly-diagnostics/<profile>/<run-id>/performance/performance-regression-report.md
 ```
 
 The manifest records the profile, resolved git ref, dirty-tree status, jar path
@@ -128,6 +136,9 @@ counts where available, and before/after memory plus GC deltas when the JVM
 exposes them. Missing or partial telemetry is represented in the manifest rather
 than launching duplicate simulations or adding assertions inside diagnostic
 exporters.
+
+The performance-regression report is also orchestration-level evidence. It is a
+soft warning surface, not a diagnostics failure gate.
 
 The health summary reuses artifacts emitted by the configured diagnostics. It
 does not launch additional simulations. The first threshold layer reads the
@@ -316,6 +327,7 @@ Primary artifacts:
 - loan-origination quality outputs
 - profile manifest and logs
 - health-summary JSON and Markdown verdicts
+- performance-regression JSON and Markdown report
 
 ## Extended Profile
 

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -71,6 +71,8 @@ reports under `performance/`. These reports compare the current manifest to the
 newest same-profile baseline artifact on `main` when one is available. The
 policy is documented in
 [performance-regression-budgets.md](performance-regression-budgets.md).
+Manual workflow dispatch can run against a feature branch for pre-merge
+validation; scheduled diagnostics remain pinned to clean `main`.
 
 ## Jar / Nix Execution
 

--- a/docs/performance-regression-budgets.md
+++ b/docs/performance-regression-budgets.md
@@ -82,11 +82,19 @@ generated performance reports before merging.
 A metric can become a hard gate only after:
 
 - the profile has several comparable successful `main` runs;
-- the metric is low-noise on GitHub-hosted runners;
+- the metric has coefficient of variation below 5% across at least 10
+  comparable successful `main` runs on GitHub-hosted runners for the same commit,
+  runner type, JFR setting, profile, and build parameters;
 - the failure message explains the affected step and metric;
 - stress-profile failures cannot be mistaken for normal-path performance
   regressions;
 - the threshold rationale is documented here.
+
+Measure noise from the generated `performance-regression-report.json` inputs by
+collecting the candidate metric across those 10 runs and computing
+`standard_deviation / median`. Use the same step id and profile for every sample;
+for example, compare only `diagnostics:nightly` duration samples from identical
+manual reruns of one `main` commit.
 
 Until then, performance reports are observability evidence. They should guide
 review and refactoring, not block correctness work.

--- a/docs/performance-regression-budgets.md
+++ b/docs/performance-regression-budgets.md
@@ -63,6 +63,20 @@ bank stress semantics in #718 are resolved. The extended profile currently
 includes stress paths that can terminate before later steps run, which makes
 step-to-step performance comparisons misleading.
 
+## Branch Validation
+
+Manual workflow dispatch can validate a feature branch before merge:
+
+```bash
+gh workflow run diagnostics-smoke.yml --ref <branch>
+gh workflow run hot-path-profiling-smoke.yml --ref <branch> -f jfr_settings=profile
+```
+
+Scheduled runs always check out `main` and pass `--require-main` to the
+diagnostics runner. Manual runs check out the dispatched branch and do not pass
+`--require-main`, so branch PRs can verify workflow wiring and inspect the
+generated performance reports before merging.
+
 ## Promotion Policy
 
 A metric can become a hard gate only after:

--- a/docs/performance-regression-budgets.md
+++ b/docs/performance-regression-budgets.md
@@ -1,0 +1,78 @@
+# Performance Regression Budgets
+
+This document defines the first performance-baseline layer for Amor Fati's
+engine diagnostics and hot-path profiling workflows.
+
+The layer is intentionally soft. It produces reviewer-facing regression reports
+from existing run manifests; it does not launch extra simulations and it does
+not fail workflows on performance drift.
+
+## Source Artifacts
+
+Performance comparisons reuse `run-manifest.json` files already produced by
+`NightlyDiagnosticsProfileRunner`.
+
+The comparison scripts run inside:
+
+```text
+.github/workflows/diagnostics-reusable.yml
+.github/workflows/hot-path-profiling-reusable.yml
+```
+
+Each workflow downloads the newest non-expired artifact for the same profile on
+`main`, extracts the baseline `run-manifest.json`, and compares it to the
+current manifest. Missing permissions, missing artifacts, expired artifacts, or
+missing manifests produce a `NO_BASELINE` report rather than a failed job.
+
+No noisy baseline files are committed to the repository.
+
+## Output Artifacts
+
+Each diagnostics or profiling run writes:
+
+```text
+<run-root>/performance/performance-regression-report.json
+<run-root>/performance/performance-regression-report.md
+```
+
+The Markdown report is also appended to the GitHub Actions step summary. The
+JSON report contains the current run id, baseline run id, commit metadata,
+budget policy, warning count, and per-step metric comparisons.
+
+## Compared Metrics
+
+The initial metrics are deliberately coarse and manifest-derived:
+
+| Metric | Direction | Soft warning threshold |
+| --- | --- | --- |
+| Step duration (`duration_ms`) | lower is better | current > 1.25 x baseline and +30s |
+| Seed-month throughput (`seed_months_per_second`) | higher is better | current < 0.75 x baseline |
+| Post-step heap used (`heap_used_bytes_after`) | lower is better | current > 1.40 x baseline and +64 MiB |
+| GC time (`gc_time_millis_delta`) | lower is better | current > 1.50 x baseline and +10s |
+
+These thresholds are soft warnings. They are meant to make regressions visible,
+not to encode a claim that the engine is too slow.
+
+## Profile Eligibility
+
+`smoke` and `nightly` are eligible for soft budget reports because they are the
+most comparable normal-validation profiles.
+
+`extended` remains report-only for performance budgets until the all-failed
+bank stress semantics in #718 are resolved. The extended profile currently
+includes stress paths that can terminate before later steps run, which makes
+step-to-step performance comparisons misleading.
+
+## Promotion Policy
+
+A metric can become a hard gate only after:
+
+- the profile has several comparable successful `main` runs;
+- the metric is low-noise on GitHub-hosted runners;
+- the failure message explains the affected step and metric;
+- stress-profile failures cannot be mistaken for normal-path performance
+  regressions;
+- the threshold rationale is documented here.
+
+Until then, performance reports are observability evidence. They should guide
+review and refactoring, not block correctness work.

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -32,9 +32,9 @@ duplicating those layers.
 | Coverage upload | PR and push | `.github/workflows/ci.yml` `test` job | `codecov/codecov-action` | Publish non-heavy unit coverage | Non-blocking upload; CI does not fail if Codecov upload fails |
 | Nightly diagnostics | Scheduled on `main`; manual dispatch | `.github/workflows/diagnostics-{smoke,nightly,extended}.yml` via reusable diagnostics workflow | Build `sbt assembly` under Nix, then run `NightlyDiagnosticsProfileRunner` from the jar | Long validation and diagnostics artifacts over `smoke`, `nightly`, and `extended` profiles | Hard fail on runner/build failure and hard invariants; economic outcomes are interpreted by profile classification |
 | Nightly health summary | After a non-dry-run diagnostics profile completes | `NightlyHealthSummary` via `NightlyDiagnosticsProfileRunner` | Reuse `run-manifest.json` and baseline Monte Carlo seed CSVs to write `health-summary.json` and `health-summary.md` | Compact machine/human verdict answering whether `main` stayed normal-path healthy overnight | Hard fail on normal-validation threshold breaches; warn/report for soft research signals; do not turn stress/exploratory outcomes into normal-path failures |
-| Nightly performance telemetry | Every diagnostics profile step | `NightlyDiagnosticsProfileRunner` manifest telemetry | Per-step duration, seed-month throughput, artifact size/row counts, and JVM memory/GC observations in `run-manifest.json` | Lightweight regression visibility before heavier profilers exist | Report-only initially; hard performance budgets belong to later baseline/regression work |
+| Nightly performance telemetry | Every diagnostics profile step | `NightlyDiagnosticsProfileRunner` manifest telemetry plus [performance regression budgets](performance-regression-budgets.md) | Per-step duration, seed-month throughput, artifact size/row counts, JVM memory/GC observations, and soft same-profile baseline comparisons in `run-manifest.json` and `performance-regression-report.*` | Lightweight regression visibility before heavier profilers exist | Soft warnings only; hard budgets require documented promotion |
 | Manual diagnostics | Local or workflow dispatch | Maintainer | `nix develop --command java -cp target/scala-3.8.2/amor-fati.jar com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunner ...` | Reproduce or inspect profile outputs outside PR CI | Evidence only unless explicitly promoted to a CI/nightly gate |
-| Hot-path profiling | Manual or weekly on `main` | `.github/workflows/hot-path-profiling-{smoke,nightly,extended}.yml` via reusable profiling workflow | Build `sbt assembly` under Nix, then run a profiled diagnostics workload with JFR | Hot-path timing/allocation visibility for FlowSimulation, banking, firms, households, runtime ledger execution, SFC projection, and diagnostics exports | Report-only; workflow fails on build/profiling/JFR capture failure, but hard performance budgets belong to #688 |
+| Hot-path profiling | Manual or weekly on `main` | `.github/workflows/hot-path-profiling-{smoke,nightly,extended}.yml` via reusable profiling workflow plus [performance regression budgets](performance-regression-budgets.md) | Build `sbt assembly` under Nix, then run a profiled diagnostics workload with JFR and a manifest-to-manifest budget report | Hot-path timing/allocation visibility for FlowSimulation, banking, firms, households, runtime ledger execution, SFC projection, and diagnostics exports | Report-only; workflow fails on build/profiling/JFR capture failure, not on soft performance-budget warnings |
 
 ## Existing Integration Ownership
 
@@ -116,8 +116,8 @@ A check can become a hard gate only when the contract is clear:
 - stress-profile findings must not mask normal-profile health;
 - health-summary hard thresholds must reuse existing nightly artifacts instead
   of launching another simulation path;
-- profiling budgets should start as warnings and become hard gates only for
-  low-noise metrics tied to commit/profile metadata.
+- profiling budgets start as warnings and become hard gates only for low-noise
+  metrics tied to commit/profile metadata.
 
 ## Relationship To Milestone #28
 
@@ -130,6 +130,6 @@ Observatory:
 - #685 adds thresholded nightly health summaries from existing artifacts.
 - #686 captures performance telemetry in nightly manifests.
 - #687 adds a manual or weekly hot-path profiling workflow under Nix.
-- #688 introduces performance baselines and regression budgets.
+- #688 introduces soft performance baselines and regression-budget reports.
 - #689 creates the canonical invariants and economic-semantics index.
 - #690 maps `FlowMechanism` semantics to ledger legs, SFC identities, and tests.

--- a/scripts/performance-regression-report.py
+++ b/scripts/performance-regression-report.py
@@ -235,7 +235,7 @@ def build_report(
 
 def render_markdown(report: dict[str, Any]) -> str:
     lines = [
-        "# Performance Regression Report",
+        "### Performance Regression Report",
         "",
         f"- Status: `{report['status']}`",
         f"- Profile: `{report['profile']}`",

--- a/scripts/performance-regression-report.py
+++ b/scripts/performance-regression-report.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Render a soft performance-regression report from two run manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+BYTES_IN_MIB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class MetricPolicy:
+    key: str
+    label: str
+    direction: str
+    warn_ratio: float
+    min_delta: float
+    unit: str
+
+
+@dataclass(frozen=True)
+class StepMetrics:
+    step_id: str
+    values: dict[str, float]
+
+
+POLICIES = [
+    MetricPolicy("duration_ms", "Duration", "lower", 1.25, 30_000.0, "ms"),
+    MetricPolicy("seed_months_per_second", "Seed-month throughput", "higher", 0.75, 0.0, "seed-months/s"),
+    MetricPolicy("heap_used_bytes_after", "Heap used after step", "lower", 1.40, 64.0 * BYTES_IN_MIB, "bytes"),
+    MetricPolicy("gc_time_millis_delta", "GC time", "lower", 1.50, 10_000.0, "ms"),
+]
+
+
+def read_json(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        result = float(value)
+        return result if math.isfinite(result) else None
+    return None
+
+
+def gc_time(telemetry: dict[str, Any]) -> float | None:
+    total = 0.0
+    seen = False
+    for row in telemetry.get("gc", []) or []:
+        value = number(row.get("collection_time_millis_delta"))
+        if value is not None:
+            total += value
+            seen = True
+    return total if seen else None
+
+
+def extract_steps(manifest: dict[str, Any] | None) -> dict[str, StepMetrics]:
+    if manifest is None:
+        return {}
+    records: dict[str, StepMetrics] = {}
+    for step in manifest.get("steps", []) or []:
+        step_id = step.get("id")
+        telemetry = step.get("telemetry")
+        if not isinstance(step_id, str) or not isinstance(telemetry, dict):
+            continue
+        after = ((telemetry.get("memory") or {}).get("after") or {})
+        values = {
+            "duration_ms": number(telemetry.get("duration_ms")),
+            "seed_months_per_second": number(telemetry.get("seed_months_per_second")),
+            "heap_used_bytes_after": number(after.get("heap_used_bytes")),
+            "gc_time_millis_delta": gc_time(telemetry),
+        }
+        records[step_id] = StepMetrics(step_id=step_id, values={k: v for k, v in values.items() if v is not None})
+    return records
+
+
+def warn(policy: MetricPolicy, current: float, baseline: float) -> bool:
+    if baseline <= 0.0:
+        return False
+    delta = current - baseline
+    if policy.direction == "lower":
+        return current > baseline * policy.warn_ratio and delta > policy.min_delta
+    if policy.direction == "higher":
+        return current < baseline * policy.warn_ratio
+    raise ValueError(f"Unsupported policy direction: {policy.direction}")
+
+
+def ratio(policy: MetricPolicy, current: float, baseline: float) -> float | None:
+    if baseline <= 0.0:
+        return None
+    if policy.direction == "higher":
+        return current / baseline
+    return current / baseline
+
+
+def format_value(value: float | None, unit: str) -> str:
+    if value is None:
+        return ""
+    if unit == "bytes":
+        return f"{value / BYTES_IN_MIB:.1f} MiB"
+    if unit == "ms":
+        return f"{value:.0f} ms"
+    return f"{value:.3f}"
+
+
+def manifest_ref(manifest: dict[str, Any] | None) -> dict[str, str]:
+    if manifest is None:
+        return {"run_id": "", "commit": "", "status": ""}
+    git = manifest.get("git") or {}
+    return {
+        "run_id": str(manifest.get("run_id", "")),
+        "commit": str(git.get("short_commit") or git.get("commit") or ""),
+        "status": str(manifest.get("status", "")),
+    }
+
+
+def build_report(
+    *,
+    profile: str,
+    source: str,
+    current: dict[str, Any] | None,
+    baseline: dict[str, Any] | None,
+    baseline_artifact: str,
+    skip_reason: str,
+) -> dict[str, Any]:
+    current_ref = manifest_ref(current)
+    baseline_ref = manifest_ref(baseline)
+    if skip_reason:
+        return {
+            "schema_version": 1,
+            "status": "SKIPPED",
+            "profile": profile,
+            "source": source,
+            "policy": "soft_warning",
+            "skip_reason": skip_reason,
+            "current": current_ref,
+            "baseline": baseline_ref,
+            "baseline_artifact": baseline_artifact,
+            "comparisons": [],
+            "warning_count": 0,
+        }
+    if current is None:
+        return {
+            "schema_version": 1,
+            "status": "CURRENT_MISSING",
+            "profile": profile,
+            "source": source,
+            "policy": "soft_warning",
+            "skip_reason": "",
+            "current": current_ref,
+            "baseline": baseline_ref,
+            "baseline_artifact": baseline_artifact,
+            "comparisons": [],
+            "warning_count": 0,
+        }
+    if baseline is None:
+        return {
+            "schema_version": 1,
+            "status": "NO_BASELINE",
+            "profile": profile,
+            "source": source,
+            "policy": "soft_warning",
+            "skip_reason": "",
+            "current": current_ref,
+            "baseline": baseline_ref,
+            "baseline_artifact": baseline_artifact,
+            "comparisons": [],
+            "warning_count": 0,
+        }
+
+    current_steps = extract_steps(current)
+    baseline_steps = extract_steps(baseline)
+    comparisons = []
+    warning_count = 0
+    for step_id in sorted(set(current_steps).intersection(baseline_steps)):
+        current_step = current_steps[step_id]
+        baseline_step = baseline_steps[step_id]
+        for policy in POLICIES:
+            current_value = current_step.values.get(policy.key)
+            baseline_value = baseline_step.values.get(policy.key)
+            if current_value is None or baseline_value is None:
+                continue
+            warning = warn(policy, current_value, baseline_value)
+            if warning:
+                warning_count += 1
+            comparisons.append(
+                {
+                    "step": step_id,
+                    "metric": policy.key,
+                    "label": policy.label,
+                    "direction": policy.direction,
+                    "unit": policy.unit,
+                    "baseline": baseline_value,
+                    "current": current_value,
+                    "ratio": ratio(policy, current_value, baseline_value),
+                    "status": "WARN" if warning else "PASS",
+                    "threshold": policy.warn_ratio,
+                },
+            )
+
+    status = "WARN" if warning_count else "PASS"
+    if not comparisons:
+        status = "NO_SHARED_TELEMETRY"
+    return {
+        "schema_version": 1,
+        "status": status,
+        "profile": profile,
+        "source": source,
+        "policy": "soft_warning",
+        "skip_reason": "",
+        "current": current_ref,
+        "baseline": baseline_ref,
+        "baseline_artifact": baseline_artifact,
+        "comparisons": comparisons,
+        "warning_count": warning_count,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Performance Regression Report",
+        "",
+        f"- Status: `{report['status']}`",
+        f"- Profile: `{report['profile']}`",
+        f"- Source: `{report['source']}`",
+        f"- Policy: `{report['policy']}`",
+        f"- Current run: `{report['current'].get('run_id', '')}` (`{report['current'].get('commit', '')}`)",
+        f"- Current status: `{report['current'].get('status', '')}`",
+        f"- Baseline run: `{report['baseline'].get('run_id', '')}` (`{report['baseline'].get('commit', '')}`)",
+        f"- Baseline status: `{report['baseline'].get('status', '')}`",
+        f"- Baseline artifact: `{report.get('baseline_artifact', '')}`",
+        f"- Warning count: `{report['warning_count']}`",
+    ]
+    if report.get("skip_reason"):
+        lines.append(f"- Skip reason: {report['skip_reason']}")
+    lines.extend(["", "| Step | Metric | Baseline | Current | Ratio | Status |", "| --- | --- | --- | --- | --- | --- |"])
+    for row in report.get("comparisons", []):
+        ratio_value = row.get("ratio")
+        ratio_text = "" if ratio_value is None else f"{ratio_value:.3f}x"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row["step"],
+                    row["label"],
+                    format_value(row["baseline"], row["unit"]),
+                    format_value(row["current"], row["unit"]),
+                    ratio_text,
+                    row["status"],
+                ],
+            )
+            + " |",
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--out-json", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--baseline-artifact", default="")
+    parser.add_argument("--skip-reason", default="")
+    args = parser.parse_args(argv)
+
+    current = read_json(args.current)
+    baseline = read_json(args.baseline)
+    report = build_report(
+        profile=args.profile,
+        source=args.source,
+        current=current,
+        baseline=baseline,
+        baseline_artifact=args.baseline_artifact,
+        skip_reason=args.skip_reason,
+    )
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.write_text(render_markdown(report), encoding="utf-8")
+    print(f"Performance regression report status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/performance-regression-report.py
+++ b/scripts/performance-regression-report.py
@@ -104,8 +104,10 @@ def ratio(policy: MetricPolicy, current: float, baseline: float) -> float | None
     if baseline <= 0.0:
         return None
     if policy.direction == "higher":
+        return None if current <= 0.0 else baseline / current
+    if policy.direction == "lower":
         return current / baseline
-    return current / baseline
+    raise ValueError(f"Unsupported policy direction: {policy.direction}")
 
 
 def format_value(value: float | None, unit: str) -> str:

--- a/scripts/select-performance-baseline.py
+++ b/scripts/select-performance-baseline.py
@@ -84,8 +84,18 @@ def main(argv: list[str]) -> int:
         return 0
 
     try:
-        payload = request_json(f"https://api.github.com/repos/{args.repo}/actions/artifacts?per_page=100", token)
-        artifact = select_artifact(payload.get("artifacts", []), args.artifact_prefix, args.branch)
+        artifact = None
+        page = 1
+        while artifact is None:
+            payload = request_json(
+                f"https://api.github.com/repos/{args.repo}/actions/artifacts?per_page=100&page={page}",
+                token,
+            )
+            artifacts = payload.get("artifacts", [])
+            artifact = select_artifact(artifacts, args.artifact_prefix, args.branch)
+            if artifact is not None or len(artifacts) < 100:
+                break
+            page += 1
         if artifact is None:
             print(f"No baseline artifact found for prefix {args.artifact_prefix!r} on branch {args.branch!r}.")
             outputs = empty_outputs | {"status": "not-found"}

--- a/scripts/select-performance-baseline.py
+++ b/scripts/select-performance-baseline.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Select the newest matching GitHub Actions artifact for performance baselines.
+
+The selector is intentionally best-effort. Missing permissions or absent
+artifacts are represented as empty outputs so workflow callers can produce a
+soft "no baseline" report instead of failing diagnostics or profiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def request_json(url: str, token: str) -> dict:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def write_outputs(github_output: Path | None, outputs: dict[str, str]) -> None:
+    if github_output is None:
+        return
+    with github_output.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def write_selection(path: Path | None, outputs: dict[str, str]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(outputs, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def select_artifact(artifacts: list[dict], prefix: str, branch: str) -> dict | None:
+    for artifact in artifacts:
+        workflow_run = artifact.get("workflow_run") or {}
+        if artifact.get("expired") is True:
+            continue
+        if not str(artifact.get("name", "")).startswith(prefix):
+            continue
+        if workflow_run.get("head_branch") != branch:
+            continue
+        return artifact
+    return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--artifact-prefix", required=True, help="Artifact-name prefix to use as the baseline selector")
+    parser.add_argument("--branch", default="main", help="Workflow-run branch to accept as a baseline")
+    parser.add_argument("--github-output", type=Path, help="Optional GITHUB_OUTPUT file to populate")
+    parser.add_argument("--out-json", type=Path, help="Optional JSON file with the selected artifact metadata")
+    parser.add_argument("--token-env", default="GITHUB_TOKEN", help="Environment variable containing the GitHub token")
+    args = parser.parse_args(argv)
+
+    empty_outputs = {
+        "artifact_id": "",
+        "artifact_name": "",
+        "run_id": "",
+        "head_sha": "",
+        "status": "missing",
+    }
+    token = os.environ.get(args.token_env, "")
+    if not token:
+        print("No GitHub token available; performance baseline unavailable.", file=sys.stderr)
+        outputs = empty_outputs | {"status": "missing-token"}
+        write_selection(args.out_json, outputs)
+        write_outputs(args.github_output, outputs)
+        return 0
+
+    try:
+        payload = request_json(f"https://api.github.com/repos/{args.repo}/actions/artifacts?per_page=100", token)
+        artifact = select_artifact(payload.get("artifacts", []), args.artifact_prefix, args.branch)
+        if artifact is None:
+            print(f"No baseline artifact found for prefix {args.artifact_prefix!r} on branch {args.branch!r}.")
+            outputs = empty_outputs | {"status": "not-found"}
+            write_selection(args.out_json, outputs)
+            write_outputs(args.github_output, outputs)
+            return 0
+
+        workflow_run = artifact.get("workflow_run") or {}
+        outputs = {
+            "artifact_id": str(artifact.get("id", "")),
+            "artifact_name": str(artifact.get("name", "")),
+            "run_id": str(workflow_run.get("id", "")),
+            "head_sha": str(workflow_run.get("head_sha", "")),
+            "status": "ok",
+        }
+        print(json.dumps(outputs, sort_keys=True))
+        write_selection(args.out_json, outputs)
+        write_outputs(args.github_output, outputs)
+        return 0
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError, KeyError, json.JSONDecodeError) as exc:
+        print(f"Performance baseline unavailable: {type(exc).__name__}: {exc}", file=sys.stderr)
+        outputs = empty_outputs | {"status": "error"}
+        write_selection(args.out_json, outputs)
+        write_outputs(args.github_output, outputs)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add manifest-to-manifest soft performance regression reports for diagnostics and hot-path profiling workflows
- select the newest same-profile baseline artifact on main and compare existing run-manifest telemetry without launching extra simulations
- keep smoke/nightly eligible for soft budget reports while marking extended as report-only until #718 resolves all-failed bank stress semantics
- document metric policy, artifact outputs, and promotion criteria for future hard gates

## Validation
- python3 -m py_compile scripts/select-performance-baseline.py scripts/performance-regression-report.py
- ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/diagnostics-reusable.yml .github/workflows/hot-path-profiling-reusable.yml .github/workflows/diagnostics-smoke.yml .github/workflows/diagnostics-nightly.yml .github/workflows/diagnostics-extended.yml .github/workflows/hot-path-profiling-smoke.yml .github/workflows/hot-path-profiling-nightly.yml .github/workflows/hot-path-profiling-extended.yml
- python3 scripts/performance-regression-report.py --current target/gh-run-26887278503/extended/extended-manual-20260603-1316-d59aa70/run-manifest.json --baseline target/gh-run-26887278503/extended/extended-manual-20260603-1316-d59aa70/run-manifest.json --out-json target/perf-report-smoke/report.json --out-md target/perf-report-smoke/report.md --profile extended --source diagnostics
- python3 scripts/performance-regression-report.py --current target/gh-run-26887278503/extended/extended-manual-20260603-1316-d59aa70/run-manifest.json --out-json target/perf-report-skip/report.json --out-md target/perf-report-skip/report.md --profile extended --source diagnostics --skip-reason 'extended profile remains report-only for performance budgets until #718 resolves all-failed bank stress semantics.'
- GITHUB_TOKEN=... python3 scripts/select-performance-baseline.py --repo boombustgroup/amor-fati --artifact-prefix amor-fati-diagnostics-nightly- --out-json target/performance-baseline-smoke/selection.json --branch main
- git diff --check

Closes #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance regression budget reporting that generates soft-warning comparison reports comparing current runs to baseline manifests across diagnostics and profiling workflows.

* **Documentation**
  * New performance regression budgets documentation defining metrics, thresholds, and promotion policy.
  * Updated profiling and diagnostics guides with performance report outputs and interpretation guidance.
  * Updated validation matrix and engine invariants documentation with performance budget semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->