### PR TITLE
Add lightweight documentation hygiene checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
 
+      - name: Check documentation hygiene
+        run: nix develop --command python3 scripts/check-docs.py
+
       - name: Check generated repository outputs
         run: nix develop --command bash scripts/check-generated-outputs.sh
 

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -144,3 +144,5 @@ When adding or changing documentation:
    generated artifacts it must track.
 5. Do not delete or merge documentation without listing the replacement path and
    preserving generated evidence.
+6. Run `nix develop --command python3 scripts/check-docs.py` before review when
+   changing local links, headings, or committed `docs/` artifacts.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -510,6 +510,20 @@ Generated local outputs normally belong in ignored paths:
 | `docs/sfc-matrix-artifacts/` | Intentional committed matrix snapshots | Yes, only when refreshed intentionally |
 | `docs/empirical-validation/` | Empirical-validation snapshot bundle | Yes, only when refreshed intentionally |
 
+### Documentation Hygiene Guard
+
+Pull-request CI also runs `scripts/check-docs.py` under the same Nix
+development shell. The documentation hygiene guard validates local Markdown
+links, local Markdown anchors, and the `docs/documentation-architecture.md`
+inventory coverage for every committed `docs/` artifact. It does not lint prose
+style or check external URLs.
+
+Run the documentation hygiene check locally with:
+
+```bash
+nix develop --command python3 scripts/check-docs.py
+```
+
 ### Generated Output Guard
 
 Pull-request CI runs `scripts/check-generated-outputs.sh` under the Nix

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -29,6 +29,7 @@ from the operations index.
 | Layer | Trigger | Owner | Command / workflow | Primary purpose | Failure semantics |
 | --- | --- | --- | --- | --- | --- |
 | Generated outputs | PR and push | `.github/workflows/ci.yml` `generated-outputs` job | `nix develop --command bash scripts/check-generated-outputs.sh` | Prove generated docs/resources match checked-in sources | Hard fail on stale or missing generated output |
