### PR TITLE
Fix QE purchase cap GDP basis

### DIFF
--- a/docs/behavioral-equations-and-decision-rules.md
+++ b/docs/behavioral-equations-and-decision-rules.md
@@ -1142,10 +1142,12 @@ referenceRate' =
 Government bond yield is:
 
 ```text
+annualGdp = 12 * monthlyGdp
+
 bondYield =
   max(referenceRate + termPremium, bundYield + termPremium)
   + fiscalRisk(debtToGdp)
-  - qeCompression(nbpBondHoldings / GDP)
+  - qeCompression(qeCumulative / annualGdp)
   - foreignDemandDiscount(if NFA > 0)
   + credibilityPremium
 ```
@@ -1153,7 +1155,15 @@ bondYield =
 QE activates near the lower bound when realized or expected inflation is below
 target by the configured threshold. QE purchases are requested by NBP but
 settled through the bond waterfall, so actual sold bonds leave banks and enter
-NBP holdings exactly.
+NBP holdings exactly. The requested purchase is capped against the same
+annualized GDP basis used by bond-market ratios:
+
+```text
+qeRequest =
+  min(max(qeMaxGdpShare * annualGdp - nbpGovBondHoldings, 0),
+      bankGovBondHoldings,
+      qePace)
+```
 
 The SGP fiscal correction applies to discretionary government purchases after
 subtracting lagged non-purchase outlays from the 3% deficit path:

--- a/docs/institutional-sector-equations.md
+++ b/docs/institutional-sector-equations.md
@@ -375,16 +375,13 @@ DebtService_tau =
 QE is a policy request, not a direct stock mutation. QE activates when the
 reference rate is near the lower bound and realized or expected inflation is
 materially below target. The requested purchase is bounded by the GDP-share
-ceiling, bank-held bond supply, and QE pace.
-
-Current executable behavior passes the same-month GDP surface into the QE cap
-helper. #728 tracks whether this should be changed to the annualized GDP basis
-used by bond-market ratios. Until that follow-up lands, the implemented request
-is:
+ceiling, bank-held bond supply, and QE pace. The GDP-share ceiling uses the
+same annualized GDP basis as the bond-market debt/GDP and QE-compression
+ratios:
 
 ```text
 QeRequest_tau =
-  min(max(qeMaxGdpShare * GDP_tau - NbpGovBondHoldings_t, 0),
+  min(max(qeMaxGdpShare * AnnualGDP_tau - NbpGovBondHoldings_t, 0),
       BankGovBondHoldings_t,
       QePace_tau)
 ```
@@ -836,9 +833,6 @@ and net/gross split.
   intra-year budget amendments, or cash/accrual reconciliation in detail.
 - The NBP rule is a Taylor-type policy heuristic with a QE lower-bound branch
   and FX-intervention band. It is not an estimated reaction function.
-- The current QE cap basis and NBP remittance output naming are tracked in
-  #728 and #729. Until those follow-ups land, this document describes the
-  executable behavior and flags the observable-output ambiguity explicitly.
 - External-sector behavior combines structural trade, GVC, remittance,
   tourism, FDI, portfolio, carry-trade, and capital-flight channels. Several
   coefficients remain calibration or scenario targets rather than final

--- a/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomics.scala
@@ -387,7 +387,8 @@ object OpenEconEconomics:
       govBondHoldings = in.ledgerFinancialState.nbp.govBondHoldings,
       foreignAssets = in.ledgerFinancialState.nbp.foreignAssets,
     )
-    val qeRequest        = Nbp.executeQe(preQeNbp, preQeNbpStocks, bankAgg.govBondHoldings, in.priceEquity.gdp, in.priceEquity.newInfl, newExp.expectedInflation)
+    val qeRequest        =
+      Nbp.executeQe(preQeNbp, preQeNbpStocks, bankAgg.govBondHoldings, annualGdpForBonds, in.priceEquity.newInfl, newExp.expectedInflation)
     val qePurchaseAmount = qeRequest.requestedPurchase
     val postFxNbp        = qeRequest.nbpState.copy(monthly = qeRequest.nbpState.monthly.copy(lastFxTraded = fxResult.eurTraded))
     val postFxNbpStocks  = preQeNbpStocks.copy(

--- a/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/engine/economics/OpenEconEconomicsSpec.scala
@@ -1,10 +1,12 @@
 package com.boombustgroup.amorfati.engine.economics
 
 import com.boombustgroup.amorfati.FixedPointSpecSupport.*
+import com.boombustgroup.amorfati.agents.Nbp
 import com.boombustgroup.amorfati.config.SimParams
 import com.boombustgroup.amorfati.engine.World
 import com.boombustgroup.amorfati.engine.SimulationMonth.ExecutionMonth
 import com.boombustgroup.amorfati.engine.flows.*
+import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.random.RandomStream
 import com.boombustgroup.amorfati.types.*
@@ -42,22 +44,27 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
     ledgerFinancialState = baseLedgerFinancialState,
   )
 
