### PR TITLE
Add typed production-sector crosswalk contract

### DIFF
--- a/docs/data-bridge-national-financial-accounts.md
+++ b/docs/data-bridge-national-financial-accounts.md
@@ -98,14 +98,23 @@ transformation code or command, and target model field.
 
 ## Production-Sector Crosswalk
 
-| Runtime production sector | Candidate NACE Rev. 2 mapping | Bridge note |
-| --- | --- | --- |
-| BPO/SSC | J, M, N, selected K support services. | Requires explicit service-export and business-services bridge. |
-| Manufacturing | C. | Direct high-level mapping. |
-| Retail/Services | G, H, I, L, selected M/N/R/S. | Broad residual services bucket; document included sections per extraction. |
-| Healthcare | Q. | Public/private split should be recorded when used for fiscal or employment targets. |
-| Public | O and P, plus public components of other sections when data allow. | Public administration and education are direct; public health belongs to healthcare unless stated otherwise. |
-| Agriculture | A. | Direct high-level mapping. |
+The test-backed runtime contract lives in
+[`ProductionSectorCrosswalk.scala`](../src/main/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalk.scala).
+Initial sector-output validation should use this table as a summary, not as a
+license to treat every row as a direct empirical match.
+
+| Runtime production sector | NACE Rev. 2 mapping | Initial validation treatment | Bridge note |
+| --- | --- | --- | --- |
+| BPO/SSC | J, M, N. | `BRIDGE_ASSUMPTION` | ICT, professional-services, and administrative-support sections proxy the business-services runtime sector until a finer service-export/BPO extraction exists. |
+| Manufacturing | C, with B, D, and E as industrial residuals. | `DIRECT` for C; `RESIDUAL` for B/D/E | The runtime schema has no separate mining, energy, utilities, water, or waste sector. |
+| Retail/Services | G, H, I, with F, L, R, and S as broad-service residuals. | `DIRECT` for G/H/I; `RESIDUAL` for F/L/R/S | Construction, real estate, arts, and other services are residuals inside the broad services bucket. |
+| Healthcare | Q. | `DIRECT` | Public/private split should be recorded when used for fiscal or employment targets. |
+| Public | O and P. | `DIRECT` | Public administration and education are direct; public health belongs to healthcare unless stated otherwise. |
+| Agriculture | A. | `DIRECT` | Direct high-level mapping. |
+
+NACE K is outside this production-sector validation perimeter because banks,
+insurance, funds, and non-bank finance are modeled as separate financial-sector
+agents. NACE T and U are also outside the runtime production-firm perimeter.
 
 ## Financial-Instrument Crosswalk
 

--- a/docs/data-bridge-national-financial-accounts.md
+++ b/docs/data-bridge-national-financial-accounts.md
@@ -83,7 +83,12 @@ transformation code or command, and target model field.
 | Financial markets and non-bank finance | NBP/ECB rates, KNF capital-market and pension-fund statistics, GPW or official market data where available. | Corporate bonds, funds, insurance, pension funds, equity market, stress channels. | `BondYield`, `CorpBondYield`, `CorpBondSpread`, `GpwIndex`, `GpwMarketCap`, fund/insurance holdings and flows. | Market prices month-end or monthly average depending state/flow semantics; fund and insurance stocks mapped to ESA S.128/S.129. | Official GPW data and non-bank holder splits need a stable open-source path. Priority: medium. |
 | Scenario-specific shocks | EU ETS/energy data, tourism statistics, EU funds absorption, policy announcements, official projections. | Named scenarios and sensitivity inputs. | `climate.*`, `tourism.*`, `fiscal.eu*`, `scenarioRun` deltas. | Baseline calibration stays empirical; scenario magnitudes must state whether they are external analogues, official projections, policy counterfactuals, or explicit assumptions. | Executable provenance is recorded per `ScenarioRegistry` delta and exported by `ScenarioRunExport`; source-extraction manifests for externally backed shocks remain future work. Priority: medium. |
 
