### PR TITLE
Consolidate operational appendix entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ the canonical first-pass path for scientific review:
 | 2. SFC evidence boundary | [SFC matrix evidence](docs/sfc-matrix-evidence.md) and [model equations to SFC map](docs/model-equations-to-sfc-map.md) | Hand-maintained entry points for generated BSM/TFM snapshots, exact identities, runtime mechanism mapping, and stock-flow reconciliation evidence. |
 | 3. Calibration evidence | [Calibration register](docs/calibration-register.md) and [data bridge](docs/data-bridge-national-financial-accounts.md) | Parameter provenance, empirical sources, transformations, assumptions, and visible calibration gaps. |
 | 4. Validation evidence | [Empirical validation report](docs/empirical-validation-report.md) and [engine invariants](docs/engine-invariants-and-semantics.md) | Empirical snapshot workflow, normal-path expectations, hard invariants, warnings, and known limitation surfaces. |
-| 5. Operational appendices | [Operations](docs/operations.md), [validation matrix](docs/validation-matrix.md), and [documentation architecture](docs/documentation-architecture.md) | Commands, CI ownership, diagnostics/profiling routing, generated-output guards, and full documentation inventory. |
+| 5. Operational appendices | [Operations](docs/operations.md) | Entry point for commands, CI ownership, diagnostics/profiling routing, generated-output guards, scenarios, robustness, and local artifacts. |
 
 ## Ledger-Derived Matrix Artifacts
 

--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -6,6 +6,11 @@ seed range, computes banking-sector and per-bank balance-sheet ratios, and
 compares them with the same stylized `2026-04-30` Poland baseline used by the
 rest of the calibration surface.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for bank balance-sheet benchmark details after starting from the
+operations index.
+
 Run the standard fixture with:
 
 ```bash

--- a/docs/bank-failure-ablations.md
+++ b/docs/bank-failure-ablations.md
@@ -6,6 +6,11 @@ baseline and targeted neutralization scenarios, then compares first failure
 timing, terminal failures, cumulative credit losses, ECL provisions, bail-in
 losses, capital destruction, and reconciliation residuals.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for bank-failure diagnostic details after starting from the
+operations index.
+
 Run the standard review fixture with:
 
 ```bash

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -126,8 +126,8 @@ merge or consolidation candidates for later cleanup tickets:
 
 | Candidate group | Current files | Proposed direction |
 | --- | --- | --- |
-| Operational validation appendix | `validation-matrix.md`, `nightly-diagnostics.md`, `nightly-baseline-comparison.md`, `operations.md`, `performance-regression-budgets.md` | Keep one operational entry point and cross-link detailed policy pages from it. |
-| Diagnostic-method appendix | `bank-balance-sheet-benchmark.md`, `bank-failure-ablations.md`, `hh-bank-lead-lag-diagnostics.md`, `loan-origination-quality-diagnostics.md`, `hot-path-profiling.md` | Create or use one diagnostic/profiling index so README and model spec do not need to enumerate each diagnostic document. |
+| Operational validation appendix | `operations.md`, `validation-matrix.md`, `nightly-diagnostics.md`, `nightly-baseline-comparison.md`, `performance-regression-budgets.md` | Use `operations.md#operational-appendix-index` as the operational entry point and keep detailed policy pages cross-linked from it. |
+| Diagnostic-method appendix | `bank-balance-sheet-benchmark.md`, `bank-failure-ablations.md`, `hh-bank-lead-lag-diagnostics.md`, `loan-origination-quality-diagnostics.md`, `hot-path-profiling.md` | Route diagnostic/profiling discovery through `operations.md#operational-appendix-index` so README and model spec do not enumerate each diagnostic document. |
 | Calibration evidence notes | `household-credit-stress-calibration.md`, `external-sector-baseline-calibration.md`, `private-credit-renewal-calibration.md` | Keep as evidence notes, but route them through calibration governance and data-bridge indexes. |
 | Publication QA checklist | `model-spec-completeness-checklist.md` | Keep as QA appendix unless #739 proves it duplicates the documentation architecture inventory. |
 

--- a/docs/hh-bank-lead-lag-diagnostics.md
+++ b/docs/hh-bank-lead-lag-diagnostics.md
@@ -4,6 +4,11 @@ This diagnostic export supports issue #584. It connects household stress flows
 to bank outcomes by `BankId` and month, then separates descriptive lead-lag
 correlation from controlled counterfactual evidence.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for HH-bank lead-lag diagnostic details after starting from the
