### PR TITLE
Replace numbered economics step notation

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala
@@ -344,7 +344,7 @@ object Banking:
       loansMedium: PLN,                                    // medium-term corporate-loan maturity bucket (1–5 years)
       loansLong: PLN,                                      // long-term corporate-loan maturity bucket (> 5 years)
       consumerNpl: PLN,                                    // consumer credit NPL stock
-      eclStaging: EclStaging.State = EclStaging.State.zero, // IFRS 9 ECL staging (S1/S2/S3)
+      eclStaging: EclStaging.State = EclStaging.State.zero, // IFRS 9 ECL staging (Stage 1/2/3)
   ):
 
     /** Whether this bank has been resolved by BFG. */

--- a/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/EclStaging.scala
@@ -11,12 +11,13 @@ import com.boombustgroup.amorfati.types.*
   *     increase in credit risk. Provision = portfolio × eclRate1 (~1%).
   *   - '''Stage 2''' (watch, lifetime ECL): loans with significant increase in
   *     credit risk (GDP decline, unemployment spike). Provision = portfolio ×
-  *     eclRate2 (~5-10%). Macro trigger shifts loans S1→S2 en masse.
+  *     eclRate2 (~5-10%). Macro trigger shifts loans from Stage 1 to Stage 2 en
+  *     masse.
   *   - '''Stage 3''' (default): non-performing loans. Provision = portfolio ×
   *     eclRate3 (= 1 − recovery rate). This is the current NPL treatment.
   *
-  * Pro-cyclical amplification: GDP downturn → mass S1→S2 migration →
-  * provisioning cliff → capital hit → lending restriction → deeper downturn.
+  * Pro-cyclical amplification: GDP downturn → mass Stage 1 to Stage 2 migration
+  * → provisioning cliff → capital hit → lending restriction → deeper downturn.
   * Forward-looking: provisions are booked BEFORE defaults materialize.
   *
   * Pure functions — no mutable state. Per-bank staging computed from macro
@@ -52,7 +53,7 @@ object EclStaging:
   def allowance(state: State)(using p: SimParams): PLN =
     state.stage1 * p.banking.eclRate1 + state.stage2 * p.banking.eclRate2 + state.stage3 * p.banking.eclRate3
 