-## Sector Crosswalk
+## Institutional-Sector Crosswalk
+
+This crosswalk maps ESA/institutional accounting sectors for balance sheets,
+financial accounts, and SFC ownership. It is separate from the production-sector
+crosswalk below, which maps NACE activities to the six runtime production
+sectors used by firms and sector-output validation.
 
 | Runtime sector | Primary ESA / institutional mapping | Bridge note |
 | --- | --- | --- |

--- a/src/main/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalk.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalk.scala
@@ -1,0 +1,131 @@
+package com.boombustgroup.amorfati.config
+
+object ProductionSectorCrosswalk:
+
+  enum AssignmentKind(val token: String):
+    case Direct           extends AssignmentKind("DIRECT")
+    case BridgeAssumption extends AssignmentKind("BRIDGE_ASSUMPTION")
+    case Residual         extends AssignmentKind("RESIDUAL")
+    case Excluded         extends AssignmentKind("EXCLUDED")
+
+  final case class RuntimeSector(name: String, outputStem: String)
+
+  final case class NaceSection(code: String, label: String):
+    require(code.matches("[A-U]"), s"NACE section code must be A-U, got $code")
+    require(label.trim.nonEmpty, s"NACE section $code must have a label")
+
+  final case class NaceAssignment(
+      section: NaceSection,
+      runtimeSector: Option[RuntimeSector],
+      kind: AssignmentKind,
+      note: String,
+  ):
+    require(note.trim.nonEmpty, s"NACE section ${section.code} must have a bridge note")
+    kind match
+      case AssignmentKind.Excluded =>
+        require(runtimeSector.isEmpty, s"Excluded NACE section ${section.code} must not target a runtime sector")
+      case _                       =>
+        require(runtimeSector.nonEmpty, s"Included NACE section ${section.code} must target a runtime sector")
+
+    def included: Boolean = runtimeSector.nonEmpty
+
+  final case class SectorMapping(runtimeSector: RuntimeSector, assignments: Vector[NaceAssignment])
+
+  val RuntimeSectors: Vector[RuntimeSector] =
+    SimParams.SchemaSectors.map(sector => RuntimeSector(sector.name, sector.outputStem))
+
+  val NaceSections: Vector[NaceSection] = Vector(
+    NaceSection("A", "Agriculture, forestry and fishing"),
+    NaceSection("B", "Mining and quarrying"),
+    NaceSection("C", "Manufacturing"),
+    NaceSection("D", "Electricity, gas, steam and air conditioning supply"),
+    NaceSection("E", "Water supply; sewerage, waste management and remediation"),
+    NaceSection("F", "Construction"),
+    NaceSection("G", "Wholesale and retail trade; repair of motor vehicles and motorcycles"),
+    NaceSection("H", "Transportation and storage"),
+    NaceSection("I", "Accommodation and food service activities"),
+    NaceSection("J", "Information and communication"),
+    NaceSection("K", "Financial and insurance activities"),
+    NaceSection("L", "Real estate activities"),
+    NaceSection("M", "Professional, scientific and technical activities"),
+    NaceSection("N", "Administrative and support service activities"),
+    NaceSection("O", "Public administration and defence; compulsory social security"),
+    NaceSection("P", "Education"),
+    NaceSection("Q", "Human health and social work activities"),
+    NaceSection("R", "Arts, entertainment and recreation"),
+    NaceSection("S", "Other service activities"),
+    NaceSection("T", "Households as employers; undifferentiated household production"),
+    NaceSection("U", "Activities of extraterritorial organisations and bodies"),
+  )
+
+  val Assignments: Vector[NaceAssignment] = Vector(
+    assign("A", "Agriculture", AssignmentKind.Direct, "Direct high-level agriculture bridge."),
+    assign("B", "Manufacturing", AssignmentKind.Residual, "Industrial residual; no separate mining sector exists in the runtime schema."),
+    assign("C", "Manufacturing", AssignmentKind.Direct, "Direct high-level manufacturing bridge."),
+    assign("D", "Manufacturing", AssignmentKind.Residual, "Energy and utilities residual; the runtime schema has no separate energy sector."),
+    assign("E", "Manufacturing", AssignmentKind.Residual, "Water and waste residual; grouped with the industrial production bridge."),
+    assign("F", "Retail/Services", AssignmentKind.Residual, "Construction residual inside the broad market-services bucket."),
+    assign("G", "Retail/Services", AssignmentKind.Direct, "Direct high-level trade and repair bridge."),
+    assign("H", "Retail/Services", AssignmentKind.Direct, "Direct high-level transport and storage bridge."),
+    assign("I", "Retail/Services", AssignmentKind.Direct, "Direct high-level accommodation and food service bridge."),
+    assign("J", "BPO/SSC", AssignmentKind.BridgeAssumption, "ICT and information services proxy for the BPO/SSC runtime sector."),
+    exclude("K", "Financial and insurance activities are modeled by separate financial-sector agents, not production-sector firms."),
+    assign("L", "Retail/Services", AssignmentKind.Residual, "Real-estate activities residual inside broad services."),
+    assign("M", "BPO/SSC", AssignmentKind.BridgeAssumption, "Professional services proxy for the business-services runtime sector."),
+    assign("N", "BPO/SSC", AssignmentKind.BridgeAssumption, "Administrative support services proxy for the business-services runtime sector."),
+    assign("O", "Public", AssignmentKind.Direct, "Direct public-administration bridge."),
+    assign("P", "Public", AssignmentKind.Direct, "Direct education bridge for the public runtime sector."),
+    assign("Q", "Healthcare", AssignmentKind.Direct, "Direct health and social-work bridge."),
+    assign("R", "Retail/Services", AssignmentKind.Residual, "Arts and recreation residual inside broad services."),
+    assign("S", "Retail/Services", AssignmentKind.Residual, "Other services residual inside broad services."),
+    exclude("T", "Household employer and own-use production is outside the runtime production-firm sector perimeter."),
+    exclude("U", "Extraterritorial organisations are outside the Poland production-sector validation perimeter."),
+  )
+
+  val IncludedAssignments: Vector[NaceAssignment] = Assignments.filter(_.included)
+  val ExcludedAssignments: Vector[NaceAssignment] = Assignments.filterNot(_.included)
+
+  val SectorMappings: Vector[SectorMapping] =
+    RuntimeSectors.map: runtimeSector =>
+      SectorMapping(runtimeSector, IncludedAssignments.filter(_.runtimeSector.contains(runtimeSector)))
+
+  def assignmentForSection(code: String): Option[NaceAssignment] =
+    Assignments.find(_.section.code == code)
+
+  def mappingForSectorName(name: String): Option[SectorMapping] =
+    SectorMappings.find(_.runtimeSector.name == name)
+
+  private val assignedCodes = Assignments.map(_.section.code)
+  require(
+    assignedCodes.distinct.length == NaceSections.length && assignedCodes.toSet == NaceSections.map(_.code).toSet,
+    "ProductionSectorCrosswalk must assign or exclude every NACE Rev. 2 section A-U exactly once",
+  )
+  require(
+    SectorMappings.map(_.runtimeSector.name) == SimParams.SchemaSectorNames,
+    s"ProductionSectorCrosswalk must preserve runtime sector order ${SimParams.SchemaSectorNames.mkString(" -> ")}",
+  )
+  require(
+    SectorMappings.forall(_.assignments.nonEmpty),
+    "ProductionSectorCrosswalk must map at least one NACE section to every runtime production sector",
+  )
+
+  private def section(code: String): NaceSection =
+    NaceSections
+      .find(_.code == code)
+      .getOrElse(throw new IllegalArgumentException(s"Unknown NACE section code: $code"))
+
+  private def runtimeSector(name: String): RuntimeSector =
+    RuntimeSectors
+      .find(_.name == name)
+      .getOrElse(throw new IllegalArgumentException(s"Unknown runtime sector: $name"))
+
+  private def assign(
+      code: String,
+      sectorName: String,
+      kind: AssignmentKind,
+      note: String,
+  ): NaceAssignment =
+    NaceAssignment(section(code), Some(runtimeSector(sectorName)), kind, note)
+
+  private def exclude(code: String, note: String): NaceAssignment =
+    NaceAssignment(section(code), None, AssignmentKind.Excluded, note)