+operations index.
+
 Run:
 
 ```bash

--- a/docs/hot-path-profiling.md
+++ b/docs/hot-path-profiling.md
@@ -4,6 +4,11 @@ This document defines the manual and weekly profiling workflow for Amor Fati's
 main engine paths. It is an observability workflow, not a replacement for CI,
 integration tests, nightly diagnostics, or nightly health summaries.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for profiling workflow details after starting from the operations
+index.
+
 ## Purpose
 
 Correctness checks answer whether the engine still respects its contracts.

--- a/docs/household-credit-stress-calibration.md
+++ b/docs/household-credit-stress-calibration.md
@@ -6,6 +6,11 @@ converts existing Monte Carlo outputs and terminal household aggregates into
 Poland-relevant guardrail ratios for the same `2026-04-30` model-start baseline
 used by the production calibration surface.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for household credit-stress diagnostic details after starting
+from the operations index.
+
 Run the standard fixture with:
 
 ```bash

--- a/docs/loan-origination-quality-diagnostics.md
+++ b/docs/loan-origination-quality-diagnostics.md
@@ -4,6 +4,11 @@ Issue #590 adds an optional diagnostic export that links household and firm
 credit-origination quality to later arrears, default, write-off, or bankruptcy
 outcomes. The export does not change production behavior.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for loan-origination diagnostic details after starting from the