+| Documentation hygiene | PR and push | `.github/workflows/ci.yml` `generated-outputs` job | `nix develop --command python3 scripts/check-docs.py` | Validate local Markdown links, local anchors, and documentation inventory coverage | Hard fail on broken local documentation links, missing anchors, or unclassified committed `docs/` artifacts |
 | Nix environment | PR and push | `.github/workflows/ci.yml` `test` job | `nix flake check --print-build-logs`; dev-shell version checks | Ensure the reproducible build shell works | Hard fail on broken Nix flake or missing toolchain |
 | Formatting | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt scalafmtCheckAll` | Keep Scala formatting deterministic | Hard fail on formatting drift |
 | Non-heavy unit tests | PR and push | `.github/workflows/ci.yml` `test` job | `nix develop --command sbt coverage "root / Test / test" coverageReport` | Fast correctness for mechanisms, economics boundaries, flows, SFC, ledger projection, diagnostics helpers, and schemas | Hard fail on broken local invariant or regression |
@@ -104,6 +105,7 @@ Use this routing rule before adding a new check:
 | Local mechanism invariant, algebraic identity, schema rule, parser behavior | Root unit/property tests | Nightly diagnostics |
 | Slow but focused mechanism/property test | Heavy-tagged root test | Integration tests unless it needs end-to-end state |
 | Short multi-month normal-path engine health | `integrationTests / Test / test` | CSV determinism tests |
+| Markdown links, anchors, and documentation ownership inventory | `scripts/check-docs.py` in the generated-output CI job | Prose style linting |
 | Generated docs/resources consistency | Existing generated-output script | Unit tests |
 | Long Monte Carlo, scenario, robustness, diagnostic export validation | Nightly diagnostics profile | PR unit tests |
 | Stress/failure-channel experiments | Stress/exploratory nightly class | Normal-validation gate |

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Lightweight documentation hygiene checks.
+
+The checker deliberately avoids prose/style linting. It validates only cheap
+structural contracts that should not require human interpretation:
+
+- local Markdown links point to existing files/directories;
+- local Markdown anchors point to existing headings;
+- every committed docs/ artifact is listed in docs/documentation-architecture.md.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+README = REPO_ROOT / "README.md"
+DOCUMENTATION_ARCHITECTURE = DOCS_DIR / "documentation-architecture.md"
+
+EXTERNAL_SCHEMES = {"http", "https", "mailto", "tel", "data"}
+
+
+@dataclass(frozen=True)
+class Link:
+    source: Path
+    line: int
+    target: str
+
+
+def main() -> int:
+    markdown_files = [README] + sorted(DOCS_DIR.rglob("*.md"))
+    anchors = {path: collect_anchors(path) for path in markdown_files}
+
+    errors: list[str] = []
+    for path in markdown_files:
+        for link in extract_links(path):
+            errors.extend(validate_link(link, anchors))
+
+    errors.extend(validate_documentation_inventory())
+
+    if errors:
+        print("Documentation hygiene check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(f"Documentation hygiene check passed for {len(markdown_files)} Markdown files.")
+    return 0
+
+
+def collect_anchors(path: Path) -> set[str]:
+    counts: dict[str, int] = {}
+    anchors: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        base = github_heading_anchor(match.group(2))
+        index = counts.get(base, 0)
+        counts[base] = index + 1
+        anchors.add(base if index == 0 else f"{base}-{index}")
+    return anchors
+
+
+def github_heading_anchor(heading: str) -> str:
+    text = re.sub(r"<[^>]+>", "", heading)
+    text = text.replace("`", "").replace("*", "").replace("_", "")
+    text = text.lower()
+    chars: list[str] = []
+    previous_dash = False
+    for char in text:
+        if char.isalnum():
+            chars.append(char)
+            previous_dash = False
+        elif char in {" ", "\t", "-"}:
+            if not previous_dash:
+                chars.append("-")
+                previous_dash = True
+    return "".join(chars).strip("-")
+
+
+def extract_links(path: Path) -> list[Link]:
+    links: list[Link] = []
+    fenced = False
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        links.extend(Link(path, line_number, target) for target in inline_link_targets(line))
+    return links
+
+
+def inline_link_targets(line: str) -> list[str]:
+    targets: list[str] = []
+    index = 0
+    while index < len(line):
+        open_label = line.find("[", index)
+        if open_label == -1:
+            break
+        close_label = line.find("](", open_label)
+        if close_label == -1:
+            break
+        target_start = close_label + 2
+        depth = 0
+        target_end = target_start
+        while target_end < len(line):
+            char = line[target_end]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            target_end += 1
+        if target_end >= len(line):
+            index = close_label + 2
+            continue
+        targets.append(line[target_start:target_end])
+        index = target_end + 1
+    return targets
+
+
+def validate_link(link: Link, anchors: dict[Path, set[str]]) -> list[str]:
+    target = normalize_link_target(link.target)
+    if not target or is_external_link(target):
+        return []
+
+    path_part, fragment = split_fragment(target)
+    if not path_part:
+        destination = link.source
+    else:
+        destination = resolve_local_path(link.source.parent, path_part)
+
+    errors: list[str] = []
+    if destination is None:
+        errors.append(format_error(link, f"link escapes repository root: {target}"))
+        return errors
+    if not destination.exists():
+        errors.append(format_error(link, f"missing local target: {target}"))
+        return errors
+
+    if fragment and destination.suffix.lower() == ".md":
+        expected_anchor = unquote(fragment)
+        known_anchors = anchors.get(destination)
+        if known_anchors is None:
+            known_anchors = collect_anchors(destination)
+        if expected_anchor not in known_anchors:
+            errors.append(format_error(link, f"missing Markdown anchor: {target}"))
+
+    return errors
+
+
+def normalize_link_target(raw: str) -> str:
+    target = raw.strip()
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1].strip()
+    return target.split()[0] if target else ""
+
+
+def is_external_link(target: str) -> bool:
+    parsed = urlsplit(target)
+    return parsed.scheme in EXTERNAL_SCHEMES or target.startswith("//")
+
+
+def split_fragment(target: str) -> tuple[str, str]:
+    if "#" not in target:
+        return target, ""
+    path_part, fragment = target.split("#", 1)
+    return path_part, fragment
+
+
+def resolve_local_path(base: Path, path_part: str) -> Path | None:
+    without_query = path_part.split("?", 1)[0]
+    decoded = unquote(without_query)
+    if decoded.startswith("/"):
+        candidate = REPO_ROOT / decoded.lstrip("/")
+    else:
+        candidate = base / decoded
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+    return resolved
+
+
+def validate_documentation_inventory() -> list[str]:
+    inventory = DOCUMENTATION_ARCHITECTURE.read_text(encoding="utf-8")
+    tracked = git_ls_files(["README.md", "docs"])
+    errors: list[str] = []
+    for relative_path in tracked:
+        expected = "README.md" if relative_path == "README.md" else relative_path
+        if expected not in inventory:
+            errors.append(
+                f"{relative_path}: missing documentation ownership entry in "
+                "docs/documentation-architecture.md"
+            )
+    return errors
+
+
+def git_ls_files(paths: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", *paths],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def format_error(link: Link, message: str) -> str:
+    relative = link.source.relative_to(REPO_ROOT)
+    return f"{relative}:{link.line}: {message}"
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #738

Summary:
- Add scripts/check-docs.py for local Markdown link/anchor validation and documentation-architecture inventory coverage.
- Run the documentation hygiene check in the cheap CI generated-outputs job before generated-output freshness validation.
- Document local usage and validation ownership in operations, validation matrix, and documentation architecture.

Validation:
- python3 scripts/check-docs.py
- python3 -m py_compile scripts/check-docs.py
- git diff --check
- bash scripts/check-generated-outputs.sh