--- a/src/main/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalk.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalk.scala
@@ -1,7 +1,23 @@
 package com.boombustgroup.amorfati.config
 
+/** Maps source-data industry classifications into AMOR-FATI's runtime
+  * production sectors.
+  *
+  * This is the industry/output axis of the model, not the ESA/SFC
+  * institutional-sector axis used for balance sheets and ownership. For
+  * example, a manufacturing firm is institutionally a firm, but its production
+  * sector is Manufacturing.
+  */
 object ProductionSectorCrosswalk:
 
+  /** Marks how strong each NACE-to-runtime-sector bridge is.
+    *
+    * Direct rows can be used as high-level empirical matches. Bridge
+    * assumptions are explicit proxies for runtime concepts that have no
+    * one-to-one NACE section. Residual rows keep source-data coverage complete
+    * without pretending to be direct matches. Excluded rows are intentionally
+    * outside the production-firm perimeter.
+    */
   enum AssignmentKind(val token: String):
     case Direct           extends AssignmentKind("DIRECT")
     case BridgeAssumption extends AssignmentKind("BRIDGE_ASSUMPTION")
@@ -34,6 +50,11 @@ object ProductionSectorCrosswalk:
   val RuntimeSectors: Vector[RuntimeSector] =
     SimParams.SchemaSectors.map(sector => RuntimeSector(sector.name, sector.outputStem))
 
