### PR TITLE
Define canonical reviewer reading path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,55 +176,28 @@ That distinction matters. A nonlinear ABM can explore unstable, surprising, even
 
 ## Model Documentation
 
-Amor Fati now includes a research-readiness documentation spine for review,
-replication, calibration, validation, and publication work:
+Start with the [model specification](docs/model-specification.md). Its
+[Reviewer Reading Path](docs/model-specification.md#reviewer-reading-path) is
+the canonical first-pass path for scientific review:
 
-| Artifact | Purpose |
-| --- | --- |
-| [Model specification](docs/model-specification.md) | Canonical publication-facing entry point: model identity, scope, state vector, monthly transition, equation families, SFC/accounting contract, stochasticity, calibration, validation, limitations, and reading order. |
-| [Model-spec completeness checklist](docs/model-spec-completeness-checklist.md) | Review checklist for model-family coverage across notation, equations, implementation anchors, output columns, SFC/ledger mapping, calibration references, validation diagnostics, and visible gaps. |
-| [Model notation and state vector](docs/model-notation-and-state-vector.md) | Canonical publication-facing notation for time, agents, sectors, stocks, flows, rates, shares, stochastic variables, the full model state vector, and runtime implementation anchors. |
-| [Monthly transition function](docs/monthly-transition-function.md) | Mathematical month-step contract from `X_t` to `X_tau`: randomness, same-month economics, flow emission, runtime ledger execution, closed-month state, SFC validation, trace evidence, and next-pre boundary. |
-| [Stochastic processes and replay](docs/stochastic-processes-and-replay.md) | Publication-facing randomness contract: initialization streams, month streams, stochastic decision surfaces, Monte Carlo seed policy, deterministic replay, validation, and limitations. |
-| [Household equations](docs/household-equations.md) | Publication-facing household-sector equations: state, income/PIT/transfers, consumption, mortgage service, consumer credit, liquidity shortfall, distress, retraining, remittances, outputs, validation, and limitations. |
-| [Firm equations](docs/firm-equations.md) | Publication-facing firm-sector equations: firm state, production/capacity, labor, pricing, inventory, investment, technology adoption, financing, default/NPL, entry/exit, outputs, validation, and limitations. |
-| [Banking and financial-sector equations](docs/banking-and-financial-sector-equations.md) | Publication-facing banking and financial-stability section: bank state, rates, approval gates, ratios, ECL, interbank, bond waterfall, capital, failure/resolution, financial-sector interfaces, outputs, validation, and limitations. |
-| [Institutional sector equations](docs/institutional-sector-equations.md) | Publication-facing central-government, social-fund, JST, NBP, external-sector, insurance, NBFI/TFI, quasi-fiscal, SFC, output, validation, and limitation surface. |
-| [Model equations to SFC map](docs/model-equations-to-sfc-map.md) | Reviewer-facing bridge from equation families and state variables to generated BSM/TFM rows, exact SFC identities, runtime evidence, and known accounting limitations. |
-| [ODD / ODD+D model documentation](docs/odd-model-documentation.md) | ODD/ODD+D source document: purpose, entities, state variables, scales, scheduling, initialization, inputs, submodels, observation surfaces, and decision-making notes. |
-| [Behavioral equations and decision rules](docs/behavioral-equations-and-decision-rules.md) | Household, firm, bank, fiscal, monetary, external, insurance, NBFI, quasi-fiscal, and JST rules linked to implementation modules and numeric output columns. |
-| [Calibration register](docs/calibration-register.md) | Key parameter values, units, implementation owners, empirical targets, transformations, provenance status, and searchable gaps. |
-| [Data bridge to national and financial accounts](docs/data-bridge-national-financial-accounts.md) | Official Polish, EU, and financial-account sources mapped to initialization stocks, calibrated parameters, scenario inputs, validation targets, transformations, and prioritized empirical gaps. |
-| [Empirical validation report](docs/empirical-validation-report.md) | Workflow for the empirical-validation snapshot: the curated source manifest is the editable input, while generated baseline artifacts live under `docs/empirical-validation/`. |
-| [Engine invariants and economic semantics](docs/engine-invariants-and-semantics.md) | Canonical reviewer-facing index of hard invariants, normal-path expectations, stress/exploratory diagnostics, calibration warnings, known limitations, enforcement points, and coverage. |
-| [Validation matrix and ownership boundaries](docs/validation-matrix.md) | CI, integration-test, generated-output, nightly, stress, and profiling ownership rules so new validation work lands in the right layer. |
-| [Performance regression budgets](docs/performance-regression-budgets.md) | Soft baseline comparisons for diagnostics and profiling telemetry, using existing run manifests without adding duplicate simulations. |
-| [Sensitivity and robustness workflow](docs/sensitivity-robustness-workflow.md) | Seed envelopes and one-at-a-time parameter-sensitivity artifacts generated from the Monte Carlo runner. |
-| [Reproducible scenario registry](docs/scenario-registry.md) | Named policy and shock scenarios with exact parameter deltas from baseline, expected channels, seed/run metadata, and the `scenarioRun` execution path. |
-| [Documentation architecture](docs/documentation-architecture.md) | Ownership map for canonical, generated, calibration, operational, diagnostics, ADR, and merge-candidate documentation artifacts. |
+| Step | Entry point | Boundary |
+| --- | --- | --- |
+| 1. Model specification | [Model specification](docs/model-specification.md) | Model identity, scope, state vector, month timing, equation families, stochasticity, limitations, and pointers to detailed sector documents. |
+| 2. Generated SFC evidence | [SFC matrix evidence](docs/sfc-matrix-evidence.md) and [model equations to SFC map](docs/model-equations-to-sfc-map.md) | Ledger-derived BSM/TFM snapshots, exact identities, runtime mechanism mapping, and stock-flow reconciliation evidence. |
+| 3. Calibration evidence | [Calibration register](docs/calibration-register.md) and [data bridge](docs/data-bridge-national-financial-accounts.md) | Parameter provenance, empirical sources, transformations, assumptions, and visible calibration gaps. |
+| 4. Validation evidence | [Empirical validation report](docs/empirical-validation-report.md) and [engine invariants](docs/engine-invariants-and-semantics.md) | Empirical snapshot workflow, normal-path expectations, hard invariants, warnings, and known limitation surfaces. |
+| 5. Operational appendices | [Operations](docs/operations.md), [validation matrix](docs/validation-matrix.md), and [documentation architecture](docs/documentation-architecture.md) | Commands, CI ownership, diagnostics/profiling routing, generated-output guards, and full documentation inventory. |
 
 ## Ledger-Derived Matrix Artifacts
 
-The project includes committed Markdown snapshots of the paper-facing SFC
-matrix artifacts:
-
-| Artifact | Purpose |
-| --- | --- |
-| [Balance Sheet Matrix (BSM)](docs/sfc-matrix-artifacts/symbolic-bsm.md) | Symbolic stock matrix by instrument and sector, using SFC asset/liability signs and explicit row sums. |
-| [Transactions Flow Matrix (TFM)](docs/sfc-matrix-artifacts/symbolic-tfm.md) | Symbolic monthly flow matrix by sector, including income, taxes, transfers, interest, trade, credit, bonds, and deposit changes. |
-| [Stock-Flow Reconciliation and Revaluation Evidence](docs/sfc-matrix-artifacts/stock-flow-reconciliation.md) | Executed-run evidence comparing observed stock deltas or level identities with independent transaction, revaluation, default, write-off, and other-change channels. |
-| [Symbolic-row to runtime mapping](docs/sfc-matrix-artifacts/matrix-mapping.md) | Traceability table linking each symbolic matrix row to runtime assets, mechanisms, ids, and coverage notes. |
-| [Economic flow-channel semantics](docs/sfc-matrix-artifacts/flow-mechanism-semantics.md) | Reviewer-facing audit map for executed economic flow channels, including family, topology, asset class, SFC/reconciliation impact, ledger survivability, and test/diagnostic coverage. |
-
-These snapshots are generated from an executed deterministic simulation step
-and committed as versioned evidence. The regeneration commands, sign
-conventions, coverage gaps, exact reconciliation rows, and review checklist are
-documented in
-[docs/sfc-matrix-evidence.md](docs/sfc-matrix-evidence.md).
-
-The hand-written [model equations to SFC map](docs/model-equations-to-sfc-map.md)
-connects model equation families to these generated rows, identities, and
-runtime evidence without being part of the generated snapshot set.
+Generated SFC snapshots live under
+[docs/sfc-matrix-artifacts/](docs/sfc-matrix-artifacts/), but they are not a
+separate README reading path. Start with
+[docs/sfc-matrix-evidence.md](docs/sfc-matrix-evidence.md) for regeneration
+commands, sign conventions, exact reconciliation rows, and coverage gaps. The
+hand-written [model equations to SFC map](docs/model-equations-to-sfc-map.md)
+connects model equation families to those generated rows, identities, and
+runtime evidence.
 
 ## Tech Stack
 

--- a/docs/banking-and-financial-sector-equations.md
+++ b/docs/banking-and-financial-sector-equations.md
@@ -15,7 +15,7 @@ financial-stability block.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Publication-facing model entry point and reading order. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md#banks) | Bank state, ledger stock, rate, ratio, and flow notation. |
 | [Monthly transition function](monthly-transition-function.md) | Month-step timing and deterministic transition contract. |
 | [Behavioral rule catalog](behavioral-equations-and-decision-rules.md#banking-rules) | Implementation-oriented banking rules and output-column map. |

--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -4,10 +4,11 @@ This document is the paper-facing rule book for Amor Fati's current
 SFC-ABM implementation. It describes implemented equations and algorithmic
 rules, not a normative target model.
 
-The document complements:
+The document complements the canonical reviewer path in
+[docs/model-specification.md](model-specification.md#reviewer-reading-path)
+with rule-level detail. Its companion links are local source anchors, not a
+separate top-level reading order:
 
-- `docs/model-specification.md`, which is the canonical publication-facing
-  model entry point;
 - `docs/odd-model-documentation.md`, which describes the model using the ODD
   and ODD+D structure;
 - `docs/sfc-matrix-evidence.md`, which documents the symbolic Balance Sheet

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -24,31 +24,24 @@ without deleting evidence.
 
 ## First-Pass Reviewer Path
 
-For a scientific reviewer, the intended first-pass path is:
+The canonical first-pass reviewer path is maintained in
+[model-specification.md#reviewer-reading-path](model-specification.md#reviewer-reading-path).
+README links to that path as the public front door; this inventory exists to
+classify the remaining documentation surfaces and prevent secondary documents
+from creating competing top-level reading orders.
 
-1. [README.md](../README.md) for project identity and status.
-2. [model-specification.md](model-specification.md) as the canonical model entry
-   point.
-3. [model-notation-and-state-vector.md](model-notation-and-state-vector.md) for
-   symbols and state.
-4. [monthly-transition-function.md](monthly-transition-function.md) for month
-   timing and execution boundaries.
-5. Sector equations:
-   [household](household-equations.md),
-   [firm](firm-equations.md),
-   [banking and financial sector](banking-and-financial-sector-equations.md),
-   and [institutional sector](institutional-sector-equations.md).
-6. [stochastic-processes-and-replay.md](stochastic-processes-and-replay.md) for
-   randomness and reproducibility.
-7. [model-equations-to-sfc-map.md](model-equations-to-sfc-map.md) plus
-   [sfc-matrix-evidence.md](sfc-matrix-evidence.md) for accounting evidence and
-   generated SFC artifacts.
-8. [model-spec-completeness-checklist.md](model-spec-completeness-checklist.md)
-   as a QA checklist, not as prose to read before the model specification.
+That canonical path separates:
 
-Operational, diagnostic, calibration, profiling, and scenario documents are
-appendices. They provide evidence and workflow detail after the reviewer
-understands the model contract.
+1. model specification and executable model contract;
+2. sector and behavior detail;
+3. generated SFC evidence;
+4. calibration evidence;
+5. validation evidence;
+6. operational appendices.
+
+Operational, diagnostic, calibration, profiling, and scenario documents remain
+appendices unless the model specification explicitly promotes them into the
+first-pass path.
 
 ## Inventory
 
@@ -81,7 +74,7 @@ understands the model contract.
 | [docs/model-equations-to-sfc-map.md](model-equations-to-sfc-map.md) | Hand-maintained companion to generated evidence | Human-maintained bridge from equation families to generated SFC rows, identities, mechanisms, and known accounting limits. |
 | [docs/model-notation-and-state-vector.md](model-notation-and-state-vector.md) | Canonical reviewer spine | Canonical notation, state-vector definitions, symbols, ownership boundaries, and implementation anchors. |
 | [docs/model-spec-completeness-checklist.md](model-spec-completeness-checklist.md) | Canonical reviewer spine | Publication-readiness QA checklist for coverage across notation, equations, implementation anchors, outputs, SFC mapping, calibration, and validation. |
-| [docs/model-specification.md](model-specification.md) | Canonical reviewer spine | Canonical publication-facing model specification and first scientific entry point. |
+| [docs/model-specification.md](model-specification.md) | Canonical reviewer spine | Canonical publication-facing model specification, reviewer reading path, and first scientific entry point. |
 | [docs/monthly-transition-function.md](monthly-transition-function.md) | Canonical reviewer spine | Formal monthly transition contract from pre-boundary state through same-month economics, ledger execution, SFC validation, and next-pre materialization. |
 | [docs/nightly-baseline-comparison.md](nightly-baseline-comparison.md) | Operational appendix | Nightly diagnostic baseline comparison policy and report semantics. |
 | [docs/nightly-diagnostics.md](nightly-diagnostics.md) | Operational appendix | Diagnostic profile taxonomy, nightly/extended execution semantics, and manifest policy. |
@@ -133,8 +126,8 @@ merge or consolidation candidates for later cleanup tickets:
 When adding or changing documentation:
 
 1. Assign exactly one owner class in this inventory.
-2. Decide whether the file belongs on the first-pass reviewer path or an
-   appendix path.
+2. Decide whether the file belongs on the canonical first-pass reviewer path in
+   [model-specification.md](model-specification.md) or an appendix path.
 3. If the file is generated, document the owning generator and keep it under
    generated-output checks where practical.
 4. If the file is hand-maintained but coupled to generated evidence, name the

--- a/docs/firm-equations.md
+++ b/docs/firm-equations.md
@@ -13,7 +13,7 @@ behavior and does not replace the implementation anchors listed below.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Canonical model overview and reading order. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md#firms) | Firm state, ledger-owned firm balances, and major symbol families. |
 | [Monthly transition function](monthly-transition-function.md) | `X_t -> X_tau` timing, randomness, flow emission, SFC validation, and next-pre boundary. |
 | [Behavioral equations and decision rules](behavioral-equations-and-decision-rules.md#firm-rules) | Detailed implementation-oriented rule catalog and output-column map. |

--- a/docs/household-equations.md
+++ b/docs/household-equations.md
@@ -13,7 +13,7 @@ rules and does not replace the implementation anchors listed below.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Canonical model overview and reading order. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md#households) | Household behavioral state, ledger-owned household balances, and major symbol families. |
 | [Monthly transition function](monthly-transition-function.md) | `X_t -> X_tau` timing, randomness, flow emission, SFC validation, and next-pre boundary. |
 | [Behavioral equations and decision rules](behavioral-equations-and-decision-rules.md#household-rules) | Detailed implementation-oriented household rule catalog and output-column map. |

--- a/docs/institutional-sector-equations.md
+++ b/docs/institutional-sector-equations.md
@@ -13,7 +13,7 @@ implementation anchors listed below.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Canonical model overview and reading order. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md) | Public, NBP, external, social-fund, insurance, NBFI, and quasi-fiscal state notation. |
 | [Monthly transition function](monthly-transition-function.md) | `X_t -> X_tau` timing, same-month economics, flow emission, SFC validation, and next-pre boundary. |
 | [Banking and financial-sector equations](banking-and-financial-sector-equations.md) | Commercial-bank, financial-stability, and bank-facing financial-sector interface equations. |

--- a/docs/model-notation-and-state-vector.md
+++ b/docs/model-notation-and-state-vector.md
@@ -10,6 +10,11 @@ stochasticity, SFC-mapping, calibration, or paper-facing overview material.
 
 ## Source Documents
 
+The canonical reviewer path lives in
+[model-specification.md#reviewer-reading-path](model-specification.md#reviewer-reading-path).
+The table below is a local source map for notation work, not a separate
+top-level reading order.
+
 | Source | Role |
 | --- | --- |
 | [Monthly transition function](monthly-transition-function.md) | Formal `X_t -> X_tau` transition, randomness contract, phase timeline, emitted evidence, and month-step invariants. |

--- a/docs/model-spec-completeness-checklist.md
+++ b/docs/model-spec-completeness-checklist.md
@@ -5,11 +5,12 @@ model specification. It links each major model family to the current notation,
 rules, implementation anchors, output surfaces, SFC/ledger mapping,
 calibration evidence, and validation coverage.
 
-It does not define new model behavior. The canonical overview remains
-[model-specification.md](model-specification.md), while detailed equations,
-ODD/ODD+D notes, the [model equations to SFC map](model-equations-to-sfc-map.md),
-generated SFC artifacts, calibration evidence, and validation ownership remain
-in their source documents.
+It does not define new model behavior. The canonical overview and reviewer path
+remain in [model-specification.md](model-specification.md#reviewer-reading-path),
+while detailed equations, ODD/ODD+D notes, the
+[model equations to SFC map](model-equations-to-sfc-map.md), generated SFC
+artifacts, calibration evidence, and validation ownership remain in their source
+documents.
 
 ## Status Legend
 

--- a/docs/model-specification.md
+++ b/docs/model-specification.md
@@ -11,6 +11,10 @@ below.
 
 ## Source Map
 
+This table lists the detailed sources used by the specification. It is not a
+second reading order; the canonical first-pass path is in
+[Reviewer Reading Path](#reviewer-reading-path).
+
 | Source | Role in the model specification |
 | --- | --- |
 | [Model notation and state vector](model-notation-and-state-vector.md) | Canonical symbols, state vector, time indexing, quantity classes, stochastic notation, and implementation anchors. |
@@ -303,40 +307,36 @@ behavioral mechanisms can be revised, calibration can be improved, and
 extensions can be added, but the accounting and validation surfaces must remain
 auditable.
 
-## Reviewer Reading Order
+## Reviewer Reading Path
 
-For a first academic review:
+For a first academic review, use this path and treat every other document as a
+supporting source rather than a competing entry point:
 
-1. Read this document for the model spine.
-2. Skim [model-spec-completeness-checklist.md](model-spec-completeness-checklist.md)
-   for current coverage and visible publication-readiness gaps.
-3. Read [model-notation-and-state-vector.md](model-notation-and-state-vector.md)
-   for notation and state ownership.
-4. Read [monthly-transition-function.md](monthly-transition-function.md) for
-   the formal month-step contract.
-5. Read [stochastic-processes-and-replay.md](stochastic-processes-and-replay.md)
-   for initialization seeds, monthly streams, Monte Carlo seed policy, and
-   deterministic replay.
-6. Read [odd-model-documentation.md](odd-model-documentation.md) for ODD/ODD+D
-   structure and agent/entity description.
-7. Read [behavioral-equations-and-decision-rules.md](behavioral-equations-and-decision-rules.md)
-   for implemented rule families.
-8. Read [household-equations.md](household-equations.md) for the consolidated
-   publication-facing household-sector section.
-9. Read [firm-equations.md](firm-equations.md) for the consolidated
-   publication-facing firm-sector section.
-10. Read [banking-and-financial-sector-equations.md](banking-and-financial-sector-equations.md)
-   for the consolidated banking and financial-stability section.
-11. Read [institutional-sector-equations.md](institutional-sector-equations.md)
-   for the consolidated public, monetary, external, insurance, NBFI, and
-   quasi-fiscal section.
-12. Read [model-equations-to-sfc-map.md](model-equations-to-sfc-map.md),
-   [sfc-matrix-evidence.md](sfc-matrix-evidence.md), and generated matrix
-   artifacts for the accounting contract.
-13. Read [calibration-register.md](calibration-register.md),
-   [data-bridge-national-financial-accounts.md](data-bridge-national-financial-accounts.md),
-   and [empirical-validation-report.md](empirical-validation-report.md) for
-   calibration and validation evidence.
-14. Read [engine-invariants-and-semantics.md](engine-invariants-and-semantics.md)
-   and [validation-matrix.md](validation-matrix.md) for failure semantics and
-   review routing.
+1. Model spine: read this document first.
+2. Executable model contract: read
+   [model-notation-and-state-vector.md](model-notation-and-state-vector.md),
+   [monthly-transition-function.md](monthly-transition-function.md), and
+   [stochastic-processes-and-replay.md](stochastic-processes-and-replay.md).
+3. Sector and behavior detail: read the sector equation documents for the
+   mechanism families relevant to the review:
+   [household](household-equations.md), [firm](firm-equations.md),
+   [banking and financial sector](banking-and-financial-sector-equations.md),
+   and [institutional sector](institutional-sector-equations.md). Use
+   [behavioral-equations-and-decision-rules.md](behavioral-equations-and-decision-rules.md)
+   and [odd-model-documentation.md](odd-model-documentation.md) as companion
+   references when implementation-level rule detail or ODD structure is needed.
+4. Generated SFC evidence: read
+   [model-equations-to-sfc-map.md](model-equations-to-sfc-map.md) and
+   [sfc-matrix-evidence.md](sfc-matrix-evidence.md), then inspect generated
+   `docs/sfc-matrix-artifacts/*` only for the specific matrix rows or
+   reconciliation evidence under review.
+5. Calibration evidence: read [calibration-register.md](calibration-register.md)
+   and [data-bridge-national-financial-accounts.md](data-bridge-national-financial-accounts.md).
+6. Validation evidence: read
+   [empirical-validation-report.md](empirical-validation-report.md) and
+   [engine-invariants-and-semantics.md](engine-invariants-and-semantics.md).
+7. Operational appendices: use [operations.md](operations.md),
+   [validation-matrix.md](validation-matrix.md), and
+   [documentation-architecture.md](documentation-architecture.md) only when
+   reproducing runs, changing CI/diagnostics, or navigating the full document
+   inventory.

--- a/docs/monthly-transition-function.md
+++ b/docs/monthly-transition-function.md
@@ -12,7 +12,7 @@ or validation documents.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Publication-facing model overview. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and publication-facing model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md) | Canonical symbols, state vector, time indices, stocks, flows, rates, shares, and stochastic notation. |
 | [Stochastic processes and replay](stochastic-processes-and-replay.md) | Detailed seed policy, initialization and month stream maps, stochastic decision surfaces, Monte Carlo replay, and validation coverage. |
 | [Behavioral equations and decision rules](behavioral-equations-and-decision-rules.md) | Detailed rule families used by the same-month economics stages. |

--- a/docs/stochastic-processes-and-replay.md
+++ b/docs/stochastic-processes-and-replay.md
@@ -12,7 +12,7 @@ assumptions, new probability distributions, or new seed scheduling rules.
 
 | Source | Role |
 | --- | --- |
-| [Model specification](model-specification.md) | Canonical model overview and reading order. |
+| [Model specification](model-specification.md#reviewer-reading-path) | Canonical reviewer path and model overview. |
 | [Model notation and state vector](model-notation-and-state-vector.md#stochastic-variables) | Stochastic notation, `RND_tau`, and stream-key notation. |
 | [Monthly transition function](monthly-transition-function.md#randomness-contract) | Formal one-month replay contract. |
 | [`random/RandomStream.scala`](../src/main/scala/com/boombustgroup/amorfati/random/RandomStream.scala) | Project-wide RNG facade. |


### PR DESCRIPTION
Closes #734

Summary:
- Replace README's broad documentation table with one concise first-pass reviewer path.
- Make docs/model-specification.md own the canonical Reviewer Reading Path and group supporting docs by model, SFC evidence, calibration, validation, and operational appendix boundaries.
- Update secondary documentation entry points to link back to the canonical path instead of implying competing reading orders.

Validation:
- git diff --check
- inventory completeness check: README.md + docs/**/* covered
- markdown link/anchor check for touched docs
- bash scripts/check-generated-outputs.sh