-  /** Compute macro-driven S1→S2 migration rate.
+  /** Compute macro-driven Stage 1 to Stage 2 migration rate.
     *
     * When unemployment deteriorates relative to the carried reference level or
     * GDP contracts, a fraction of performing loans migrates to Stage 2
@@ -96,16 +97,16 @@ object EclStaging:
     val migration: Share = migrationRate(unemployment, referenceUnemployment, gdpGrowthMonthly)
 
     // Stage transitions
-    val s1ToS2: PLN = prev.stage1 * migration             // macro-driven migration
-    val s2ToS3: PLN = nplNew                              // actual defaults enter S3
-    val s3Cure: PLN = prev.stage3 * p.banking.eclCureRate // some S3 loans recover
+    val stage1ToStage2: PLN = prev.stage1 * migration             // macro-driven migration
+    val stage2ToStage3: PLN = nplNew                              // actual defaults enter Stage 3
+    val stage3Cure: PLN     = prev.stage3 * p.banking.eclCureRate // some Stage 3 loans recover
 
     // Updated stages
-    val newS3: PLN = (prev.stage3 + s2ToS3 - s3Cure).max(PLN.Zero)
-    val newS2: PLN = (prev.stage2 + s1ToS2 - s2ToS3 + s3Cure).max(PLN.Zero)
-    val newS1: PLN = (totalLoans - newS2 - newS3).max(PLN.Zero)
+    val newStage3: PLN = (prev.stage3 + stage2ToStage3 - stage3Cure).max(PLN.Zero)
+    val newStage2: PLN = (prev.stage2 + stage1ToStage2 - stage2ToStage3 + stage3Cure).max(PLN.Zero)
+    val newStage1: PLN = (totalLoans - newStage2 - newStage3).max(PLN.Zero)
 
-    val newStaging: State = State(newS1, newS2, newS3)
+    val newStaging: State = State(newStage1, newStage2, newStage3)
 
     // Provision = Σ(stage × eclRate) — change vs previous month
     val prevProvision: PLN   = allowance(prev)

--- a/src/main/scala/com/boombustgroup/amorfati/agents/README.md
+++ b/src/main/scala/com/boombustgroup/amorfati/agents/README.md
@@ -22,7 +22,7 @@ carry behavioral state, operational diagnostics, and legacy unsupported metrics.
 | `Nbp.scala` | National Bank of Poland | Reference rate, QE policy metrics, monthly FX operations; gov bond holdings and FX reserves are ledger-owned | BankCapital (reserve interest), Nfa (FX intervention), BondClearing (QE bonds) |
 | `DepositMobility.scala` | Deposit flight (Diamond-Dybvig) | Boundary `bankId` reassignment, health-based flight, panic contagion; delayed routing only, no same-month balance-sheet transfer | Future BankDeposits routing via reassigned households |
 | `EarmarkedFunds.scala` | FP, PFRON, FGŚP | Payroll-funded statutory funds, bankruptcy payouts, ALMP | GovDebt (gov subvention) |
-| `EclStaging.scala` | IFRS 9 ECL provisioning | S1/S2/S3 staging, macro-driven migration, forward-looking provisions | BankCapital (provision) |
+| `EclStaging.scala` | IFRS 9 ECL provisioning | Stage 1/2/3 staging, macro-driven migration, forward-looking provisions | BankCapital (provision) |
 | `InterbankContagion.scala` | Interbank contagion (Lehman channel) | 7×7 bilateral exposure matrix, counterparty losses, liquidity hoarding | InterbankNetting |
 | `QuasiFiscal.scala` | BGK + PFR (consolidated) | Monthly issuance and lending diagnostics; bonds, holder split, and loan portfolio are ledger projections | BondClearing (quasi-fiscal bonds) |
 | `SocialSecurity.scala` | ZUS, NFZ, PPK, demographics | Contribution/pension/health flows, retirees, working-age pop; fund cash and PPK bond holdings are ledger-owned | BondClearing (PPK bonds), FusBalance, NfzBalance |

--- a/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/BankingConfig.scala
@@ -156,14 +156,15 @@ import com.boombustgroup.amorfati.types.*
   * @param eclRate3
   *   Stage 3 (default) ECL provision rate (1 − recovery, KNF: ~50%)
   * @param eclMigrationSensitivity
-  *   sensitivity of S1→S2 migration to unemployment deterioration over the
-  *   carried reference unemployment rate
+  *   sensitivity of Stage 1 to Stage 2 migration to unemployment deterioration
+  *   over the carried reference unemployment rate
   * @param eclGdpSensitivity
-  *   sensitivity of S1→S2 migration to GDP contraction
+  *   sensitivity of Stage 1 to Stage 2 migration to GDP contraction
   * @param eclMaxMigration
-  *   maximum monthly S1→S2 migration rate (structural cap)
+  *   maximum monthly Stage 1 to Stage 2 migration rate (structural cap)
   * @param eclCureRate
-  *   monthly cure rate: fraction of S3 loans returning to S2 (restructuring)
+  *   monthly cure rate: fraction of Stage 3 loans returning to Stage 2
+  *   (restructuring)
   */
 case class BankingConfig(
     // Initial balance sheet (raw — scaled by gdpRatio in SimParams.defaults)

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/InflationProbe.scala
@@ -78,161 +78,172 @@ object InflationProbe:
     println(s"seed=$seed months=$months")
 
     (1 to months).foreach: month =>
-      val population        = world.laborForcePopulation
-      val contract          = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
-      val s1                = FiscalConstraintEconomics.compute(world, banks, ledgerFinancialState, ExecutionMonth(month))
-      val s2Pre             = LaborEconomics.compute(world, firms, hhs, s1)
-      val prevWage          = world.householdMarket.marketWage
-      val rawLaborWage      = RegionalClearing.clear(world.regionalWages, s1.resWage, s2Pre.laborDemand, population).nationalWage
-      val expWagePressure   =
+      val population         = world.laborForcePopulation
+      val contract           = MonthRandomness.Contract.fromSeed(seed * 1000 + month)
+      val fiscal             = FiscalConstraintEconomics.compute(world, banks, ledgerFinancialState, ExecutionMonth(month))
+      val openingLabor       = LaborEconomics.compute(world, firms, hhs, fiscal)
+      val prevWage           = world.householdMarket.marketWage
+      val rawLaborWage       = RegionalClearing.clear(world.regionalWages, fiscal.resWage, openingLabor.laborDemand, population).nationalWage
+      val expWagePressure    =
         (summon[SimParams].labor.expWagePassthrough * world.mechanisms.expectations.expectedInflation.max(Rate.Zero).toCoefficient) / 12
-      val observedEmployed  = Household.countEmployed(hhs)
-      val tightWagePressure = LaborEconomics.nairuWagePressure(population, Math.max(s2Pre.employed, observedEmployed))
-      val expectedWage      = rawLaborWage * expWagePressure.growthMultiplier
-      val tightnessFloor    = prevWage * tightWagePressure.growthMultiplier
-      val wageAfterExp      = s1.resWage.max(expectedWage.max(tightnessFloor))
-      val aggUnionDensity   =
+      val observedEmployed   = Household.countEmployed(hhs)
+      val tightWagePressure  = LaborEconomics.nairuWagePressure(population, Math.max(openingLabor.employed, observedEmployed))
+      val expectedWage       = rawLaborWage * expWagePressure.growthMultiplier
+      val tightnessFloor     = prevWage * tightWagePressure.growthMultiplier
+      val wageAfterExp       = fiscal.resWage.max(expectedWage.max(tightnessFloor))
+      val aggUnionDensity    =
         summon[SimParams].sectorDefs.zipWithIndex
           .map((s, i) => s.share * summon[SimParams].labor.unionDensity(i))
           .foldLeft(Share.Zero)(_ + _)
-      val unionAdjustedWage =
+      val unionAdjustedWage  =
         if wageAfterExp < prevWage then
           val decline = prevWage - wageAfterExp
-          s1.resWage.max(wageAfterExp + decline * summon[SimParams].labor.unionRigidity * aggUnionDensity)
+          fiscal.resWage.max(wageAfterExp + decline * summon[SimParams].labor.unionRigidity * aggUnionDensity)
         else wageAfterExp
-      val supplyAtPrev      = laborSupplyCount(world.householdMarket.marketWage, s1.resWage, population)
-      val newSupply         = laborSupplyCount(unionAdjustedWage, s1.resWage, population)
-      val excessDemand      = (s2Pre.laborDemand - supplyAtPrev).ratioTo(population)
-      val phillipsGrowth    = if prevWage > PLN.Zero then rawLaborWage / prevWage - Scalar.One else Scalar.Zero
-      val expGrowth         = expWagePressure.toScalar
-      val tightGrowth       = tightWagePressure.toScalar
-      val unionGrowth       = if wageAfterExp > PLN.Zero then unionAdjustedWage / wageAfterExp - Scalar.One else Scalar.Zero
-      val payroll           = SocialSecurity.payrollBase(hhs)
-      val payrollZus        = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
-      val s3                =
+      val supplyAtPrev       = laborSupplyCount(world.householdMarket.marketWage, fiscal.resWage, population)
+      val newSupply          = laborSupplyCount(unionAdjustedWage, fiscal.resWage, population)
+      val excessDemand       = (openingLabor.laborDemand - supplyAtPrev).ratioTo(population)
+      val phillipsGrowth     = if prevWage > PLN.Zero then rawLaborWage / prevWage - Scalar.One else Scalar.Zero
+      val expGrowth          = expWagePressure.toScalar
+      val tightGrowth        = tightWagePressure.toScalar
+      val unionGrowth        = if wageAfterExp > PLN.Zero then unionAdjustedWage / wageAfterExp - Scalar.One else Scalar.Zero
+      val payroll            = SocialSecurity.payrollBase(hhs)
+      val payrollZus         = SocialSecurity.zusStep(payroll, openingLabor.newDemographics.retirees)
+      val householdIncome    =
         HouseholdIncomeEconomics.compute(
           world,
           firms,
           hhs,
           banks,
           ledgerFinancialState,
-          s1.lendingBaseRate,
-          s1.resWage,
-          s2Pre.newWage,
+          fiscal.lendingBaseRate,
+          fiscal.resWage,
+          openingLabor.newWage,
           contract.stages.householdIncomeEconomics.newStream(),
           pensionIncome = payrollZus.pensionPayments,
         )
-      val s4                = DemandEconomics.compute(world, s2Pre.employed, s2Pre.living, s3.domesticCons)
-      val s5                = FirmEconomics.runStep(world, firms, hhs, banks, ledgerFinancialState, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
-      val living            = s5.ioFirms.filter(Firm.isAlive)
-      val s2                = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, living, s5.households)
-      val s6                =
-        HouseholdFinancialEconomics.compute(world, s1.m, s2.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
-      val s7                = PriceEquityEconomics.compute(
+      val demand             = DemandEconomics.compute(world, openingLabor.employed, openingLabor.living, householdIncome.domesticCons)
+      val firm               = FirmEconomics.runStep(
+        world,
+        firms,
+        hhs,
+        banks,
+        ledgerFinancialState,
+        fiscal,
+        openingLabor,
+        householdIncome,
+        demand,
+        contract.stages.firmEconomics.newStream(),
+      )
+      val living             = firm.ioFirms.filter(Firm.isAlive)
+      val labor              = LaborEconomics.reconcilePostFirmStep(world, fiscal, openingLabor, living, firm.households)
+      val householdFinancial =
+        HouseholdFinancialEconomics.compute(world, fiscal.m, labor.employed, householdIncome.hhAgg, contract.stages.householdFinancialEconomics.newStream())
+      val priceEquity        = PriceEquityEconomics.compute(
         w = world,
-        month = s1.m,
-        wageGrowth = s2.wageGrowth,
-        avgDemandMult = s4.avgDemandMult,
-        sectorMults = s4.sectorMults,
+        month = fiscal.m,
+        wageGrowth = labor.wageGrowth,
+        avgDemandMult = demand.avgDemandMult,
+        sectorMults = demand.sectorMults,
         totalSystemLoans = ledgerFinancialState.banks.map(_.firmLoan).sumPln,
-        firmStep = s5,
+        firmStep = firm,
         ledgerFinancialState = ledgerFinancialState,
       )
-      val s8                =
+      val openEconomy        =
         OpenEconEconomics.runStep(
           OpenEconEconomics.StepInput(
-            world,
-            ledgerFinancialState,
-            s1,
-            s2,
-            s3,
-            s4,
-            s5,
-            s6,
-            s7,
-            banks,
-            contract.stages.openEconEconomics.newStream(),
+            world = world,
+            ledgerFinancialState = ledgerFinancialState,
+            fiscal = fiscal,
+            labor = labor,
+            householdIncome = householdIncome,
+            demand = demand,
+            firm = firm,
+            householdFinancial = householdFinancial,
+            priceEquity = priceEquity,
+            banks = banks,
+            commodityRng = contract.stages.openEconEconomics.newStream(),
           ),
         )
-      val s9                =
+      val banking            =
         BankingEconomics.runStep(
           BankingEconomics.StepInput(
-            world,
-            ledgerFinancialState,
-            s1,
-            s2,
-            s3,
-            s4,
-            s5,
-            s6,
-            s7,
-            s8,
-            banks,
-            contract.stages.bankingEconomics.newStream(),
+            world = world,
+            ledgerFinancialState = ledgerFinancialState,
+            fiscal = fiscal,
+            labor = labor,
+            householdIncome = householdIncome,
+            demand = demand,
+            firm = firm,
+            householdFinancial = householdFinancial,
+            priceEquity = priceEquity,
+            openEconomy = openEconomy,
+            banks = banks,
+            depositRng = contract.stages.bankingEconomics.newStream(),
           ),
         )
 
       val exRateDeviation = world.forex.exchangeRate.deviationFrom(summon[SimParams].forex.baseExRate)
       val priceUpd        = PriceLevel.update(
-        // PriceLevel reads the current pre-policy expectation; s8.newExp is next month's post-policy anchor.
+        // PriceLevel reads the current pre-policy expectation; openEconomy.monetary.newExp is next month's post-policy anchor.
         expectedInflation = world.mechanisms.expectations.expectedInflation,
         prevPrice = world.priceLevel,
-        demandMult = s4.avgDemandMult,
-        wageGrowth = s2.wageGrowth,
+        demandMult = demand.avgDemandMult,
+        wageGrowth = labor.wageGrowth,
         exRateDeviation = exRateDeviation,
         importCostIndex = world.external.gvc.importCostIndex,
       )
-      val unemp           = world.unemploymentRate(s2.employed)
-      val realRate        = s8.monetary.newRefRate - s8.monetary.newExp.expectedInflation
-      val govBreakdown    = govPurchasesBreakdown(world, s2Pre.employed)
+      val unemp           = world.unemploymentRate(labor.employed)
+      val realRate        = openEconomy.monetary.newRefRate - openEconomy.monetary.newExp.expectedInflation
+      val govBreakdown    = govPurchasesBreakdown(world, openingLabor.employed)
       val debtToGdp       =
-        if s7.gdp > PLN.Zero then s9.newGovWithYield.cumulativeDebt / (s7.gdp * 12) else Scalar.Zero
+        if priceEquity.gdp > PLN.Zero then banking.newGovWithYield.cumulativeDebt / (priceEquity.gdp * 12) else Scalar.Zero
       val deficitToGdp    =
-        if s7.gdp > PLN.Zero then s9.newGovWithYield.deficit / s7.gdp else Scalar.Zero
+        if priceEquity.gdp > PLN.Zero then banking.newGovWithYield.deficit / priceEquity.gdp else Scalar.Zero
 
       println(
-        s"m=$month u=${pct(unemp.toScalar)} pi=${pct(s7.newInfl.toScalar)} wage=${s2.newWage.format(0)} wg=${pct(s2.wageGrowth.toScalar)} demand=${(s4.avgDemandMult / Multiplier.One).format(3)} markup=${pct(s5.markupInflation.toScalar)}",
+        s"m=$month u=${pct(unemp.toScalar)} pi=${pct(priceEquity.newInfl.toScalar)} wage=${labor.newWage.format(0)} wg=${pct(labor.wageGrowth.toScalar)} demand=${(demand.avgDemandMult / Multiplier.One).format(3)} markup=${pct(firm.markupInflation.toScalar)}",
       )
       println(
         s"  channels monthly: demand=${pct(priceUpd.demandPull.toScalar)}pp cost=${pct(priceUpd.costPush.toScalar)}pp import=${pct(priceUpd.importPush.toScalar)}pp raw=${pct(priceUpd.rawMonthly.toScalar)}pp floor=${pct(priceUpd.flooredMonthly.toScalar)}pp",
       )
       println(
-        s"  annualized: base=${pct(priceUpd.inflation.toScalar)} markup=${pct(s5.markupInflation.toScalar)} total=${pct(s7.newInfl.toScalar)} exDev=${pct(exRateDeviation.toCoefficient.toScalar)} importCost=${world.external.gvc.importCostIndex.format(3)} commodity=${world.external.gvc.commodityPriceIndex.format(3)}",
+        s"  annualized: base=${pct(priceUpd.inflation.toScalar)} markup=${pct(firm.markupInflation.toScalar)} total=${pct(priceEquity.newInfl.toScalar)} exDev=${pct(exRateDeviation.toCoefficient.toScalar)} importCost=${world.external.gvc.importCostIndex.format(3)} commodity=${world.external.gvc.commodityPriceIndex.format(3)}",
       )
       println(
-        s"  policy: ref=${pct(s8.monetary.newRefRate.toScalar)} expPi=${pct(s8.monetary.newExp.expectedInflation.toScalar)} real=${pct(realRate.toScalar)} cred=${pct(s8.monetary.newExp.credibility.toScalar)} fg=${pct(s8.monetary.newExp.forwardGuidanceRate.toScalar)}",
+        s"  policy: ref=${pct(openEconomy.monetary.newRefRate.toScalar)} expPi=${pct(openEconomy.monetary.newExp.expectedInflation.toScalar)} real=${pct(realRate.toScalar)} cred=${pct(openEconomy.monetary.newExp.credibility.toScalar)} fg=${pct(openEconomy.monetary.newExp.forwardGuidanceRate.toScalar)}",
       )
       println(
         s"  wages: phillips=${pct(phillipsGrowth)} exp=${pct(expGrowth)} tight=${pct(tightGrowth)} union=${pct(unionGrowth)} raw=${rawLaborWage.format(0)} afterExp=${wageAfterExp.format(0)} final=${unionAdjustedWage.format(0)}",
       )
       println(
-        s"  labor: demand=${s2Pre.laborDemand} supplyPrev=${supplyAtPrev} supplyNew=${newSupply} excess=${pct(excessDemand)} employedPre=${s2Pre.employed} employedPost=${s2.employed}",
+        s"  labor: demand=${openingLabor.laborDemand} supplyPrev=${supplyAtPrev} supplyNew=${newSupply} excess=${pct(excessDemand)} employedPre=${openingLabor.employed} employedPost=${labor.employed}",
       )
       println(
-        s"  households: income=${s3.totalIncome.format(0)} cons=${s3.consumption.format(0)} domesticCons=${s3.domesticCons.format(0)} importCons=${s3.importCons.format(0)}",
+        s"  households: income=${householdIncome.totalIncome.format(0)} cons=${householdIncome.consumption.format(0)} domesticCons=${householdIncome.domesticCons.format(0)} importCons=${householdIncome.importCons.format(0)}",
       )
       println(
-        s"  fiscal: govPurch=${s4.govPurchases.format(0)} govCur=${s9.newGovWithYield.govCurrentSpend.format(0)} govCapDom=${s9.newGovWithYield.govCapitalSpend.format(0)} euProjCap=${s9.newGovWithYield.euProjectCapital.format(0)} euCofinDom=${s9.newGovWithYield.euCofinancing.format(0)} def=${s9.newGovWithYield.deficit.format(0)} def/gdp=${pct(deficitToGdp)} debt/gdp=${pct(debtToGdp)} rule=${s4.fiscalRuleStatus.bindingRule} cut=${pct(s4.fiscalRuleStatus.spendingCutRatio.toScalar)}",
+        s"  fiscal: govPurch=${demand.govPurchases.format(0)} govCur=${banking.newGovWithYield.govCurrentSpend.format(0)} govCapDom=${banking.newGovWithYield.govCapitalSpend.format(0)} euProjCap=${banking.newGovWithYield.euProjectCapital.format(0)} euCofinDom=${banking.newGovWithYield.euCofinancing.format(0)} def=${banking.newGovWithYield.deficit.format(0)} def/gdp=${pct(deficitToGdp)} debt/gdp=${pct(debtToGdp)} rule=${demand.fiscalRuleStatus.bindingRule} cut=${pct(demand.fiscalRuleStatus.spendingCutRatio.toScalar)}",
       )
       println(
         s"  gov raw target: base=${govBreakdown.base.format(0)} recycleCf=${govBreakdown.recycleCounterfactual.format(0)} stimulus=${govBreakdown.stimulus.format(0)} raw=${govBreakdown.rawTarget.format(0)} zusSurplus=${govBreakdown.zusNetSurplus.format(0)} unempGap=${pct(govBreakdown.unempGap.toScalar)}",
       )
-      println(s"  top pressure: ${topPressures(s4.sectorDemandPressure)}")
-      println(s"  ${sectorSignals("sectorMult", s4.sectorMults)}")
-      println(s"  ${sectorSignals("pressure", s4.sectorDemandPressure)}")
-      println(s"  ${sectorSignals("hiring", s4.sectorHiringSignal)}")
+      println(s"  top pressure: ${topPressures(demand.sectorDemandPressure)}")
+      println(s"  ${sectorSignals("sectorMult", demand.sectorMults)}")
+      println(s"  ${sectorSignals("pressure", demand.sectorDemandPressure)}")
+      println(s"  ${sectorSignals("hiring", demand.sectorHiringSignal)}")
 
       val monthExecution = MonthExecution(
         openingWorld = world,
-        fiscal = s1,
-        labor = s2,
-        householdIncome = s3,
-        demand = s4,
-        firm = s5,
-        householdFinancial = s6,
-        priceEquity = s7,
-        openEconomy = s8,
-        banking = s9,
+        fiscal = fiscal,
+        labor = labor,
+        householdIncome = householdIncome,
+        demand = demand,
+        firm = firm,
+        householdFinancial = householdFinancial,
+        priceEquity = priceEquity,
+        openEconomy = openEconomy,
+        banking = banking,
       )
       val closing        = MonthClosing.closeExecution(monthExecution, contract.closing.newStreams())
       val seedOut        = SignalExtraction

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/LaborDemandProbe.scala
@@ -204,76 +204,88 @@ object LaborDemandProbe:
       val beforeAll = sectorSnapshots(firms)
       val hiring    = hiringSummaries(world, firms, ledgerFinancialState)
 
-      val s1      = FiscalConstraintEconomics.compute(world, banks, ledgerFinancialState, ExecutionMonth(month))
-      val s2Pre   = LaborEconomics.compute(world, firms, hhs, s1)
-      val payroll = SocialSecurity.payrollBase(hhs)
-      val zus     = SocialSecurity.zusStep(payroll, s2Pre.newDemographics.retirees)
-      val s3      =
+      val fiscal             = FiscalConstraintEconomics.compute(world, banks, ledgerFinancialState, ExecutionMonth(month))
+      val openingLabor       = LaborEconomics.compute(world, firms, hhs, fiscal)
+      val payroll            = SocialSecurity.payrollBase(hhs)
+      val zus                = SocialSecurity.zusStep(payroll, openingLabor.newDemographics.retirees)
+      val householdIncome    =
         HouseholdIncomeEconomics.compute(
           world,
           firms,
           hhs,
           banks,
           ledgerFinancialState,
-          s1.lendingBaseRate,
-          s1.resWage,
-          s2Pre.newWage,
+          fiscal.lendingBaseRate,
+          fiscal.resWage,
+          openingLabor.newWage,
           contract.stages.householdIncomeEconomics.newStream(),
           pensionIncome = zus.pensionPayments,
         )
-      val s4      = DemandEconomics.compute(world, s2Pre.employed, s2Pre.living, s3.domesticCons)
-      val s5      = FirmEconomics.runStep(world, firms, hhs, banks, ledgerFinancialState, s1, s2Pre, s3, s4, contract.stages.firmEconomics.newStream())
-      val s2Post  = LaborEconomics.reconcilePostFirmStep(world, s1, s2Pre, s5.ioFirms.filter(Firm.isAlive), s5.households)
-      val s6      = HouseholdFinancialEconomics.compute(world, s1.m, s2Post.employed, s3.hhAgg, contract.stages.householdFinancialEconomics.newStream())
-      val s7      = PriceEquityEconomics.compute(
+      val demand             = DemandEconomics.compute(world, openingLabor.employed, openingLabor.living, householdIncome.domesticCons)
+      val firm               = FirmEconomics.runStep(
+        world,
+        firms,
+        hhs,
+        banks,
+        ledgerFinancialState,
+        fiscal,
+        openingLabor,
+        householdIncome,
+        demand,
+        contract.stages.firmEconomics.newStream(),
+      )
+      val labor              = LaborEconomics.reconcilePostFirmStep(world, fiscal, openingLabor, firm.ioFirms.filter(Firm.isAlive), firm.households)
+      val householdFinancial =
+        HouseholdFinancialEconomics.compute(world, fiscal.m, labor.employed, householdIncome.hhAgg, contract.stages.householdFinancialEconomics.newStream())
+      val priceEquity        = PriceEquityEconomics.compute(
         w = world,
-        month = s1.m,
-        wageGrowth = s2Post.wageGrowth,
-        avgDemandMult = s4.avgDemandMult,
-        sectorMults = s4.sectorMults,
+        month = fiscal.m,
+        wageGrowth = labor.wageGrowth,
+        avgDemandMult = demand.avgDemandMult,
+        sectorMults = demand.sectorMults,
         totalSystemLoans = ledgerFinancialState.banks.map(_.firmLoan).sumPln,
-        firmStep = s5,
+        firmStep = firm,
         ledgerFinancialState = ledgerFinancialState,
       )
-      val s8      =
+      val openEconomy        =
         OpenEconEconomics.runStep(
           OpenEconEconomics.StepInput(
-            world,
-            ledgerFinancialState,
-            s1,
-            s2Post,
-            s3,
-            s4,
-            s5,
-            s6,
-            s7,
-            banks,
-            contract.stages.openEconEconomics.newStream(),
+            world = world,
+            ledgerFinancialState = ledgerFinancialState,
+            fiscal = fiscal,
+            labor = labor,
+            householdIncome = householdIncome,
+            demand = demand,
+            firm = firm,
+            householdFinancial = householdFinancial,
+            priceEquity = priceEquity,
+            banks = banks,
+            commodityRng = contract.stages.openEconEconomics.newStream(),
           ),
         )
-      val s9      =
+      val banking            =
         BankingEconomics.runStep(
           BankingEconomics.StepInput(
-            world,
-            ledgerFinancialState,
-            s1,
-            s2Post,
-            s3,
-            s4,
-            s5,
-            s6,
-            s7,
-            s8,
-            banks,
-            contract.stages.bankingEconomics.newStream(),
+            world = world,
+            ledgerFinancialState = ledgerFinancialState,
+            fiscal = fiscal,
+            labor = labor,
+            householdIncome = householdIncome,
+            demand = demand,
+            firm = firm,
+            householdFinancial = householdFinancial,
+            priceEquity = priceEquity,
+            openEconomy = openEconomy,
+            banks = banks,
+            depositRng = contract.stages.bankingEconomics.newStream(),
           ),
         )
 
-      val afterFirm = sectorSnapshots(s5.ioFirms)
-      val changes   = sectorChangeSummaries(firms, s5.ioFirms)
-      val matchPost = laborMatchSnapshot(s5.ioFirms, s5.households)
+      val afterFirm = sectorSnapshots(firm.ioFirms)
+      val changes   = sectorChangeSummaries(firms, firm.ioFirms)
+      val matchPost = laborMatchSnapshot(firm.ioFirms, firm.households)
       println(
-        s"m=$month preLaborDemand=${s2Pre.laborDemand} postFirmDemand=${s5.ioFirms.filter(Firm.isAlive).map(Firm.workerCount).sum} employedPre=${s2Pre.employed} employedPost=${s2Post.employed} unempPost=${matchPost.unemployed} retrainingPost=${matchPost.retraining} bankruptPost=${matchPost.bankrupt} vacanciesPost=${matchPost.vacancies} overstaffedPost=${matchPost.overstaffed} invalidEmp=${matchPost.invalidEmployed} immIn=${s2Pre.newImmig.monthlyInflow} immOut=${s2Pre.newImmig.monthlyOutflow}",
+        s"m=$month preLaborDemand=${openingLabor.laborDemand} postFirmDemand=${firm.ioFirms.filter(Firm.isAlive).map(Firm.workerCount).sum} employedPre=${openingLabor.employed} employedPost=${labor.employed} unempPost=${matchPost.unemployed} retrainingPost=${matchPost.retraining} bankruptPost=${matchPost.bankrupt} vacanciesPost=${matchPost.vacancies} overstaffedPost=${matchPost.overstaffed} invalidEmp=${matchPost.invalidEmployed} immIn=${openingLabor.newImmig.monthlyInflow} immOut=${openingLabor.newImmig.monthlyOutflow}",
       )
       printHiringSummaries("  pre-step hiring diagnostics:", hiring)
       printSectorTable("  sector deltas after FirmEconomics:", beforeAll, afterFirm)
@@ -281,15 +293,15 @@ object LaborDemandProbe:
 
       val monthExecution = MonthExecution(
         openingWorld = world,
-        fiscal = s1,
-        labor = s2Post,
-        householdIncome = s3,
-        demand = s4,
-        firm = s5,
-        householdFinancial = s6,
-        priceEquity = s7,
-        openEconomy = s8,
-        banking = s9,
+        fiscal = fiscal,
+        labor = labor,
+        householdIncome = householdIncome,
+        demand = demand,
+        firm = firm,
+        householdFinancial = householdFinancial,
+        priceEquity = priceEquity,
+        openEconomy = openEconomy,
+        banking = banking,
       )
       val closing        = MonthClosing.closeExecution(monthExecution, contract.closing.newStreams())
       val seedOut        = SignalExtraction

--- a/src/main/scala/com/boombustgroup/amorfati/engine/SignalExtraction.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/SignalExtraction.scala
@@ -153,17 +153,17 @@ object SignalExtraction:
         inflation = SignalProvenance(
           seedOut.inflation,
           MonthTraceStage.PriceEquityEconomics,
-          "s7.newInfl -> closedWorld.inflation",
+          "priceEquity.newInfl -> closedWorld.inflation",
         ),
         expectedInflation = SignalProvenance(
           seedOut.expectedInflation,
           MonthTraceStage.OpenEconEconomics,
-          "s8.monetary.newExp.expectedInflation -> closedWorld.mechanisms.expectations.expectedInflation",
+          "openEconomy.monetary.newExp.expectedInflation -> closedWorld.mechanisms.expectations.expectedInflation",
         ),
         laggedHiringSlack = SignalProvenance(
           seedOut.laggedHiringSlack,
           MonthTraceStage.LaborEconomics,
-          "s2.operationalHiringSlack",
+          "labor.operationalHiringSlack",
         ),
         startupAbsorptionRate = SignalProvenance(
           seedOut.startupAbsorptionRate,
@@ -173,17 +173,17 @@ object SignalExtraction:
         sectorDemandMult = SignalProvenance(
           seedOut.sectorDemandMult,
           MonthTraceStage.DemandEconomics,
-          "s4.sectorMults",
+          "demand.sectorMults",
         ),
         sectorDemandPressure = SignalProvenance(
           seedOut.sectorDemandPressure,
           MonthTraceStage.DemandEconomics,
-          "s4.sectorDemandPressure",
+          "demand.sectorDemandPressure",
         ),
         sectorHiringSignal = SignalProvenance(
           seedOut.sectorHiringSignal,
           MonthTraceStage.DemandEconomics,
-          "s4.sectorHiringSignal",
+          "demand.sectorHiringSignal",
         ),
       ),
     )

--- a/src/main/scala/com/boombustgroup/amorfati/engine/diagnostics/banking/BankDiagnostics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/diagnostics/banking/BankDiagnostics.scala
@@ -199,15 +199,16 @@ object BankReconciliationDiagnostics:
 
 /** Monthly IFRS 9 / ECL provisioning diagnostics.
   *
-  * Allowances are accounting provisions implied by the S1/S2/S3 staging stock.
-  * `excessAllowance` is the amount above an all-performing Stage-1 baseline.
+  * Allowances are accounting provisions implied by the Stage 1/2/3 staging
+  * stock. `excessAllowance` is the amount above an all-performing Stage-1
+  * baseline.
   */
 case class BankEclDiagnostics(
     openingAllowance: PLN = PLN.Zero,                // ECL allowance implied by opening bank staging
     closingAllowance: PLN = PLN.Zero,                // ECL allowance implied by closing bank staging
     baselineStage1Allowance: PLN = PLN.Zero,         // closing staged ECL book if all stayed at Stage 1
     excessAllowance: PLN = PLN.Zero,                 // closing allowance above the all-Stage-1 baseline
-    migrationRate: Share = Share.Zero,               // macro-driven S1->S2 migration rate used this month
+    migrationRate: Share = Share.Zero,               // macro-driven Stage 1 to Stage 2 migration rate used this month
     gdpGrowthMonthly: Coefficient = Coefficient.Zero, // month-on-month GDP growth used by ECL staging
 )
 

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/LaborEconomics.scala
@@ -73,14 +73,14 @@ object LaborEconomics:
       w: World,
       firms: Vector[Firm.State],
       households: Vector[Household.State],
-      s1: FiscalConstraintEconomics.StepOutput,
+      fiscal: FiscalConstraintEconomics.StepOutput,
   )(using p: SimParams): StepOutput =
     val living           = firms.filter(Firm.isAlive)
     val laborDemand      = living.map(f => Firm.workerCount(f)).sum
     val laborForce       = w.laborForcePopulation
     val observedEmployed = Household.countEmployed(households)
-    val cleared          = clearLaborMarket(w, s1.resWage, laborDemand, laborForce, observedEmployed)
-    val availableLabor   = LaborMarket.laborSupplyAtWage(cleared.wage, s1.resWage, laborForce)
+    val cleared          = clearLaborMarket(w, fiscal.resWage, laborDemand, laborForce, observedEmployed)
+    val availableLabor   = LaborMarket.laborSupplyAtWage(cleared.wage, fiscal.resWage, laborForce)
 
     // Immigration
     val unempRateForImmig      = w.unemploymentRate(cleared.employed)
@@ -130,7 +130,7 @@ object LaborEconomics:
     */
   def reconcilePostFirmStep(
       w: World,
-      s1: FiscalConstraintEconomics.StepOutput,
+      fiscal: FiscalConstraintEconomics.StepOutput,
       pre: StepOutput,
       postLiving: Vector[Firm.State],
       postHouseholds: Vector[Household.State],
@@ -138,9 +138,9 @@ object LaborEconomics:
     val postLaborDemand    = postLiving.map(Firm.workerCount).sum
     val postLaborForce     = pre.newDemographics.workingAgePop.max(1)
     val realizedEmployment = Household.countEmployed(postHouseholds)
-    val cleared            = clearLaborMarket(w, s1.resWage, postLaborDemand, postLaborForce, realizedEmployment)
+    val cleared            = clearLaborMarket(w, fiscal.resWage, postLaborDemand, postLaborForce, realizedEmployment)
     val employedCap        = Math.min(realizedEmployment, pre.newDemographics.workingAgePop)
-    val postAvailableLabor = LaborMarket.laborSupplyAtWage(cleared.wage, s1.resWage, postLaborForce)
+    val postAvailableLabor = LaborMarket.laborSupplyAtWage(cleared.wage, fiscal.resWage, postLaborForce)
     val postHiringHeadroom = postLiving.map(f => Firm.monthlyHiringHeadroom(Firm.workerCount(f))).sum
     val newNfz             = SocialSecurity.nfzStep(
       employedCap,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -102,15 +102,15 @@ object OpenEconEconomics:
   // ---------------------------------------------------------------------------
 
   case class StepInput(
-      w: World,
+      world: World,
       ledgerFinancialState: LedgerFinancialState,
-      s1: FiscalConstraintEconomics.StepOutput,
-      s2: LaborEconomics.StepOutput,
-      s3: HouseholdIncomeEconomics.StepOutput,
-      s4: DemandEconomics.StepOutput,
-      s5: FirmEconomics.StepOutput,
-      s6: HouseholdFinancialEconomics.StepOutput,
-      s7: PriceEquityEconomics.StepOutput,
+      fiscal: FiscalConstraintEconomics.StepOutput,
+      labor: LaborEconomics.StepOutput,
+      householdIncome: HouseholdIncomeEconomics.StepOutput,
+      demand: DemandEconomics.StepOutput,
+      firm: FirmEconomics.StepOutput,
+      householdFinancial: HouseholdFinancialEconomics.StepOutput,
+      priceEquity: PriceEquityEconomics.StepOutput,
       banks: Vector[Banking.BankState],
       commodityRng: RandomStream,
   )
@@ -167,10 +167,10 @@ object OpenEconEconomics:
       bankFinancialStocks,
       bankId => CorporateBondOwnership.bankHolderFor(in.ledgerFinancialState, bankId),
     )
-    val sectorOutputs       = in.s7.realizedSectorOutputs
+    val sectorOutputs       = in.priceEquity.realizedSectorOutputs
     val external            = runStepExternalSector(in, sectorOutputs)
     val rateAndExp          = runStepRateAndExpectations(in, external.newForex)
-    val interbank           = runStepInterbankFlows(in.w, in.banks, bankFinancialStocks)
+    val interbank           = runStepInterbankFlows(in.world, in.banks, bankFinancialStocks)
     val bondQe              = runStepBondYieldAndQe(in, bankAgg, rateAndExp.refRate, rateAndExp.expectations, external.fxIntervention, interbank)
     val corpBonds           = runStepCorporateBonds(in, bankAgg, bondQe.marketYield)
     val insurance           = runStepInsurance(
@@ -237,12 +237,12 @@ object OpenEconEconomics:
   private def runStepGvc(in: StepInput, sectorOutputs: Vector[PLN])(using p: SimParams): GvcTrade.State =
     GvcTrade.step(
       GvcTrade.StepInput(
-        prev = in.w.external.gvc,
+        prev = in.world.external.gvc,
         sectorOutputs = sectorOutputs,
-        priceLevel = in.w.priceLevel,
-        exchangeRate = in.w.forex.exchangeRate,
-        autoRatio = in.s7.autoR,
-        month = in.s1.m,
+        priceLevel = in.world.priceLevel,
+        exchangeRate = in.world.forex.exchangeRate,
+        autoRatio = in.priceEquity.autoR,
+        month = in.fiscal.m,
         rng = in.commodityRng,
       ),
     )
@@ -250,54 +250,54 @@ object OpenEconEconomics:
   private def runStepForex(in: StepInput, sectorOutputs: Vector[PLN], newGvc: GvcTrade.State)(using p: SimParams): ForexResult =
     val (gvcExp, gvcImp) = (Some(newGvc.totalExports), Some(newGvc.sectorImports))
 
-    val totalTechAndInvImports = in.s5.sumTechImp + in.s7.investmentImports
+    val totalTechAndInvImports = in.firm.sumTechImp + in.priceEquity.investmentImports
     val oeResult               = OpenEconomy.step(
       OpenEconomy.StepInput(
-        prevBop = in.w.bop,
-        prevForex = in.w.forex,
-        importCons = in.s3.importCons,
+        prevBop = in.world.bop,
+        prevForex = in.world.forex,
+        importCons = in.householdIncome.importCons,
         techImports = totalTechAndInvImports,
-        autoRatio = in.s7.autoR,
-        domesticRate = in.w.nbp.referenceRate,
-        gdp = in.s7.gdp,
-        inflation = in.w.inflation,
-        priceLevel = in.w.priceLevel,
+        autoRatio = in.priceEquity.autoR,
+        domesticRate = in.world.nbp.referenceRate,
+        gdp = in.priceEquity.gdp,
+        inflation = in.world.inflation,
+        priceLevel = in.world.priceLevel,
         sectorOutputs = sectorOutputs,
-        month = in.s1.m,
+        month = in.fiscal.m,
         nbpFxReserves = in.ledgerFinancialState.nbp.foreignAssets,
         gvcExports = gvcExp,
         gvcIntermImports = gvcImp,
-        remittanceOutflow = in.s6.remittanceOutflow,
-        euFundsMonthly = in.s7.euMonthly,
-        diasporaInflow = in.s6.diasporaInflow,
-        tourismExport = in.s6.tourismExport,
-        tourismImport = in.s6.tourismImport,
+        remittanceOutflow = in.householdFinancial.remittanceOutflow,
+        euFundsMonthly = in.priceEquity.euMonthly,
+        diasporaInflow = in.householdFinancial.diasporaInflow,
+        tourismExport = in.householdFinancial.tourismExport,
+        tourismImport = in.householdFinancial.tourismImport,
       ),
     )
     ForexResult(oeResult.forex, oeResult.bop, oeResult.valuationEffect, oeResult.fxIntervention)
 
   private def runStepAdjustBop(in: StepInput, bop0: OpenEconomy.BopState)(using p: SimParams): (OpenEconomy.BopState, PLN) =
     val bop1             =
-      if in.s7.foreignDividendOutflow > PLN.Zero then
+      if in.priceEquity.foreignDividendOutflow > PLN.Zero then
         bop0.copy(
-          currentAccount = bop0.currentAccount - in.s7.foreignDividendOutflow,
-          nfa = bop0.nfa - in.s7.foreignDividendOutflow,
+          currentAccount = bop0.currentAccount - in.priceEquity.foreignDividendOutflow,
+          nfa = bop0.nfa - in.priceEquity.foreignDividendOutflow,
         )
       else bop0
-    val fdiTotalBopDebit = in.s5.sumProfitShifting + in.s5.sumFdiRepatriation
+    val fdiTotalBopDebit = in.firm.sumProfitShifting + in.firm.sumFdiRepatriation
     val bop2             =
       if fdiTotalBopDebit > PLN.Zero then
         bop1.copy(
           currentAccount = bop1.currentAccount - fdiTotalBopDebit,
           nfa = bop1.nfa - fdiTotalBopDebit,
-          tradeBalance = bop1.tradeBalance - in.s5.sumProfitShifting,
-          totalImports = bop1.totalImports + in.s5.sumProfitShifting,
+          tradeBalance = bop1.tradeBalance - in.firm.sumProfitShifting,
+          totalImports = bop1.totalImports + in.firm.sumProfitShifting,
         )
       else bop1
-    val fdiCitLoss       = in.s5.sumProfitShifting * p.fiscal.citRate
+    val fdiCitLoss       = in.firm.sumProfitShifting * p.fiscal.citRate
     val bop              = bop2.copy(
-      euFundsMonthly = in.s7.euMonthly,
-      euCumulativeAbsorption = in.w.bop.euCumulativeAbsorption + in.s7.euMonthly,
+      euFundsMonthly = in.priceEquity.euMonthly,
+      euCumulativeAbsorption = in.world.bop.euCumulativeAbsorption + in.priceEquity.euMonthly,
     )
     (bop, fdiCitLoss)
 
@@ -316,18 +316,18 @@ object OpenEconEconomics:
     )
 
   private def runStepRateAndExpectations(in: StepInput, newForex: OpenEconomy.ForexState)(using p: SimParams): RateExpResult =
-    val exRateChg       = newForex.exchangeRate.deviationFrom(in.w.forex.exchangeRate).toCoefficient
+    val exRateChg       = newForex.exchangeRate.deviationFrom(in.world.forex.exchangeRate).toCoefficient
     val newRefRate      = Nbp.updateRate(
-      in.w.nbp.referenceRate,
-      in.s7.newInfl,
+      in.world.nbp.referenceRate,
+      in.priceEquity.newInfl,
       exRateChg,
-      in.s2.employed,
-      in.w.laborForcePopulation,
-      expectedInflation = in.w.mechanisms.expectations.expectedInflation,
+      in.labor.employed,
+      in.world.laborForcePopulation,
+      expectedInflation = in.world.mechanisms.expectations.expectedInflation,
     )
-    val unempRateForExp = in.w.unemploymentRate(in.s2.employed)
+    val unempRateForExp = in.world.unemploymentRate(in.labor.employed)
     val newExp          =
-      Expectations.step(in.w.mechanisms.expectations, in.s7.newInfl, newRefRate, unempRateForExp)
+      Expectations.step(in.world.mechanisms.expectations, in.priceEquity.newInfl, newRefRate, unempRateForExp)
     RateExpResult(newRefRate, newExp)
 
   private def runStepInterbankFlows(w: World, banks: Vector[Banking.BankState], bankFinancialStocks: Vector[Banking.BankFinancialStocks])(using
@@ -348,46 +348,46 @@ object OpenEconEconomics:
       fxResult: Nbp.FxInterventionResult,
       interbank: InterbankResult,
   )(using p: SimParams): BondQeResult =
-    val annualGdpForBonds = in.s7.gdp * 12
-    val debtToGdp         = if annualGdpForBonds > PLN.Zero then (in.w.gov.cumulativeDebt / annualGdpForBonds).toShare else Share.Zero
-    val nbpBondGdpShare   = if annualGdpForBonds > PLN.Zero then (in.w.nbp.qeCumulative / annualGdpForBonds).toShare else Share.Zero
+    val annualGdpForBonds = in.priceEquity.gdp * 12
+    val debtToGdp         = if annualGdpForBonds > PLN.Zero then (in.world.gov.cumulativeDebt / annualGdpForBonds).toShare else Share.Zero
+    val nbpBondGdpShare   = if annualGdpForBonds > PLN.Zero then (in.world.nbp.qeCumulative / annualGdpForBonds).toShare else Share.Zero
     val credPremium       =
-      val deAnchor = (Share.One - in.w.mechanisms.expectations.credibility) *
-        (in.w.mechanisms.expectations.expectedInflation - p.monetary.targetInfl).abs.toScalar.toShare
+      val deAnchor = (Share.One - in.world.mechanisms.expectations.credibility) *
+        (in.world.mechanisms.expectations.expectedInflation - p.monetary.targetInfl).abs.toScalar.toShare
       (deAnchor * p.labor.expBondSensitivity).toRate
-    val marketYield       = Nbp.bondYield(newRefRate, debtToGdp, nbpBondGdpShare, in.w.bop.nfa, credPremium)
+    val marketYield       = Nbp.bondYield(newRefRate, debtToGdp, nbpBondGdpShare, in.world.bop.nfa, credPremium)
 
     val newWeightedCoupon = updateWeightedCouponPublic(
-      prevCoupon = in.w.gov.weightedCoupon,
+      prevCoupon = in.world.gov.weightedCoupon,
       marketYield = marketYield,
       bondsOutstanding = in.ledgerFinancialState.government.govBondOutstanding,
-      deficit = in.w.gov.deficit,
+      deficit = in.world.gov.deficit,
       avgMaturityMonths = p.fiscal.govAvgMaturityMonths,
     )
 
     val rawDebtService     = in.ledgerFinancialState.government.govBondOutstanding * newWeightedCoupon.monthly
-    val monthlyDebtService = rawDebtService.min(in.s7.gdp * MaxDebtServiceGdpShare)
+    val monthlyDebtService = rawDebtService.min(in.priceEquity.gdp * MaxDebtServiceGdpShare)
     val bankBondIncome     = bankAgg.govBondHoldings * marketYield.monthly
     val nbpBondIncome      = in.ledgerFinancialState.nbp.govBondHoldings * marketYield.monthly
     val nbpRemittance      = nbpBondIncome - interbank.reserveInterest - interbank.standingFacilityIncome
 
-    val qeActivate       = Nbp.shouldActivateQe(newRefRate, in.s7.newInfl, newExp.expectedInflation)
-    val qeTaper          = Nbp.shouldTaperQe(in.s7.newInfl, newExp.expectedInflation)
+    val qeActivate       = Nbp.shouldActivateQe(newRefRate, in.priceEquity.newInfl, newExp.expectedInflation)
+    val qeTaper          = Nbp.shouldTaperQe(in.priceEquity.newInfl, newExp.expectedInflation)
     val qeActive         =
       if qeActivate then true
       else if qeTaper then false
-      else in.w.nbp.qeActive
+      else in.world.nbp.qeActive
     val preQeNbp         = Nbp.State(
       newRefRate,
       qeActive,
-      in.w.nbp.qeCumulative,
-      in.w.nbp.lastFxTraded,
+      in.world.nbp.qeCumulative,
+      in.world.nbp.lastFxTraded,
     )
     val preQeNbpStocks   = Nbp.FinancialStocks(
       govBondHoldings = in.ledgerFinancialState.nbp.govBondHoldings,
       foreignAssets = in.ledgerFinancialState.nbp.foreignAssets,
     )
-    val qeRequest        = Nbp.executeQe(preQeNbp, preQeNbpStocks, bankAgg.govBondHoldings, in.s7.gdp, in.s7.newInfl, newExp.expectedInflation)
+    val qeRequest        = Nbp.executeQe(preQeNbp, preQeNbpStocks, bankAgg.govBondHoldings, in.priceEquity.gdp, in.priceEquity.newInfl, newExp.expectedInflation)
     val qePurchaseAmount = qeRequest.requestedPurchase
     val postFxNbp        = qeRequest.nbpState.copy(monthly = qeRequest.nbpState.monthly.copy(lastFxTraded = fxResult.eurTraded))
     val postFxNbpStocks  = preQeNbpStocks.copy(
@@ -402,17 +402,17 @@ object OpenEconEconomics:
     val corpBondStep              = CorporateBondMarket
       .step(
         CorporateBondMarket.StepInput(
-          prevState = in.w.financialMarkets.corporateBonds,
+          prevState = in.world.financialMarkets.corporateBonds,
           prevStock = openingCorpBondProjection,
           govBondYield = newBondYield,
           nplRatio = bankAgg.nplRatio,
-          totalBondDefault = in.s5.totalBondDefault,
-          totalBondIssuance = in.s5.actualBondIssuance,
+          totalBondDefault = in.firm.totalBondDefault,
+          totalBondIssuance = in.firm.actualBondIssuance,
         ),
       )
-    val newCorpBonds              = corpBondStep.state.copy(lastAbsorptionRate = in.s5.corpBondAbsorption)
-    val corpBondCoupon            = CorporateBondMarket.computeCoupon(in.w.financialMarkets.corporateBonds, openingCorpBondProjection)
-    val corpBondDefaults          = CorporateBondMarket.processDefaults(openingCorpBondProjection, in.s5.totalBondDefault)
+    val newCorpBonds              = corpBondStep.state.copy(lastAbsorptionRate = in.firm.corpBondAbsorption)
+    val corpBondCoupon            = CorporateBondMarket.computeCoupon(in.world.financialMarkets.corporateBonds, openingCorpBondProjection)
+    val corpBondDefaults          = CorporateBondMarket.processDefaults(openingCorpBondProjection, in.firm.totalBondDefault)
     CorporateBonds(
       newCorpBonds = newCorpBonds,
       closingCorpBondProjection = corpBondStep.stock,
@@ -430,22 +430,22 @@ object OpenEconEconomics:
       newCorpBondYield: Rate,
       corpBondDefaultLoss: PLN,
   )(using p: SimParams): InsuranceResult =
-    val laborForce    = in.s2.newDemographics.workingAgePop.max(1)
-    val employed      = Math.max(0, Math.min(in.s2.employed, laborForce))
+    val laborForce    = in.labor.newDemographics.workingAgePop.max(1)
+    val employed      = Math.max(0, Math.min(in.labor.employed, laborForce))
     val unempRate     = Share.One - Share.fraction(employed, laborForce)
-    // Insurance remains anchored to the reconciled labor state carried by s2.
+    // Insurance remains anchored to the reconciled labor state.
     // Unlike social payroll funds, moving premiums to the opening payroll
     // boundary would require changing both Insurance.step and runtime emission.
     val insuranceStep =
       Insurance.step(
         Insurance.StepInput(
           opening = LedgerFinancialState.insuranceOpeningBalances(in.ledgerFinancialState),
-          employed = in.s2.employed,
-          wage = in.s2.newWage,
+          employed = in.labor.employed,
+          wage = in.labor.newWage,
           unempRate = unempRate,
           govBondYield = newBondYield,
           corpBondYield = newCorpBondYield,
-          equityReturn = in.s7.equityAfterForeignStock.monthlyReturn,
+          equityReturn = in.priceEquity.equityAfterForeignStock.monthlyReturn,
           corpBondDefaultLoss = corpBondDefaultLoss,
         ),
       )
@@ -460,19 +460,19 @@ object OpenEconEconomics:
       corpBondDefaultLoss: PLN,
   )(using p: SimParams): NbfiResult =
     val nbfiDepositRate = (postFxNbp.referenceRate - NbfiDepositRateSpread).max(Rate.Zero)
-    val nbfiUnempRate   = in.w.unemploymentRate(in.s2.employed)
+    val nbfiUnempRate   = in.world.unemploymentRate(in.labor.employed)
     val nbfiStep        =
       Nbfi.step(
         Nbfi.StepInput(
           opening = LedgerFinancialState.nbfiOpeningBalances(in.ledgerFinancialState),
-          employed = in.s2.employed,
-          wage = in.s2.newWage,
-          priceLevel = in.w.priceLevel,
+          employed = in.labor.employed,
+          wage = in.labor.newWage,
+          priceLevel = in.world.priceLevel,
           unempRate = nbfiUnempRate,
           bankNplRatio = bankAgg.nplRatio,
           govBondYield = newBondYield,
           corpBondYield = newCorpBondYield,
-          equityReturn = in.s7.equityAfterForeignStock.monthlyReturn,
+          equityReturn = in.priceEquity.equityAfterForeignStock.monthlyReturn,
           depositRate = nbfiDepositRate,
           corpBondDefaultLoss = corpBondDefaultLoss,
         ),

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/banking/BankMultiBankStage.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/banking/BankMultiBankStage.scala
@@ -32,8 +32,9 @@ private[banking] object BankMultiBankStage:
     val openingBankStocks   = in.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
     // We keep the opening bank-side consumer-loan stock but realign it to the
     // current household routing keys and household-level consumer-loan balances
-    // carried into s5. This assumes no stage between the opening ledger snapshot
-    // and s5 mutates household consumerLoan principal; only routing may drift.
+    // carried into the firm stage. This assumes no stage between the opening
+    // ledger snapshot and firm stage mutates household consumerLoan principal;
+    // only routing may drift.
     val bankStocks          = BankingHouseholdBooks.alignConsumerLoanBookToHouseholdRouting(
       in.firm.households,
       in.firm.ledgerFinancialState.households,

--- a/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthEconomicsDsl.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/flows/SameMonthEconomicsDsl.scala
@@ -300,17 +300,17 @@ private[flows] object SameMonthEconomicsDsl:
     MonthWorkflow.pure(
       OpenEconEconomics.runStep(
         OpenEconEconomics.StepInput(
-          in.world,
-          in.ledger,
-          in.fiscal,
-          in.labor,
-          in.householdIncome,
-          in.demand,
-          in.firm,
-          in.householdFinancial,
-          in.priceEquity,
-          in.banks,
-          in.rng,
+          world = in.world,
+          ledgerFinancialState = in.ledger,
+          fiscal = in.fiscal,
+          labor = in.labor,
+          householdIncome = in.householdIncome,
+          demand = in.demand,
+          firm = in.firm,
+          householdFinancial = in.householdFinancial,
+          priceEquity = in.priceEquity,
+          banks = in.banks,
+          commodityRng = in.rng,
         ),
       ),
     )

--- a/src/test/scala/com/boombustgroup/amorfati/engine/SignalExtractionSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/SignalExtractionSpec.scala
@@ -68,6 +68,6 @@ class SignalExtractionSpec extends AnyFlatSpec with Matchers:
     result.provenance.sectorHiringSignal.stage shouldBe MonthTraceStage.DemandEconomics
     result.provenance.startupAbsorptionRate.value shouldBe Share.decimal(55, 2)
     result.provenance.startupAbsorptionRate.source shouldBe "StartupStaffing.assign.startupAbsorptionRate"
-    result.provenance.sectorDemandPressure.source shouldBe "s4.sectorDemandPressure"
-    result.provenance.sectorHiringSignal.source shouldBe "s4.sectorHiringSignal"
+    result.provenance.sectorDemandPressure.source shouldBe "demand.sectorDemandPressure"
+    result.provenance.sectorHiringSignal.source shouldBe "demand.sectorHiringSignal"
   }

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -45,15 +45,15 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
   private def runOpenEcon(world: World): OpenEconEconomics.StepOutput =
     OpenEconEconomics.runStep(
       OpenEconEconomics.StepInput(
-        w = world,
+        world = world,
         ledgerFinancialState = baseLedgerFinancialState,
-        s1 = s1,
-        s2 = s2,
-        s3 = s3,
-        s4 = s4,
-        s5 = s5,
-        s6 = s6,
-        s7 = s7,
+        fiscal = s1,
+        labor = s2,
+        householdIncome = s3,
+        demand = s4,
+        firm = s5,
+        householdFinancial = s6,
+        priceEquity = s7,
         banks = init.banks,
         commodityRng = RandomStream.seeded(TestSeed),
       ),


### PR DESCRIPTION
## Summary
- rename remaining production month-stage references from s1/s9 notation to named economics boundaries
- align OpenEconEconomics.StepInput with the same named contract used by the month DSL and banking stage
- expand IFRS ECL Stage 1/2/3 comments and locals to avoid visual collision with month-step notation

## Tests
- sbt scalafmtAll
- sbt Test/compile
- sbt "testOnly com.boombustgroup.amorfati.engine.SignalExtractionSpec com.boombustgroup.amorfati.engine.economics.OpenEconEconomicsSpec"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized IFRS 9 Expected Credit Loss (ECL) terminology from abbreviated notation to full stage naming (Stage 1/2/3) across all documentation and parameter descriptions for improved clarity.

* **Refactoring**
  * Enhanced code readability by replacing sequential intermediate variable naming with descriptive identifiers throughout computation pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->