+  /** NACE Rev. 2 sections A-U.
+    *
+    * Keeping the complete source taxonomy here makes missing or duplicated
+    * sections fail fast when assignments are edited.
+    */
   val NaceSections: Vector[NaceSection] = Vector(
     NaceSection("A", "Agriculture, forestry and fishing"),
     NaceSection("B", "Mining and quarrying"),
@@ -58,6 +79,16 @@ object ProductionSectorCrosswalk:
     NaceSection("U", "Activities of extraterritorial organisations and bodies"),
   )
 
+  /** Production-sector bridge from NACE Rev. 2 sections to the six runtime
+    * sectors.
+    *
+    * The runtime schema is intentionally coarser than NACE. K is excluded
+    * because financial and insurance institutions are represented by dedicated
+    * financial agents. T and U are excluded because they are not Poland
+    * production-firm sectors. BPO/SSC is a model concept, so J/M/N are recorded
+    * as bridge assumptions until a finer empirical service-export or
+    * shared-services extraction exists.
+    */
   val Assignments: Vector[NaceAssignment] = Vector(
     assign("A", "Agriculture", AssignmentKind.Direct, "Direct high-level agriculture bridge."),
     assign("B", "Manufacturing", AssignmentKind.Residual, "Industrial residual; no separate mining sector exists in the runtime schema."),

--- a/src/test/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalkSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/ProductionSectorCrosswalkSpec.scala
@@ -1,0 +1,67 @@
+package com.boombustgroup.amorfati.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ProductionSectorCrosswalkSpec extends AnyFlatSpec with Matchers:
+
+  import ProductionSectorCrosswalk.*
+
+  "ProductionSectorCrosswalk" should "preserve the runtime sector schema order and output stems" in {
+    RuntimeSectors.map(_.name) shouldBe SimParams.SchemaSectorNames
+    RuntimeSectors.map(_.outputStem) shouldBe SimParams.SchemaSectors.map(_.outputStem)
+    SectorMappings.map(_.runtimeSector) shouldBe RuntimeSectors
+  }
+
+  it should "assign or exclude every NACE Rev. 2 section A-U exactly once" in {
+    val expectedCodes = ('A' to 'U').map(_.toString).toVector
+
+    NaceSections.map(_.code) shouldBe expectedCodes
+    Assignments.map(_.section.code).sorted shouldBe expectedCodes
+    Assignments.groupBy(_.section.code).view.mapValues(_.size).toMap.values.foreach(_ shouldBe 1)
+  }
+
+  it should "map at least one included source section to every runtime sector" in {
+    SectorMappings.map(_.runtimeSector.name) shouldBe Vector(
+      "BPO/SSC",
+      "Manufacturing",
+      "Retail/Services",
+      "Healthcare",
+      "Public",
+      "Agriculture",
+    )
+    SectorMappings.foreach(_.assignments should not be empty)
+  }
+
+  it should "mark mixed business-service mappings as bridge assumptions" in {
+    assignmentForSection("J").map(_.kind) shouldBe Some(AssignmentKind.BridgeAssumption)
+    assignmentForSection("M").map(_.kind) shouldBe Some(AssignmentKind.BridgeAssumption)
+    assignmentForSection("N").map(_.kind) shouldBe Some(AssignmentKind.BridgeAssumption)
+  }
+
+  it should "keep financial and out-of-perimeter sections outside production-sector validation" in {
+    assignmentForSection("K").map(_.kind) shouldBe Some(AssignmentKind.Excluded)
+    assignmentForSection("T").map(_.kind) shouldBe Some(AssignmentKind.Excluded)
+    assignmentForSection("U").map(_.kind) shouldBe Some(AssignmentKind.Excluded)
+    ExcludedAssignments.flatMap(_.runtimeSector) shouldBe empty
+  }
+
+  it should "label broad residual sections explicitly" in {
+    val residualCodes = Assignments.collect {
+      case assignment if assignment.kind == AssignmentKind.Residual => assignment.section.code
+    }
+
+    residualCodes should contain allOf ("B", "D", "E", "F", "L", "R", "S")
+  }
+
+  it should "keep direct high-level mappings distinguishable from bridge assumptions" in {
+    val directBySector = SectorMappings.map { mapping =>
+      mapping.runtimeSector.name -> mapping.assignments.filter(_.kind == AssignmentKind.Direct).map(_.section.code)
+    }.toMap
+
+    directBySector("Agriculture") shouldBe Vector("A")
+    directBySector("Manufacturing") shouldBe Vector("C")
+    directBySector("Healthcare") shouldBe Vector("Q")
+    directBySector("Public") shouldBe Vector("O", "P")
+    directBySector("Retail/Services") should contain allOf ("G", "H", "I")
+  }


### PR DESCRIPTION
## Summary

- Add a typed `ProductionSectorCrosswalk` contract for NACE Rev. 2 A-U to the six runtime production sectors.
- Mark direct, residual, bridge-assumption, and excluded mappings explicitly.
- Add tests that pin runtime sector order, output stems, full A-U coverage, bridge assumptions, residuals, and excluded sections.
- Update the existing production-sector data bridge table to point to the test-backed contract.

## Notes

- No sector parameter values changed.
- NACE K/T/U stay outside the production-sector validation perimeter.
- BPO/SSC J/M/N mappings are explicitly `BRIDGE_ASSUMPTION`.
- Manufacturing and Retail/Services residual sections are explicit rather than hidden.

## Validation

- `nix develop . --command sbt scalafmtAll`
- `nix develop . --command sbt "testOnly com.boombustgroup.amorfati.config.ProductionSectorCrosswalkSpec"`
- `git diff --cached --check`

Closes #818.
Updates #817.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced formalized production sector mapping configuration with validation rules to ensure data consistency.

* **Documentation**
  * Updated production sector crosswalk documentation with clarified mapping semantics and assignment guidelines.

* **Tests**
  * Added comprehensive test coverage validating sector mapping configuration and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->