+operations index.
+
 Run the standard review fixture with:
 
 ```bash

--- a/docs/model-specification.md
+++ b/docs/model-specification.md
@@ -32,7 +32,7 @@ second reading order; the canonical first-pass path is in
 | [Calibration register](calibration-register.md) | Parameter names, units, owners, empirical targets, transformations, provenance status, and searchable gaps. |
 | [Data bridge to national and financial accounts](data-bridge-national-financial-accounts.md) | Official data sources and empirical bridges used for initialization, calibration, scenarios, and validation. |
 | [Empirical validation report](empirical-validation-report.md) | Empirical-validation workflow and current snapshot artifacts. |
-| [Validation matrix](validation-matrix.md) | Ownership boundary for CI, integration tests, generated outputs, nightly diagnostics, stress profiles, profiling, and observability. |
+| [Operational appendix index](operations.md#operational-appendix-index) | Entry point for CI, integration tests, generated outputs, nightly diagnostics, stress profiles, profiling, scenarios, robustness, and observability appendices. |
 
 ## Model Identity
 
@@ -171,7 +171,7 @@ The canonical detailed rule source remains
 | Housing and mortgages | Updates housing prices, mortgage stock, origination, repayment, default, and mortgage-to-GDP outputs | `HousingMarket.scala`, banking housing stage, mortgage flow modules |
 | Fiscal, NBP, bonds, external sector | Computes public budget, public debt, rates, QE, bond yields, BoP/forex, GVC, trade, and current-account closure | [institutional sector equations](institutional-sector-equations.md), fiscal, NBP, open-economy, bond-market, and external-sector modules |
 | Insurance, NBFI, quasi-fiscal, JST | Computes premiums, claims, reserves, NBFI credit, fund AUM, PPK holdings, quasi-fiscal issuance/lending, and local-government flows | [institutional sector equations](institutional-sector-equations.md), insurance, NBFI, quasi-fiscal, PPK, JST modules |
-| Scenario, robustness, diagnostics | Defines executable counterfactuals, sensitivity envelopes, health summaries, and profiling evidence | [scenario registry](scenario-registry.md), [sensitivity workflow](sensitivity-robustness-workflow.md), [nightly diagnostics](nightly-diagnostics.md), [hot-path profiling](hot-path-profiling.md) |
+| Scenario, robustness, diagnostics | Defines executable counterfactuals, sensitivity envelopes, health summaries, and profiling evidence | [operational appendix index](operations.md#operational-appendix-index), which routes to the detailed scenario, robustness, diagnostics, and profiling appendices |
 
 When writing publication equations, use the notation in
 [model-notation-and-state-vector.md](model-notation-and-state-vector.md) and
@@ -268,7 +268,9 @@ breaks are hard failures. Calibration metrics, stress outcomes, exploratory
 diagnostics, and performance budgets start as warning/report evidence unless a
 written threshold rationale promotes them.
 
-The routing contract lives in [validation-matrix.md](validation-matrix.md).
+The operational appendix index in
+[operations.md](operations.md#operational-appendix-index) routes to the detailed
+validation, diagnostics, profiling, scenario, and generated-output contracts.
 
 ## Observation Surfaces
 
@@ -335,8 +337,7 @@ supporting source rather than a competing entry point:
 6. Validation evidence: read
    [empirical-validation-report.md](empirical-validation-report.md) and
    [engine-invariants-and-semantics.md](engine-invariants-and-semantics.md).
-7. Operational appendices: use [operations.md](operations.md),
-   [validation-matrix.md](validation-matrix.md), and
-   [documentation-architecture.md](documentation-architecture.md) only when
-   reproducing runs, changing CI/diagnostics, or navigating the full document
-   inventory.
+7. Operational appendices: use
+   [operations.md](operations.md#operational-appendix-index) as the entry point
+   only when reproducing runs, changing CI/diagnostics, or navigating local
+   run artifacts.

--- a/docs/nightly-baseline-comparison.md
+++ b/docs/nightly-baseline-comparison.md
@@ -5,6 +5,11 @@ baseline evidence. It is the comparison contract for the nightly validation
 milestone. It intentionally comes before the jar runner and scheduled workflow
 so automation does not encode unclear regression semantics.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for nightly comparison policy after starting from the operations
+index.
+
 The comparison layer has two jobs:
 
 - fail fast on accounting and output invariants that must never drift;

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -10,6 +10,11 @@ operational horizon of the model. They are not long-horizon cycle claims.
 The comparison semantics for these profiles are defined in
 [nightly-baseline-comparison.md](nightly-baseline-comparison.md).
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for diagnostics profile semantics after starting from the
+operations index.
+
 ## Principles
 
 - Run against a clean `main` ref, not a dirty local checkout.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,6 +4,23 @@ This document is the command-oriented operating guide for Amor Fati. It is not
 model documentation; it records how to run, test, inspect, and compare the
 current codebase from a local checkout.
 
+## Operational Appendix Index
+
+This document is the entry point for operational appendices. Use the table
+below to find the owning page for CI, generated outputs, diagnostics,
+profiling, scenarios, and local run artifacts. Detailed appendices should link
+back here instead of each maintaining a separate top-level operations map.
+
+| Need | Start here | Detail owner |
+| --- | --- | --- |
+| Local setup, test commands, Nix shell, heavy tests, integration tests, output paths | This document | Sections below |
+| CI, generated-output guard, validation ownership, failure semantics | [Validation matrix](validation-matrix.md) | `docs/validation-matrix.md` |
+| Nightly diagnostics profiles, health summary, run manifests, artifact retention | [Nightly diagnostics](nightly-diagnostics.md) | `docs/nightly-diagnostics.md` |
+| Nightly baseline comparison and threshold promotion policy | [Nightly baseline comparison](nightly-baseline-comparison.md) | `docs/nightly-baseline-comparison.md` |
+| Hot-path profiling, JFR artifacts, performance telemetry | [Hot-path profiling](hot-path-profiling.md) and [performance regression budgets](performance-regression-budgets.md) | `docs/hot-path-profiling.md`, `docs/performance-regression-budgets.md` |
+| Named scenario runs and robustness envelopes | [Scenario registry](scenario-registry.md) and [sensitivity robustness workflow](sensitivity-robustness-workflow.md) | `docs/scenario-registry.md`, `docs/sensitivity-robustness-workflow.md` |
+| Focused banking/household/credit diagnostics | [Household credit stress calibration](household-credit-stress-calibration.md), [bank balance-sheet benchmark](bank-balance-sheet-benchmark.md), [bank failure ablations](bank-failure-ablations.md), [HH-bank lead-lag diagnostics](hh-bank-lead-lag-diagnostics.md), [loan-origination quality diagnostics](loan-origination-quality-diagnostics.md) | Diagnostic-specific appendices |
+
 ## Requirements
 
 Use the same toolchain shape as CI:

--- a/docs/performance-regression-budgets.md
+++ b/docs/performance-regression-budgets.md
@@ -7,6 +7,11 @@ The layer is intentionally soft. It produces reviewer-facing regression reports
 from existing run manifests; it does not launch extra simulations and it does
 not fail workflows on performance drift.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for performance-budget policy after starting from the operations
+index.
+
 ## Source Artifacts
 
 Performance comparisons reuse `run-manifest.json` files already produced by

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -10,6 +10,11 @@ The source of truth is
 The executable runner is
 `src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala`.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for named scenario execution details after starting from the
+operations index.
+
 ## Command
 
 Run the baseline plus two nontrivial scenarios:

--- a/docs/sensitivity-robustness-workflow.md
+++ b/docs/sensitivity-robustness-workflow.md
@@ -16,6 +16,11 @@ This is not a full global sensitivity design. It is a local research-review
 workflow that should stay cheap enough to run before larger empirical and
 scenario work.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for robustness workflow details after starting from the operations
+index.
+
 ## Command
 
 Local review default:

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -6,6 +6,11 @@ replacement for CI, integration tests, generated-output checks, or nightly
 diagnostics; it is the routing rule that keeps future validation work from
 duplicating those layers.
 
+Operational appendix entry point:
+[operations.md#operational-appendix-index](operations.md#operational-appendix-index).
+Use this page for validation ownership and failure semantics after starting
+from the operations index.
+
 ## Principles
 
 - PR feedback should stay fast enough for normal development.


### PR DESCRIPTION
Closes #736

Summary:
- Make docs/operations.md the operational appendix entry point for CI, generated outputs, diagnostics, profiling, scenarios, robustness, and focused diagnostic appendices.
- Update README and model-specification routing so operational appendices are discovered through operations.md instead of being enumerated in publication-facing entry points.
- Add backlink notes from operational and diagnostic appendix docs to the operations index.

Validation:
- git diff --check
- markdown link/anchor sanity check for README.md and docs/**/*.md
- bash scripts/check-generated-outputs.sh