-  private def runOpenEcon(world: World): OpenEconEconomics.StepOutput =
+  private def runOpenEcon(
+      world: World,
+      ledgerFinancialState: LedgerFinancialState = baseLedgerFinancialState,
+      priceEquity: PriceEquityEconomics.StepOutput = s7,
+      params: SimParams = p,
+  ): OpenEconEconomics.StepOutput =
     OpenEconEconomics.runStep(
       OpenEconEconomics.StepInput(
         world = world,
-        ledgerFinancialState = baseLedgerFinancialState,
+        ledgerFinancialState = ledgerFinancialState,
         fiscal = s1,
         labor = s2,
         householdIncome = s3,
         demand = s4,
         firm = s5,
         householdFinancial = s6,
-        priceEquity = s7,
+        priceEquity = priceEquity,
         banks = init.banks,
         commodityRng = RandomStream.seeded(TestSeed),
       ),
-    )
+    )(using params)
 
   private val result = runOpenEcon(w)
 
@@ -95,6 +102,36 @@ class OpenEconEconomicsSpec extends AnyFlatSpec with Matchers:
 
   it should "produce a valid bond yield" in {
     decimal(result.monetary.newBondYield) should be >= BigDecimal("0.0")
+  }
+
+  it should "cap QE requests against annualized GDP in the open-economy call-site" in {
+    val monthlyGdp        = s7.gdp
+    val annualGdp         = monthlyGdp * 12
+    val annualCapHeadroom = p.monetary.qePace
+    val openingNbpBonds   = annualGdp * p.monetary.qeMaxGdpShare - annualCapHeadroom
+    val bankSupply        = annualCapHeadroom * 2
+    val qeLedger          = baseLedgerFinancialState.copy(
+      banks = baseLedgerFinancialState.banks.zipWithIndex.map {
+        case (bank, 0) => bank.copy(govBondAfs = bankSupply, govBondHtm = PLN.Zero)
+        case (bank, _) => bank.copy(govBondAfs = PLN.Zero, govBondHtm = PLN.Zero)
+      },
+      nbp = baseLedgerFinancialState.nbp.copy(govBondHoldings = openingNbpBonds),
+    )
+    val qeWorld           = w.copy(
+      nbp = Nbp.State(p.monetary.rateFloor, qeActive = true, qeCumulative = PLN.Zero, lastFxTraded = PLN.Zero),
+      mechanisms = w.mechanisms.copy(
+        expectations = w.mechanisms.expectations.copy(
+          expectedInflation = Rate.decimal(-2, 2),
+          expectedRate = p.monetary.rateFloor,
+          forwardGuidanceRate = p.monetary.rateFloor,
+        ),
+      ),
+    )
+    val qeSurface         = s7.copy(newInfl = Rate.decimal(-5, 2))
+    val qeResult          = runOpenEcon(qeWorld, qeLedger, qeSurface)
+
+    openingNbpBonds should be > (monthlyGdp * p.monetary.qeMaxGdpShare)
+    qeResult.monetary.qePurchaseAmount shouldBe annualCapHeadroom
   }
 
   it should "return corporate bond projection separately from market memory in runStep" in {


### PR DESCRIPTION
## Summary
- pass annualized GDP into NBP QE purchase-cap calculation from OpenEconEconomics
- add regression coverage for the open-economy QE call-site
- sync QE documentation with the annualized GDP basis and remove stale follow-up wording

Fixes #728

## Tests
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.engine.economics.OpenEconEconomicsSpec com.boombustgroup.amorfati.agents.CentralBankSpec"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated QE compression and purchase cap calculations to use annualized GDP, improving accuracy of quantitative easing measurements.
  * Fixed QE cap logic to properly account for annualized GDP headroom.

* **Documentation**
  * Revised QE and bond yield equations to reflect annualized GDP methodology.

* **Tests**
  * Added test coverage validating QE purchase cap constraints against annualized GDP headroom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->