### PR TITLE
Clarify calibration evidence boundary

### DIFF
--- a/docs/data-bridge-national-financial-accounts.md
+++ b/docs/data-bridge-national-financial-accounts.md
@@ -9,6 +9,9 @@ scripts should use this file as the reference for source selection,
 transformation rules, vintages, and model ownership. The calibration register
 documents current parameter provenance; the empirical validation report
 documents model-output comparisons. This bridge connects both to external data.
+It does not define the long-term parameter governance policy; deeper
+source-of-truth, versioning, and lifecycle decisions belong to Calibration
+Governance (#27).
 
 ## Boundary And Data Roles
 

--- a/docs/data-bridge-national-financial-accounts.md
+++ b/docs/data-bridge-national-financial-accounts.md
@@ -10,8 +10,8 @@ transformation rules, vintages, and model ownership. The calibration register
 documents current parameter provenance; the empirical validation report
 documents model-output comparisons. This bridge connects both to external data.
 It does not define the long-term parameter governance policy; deeper
-source-of-truth, versioning, and lifecycle decisions belong to Calibration
-Governance (#27).
+source-of-truth, versioning, and lifecycle decisions belong to the
+[Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27).
 
 ## Boundary And Data Roles
 

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -16,7 +16,7 @@ without deleting evidence.
 | Canonical reviewer spine | Paper-facing model contract or primary reviewer reference. These files define how the implemented model should be read. |
 | Generated evidence | Committed output produced by a task or exporter. Do not edit by hand; regenerate through the owning command. |
 | Hand-maintained companion to generated evidence | Human-written bridge, index, or workflow note that explains generated evidence and must stay aligned with it. |
-| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. Deeper governance belongs to Calibration Governance (#27). |
+| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. These files do not define parameter governance policy; deeper governance belongs to Calibration Governance (#27). |
 | Operational appendix | Commands, CI, validation ownership, scenarios, robustness, and runbook material. Useful, but not the first scientific reading path. |
 | Diagnostics or profiling appendix | Specific diagnostic/profiling methodology, exporter interpretation, or investigation evidence. |
 | ADR or decision record | Durable architectural or semantic decision record. Preserve history unless superseded explicitly. |

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -16,7 +16,7 @@ without deleting evidence.
 | Canonical reviewer spine | Paper-facing model contract or primary reviewer reference. These files define how the implemented model should be read. |
 | Generated evidence | Committed output produced by a task or exporter. Do not edit by hand; regenerate through the owning command. |
 | Hand-maintained companion to generated evidence | Human-written bridge, index, or workflow note that explains generated evidence and must stay aligned with it. |
-| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. These files do not define parameter governance policy; deeper governance belongs to Calibration Governance (#27). |
+| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. These files do not define parameter governance policy; deeper governance belongs to the [Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27). |
 | Operational appendix | Commands, CI, validation ownership, scenarios, robustness, and runbook material. Useful, but not the first scientific reading path. |
 | Diagnostics or profiling appendix | Specific diagnostic/profiling methodology, exporter interpretation, or investigation evidence. |
 | ADR or decision record | Durable architectural or semantic decision record. Preserve history unless superseded explicitly. |

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -11,8 +11,8 @@ The goal is to keep failed, missing, or weak validation targets visible. A row
 with `MISSING_OUTPUT`, `MISSING_DATA_BRIDGE`, `MISSING_SOURCE_DETAIL`, or
 `BRIDGE_ASSUMPTION` is part of the report surface, not an omission.
 This report is empirical evidence, not calibration governance policy; deeper
-source-of-truth, versioning, and parameter lifecycle decisions belong to
-Calibration Governance (#27).
+source-of-truth, versioning, and parameter lifecycle decisions belong to the
+[Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27).
 
 ## Validation Boundary
 

--- a/docs/empirical-validation-report.md
+++ b/docs/empirical-validation-report.md
@@ -10,6 +10,9 @@ while pass/fail baseline results live in
 The goal is to keep failed, missing, or weak validation targets visible. A row
 with `MISSING_OUTPUT`, `MISSING_DATA_BRIDGE`, `MISSING_SOURCE_DETAIL`, or
 `BRIDGE_ASSUMPTION` is part of the report surface, not an omission.
+This report is empirical evidence, not calibration governance policy; deeper
+source-of-truth, versioning, and parameter lifecycle decisions belong to
+Calibration Governance (#27).
 
 ## Validation Boundary
 

--- a/docs/model-notation-and-state-vector.md
+++ b/docs/model-notation-and-state-vector.md
@@ -429,7 +429,7 @@ an explicit seed contract.
 
 - This document does not define new equations.
 - This document does not settle calibration governance; that is tracked by
-  milestone #27.
+  the [Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27).
 - This document does not replace generated SFC matrix artifacts.
 - This document intentionally mirrors the current implementation. Future model
   changes should update this notation only when the runtime state boundary or

--- a/docs/model-specification.md
+++ b/docs/model-specification.md
@@ -244,9 +244,12 @@ Calibration is currently documented through:
 - targeted calibration notes for external sector, household credit stress, and
   private credit renewal.
 
-Calibration governance is intentionally treated as a separate design problem.
-This model specification references current calibration artifacts but does not
-declare a new parameter source-of-truth policy.
+Use these artifacts after the model-equation and SFC review when the question
+becomes "which sources, transformations, snapshots, and visible gaps support
+the current parameterization?" They are evidence surfaces, not a second
+equation narrative. Calibration governance is intentionally treated as a
+separate design problem; this model specification references current
+calibration artifacts but does not declare a parameter source-of-truth policy.
 
 ## Validation And Diagnostics
 
@@ -332,8 +335,11 @@ supporting source rather than a competing entry point:
    [sfc-matrix-evidence.md](sfc-matrix-evidence.md) as hand-maintained entry
    points, then inspect generated `docs/sfc-matrix-artifacts/*` only for the
    specific matrix rows or reconciliation evidence under review.
-5. Calibration evidence: read [calibration-register.md](calibration-register.md)
-   and [data-bridge-national-financial-accounts.md](data-bridge-national-financial-accounts.md).
+5. Calibration evidence: after the equation and SFC review, use
+   [calibration-register.md](calibration-register.md) and
+   [data-bridge-national-financial-accounts.md](data-bridge-national-financial-accounts.md)
+   to inspect current parameter evidence, external-source bridges, and visible
+   provenance gaps.
 6. Validation evidence: read
    [empirical-validation-report.md](empirical-validation-report.md) and
    [engine-invariants-and-semantics.md](engine-invariants-and-semantics.md).


### PR DESCRIPTION
Closes #737

Summary:
- Clarify in model-specification.md when reviewers should leave equations/SFC and enter calibration evidence.
- Mark calibration and empirical docs as evidence surfaces, not parameter governance policy.
- Add minimal Calibration Governance (#27) boundary references in the hand-maintained data bridge and empirical validation report.

Non-goals:
- No parameter semantics changed.
- No calibration-register generator changes.
- No new documentation index or governance process added.

Validation:
- git diff --check
- markdown link/anchor sanity check for README.md and docs/**/*.md
- bash scripts/check-generated-outputs.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope of specification and validation documentation to distinguish them from governance policy.
  * Enhanced reviewer guidance with structured instructions for evaluating calibration evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->