### PR TITLE
Stream Monte Carlo snapshot row writers

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotSchema.scala
@@ -53,21 +53,23 @@ private[montecarlo] object McFirmSnapshotSchema:
       render = row => columns.map(_._2(row)).mkString("\t"),
     )
 
-  def rows(runId: String, seed: Long, month: ExecutionMonth, state: FlowSimulation.SimState)(using SimParams): Vector[Row] =
-    state.firms.map: firm =>
+  def foreachRow(runId: String, seed: Long, month: ExecutionMonth, state: FlowSimulation.SimState)(consume: Row => Unit)(using SimParams): Unit =
+    state.firms.foreach: firm =>
       val workers = Firm.workerCount(firm)
-      Row(
-        runId = runId,
-        seed = seed,
-        month = month,
-        firm = firm,
-        sectorName = sectorName(firm),
-        workers = workers,
-        sizeClass = McFirmSizeClass.fromWorkerCount(workers),
-        balances = state.ledgerFinancialState.firms
-          .lift(firm.id.toInt)
-          .getOrElse:
-            throw IllegalStateException(s"Missing ledger financial balances for firm ${firm.id.toInt}"),
+      consume(
+        Row(
+          runId = runId,
+          seed = seed,
+          month = month,
+          firm = firm,
+          sectorName = sectorName(firm),
+          workers = workers,
+          sizeClass = McFirmSizeClass.fromWorkerCount(workers),
+          balances = state.ledgerFinancialState.firms
+            .lift(firm.id.toInt)
+            .getOrElse:
+              throw IllegalStateException(s"Missing ledger financial balances for firm ${firm.id.toInt}"),
+        ),
       )
 
   private def sectorName(firm: Firm.State)(using p: SimParams): String =

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotTsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McFirmSnapshotTsv.scala
@@ -83,8 +83,7 @@ private[montecarlo] object McFirmSnapshotTsv:
         .attemptBlocking:
           val schema = McFirmSnapshotSchema.tsvSchema
           McFirmSnapshotSchema
-            .rows(rc.runId, seed, month, state)
-            .foreach: row =>
+            .foreachRow(rc.runId, seed, month, state): row =>
               writer.write(schema.render(row))
               writer.newLine()
         .unit

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdShortfallCohortSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdShortfallCohortSchema.scala
@@ -105,7 +105,7 @@ private[montecarlo] object McHouseholdShortfallCohortSchema:
       state: FlowSimulation.HouseholdSnapshotState,
       monthlyFlows: Vector[Household.MonthlyFlow],
   ): Vector[Row] =
-    val snapshotRows   = McHouseholdSnapshotSchema.rows(runId, seed, month, state, monthlyFlows, McHouseholdSnapshotSelection.All)
+    val snapshotRows   = fullSnapshotRows(runId, seed, month, state, monthlyFlows)
     val monthShortfall = snapshotRows.map(_.monthlyFlow.liquidityShortfallFinancing).sumPln
     val incomeDeciles  = incomeDecileByIndex(snapshotRows)
 
@@ -130,6 +130,17 @@ private[montecarlo] object McHouseholdShortfallCohortSchema:
         .toVector
         .sortBy(_._1)
         .map((cohort, rows) => aggregate(runId, seed, month, dimension, cohort, rows.map(_._1), monthShortfall))
+
+  private def fullSnapshotRows(
+      runId: String,
+      seed: Long,
+      month: ExecutionMonth,
+      state: FlowSimulation.HouseholdSnapshotState,
+      monthlyFlows: Vector[Household.MonthlyFlow],
+  ): Vector[McHouseholdSnapshotSchema.Row] =
+    val builder = Vector.newBuilder[McHouseholdSnapshotSchema.Row]
+    McHouseholdSnapshotSchema.foreachRow(runId, seed, month, state, monthlyFlows, McHouseholdSnapshotSelection.All)(builder += _)
+    builder.result()
 
   private def aggregate(
       runId: String,

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotSchema.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotSchema.scala
@@ -97,14 +97,14 @@ private[montecarlo] object McHouseholdSnapshotSchema:
       render = row => columns.map(_._2(row)).mkString("\t"),
     )
 
-  def rows(
+  def foreachRow(
       runId: String,
       seed: Long,
       month: ExecutionMonth,
       state: FlowSimulation.HouseholdSnapshotState,
       monthlyFlows: Vector[Household.MonthlyFlow],
       selection: McHouseholdSnapshotSelection,
-  ): Vector[Row] =
+  )(consume: Row => Unit): Unit =
     require(
       state.households.length == state.ledgerFinancialState.households.length,
       s"Household snapshot export requires aligned households and ledger balances, got ${state.households.length} households and ${state.ledgerFinancialState.households.length} balance rows",
@@ -113,15 +113,17 @@ private[montecarlo] object McHouseholdSnapshotSchema:
       state.households.length == monthlyFlows.length,
       s"Household snapshot export requires aligned households and monthly flow rows, got ${state.households.length} households and ${monthlyFlows.length} flow rows",
     )
-    state.households
-      .zip(state.ledgerFinancialState.households)
-      .zip(monthlyFlows)
-      .map: pair =>
-        val ((household, balances), monthlyFlow) = pair
-        require(
-          household.id == monthlyFlow.householdId,
-          s"Household snapshot export requires positional household-flow alignment, got household ${household.id.toInt} and flow ${monthlyFlow.householdId.toInt}",
-        )
+
+    var index = 0
+    while index < state.households.length do
+      val household   = state.households(index)
+      val balances    = state.ledgerFinancialState.households(index)
+      val monthlyFlow = monthlyFlows(index)
+      require(
+        household.id == monthlyFlow.householdId,
+        s"Household snapshot export requires positional household-flow alignment, got household ${household.id.toInt} and flow ${monthlyFlow.householdId.toInt}",
+      )
+      val row         =
         Row(
           runId = runId,
           seed = seed,
@@ -130,7 +132,8 @@ private[montecarlo] object McHouseholdSnapshotSchema:
           balances = balances,
           monthlyFlow = monthlyFlow,
         )
-      .filter(row => selection.includes(row.balances.demandDeposit, row.monthlyFlow.liquidityShortfallFinancing))
+      if selection.includes(row.balances.demandDeposit, row.monthlyFlow.liquidityShortfallFinancing) then consume(row)
+      index += 1
 
   private def status(status: HhStatus): String =
     status match

--- a/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotTsv.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotTsv.scala
@@ -85,8 +85,7 @@ private[montecarlo] object McHouseholdSnapshotTsv:
         .attemptBlocking:
           val schema = McHouseholdSnapshotSchema.tsvSchema
           McHouseholdSnapshotSchema
-            .rows(rc.runId, seed, month, state, monthlyFlows, rc.householdSnapshotSelection)
-            .foreach: row =>
+            .foreachRow(rc.runId, seed, month, state, monthlyFlows, rc.householdSnapshotSelection): row =>
               writer.write(schema.render(row))
               writer.newLine()
         .unit

--- a/src/test/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotSchemaSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/montecarlo/McHouseholdSnapshotSchemaSpec.scala
@@ -174,7 +174,7 @@ class McHouseholdSnapshotSchemaSpec extends AnyFlatSpec with Matchers:
             )
           else flow
 
-    val rows = McHouseholdSnapshotSchema.rows(
+    val rows = snapshotRows(
       runId = "run",
       seed = 1L,
       month = ExecutionMonth.First,
@@ -253,3 +253,15 @@ class McHouseholdSnapshotSchemaSpec extends AnyFlatSpec with Matchers:
     rentBurden.rentArrears shouldBe PLN(123)
     rentBurden.rentToIncome shouldBe Scalar.decimal(5, 1)
   }
+
+  private def snapshotRows(
+      runId: String,
+      seed: Long,
+      month: ExecutionMonth,
+      state: FlowSimulation.HouseholdSnapshotState,
+      monthlyFlows: Vector[Household.MonthlyFlow],
+      selection: McHouseholdSnapshotSelection,
+  ): Vector[McHouseholdSnapshotSchema.Row] =
+    val builder = Vector.newBuilder[McHouseholdSnapshotSchema.Row]
+    McHouseholdSnapshotSchema.foreachRow(runId, seed, month, state, monthlyFlows, selection)(builder += _)
+    builder.result()


### PR DESCRIPTION
## Summary
- replace materializing firm and household snapshot row APIs with streaming foreachRow writers
- keep cohort materialization explicit where aggregation needs full household rows
- update snapshot schema test helper to collect rows locally instead of using schema-level rows APIs

## Validation
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.montecarlo.McFirmSnapshotSchemaSpec com.boombustgroup.amorfati.montecarlo.McHouseholdSnapshotSchemaSpec com.boombustgroup.amorfati.montecarlo.McRunnerOutputSpec"
- sbt "runMain com.boombustgroup.amorfati.Main 1 snapshot-stream-smoke --duration 1 --run-id snapshot-stream-smoke2 --firm-snapshots terminal --household-snapshots terminal --household-snapshot-selector negative-or-shortfall"
- nix develop -c sbt assembly
- nix develop -c /usr/bin/time -l java -Xmx8g -jar target/scala-3.8.2/amor-fati.jar 5 snapshot-stream-5x60 --duration 60 --run-id snapshot-stream-5x60 --firm-snapshots every:12 --household-snapshots every:12 --household-snapshot-selector negative-or-shortfall

5x60 snapshot run completed in 142.8s with max RSS 5.73 GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot generation now uses a streaming row-processing approach, improving how large output sets are produced.
  * Household snapshot selection is now passed through more directly when writing TSV output.

* **Bug Fixes**
  * Preserved existing row contents and validation while changing how rows are emitted.
  * Maintained alignment checks for household snapshot data during row creation.

* **Tests**
  * Updated snapshot-related tests to use the new row-processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->