### PR TITLE
Reconcile opening bank profile targets with init routing

### DIFF
--- a/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
@@ -63,13 +63,13 @@ object BankInit:
           )
           .map(PLN.fromRaw)
           .toVector
-      else requireBankVector("government-bond", bankGovBondHoldings)
+      else requireBankVectorTotal("government-bond", bankGovBondHoldings, p.banking.initGovBonds)
     val reserveHoldings         =
       if bankReserveHoldings.isEmpty then Vector.empty
-      else requireBankVector("reserve", bankReserveHoldings)
+      else requireBankVectorTotal("reserve", bankReserveHoldings, p.banking.initDeposits * p.banking.reserveReq)
     val corpBondHoldings        =
       if bankCorpBondHoldings.isEmpty then Vector.fill(Banking.DefaultConfigs.length)(PLN.Zero)
-      else requireBankVector("corporate-bond", bankCorpBondHoldings)
+      else requireBankVectorTotal("corporate-bond", bankCorpBondHoldings, p.corpBond.initStock * p.corpBond.bankShare)
     val capitalProfilesByBankId = openingCapitalProfiles.map(profile => profile.bankId -> profile).toMap
     require(
       capitalProfilesByBankId.size == openingCapitalProfiles.size,
@@ -174,6 +174,15 @@ object BankInit:
     )
     require(values.forall(_ >= PLN.Zero), s"BankInit.create requires non-negative bank $label rows")
     values
+
+  private def requireBankVectorTotal(label: String, values: Vector[PLN], expectedTotal: PLN): Vector[PLN] =
+    val checked = requireBankVector(label, values)
+    val actual  = checked.sumPln
+    require(
+      actual == expectedTotal,
+      s"BankInit.create requires bank $label rows to sum to $expectedTotal, got $actual",
+    )
+    checked
 
   private def bankVectorValue(label: String, values: Vector[PLN], bankIndex: Int): PLN =
     require(

--- a/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/BankInit.scala
@@ -33,6 +33,8 @@ object BankInit:
       firmFinancialStocks: Vector[Firm.FinancialStocks],
       households: Vector[Household.State],
       householdFinancialStocks: Vector[Household.FinancialStocks],
+      bankGovBondHoldings: Vector[PLN] = Vector.empty,
+      bankReserveHoldings: Vector[PLN] = Vector.empty,
       bankCorpBondHoldings: Vector[PLN] = Vector.empty,
       openingCapitalProfiles: Vector[Banking.OpeningCapitalProfile] = Banking.DefaultOpeningCapitalProfiles,
   )(using p: SimParams): Result =
@@ -52,19 +54,22 @@ object BankInit:
     val perBankMortgages  = householdRows.groupMapReduce(_._1.bankId.toInt)(_._2.mortgageLoan)(_ + _)
     val perBankHhDeposits = householdRows.groupMapReduce(_._1.bankId.toInt)(_._2.demandDeposit)(_ + _)
 
-    val totalGovBonds           = p.banking.initGovBonds
-    val bondAlloc               = com.boombustgroup.ledger.Distribute.distribute(
-      totalGovBonds.toLong,
-      Banking.DefaultConfigs.map(_.openingBalanceWeight.toLong).toArray,
-    )
+    val govBondHoldings         =
+      if bankGovBondHoldings.isEmpty then
+        com.boombustgroup.ledger.Distribute
+          .distribute(
+            p.banking.initGovBonds.toLong,
+            Banking.DefaultConfigs.map(_.openingBalanceWeight.toLong).toArray,
+          )
+          .map(PLN.fromRaw)
+          .toVector
+      else requireBankVector("government-bond", bankGovBondHoldings)
+    val reserveHoldings         =
+      if bankReserveHoldings.isEmpty then Vector.empty
+      else requireBankVector("reserve", bankReserveHoldings)
     val corpBondHoldings        =
       if bankCorpBondHoldings.isEmpty then Vector.fill(Banking.DefaultConfigs.length)(PLN.Zero)
-      else
-        require(
-          bankCorpBondHoldings.length == Banking.DefaultConfigs.length,
-          s"BankInit.create requires ${Banking.DefaultConfigs.length} bank corporate-bond rows, got ${bankCorpBondHoldings.length}",
-        )
-        bankCorpBondHoldings
+      else requireBankVector("corporate-bond", bankCorpBondHoldings)
     val capitalProfilesByBankId = openingCapitalProfiles.map(profile => profile.bankId -> profile).toMap
     require(
       capitalProfilesByBankId.size == openingCapitalProfiles.size,
@@ -72,19 +77,21 @@ object BankInit:
     )
 
     val openingRows             = Banking.DefaultConfigs
-      .zip(bondAlloc)
+      .zip(govBondHoldings)
       .zip(corpBondHoldings)
-      .map { case ((cfg, bankBondRaw), bankCorpBonds) =>
+      .map { case ((cfg, bankBonds), bankCorpBonds) =>
         val bId             = cfg.id.toInt
         val corpLoans       = perBankCorpLoans.getOrElse(bId, PLN.Zero)
         val consLoans       = perBankConsLoans.getOrElse(bId, PLN.Zero)
         val mortgageLoans   = perBankMortgages.getOrElse(bId, PLN.Zero)
         val firmDeposits    = perBankCash.getOrElse(bId, PLN.Zero)
         val hhDeposits      = perBankHhDeposits.getOrElse(bId, PLN.Zero)
-        val bankBonds       = PLN.fromRaw(bankBondRaw)
         val deposits        = firmDeposits + hhDeposits
         val termDeposits    = deposits * p.banking.termDepositFrac
         val demandDeposits  = deposits - termDeposits
+        val reserve         =
+          if reserveHoldings.isEmpty then deposits * p.banking.reserveReq
+          else bankVectorValue("reserve", reserveHoldings, bId)
         val eclCoveredLoans = corpLoans + consLoans
         OpeningRow(
           config = cfg,
@@ -93,7 +100,7 @@ object BankInit:
             firmLoan = corpLoans,
             govBondAfs = bankBonds * (Share.One - p.banking.htmShare),
             govBondHtm = bankBonds * p.banking.htmShare,
-            reserve = deposits * p.banking.reserveReq,
+            reserve = reserve,
             interbankLoan = PLN.Zero,
             demandDeposit = demandDeposits,
             termDeposit = termDeposits,
@@ -159,3 +166,18 @@ object BankInit:
 
   private def absoluteDelta(left: PLN, right: PLN): PLN =
     if left >= right then left - right else right - left
+
+  private def requireBankVector(label: String, values: Vector[PLN]): Vector[PLN] =
+    require(
+      values.length == Banking.DefaultConfigs.length,
+      s"BankInit.create requires ${Banking.DefaultConfigs.length} bank $label rows, got ${values.length}",
+    )
+    require(values.forall(_ >= PLN.Zero), s"BankInit.create requires non-negative bank $label rows")
+    values
+
+  private def bankVectorValue(label: String, values: Vector[PLN], bankIndex: Int): PLN =
+    require(
+      bankIndex >= 0 && bankIndex < values.length,
+      s"BankInit.create $label rows missing BankId index $bankIndex; rows=${values.length}",
+    )
+    values(bankIndex)

--- a/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
@@ -74,14 +74,26 @@ object OpeningBankProfileTargets:
       else Resolution.Pending("Opening bank profile has no complete runtime stock targets yet")
     else
       val bankIds       = orderedRows.map(row => BankId(row.bankId.toInt))
-      val deposits      = orderedRows.map(row => mPlnToRuntime(row.depositsMPln.get))
-      val firmLoans     = orderedRows.map(row => mPlnToRuntime(row.firmLoansMPln.get))
-      val consumerLoans = orderedRows.map(row => mPlnToRuntime(row.consumerLoansMPln.get))
-      val mortgageLoans = orderedRows.map(row => mPlnToRuntime(row.mortgageLoansMPln.get))
-      val govBonds      = orderedRows.map(row => mPlnToRuntime(row.govBondsMPln.get))
+      val residualIndex = residualBankIndex(orderedRows)
+      val deposits      = closeResidual("opening bank deposits", orderedRows.map(row => mPlnToRuntime(row.depositsMPln.get)), p.banking.initDeposits, residualIndex)
+      val firmLoans     = closeResidual("opening bank firm loans", orderedRows.map(row => mPlnToRuntime(row.firmLoansMPln.get)), p.banking.initLoans, residualIndex)
+      val consumerLoans =
+        closeResidual(
+          "opening bank consumer loans",
+          orderedRows.map(row => mPlnToRuntime(row.consumerLoansMPln.get)),
+          p.banking.initConsumerLoans,
+          residualIndex,
+        )
+      val mortgageLoans =
+        closeResidual("opening bank mortgage loans", orderedRows.map(row => mPlnToRuntime(row.mortgageLoansMPln.get)), p.housing.initMortgage, residualIndex)
+      val govBonds      =
+        closeResidual("opening bank government bonds", orderedRows.map(row => mPlnToRuntime(row.govBondsMPln.get)), p.banking.initGovBonds, residualIndex)
       val reserves      = optionalPlnVector("reserves_m_pln", orderedRows, _.reservesMPln)
+        .map(values => closeResidual("opening bank reserves", values, p.banking.initDeposits * p.banking.reserveReq, residualIndex))
       val corpBonds     = optionalPlnVector("corp_bonds_m_pln", orderedRows, _.corpBondsMPln)
+        .map(values => closeResidual("opening bank corporate bonds", values, p.corpBond.initStock * p.corpBond.bankShare, residualIndex))
       val ownFunds      = optionalPlnVector("own_funds_m_pln", orderedRows, _.ownFundsMPln)
+        .map(values => closeResidual("opening bank own funds", values, p.banking.initCapital, residualIndex))
       val capitalRatios = optionalMultiplierVector("total_capital_ratio", orderedRows, _.totalCapitalRatio)
 
       val capitalProfiles = bankIds.indices.map: i =>
@@ -90,15 +102,6 @@ object OpeningBankProfileTargets:
           ownFunds = ownFunds.map(_(i)),
           totalCapitalRatio = capitalRatios.map(_(i)),
         )
-
-      requireClose("opening bank deposits", deposits.sumPln, p.banking.initDeposits)
-      requireClose("opening bank firm loans", firmLoans.sumPln, p.banking.initLoans)
-      requireClose("opening bank consumer loans", consumerLoans.sumPln, p.banking.initConsumerLoans)
-      requireClose("opening bank mortgage loans", mortgageLoans.sumPln, p.housing.initMortgage)
-      requireClose("opening bank government bonds", govBonds.sumPln, p.banking.initGovBonds)
-      reserves.foreach(values => requireClose("opening bank reserves", values.sumPln, p.banking.initDeposits * p.banking.reserveReq))
-      corpBonds.foreach(values => requireClose("opening bank corporate bonds", values.sumPln, p.corpBond.initStock * p.corpBond.bankShare))
-      ownFunds.foreach(values => requireClose("opening bank own funds", values.sumPln, p.banking.initCapital))
 
       Resolution.Complete(
         Targets(
@@ -158,6 +161,11 @@ object OpeningBankProfileTargets:
       val missing = rows.zip(extracted).collect { case (row, None) => s"${row.runtimeBankName}.$column" }
       throw new IllegalStateException(s"Opening bank profile has partial $column coverage; missing ${missing.mkString(", ")}")
 
+  private def residualBankIndex(rows: Vector[OpeningBankBalanceProfileBridge.Row]): Int =
+    val index = rows.indexWhere(_.rowType == "residual_bank")
+    require(index >= 0, "Opening bank profile requires a residual_bank row for residual closure")
+    index
+
   private def mPlnToRuntime(value: BigDecimal)(using p: SimParams): PLN =
     val pln = value * BigDecimal(1000000L)
     val raw = (pln * FixedPointBase.ScaleDecimal)
@@ -179,3 +187,17 @@ object OpeningBankProfileTargets:
       delta <= tolerance,
       s"$label target sum $actual differs from model aggregate $expected by $delta, above tolerance $tolerance",
     )
+
+  private def closeResidual(label: String, values: Vector[PLN], expected: PLN, residualIndex: Int): Vector[PLN] =
+    requireClose(label, values.sumPln, expected)
+    val delta = expected - values.sumPln
+    if delta == PLN.Zero then values
+    else
+      val closedResidual = values(residualIndex) + delta
+      require(
+        closedResidual >= PLN.Zero,
+        s"$label residual closure would make residual bank negative: current=${values(residualIndex)} delta=$delta",
+      )
+      val closed         = values.updated(residualIndex, closedResidual)
+      require(closed.sumPln == expected, s"$label residual closure failed: ${closed.sumPln} != $expected")
+      closed

--- a/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
@@ -30,6 +30,10 @@ object OpeningBankProfileTargets:
 
     require(bankCount > 0, "Opening bank profile targets require at least one bank")
     require(
+      bankIds == Banking.DefaultConfigs.map(_.id),
+      s"Opening bank profile targets must follow DefaultConfigs BankId order ${Banking.DefaultConfigs.map(_.id.toInt).mkString("[", ",", "]")}",
+    )
+    require(
       deposits.length == bankCount &&
         firmLoans.length == bankCount &&
         consumerLoans.length == bankCount &&

--- a/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTargets.scala
@@ -1,0 +1,177 @@
+package com.boombustgroup.amorfati.init
+
+import com.boombustgroup.amorfati.agents.Banking
+import com.boombustgroup.amorfati.config.{OpeningBankBalanceProfileBridge, SimParams}
+import com.boombustgroup.amorfati.fp.FixedPointBase
+import com.boombustgroup.amorfati.types.*
+
+import scala.math.BigDecimal.RoundingMode
+
+object OpeningBankProfileTargets:
+
+  sealed trait Resolution
+
+  object Resolution:
+    final case class Complete(targets: Targets) extends Resolution
+    final case class Pending(reason: String)    extends Resolution
+
+  final case class Targets(
+      bankIds: Vector[BankId],
+      deposits: Vector[PLN],
+      firmLoans: Vector[PLN],
+      consumerLoans: Vector[PLN],
+      mortgageLoans: Vector[PLN],
+      govBonds: Vector[PLN],
+      reserves: Option[Vector[PLN]],
+      corpBonds: Option[Vector[PLN]],
+      openingCapitalProfiles: Vector[Banking.OpeningCapitalProfile],
+  ):
+    val bankCount: Int = bankIds.length
+
+    require(bankCount > 0, "Opening bank profile targets require at least one bank")
+    require(
+      deposits.length == bankCount &&
+        firmLoans.length == bankCount &&
+        consumerLoans.length == bankCount &&
+        mortgageLoans.length == bankCount &&
+        govBonds.length == bankCount &&
+        openingCapitalProfiles.length == bankCount,
+      "Opening bank profile targets require aligned per-bank vectors",
+    )
+    reserves.foreach(rows => require(rows.length == bankCount, s"Opening bank reserve targets require $bankCount rows, got ${rows.length}"))
+    corpBonds.foreach(rows => require(rows.length == bankCount, s"Opening bank corporate-bond targets require $bankCount rows, got ${rows.length}"))
+
+  private val MandatoryColumns: Vector[(String, OpeningBankBalanceProfileBridge.Row => Option[BigDecimal])] = Vector(
+    "deposits_m_pln"       -> (_.depositsMPln),
+    "firm_loans_m_pln"     -> (_.firmLoansMPln),
+    "consumer_loans_m_pln" -> (_.consumerLoansMPln),
+    "mortgage_loans_m_pln" -> (_.mortgageLoansMPln),
+    "gov_bonds_m_pln"      -> (_.govBondsMPln),
+  )
+
+  private val AggregateToleranceFloor: PLN   = PLN(1000000)
+  private val AggregateToleranceShare: Share = Share.decimal(1, 6)
+
+  def fromBridgeRows(rows: Vector[OpeningBankBalanceProfileBridge.Row])(using p: SimParams): Resolution =
+    val orderedRows      = runtimeRows(rows)
+    val missingMandatory =
+      orderedRows.flatMap: row =>
+        MandatoryColumns.collect:
+          case (column, value) if value(row).isEmpty => s"${row.runtimeBankName}.$column"
+
+    val anyMandatoryValue =
+      orderedRows.exists(row => MandatoryColumns.exists((_, value) => value(row).nonEmpty))
+
+    if missingMandatory.nonEmpty then
+      if anyMandatoryValue then
+        throw new IllegalStateException(
+          s"Opening bank profile has partial runtime stock targets; missing ${missingMandatory.mkString(", ")}",
+        )
+      else Resolution.Pending("Opening bank profile has no complete runtime stock targets yet")
+    else
+      val bankIds       = orderedRows.map(row => BankId(row.bankId.toInt))
+      val deposits      = orderedRows.map(row => mPlnToRuntime(row.depositsMPln.get))
+      val firmLoans     = orderedRows.map(row => mPlnToRuntime(row.firmLoansMPln.get))
+      val consumerLoans = orderedRows.map(row => mPlnToRuntime(row.consumerLoansMPln.get))
+      val mortgageLoans = orderedRows.map(row => mPlnToRuntime(row.mortgageLoansMPln.get))
+      val govBonds      = orderedRows.map(row => mPlnToRuntime(row.govBondsMPln.get))
+      val reserves      = optionalPlnVector("reserves_m_pln", orderedRows, _.reservesMPln)
+      val corpBonds     = optionalPlnVector("corp_bonds_m_pln", orderedRows, _.corpBondsMPln)
+      val ownFunds      = optionalPlnVector("own_funds_m_pln", orderedRows, _.ownFundsMPln)
+      val capitalRatios = optionalMultiplierVector("total_capital_ratio", orderedRows, _.totalCapitalRatio)
+
+      val capitalProfiles = bankIds.indices.map: i =>
+        Banking.OpeningCapitalProfile(
+          bankId = bankIds(i),
+          ownFunds = ownFunds.map(_(i)),
+          totalCapitalRatio = capitalRatios.map(_(i)),
+        )
+
+      requireClose("opening bank deposits", deposits.sumPln, p.banking.initDeposits)
+      requireClose("opening bank firm loans", firmLoans.sumPln, p.banking.initLoans)
+      requireClose("opening bank consumer loans", consumerLoans.sumPln, p.banking.initConsumerLoans)
+      requireClose("opening bank mortgage loans", mortgageLoans.sumPln, p.housing.initMortgage)
+      requireClose("opening bank government bonds", govBonds.sumPln, p.banking.initGovBonds)
+      reserves.foreach(values => requireClose("opening bank reserves", values.sumPln, p.banking.initDeposits * p.banking.reserveReq))
+      corpBonds.foreach(values => requireClose("opening bank corporate bonds", values.sumPln, p.corpBond.initStock * p.corpBond.bankShare))
+      ownFunds.foreach(values => requireClose("opening bank own funds", values.sumPln, p.banking.initCapital))
+
+      Resolution.Complete(
+        Targets(
+          bankIds = bankIds,
+          deposits = deposits,
+          firmLoans = firmLoans,
+          consumerLoans = consumerLoans,
+          mortgageLoans = mortgageLoans,
+          govBonds = govBonds,
+          reserves = reserves,
+          corpBonds = corpBonds,
+          openingCapitalProfiles = capitalProfiles.toVector,
+        ),
+      )
+
+  private def runtimeRows(rows: Vector[OpeningBankBalanceProfileBridge.Row]): Vector[OpeningBankBalanceProfileBridge.Row] =
+    val runtime = rows.filterNot(_.rowType == "sector_total")
+    require(
+      runtime.length == Banking.DefaultConfigs.length,
+      s"Opening bank profile requires ${Banking.DefaultConfigs.length} runtime bank rows, got ${runtime.length}",
+    )
+    val byId    = runtime.map(row => row.bankId.toInt -> row).toMap
+    require(byId.size == runtime.length, "Opening bank profile requires unique runtime bank_id values")
+
+    Banking.DefaultConfigs.map: config =>
+      val bankId = config.id.toInt
+      val row    = byId.getOrElse(bankId, throw new IllegalStateException(s"Missing opening bank profile row for BankId $bankId"))
+      require(
+        row.runtimeBankName == config.name,
+        s"Opening bank profile row $bankId names ${row.runtimeBankName}, expected ${config.name}",
+      )
+      row
+
+  private def optionalPlnVector(
+      column: String,
+      rows: Vector[OpeningBankBalanceProfileBridge.Row],
+      value: OpeningBankBalanceProfileBridge.Row => Option[BigDecimal],
+  )(using SimParams): Option[Vector[PLN]] =
+    optionalVector(column, rows, value).map(_.map(mPlnToRuntime))
+
+  private def optionalMultiplierVector(
+      column: String,
+      rows: Vector[OpeningBankBalanceProfileBridge.Row],
+      value: OpeningBankBalanceProfileBridge.Row => Option[BigDecimal],
+  ): Option[Vector[Multiplier]] =
+    optionalVector(column, rows, value).map(_.map(decimalToMultiplier))
+
+  private def optionalVector(
+      column: String,
+      rows: Vector[OpeningBankBalanceProfileBridge.Row],
+      value: OpeningBankBalanceProfileBridge.Row => Option[BigDecimal],
+  ): Option[Vector[BigDecimal]] =
+    val extracted = rows.map(value)
+    if extracted.forall(_.isEmpty) then None
+    else if extracted.forall(_.nonEmpty) then Some(extracted.flatten)
+    else
+      val missing = rows.zip(extracted).collect { case (row, None) => s"${row.runtimeBankName}.$column" }
+      throw new IllegalStateException(s"Opening bank profile has partial $column coverage; missing ${missing.mkString(", ")}")
+
+  private def mPlnToRuntime(value: BigDecimal)(using p: SimParams): PLN =
+    val pln = value * BigDecimal(1000000L)
+    val raw = (pln * FixedPointBase.ScaleDecimal)
+      .setScale(0, RoundingMode.HALF_EVEN)
+      .toLongExact
+    PLN.fromRaw(raw) * p.gdpRatio
+
+  private def decimalToMultiplier(value: BigDecimal): Multiplier =
+    Multiplier.fromRaw(
+      (value * FixedPointBase.ScaleDecimal)
+        .setScale(0, RoundingMode.HALF_EVEN)
+        .toLongExact,
+    )
+
+  private def requireClose(label: String, actual: PLN, expected: PLN): Unit =
+    val delta     = (actual - expected).abs
+    val tolerance = (expected * AggregateToleranceShare).max(AggregateToleranceFloor)
+    require(
+      delta <= tolerance,
+      s"$label target sum $actual differs from model aggregate $expected by $delta, above tolerance $tolerance",
+    )

--- a/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankRoutingReconciler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankRoutingReconciler.scala
@@ -31,6 +31,8 @@ object OpeningBankRoutingReconciler:
     )
 
     val firmDepositTotal        = firmFinancialStocks.map(_.cash).sumPln
+    // The profile exposes aggregate deposits. Preserve the existing firm/HH
+    // aggregate split, then reconcile both holder groups to each bank target.
     val firmDepositTargets      = distributePln(firmDepositTotal, targets.deposits)
     val householdDepositTargets =
       targets.deposits
@@ -104,6 +106,9 @@ object OpeningBankRoutingReconciler:
     if entityCount == 0 then
       require(targetStocks.forall(_ <= PLN.Zero), s"Cannot route positive opening bank $label targets without $label")
       Vector.empty
+    else if targetStocks.forall(_ <= PLN.Zero) then
+      validateBankIds(currentBankIds, targetStocks.length, label)
+      currentBankIds
     else
       val desiredCounts = desiredEntityCounts(entityCount, targetStocks, label)
       val assigned      = Array.fill[Option[BankId]](entityCount)(None)
@@ -125,6 +130,13 @@ object OpeningBankRoutingReconciler:
       assigned.toVector.map:
         case Some(bankId) => bankId
         case None         => throw new IllegalStateException(s"Opening bank routing left an unassigned $label row")
+
+  private def validateBankIds(bankIds: Vector[BankId], bankCount: Int, label: String): Unit =
+    bankIds.foreach: bankId =>
+      require(
+        bankId.toInt >= 0 && bankId.toInt < bankCount,
+        s"Opening bank routing found invalid BankId ${bankId.toInt} in $label",
+      )
 
   private def desiredEntityCounts(entityCount: Int, targetStocks: Vector[PLN], label: String): Vector[Int] =
     val positiveBanks = targetStocks.zipWithIndex.collect { case (target, bankIndex) if target > PLN.Zero => bankIndex }

--- a/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankRoutingReconciler.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/OpeningBankRoutingReconciler.scala
@@ -1,0 +1,186 @@
+package com.boombustgroup.amorfati.init
+
+import com.boombustgroup.amorfati.agents.{Firm, Household}
+import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.types.*
+import com.boombustgroup.ledger.Distribute
+
+object OpeningBankRoutingReconciler:
+
+  final case class Result(
+      firms: Vector[Firm.State],
+      firmFinancialStocks: Vector[Firm.FinancialStocks],
+      households: Vector[Household.State],
+      householdFinancialStocks: Vector[Household.FinancialStocks],
+  )
+
+  def reconcile(
+      firms: Vector[Firm.State],
+      firmFinancialStocks: Vector[Firm.FinancialStocks],
+      households: Vector[Household.State],
+      householdFinancialStocks: Vector[Household.FinancialStocks],
+      targets: OpeningBankProfileTargets.Targets,
+  )(using p: SimParams): Result =
+    require(
+      firms.length == firmFinancialStocks.length,
+      s"OpeningBankRoutingReconciler requires aligned firms and stocks, got ${firms.length} firms and ${firmFinancialStocks.length} stocks",
+    )
+    require(
+      households.length == householdFinancialStocks.length,
+      s"OpeningBankRoutingReconciler requires aligned households and stocks, got ${households.length} households and ${householdFinancialStocks.length} stocks",
+    )
+
+    val firmDepositTotal        = firmFinancialStocks.map(_.cash).sumPln
+    val firmDepositTargets      = distributePln(firmDepositTotal, targets.deposits)
+    val householdDepositTargets =
+      targets.deposits
+        .zip(firmDepositTargets)
+        .map: (deposits, firmDeposits) =>
+          val householdDeposits = deposits - firmDeposits
+          require(
+            householdDeposits >= PLN.Zero,
+            s"Opening bank deposit target cannot cover firm-deposit split: deposits=$deposits firmDeposits=$firmDeposits",
+          )
+          householdDeposits
+
+    val firmWeights = targets.firmLoans.zip(firmDepositTargets).map { case (firmLoans, firmDeposits) =>
+      firmLoans + firmDeposits
+    }
+    val firmBankIds = assignBankIds(firms.map(_.bankId), firmWeights, "firms")
+
+    val householdWeights =
+      householdDepositTargets.zip(targets.consumerLoans).zip(targets.mortgageLoans).map { case ((deposits, consumerLoans), mortgageLoans) =>
+        deposits + consumerLoans + mortgageLoans
+      }
+    val householdBankIds = assignBankIds(households.map(_.bankId), householdWeights, "households")
+
+    val firmLoans     = distributeProductByBank(targets.firmLoans, firmBankIds, firmFinancialStocks.map(_.firmLoan), "firm loans")
+    val firmCash      = distributeProductByBank(firmDepositTargets, firmBankIds, firmFinancialStocks.map(_.cash), "firm deposits")
+    val hhDeposits    =
+      distributeProductByBank(householdDepositTargets, householdBankIds, householdFinancialStocks.map(_.demandDeposit), "household deposits")
+    val consumerLoans =
+      distributeProductByBank(targets.consumerLoans, householdBankIds, householdFinancialStocks.map(_.consumerLoan), "household consumer loans")
+    val mortgageLoans =
+      distributeProductByBank(targets.mortgageLoans, householdBankIds, householdFinancialStocks.map(_.mortgageLoan), "household mortgage loans")
+
+    val reconciledFirms      = firms.zip(firmBankIds).map { case (firm, bankId) =>
+      firm.copy(bankId = bankId)
+    }
+    val reconciledFirmStocks = firmFinancialStocks.indices.map: i =>
+      firmFinancialStocks(i).copy(
+        cash = firmCash(i),
+        firmLoan = firmLoans(i),
+      )
+
+    val reconciledHouseholds      = households.zip(householdBankIds).map { case (household, bankId) =>
+      household.copy(bankId = bankId)
+    }
+    val reconciledHouseholdStocks = householdFinancialStocks.indices.map: i =>
+      val mortgageLoan = mortgageLoans(i)
+      householdFinancialStocks(i).copy(
+        demandDeposit = hhDeposits(i),
+        consumerLoan = consumerLoans(i),
+        mortgageLoan = mortgageLoan,
+        mortgageRemainingMonths =
+          if mortgageLoan <= PLN.Zero then 0
+          else if householdFinancialStocks(i).mortgageRemainingMonths > 0 then householdFinancialStocks(i).mortgageRemainingMonths
+          else p.housing.mortgageMaturity,
+      )
+
+    require(firmCash.sumPln + hhDeposits.sumPln == targets.deposits.sumPln, "Opening bank reconciler did not preserve aggregate deposits")
+    require(firmLoans.sumPln == targets.firmLoans.sumPln, "Opening bank reconciler did not preserve aggregate firm loans")
+    require(consumerLoans.sumPln == targets.consumerLoans.sumPln, "Opening bank reconciler did not preserve aggregate consumer loans")
+    require(mortgageLoans.sumPln == targets.mortgageLoans.sumPln, "Opening bank reconciler did not preserve aggregate mortgage loans")
+
+    Result(
+      firms = reconciledFirms,
+      firmFinancialStocks = reconciledFirmStocks.toVector,
+      households = reconciledHouseholds,
+      householdFinancialStocks = reconciledHouseholdStocks.toVector,
+    )
+
+  private def assignBankIds(currentBankIds: Vector[BankId], targetStocks: Vector[PLN], label: String): Vector[BankId] =
+    val entityCount = currentBankIds.length
+    if entityCount == 0 then
+      require(targetStocks.forall(_ <= PLN.Zero), s"Cannot route positive opening bank $label targets without $label")
+      Vector.empty
+    else
+      val desiredCounts = desiredEntityCounts(entityCount, targetStocks, label)
+      val assigned      = Array.fill[Option[BankId]](entityCount)(None)
+      val rowsByBank    = currentBankIds.zipWithIndex.groupMap(_._1.toInt)(_._2)
+
+      desiredCounts.indices.foreach: bankIndex =>
+        val kept = rowsByBank.getOrElse(bankIndex, Vector.empty).take(desiredCounts(bankIndex))
+        kept.foreach(index => assigned(index) = Some(BankId(bankIndex)))
+
+      val surplus = currentBankIds.indices.filter(index => assigned(index).isEmpty).iterator
+      desiredCounts.indices.foreach: bankIndex =>
+        val current = assigned.count(_.contains(BankId(bankIndex)))
+        val needed  = desiredCounts(bankIndex) - current
+        require(needed >= 0, s"Opening bank routing over-assigned BankId $bankIndex for $label")
+        (0 until needed).foreach: _ =>
+          require(surplus.hasNext, s"Opening bank routing ran out of $label while filling BankId $bankIndex")
+          assigned(surplus.next()) = Some(BankId(bankIndex))
+
+      assigned.toVector.map:
+        case Some(bankId) => bankId
+        case None         => throw new IllegalStateException(s"Opening bank routing left an unassigned $label row")
+
+  private def desiredEntityCounts(entityCount: Int, targetStocks: Vector[PLN], label: String): Vector[Int] =
+    val positiveBanks = targetStocks.zipWithIndex.collect { case (target, bankIndex) if target > PLN.Zero => bankIndex }
+    require(
+      entityCount >= positiveBanks.length,
+      s"Cannot assign $entityCount $label rows across ${positiveBanks.length} positive opening bank targets",
+    )
+    val weights       = targetStocks.map(_.distributeRaw.max(0L)).toArray
+    val base          =
+      if weights.exists(_ > 0L) then Distribute.distribute(entityCount.toLong, weights).map(_.toInt).toArray
+      else Array.fill(targetStocks.length)(0)
+
+    positiveBanks.foreach: bankIndex =>
+      if base(bankIndex) == 0 then
+        val donor = base.indices
+          .filter(index => base(index) > 1 || (targetStocks(index) <= PLN.Zero && base(index) > 0))
+          .maxByOption(base)
+          .getOrElse:
+            throw new IllegalStateException(s"Cannot reserve one $label row for BankId $bankIndex")
+        base(donor) -= 1
+        base(bankIndex) += 1
+
+    require(base.sum == entityCount, s"Opening bank routing count mismatch for $label: ${base.sum} != $entityCount")
+    base.toVector
+
+  private def distributeProductByBank(
+      targets: Vector[PLN],
+      bankIds: Vector[BankId],
+      currentValues: Vector[PLN],
+      label: String,
+  ): Vector[PLN] =
+    require(bankIds.length == currentValues.length, s"Opening bank $label distribution requires aligned bank ids and values")
+    val out = Array.fill(currentValues.length)(PLN.Zero)
+    targets.indices.foreach: bankIndex =>
+      val indices = bankIds.zipWithIndex.collect { case (bankId, index) if bankId.toInt == bankIndex => index }
+      val target  = targets(bankIndex)
+      if indices.isEmpty then require(target <= PLN.Zero, s"Opening bank $label target for BankId $bankIndex is positive but no rows are assigned")
+      else
+        val weights          = indices.map(index => currentValues(index).distributeRaw.max(0L)).toArray
+        val effectiveWeights =
+          if weights.exists(_ > 0L) then weights
+          else Array.fill(indices.length)(1L)
+        val allocated        = Distribute.distribute(target.distributeRaw, effectiveWeights)
+        indices.zip(allocated).foreach { case (index, raw) =>
+          out(index) = PLN.fromRaw(raw)
+        }
+    out.toVector
+
+  private def distributePln(amount: PLN, weights: Vector[PLN]): Vector[PLN] =
+    require(amount >= PLN.Zero, s"Opening bank distribution amount must be non-negative: $amount")
+    if weights.isEmpty then
+      require(amount == PLN.Zero, s"Cannot distribute $amount across an empty target vector")
+      Vector.empty
+    else
+      val rawWeights = weights.map(_.distributeRaw.max(0L)).toArray
+      val effective  =
+        if rawWeights.exists(_ > 0L) then rawWeights
+        else Array.fill(weights.length)(1L)
+      Distribute.distribute(amount.distributeRaw, effective).map(PLN.fromRaw).toVector

--- a/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala
@@ -14,25 +14,56 @@ object WorldInit:
   /** Initialize a complete simulation world from an explicit randomness
     * contract.
     */
-  def initialize(randomness: InitRandomness.Contract)(using p: SimParams): InitResult =
+  def initialize(
+      randomness: InitRandomness.Contract,
+      openingBankProfileRows: Vector[OpeningBankBalanceProfileBridge.Row] = OpeningBankBalanceProfileBridge.Rows,
+  )(using p: SimParams): InitResult =
     // --- Firms ---
     val initCorporateBonds      = CorporateBondMarket.initial
     val initCorporateBondStocks = CorporateBondMarket.initialStock
     val firmPop                 = FirmInit.create(randomness.firms.newStreams())
-    val firms                   = firmPop.firms
-    val firmStocks              = firmPop.financialStocks
-    val initFirmBalances        = CorporateBondOwnership.initializeIssuerBalances(firms, firmStocks, initCorporateBondStocks.outstanding)
-    assert(firms.length == p.pop.firmsCount)
+    val firms0                  = firmPop.firms
+    val firmStocks0             = firmPop.financialStocks
+    assert(firms0.length == p.pop.firmsCount)
 
     // --- Households ---
-    val households0     = Household.Init.create(randomness.households.newStreams(), firms)
-    val householdPop    = ImmigrantInit.create(randomness.immigration.newStreams(), households0)
-    val households      = householdPop.households
+    val households0        = Household.Init.create(randomness.households.newStreams(), firms0)
+    val householdPop       = ImmigrantInit.create(randomness.immigration.newStreams(), households0)
+    val householdsRaw      = householdPop.households
     // Household deposits absorb the residual after the firm split, preserving holder-side assets.
-    val householdStocks = normalizeHouseholdOpeningDeposits(householdPop.financialStocks, firmStocks)
-    val totalPop        = households.length
-    val initEmployed    = households.count(_.status.isInstanceOf[HhStatus.Employed])
-    val initUnemployed  = totalPop - initEmployed
+    val householdStocksRaw = normalizeHouseholdOpeningDeposits(householdPop.financialStocks, firmStocks0)
+
+    val openingBankTargets =
+      OpeningBankProfileTargets.fromBridgeRows(openingBankProfileRows) match
+        case OpeningBankProfileTargets.Resolution.Complete(targets) => Some(targets)
+        case OpeningBankProfileTargets.Resolution.Pending(_)        => None
+
+    val openingBooks =
+      openingBankTargets match
+        case Some(targets) =>
+          OpeningBankRoutingReconciler.reconcile(
+            firms = firms0,
+            firmFinancialStocks = firmStocks0,
+            households = householdsRaw,
+            householdFinancialStocks = householdStocksRaw,
+            targets = targets,
+          )
+        case None          =>
+          OpeningBankRoutingReconciler.Result(
+            firms = firms0,
+            firmFinancialStocks = firmStocks0,
+            households = householdsRaw,
+            householdFinancialStocks = householdStocksRaw,
+          )
+
+    val firms            = openingBooks.firms
+    val firmStocks       = openingBooks.firmFinancialStocks
+    val households       = openingBooks.households
+    val householdStocks  = openingBooks.householdFinancialStocks
+    val initFirmBalances = CorporateBondOwnership.initializeIssuerBalances(firms, firmStocks, initCorporateBondStocks.outstanding)
+    val totalPop         = households.length
+    val initEmployed     = households.count(_.status.isInstanceOf[HhStatus.Employed])
+    val initUnemployed   = totalPop - initEmployed
     assert(totalPop > 0)
 
     // --- Banking sector ---
@@ -44,14 +75,26 @@ object WorldInit:
     val initImportCons   = initConsumption - initDomesticCons
 
     val initBankCorpBonds =
-      com.boombustgroup.ledger.Distribute
-        .distribute(
-          initCorporateBondStocks.bankHoldings.toLong,
-          Banking.DefaultConfigs.map(_.openingBalanceWeight.toLong).toArray,
-        )
-        .map(PLN.fromRaw)
-        .toVector
-    val initBankingSector = BankInit.create(firms, firmStocks, households, householdStocks, bankCorpBondHoldings = initBankCorpBonds)
+      openingBankTargets
+        .flatMap(_.corpBonds)
+        .getOrElse:
+          com.boombustgroup.ledger.Distribute
+            .distribute(
+              initCorporateBondStocks.bankHoldings.toLong,
+              Banking.DefaultConfigs.map(_.openingBalanceWeight.toLong).toArray,
+            )
+            .map(PLN.fromRaw)
+            .toVector
+    val initBankingSector = BankInit.create(
+      firms,
+      firmStocks,
+      households,
+      householdStocks,
+      bankGovBondHoldings = openingBankTargets.map(_.govBonds).getOrElse(Vector.empty),
+      bankReserveHoldings = openingBankTargets.flatMap(_.reserves).getOrElse(Vector.empty),
+      bankCorpBondHoldings = initBankCorpBonds,
+      openingCapitalProfiles = openingBankTargets.map(_.openingCapitalProfiles).getOrElse(Banking.DefaultOpeningCapitalProfiles),
+    )
     val initBankBalances  =
       initBankingSector.banks
         .zip(initBankingSector.financialStocks)

--- a/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
@@ -90,10 +90,35 @@ class OpeningBankBalanceProfileBridgeSpec extends AnyFlatSpec with Matchers with
     targets.mortgageLoans.sumPln shouldBe summon[SimParams].housing.initMortgage
     targets.govBonds.sumPln shouldBe summon[SimParams].banking.initGovBonds
     targets.reserves.value.sumPln shouldBe summon[SimParams].banking.initDeposits * summon[SimParams].banking.reserveReq
+    targets.corpBonds.value.sumPln shouldBe summon[SimParams].corpBond.initStock * summon[SimParams].corpBond.bankShare
     targets.openingCapitalProfiles.flatMap(_.ownFunds).sumPln shouldBe summon[SimParams].banking.initCapital
-    targets.deposits
-      .zip(Banking.DefaultConfigs.map(cfg => summon[SimParams].banking.initDeposits * cfg.relationshipWeight))
-      .exists((actual, relationshipWeightSplit) => actual != relationshipWeightSplit) shouldBe true
+    targets.deposits(0) shouldBe summon[SimParams].banking.initDeposits * Share.decimal(2, 1)
+    targets.deposits(1) shouldBe summon[SimParams].banking.initDeposits * Share.decimal(13, 2)
+    targets.deposits(0) should not be (summon[SimParams].banking.initDeposits * Banking.DefaultConfigs.head.relationshipWeight)
+  }
+
+  it should "fail fast when runtime stock target coverage is mixed" in {
+    val mixedRows = OpeningBankProfileTestFixtures.completeRows.map:
+      case row if row.rowType != "sector_total" && row.bankId == "0" => row.copy(depositsMPln = None)
+      case row                                                       => row
+
+    val err = intercept[IllegalStateException]:
+      OpeningBankProfileTargets.fromBridgeRows(mixedRows)
+
+    err.getMessage should include("partial runtime stock targets")
+    err.getMessage should include("PKO BP.deposits_m_pln")
+  }
+
+  it should "close accepted residual differences into the residual bank target" in {
+    val rows = OpeningBankProfileTestFixtures.completeRows.map:
+      case row if row.rowType == "residual_bank" => row.copy(corpBondsMPln = row.corpBondsMPln.map(_ - BigDecimal("0.001")))
+      case row                                   => row
+
+    val targets = OpeningBankProfileTargets.fromBridgeRows(rows) match
+      case OpeningBankProfileTargets.Resolution.Complete(targets) => targets
+      case other                                                  => fail(s"Expected complete opening bank targets, got $other")
+
+    targets.corpBonds.value.sumPln shouldBe summon[SimParams].corpBond.initStock * summon[SimParams].corpBond.bankShare
   }
 
   it should "render the committed TSV extract from the typed bridge" in {

--- a/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
@@ -91,6 +91,9 @@ class OpeningBankBalanceProfileBridgeSpec extends AnyFlatSpec with Matchers with
     targets.govBonds.sumPln shouldBe summon[SimParams].banking.initGovBonds
     targets.reserves.value.sumPln shouldBe summon[SimParams].banking.initDeposits * summon[SimParams].banking.reserveReq
     targets.openingCapitalProfiles.flatMap(_.ownFunds).sumPln shouldBe summon[SimParams].banking.initCapital
+    targets.deposits
+      .zip(Banking.DefaultConfigs.map(cfg => summon[SimParams].banking.initDeposits * cfg.relationshipWeight))
+      .exists((actual, relationshipWeightSplit) => actual != relationshipWeightSplit) shouldBe true
   }
 
   it should "render the committed TSV extract from the typed bridge" in {

--- a/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/config/OpeningBankBalanceProfileBridgeSpec.scala
@@ -2,6 +2,8 @@ package com.boombustgroup.amorfati.config
 
 import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.fp.FixedPointBase
+import com.boombustgroup.amorfati.init.{OpeningBankProfileTargets, OpeningBankProfileTestFixtures}
+import com.boombustgroup.amorfati.types.*
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -13,6 +15,8 @@ import scala.jdk.CollectionConverters.*
 class OpeningBankBalanceProfileBridgeSpec extends AnyFlatSpec with Matchers with OptionValues:
 
   import OpeningBankBalanceProfileBridge.*
+
+  given SimParams = SimParams.defaults
 
   "OpeningBankBalanceProfileBridge" should "cover every runtime bank row exactly once" in {
     val profileRows = Rows.filterNot(_.rowType == "sector_total")
@@ -65,6 +69,28 @@ class OpeningBankBalanceProfileBridgeSpec extends AnyFlatSpec with Matchers with
     priorSum shouldBe BigDecimal(1)
     profileRows.foreach: row =>
       row.relationshipWeightPrior.value should be > BigDecimal(0)
+  }
+
+  it should "leave runtime bank targets pending while profile stock columns are empty" in {
+    OpeningBankProfileTargets.fromBridgeRows(Rows) shouldBe OpeningBankProfileTargets.Resolution.Pending(
+      "Opening bank profile has no complete runtime stock targets yet",
+    )
+  }
+
+  it should "resolve complete runtime bank target rows without falling back to relationship weights" in {
+    val resolved = OpeningBankProfileTargets.fromBridgeRows(OpeningBankProfileTestFixtures.completeRows)
+
+    resolved shouldBe a[OpeningBankProfileTargets.Resolution.Complete]
+    val targets = resolved.asInstanceOf[OpeningBankProfileTargets.Resolution.Complete].targets
+
+    targets.bankIds.map(_.toInt) shouldBe Banking.DefaultConfigs.map(_.id.toInt)
+    targets.deposits.sumPln shouldBe summon[SimParams].banking.initDeposits
+    targets.firmLoans.sumPln shouldBe summon[SimParams].banking.initLoans
+    targets.consumerLoans.sumPln shouldBe summon[SimParams].banking.initConsumerLoans
+    targets.mortgageLoans.sumPln shouldBe summon[SimParams].housing.initMortgage
+    targets.govBonds.sumPln shouldBe summon[SimParams].banking.initGovBonds
+    targets.reserves.value.sumPln shouldBe summon[SimParams].banking.initDeposits * summon[SimParams].banking.reserveReq
+    targets.openingCapitalProfiles.flatMap(_.ownFunds).sumPln shouldBe summon[SimParams].banking.initCapital
   }
 
   it should "render the committed TSV extract from the typed bridge" in {

--- a/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
@@ -11,6 +11,8 @@ object OpeningBankProfileTestFixtures:
   private val TestProfileWeights: Vector[BigDecimal] =
     Vector("0.200", "0.130", "0.090", "0.080", "0.070", "0.040", "0.080", "0.060", "0.050", "0.200").map(BigDecimal(_))
 
+  private val TestBankCorpBondsMPln: BigDecimal = BigDecimal("32550")
+
   def completeRows: Vector[Row] =
     val runtimeRows = Rows.filterNot(_.rowType == "sector_total")
     require(
@@ -28,6 +30,7 @@ object OpeningBankProfileTestFixtures:
     val mortgageLoans = split(SectorTotals.mortgageLoansMPln, TestProfileWeights)
     val govBonds      = split(SectorTotals.govBondsMPln, TestProfileWeights)
     val reserves      = split(SectorTotals.reservesMPln, TestProfileWeights)
+    val corpBonds     = split(TestBankCorpBondsMPln, TestProfileWeights)
     val ownFunds      = split(SectorTotals.ownFundsMPln, TestProfileWeights)
     val rwa           = split(SectorTotals.rwaMPln, TestProfileWeights)
 
@@ -44,6 +47,7 @@ object OpeningBankProfileTestFixtures:
           mortgageLoansMPln = Some(mortgageLoans(bankIndex)),
           govBondsMPln = Some(govBonds(bankIndex)),
           reservesMPln = Some(reserves(bankIndex)),
+          corpBondsMPln = Some(corpBonds(bankIndex)),
           rwaMPln = Some(rwa(bankIndex)),
           ownFundsMPln = Some(ownFunds(bankIndex)),
           totalCapitalRatio = Some(SectorTotals.totalCapitalRatio),

--- a/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
@@ -1,0 +1,52 @@
+package com.boombustgroup.amorfati.init
+
+import com.boombustgroup.amorfati.config.OpeningBankBalanceProfileBridge
+
+import scala.math.BigDecimal.RoundingMode
+
+object OpeningBankProfileTestFixtures:
+
+  import OpeningBankBalanceProfileBridge.*
+
+  def completeRows: Vector[Row] =
+    val runtimeRows = Rows.filterNot(_.rowType == "sector_total")
+    val weights     = runtimeRows.map(_.relationshipWeightPrior.getOrElse(BigDecimal(0)))
+
+    val deposits      = split(SectorTotals.depositsMPln, weights)
+    val firmLoans     = split(SectorTotals.firmLoansMPln, weights)
+    val consumerLoans = split(SectorTotals.consumerLoansMPln, weights)
+    val mortgageLoans = split(SectorTotals.mortgageLoansMPln, weights)
+    val govBonds      = split(SectorTotals.govBondsMPln, weights)
+    val reserves      = split(SectorTotals.reservesMPln, weights)
+    val ownFunds      = split(SectorTotals.ownFundsMPln, weights)
+    val rwa           = split(SectorTotals.rwaMPln, weights)
+
+    Rows.map:
+      case row if row.rowType == "sector_total" => row
+      case row                                  =>
+        val bankIndex = row.bankId.toInt
+        row.copy(
+          bridgeStatus = "TEST_COMPLETE_RUNTIME_PROFILE",
+          depositsMPln = Some(deposits(bankIndex)),
+          firmLoansMPln = Some(firmLoans(bankIndex)),
+          consumerLoansMPln = Some(consumerLoans(bankIndex)),
+          mortgageLoansMPln = Some(mortgageLoans(bankIndex)),
+          govBondsMPln = Some(govBonds(bankIndex)),
+          reservesMPln = Some(reserves(bankIndex)),
+          rwaMPln = Some(rwa(bankIndex)),
+          ownFundsMPln = Some(ownFunds(bankIndex)),
+          totalCapitalRatio = Some(SectorTotals.totalCapitalRatio),
+          depositShare = row.relationshipWeightPrior,
+          firmLoanShare = row.relationshipWeightPrior,
+          consumerLoanShare = row.relationshipWeightPrior,
+          mortgageLoanShare = row.relationshipWeightPrior,
+          govBondShare = row.relationshipWeightPrior,
+          rwaShare = row.relationshipWeightPrior,
+          transformation = "Test fixture: complete runtime profile split by normalized runtime priors.",
+          notes = "Used only to exercise explicit opening-bank target reconciliation in tests.",
+        )
+
+  private def split(total: BigDecimal, weights: Vector[BigDecimal]): Vector[BigDecimal] =
+    require(weights.nonEmpty, "OpeningBankProfileTestFixtures.split requires non-empty weights")
+    val leading = weights.dropRight(1).map(weight => (total * weight).setScale(6, RoundingMode.HALF_EVEN))
+    leading :+ (total - leading.sum)

--- a/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/OpeningBankProfileTestFixtures.scala
@@ -8,23 +8,34 @@ object OpeningBankProfileTestFixtures:
 
   import OpeningBankBalanceProfileBridge.*
 
+  private val TestProfileWeights: Vector[BigDecimal] =
+    Vector("0.200", "0.130", "0.090", "0.080", "0.070", "0.040", "0.080", "0.060", "0.050", "0.200").map(BigDecimal(_))
+
   def completeRows: Vector[Row] =
     val runtimeRows = Rows.filterNot(_.rowType == "sector_total")
-    val weights     = runtimeRows.map(_.relationshipWeightPrior.getOrElse(BigDecimal(0)))
+    require(
+      TestProfileWeights.length == runtimeRows.length,
+      s"OpeningBankProfileTestFixtures requires ${runtimeRows.length} weights, got ${TestProfileWeights.length}",
+    )
+    require(
+      TestProfileWeights.sum == BigDecimal(1),
+      s"OpeningBankProfileTestFixtures weights must sum to 1, got ${TestProfileWeights.sum}",
+    )
 
-    val deposits      = split(SectorTotals.depositsMPln, weights)
-    val firmLoans     = split(SectorTotals.firmLoansMPln, weights)
-    val consumerLoans = split(SectorTotals.consumerLoansMPln, weights)
-    val mortgageLoans = split(SectorTotals.mortgageLoansMPln, weights)
-    val govBonds      = split(SectorTotals.govBondsMPln, weights)
-    val reserves      = split(SectorTotals.reservesMPln, weights)
-    val ownFunds      = split(SectorTotals.ownFundsMPln, weights)
-    val rwa           = split(SectorTotals.rwaMPln, weights)
+    val deposits      = split(SectorTotals.depositsMPln, TestProfileWeights)
+    val firmLoans     = split(SectorTotals.firmLoansMPln, TestProfileWeights)
+    val consumerLoans = split(SectorTotals.consumerLoansMPln, TestProfileWeights)
+    val mortgageLoans = split(SectorTotals.mortgageLoansMPln, TestProfileWeights)
+    val govBonds      = split(SectorTotals.govBondsMPln, TestProfileWeights)
+    val reserves      = split(SectorTotals.reservesMPln, TestProfileWeights)
+    val ownFunds      = split(SectorTotals.ownFundsMPln, TestProfileWeights)
+    val rwa           = split(SectorTotals.rwaMPln, TestProfileWeights)
 
     Rows.map:
       case row if row.rowType == "sector_total" => row
       case row                                  =>
         val bankIndex = row.bankId.toInt
+        val share     = Some(TestProfileWeights(bankIndex))
         row.copy(
           bridgeStatus = "TEST_COMPLETE_RUNTIME_PROFILE",
           depositsMPln = Some(deposits(bankIndex)),
@@ -36,13 +47,13 @@ object OpeningBankProfileTestFixtures:
           rwaMPln = Some(rwa(bankIndex)),
           ownFundsMPln = Some(ownFunds(bankIndex)),
           totalCapitalRatio = Some(SectorTotals.totalCapitalRatio),
-          depositShare = row.relationshipWeightPrior,
-          firmLoanShare = row.relationshipWeightPrior,
-          consumerLoanShare = row.relationshipWeightPrior,
-          mortgageLoanShare = row.relationshipWeightPrior,
-          govBondShare = row.relationshipWeightPrior,
-          rwaShare = row.relationshipWeightPrior,
-          transformation = "Test fixture: complete runtime profile split by normalized runtime priors.",
+          depositShare = share,
+          firmLoanShare = share,
+          consumerLoanShare = share,
+          mortgageLoanShare = share,
+          govBondShare = share,
+          rwaShare = share,
+          transformation = "Test fixture: complete runtime profile split by explicit non-default test weights.",
           notes = "Used only to exercise explicit opening-bank target reconciliation in tests.",
         )
 

--- a/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
@@ -140,3 +140,36 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
     }
     init.ledgerFinancialState.nbp.reserveLiability shouldBe reserves
   }
+
+  it should "reconcile opening bank books to complete explicit bank profile targets" in {
+    val rows    = OpeningBankProfileTestFixtures.completeRows
+    val targets = OpeningBankProfileTargets.fromBridgeRows(rows) match
+      case OpeningBankProfileTargets.Resolution.Complete(targets) => targets
+      case other                                                  => fail(s"Expected complete opening bank targets, got $other")
+    val init    = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L), openingBankProfileRows = rows)
+
+    val bankBalances = init.ledgerFinancialState.banks
+    bankBalances.map(_.totalDeposits) shouldBe targets.deposits
+    bankBalances.map(_.firmLoan) shouldBe targets.firmLoans
+    bankBalances.map(_.consumerLoan) shouldBe targets.consumerLoans
+    bankBalances.map(_.mortgageLoan) shouldBe targets.mortgageLoans
+    bankBalances.map(_.reserve) shouldBe targets.reserves.getOrElse(fail("Expected reserve targets in complete fixture"))
+    bankBalances.map(bank => bank.govBondAfs + bank.govBondHtm).zip(targets.govBonds).foreach { case (actual, expected) =>
+      (actual - expected).abs should be <= PLN(1)
+    }
+
+    val firmRows         = init.firms.zip(init.ledgerFinancialState.firms)
+    val householdRows    = init.households.zip(init.ledgerFinancialState.households)
+    val firmCashByBank   = firmRows.groupMapReduce(_._1.bankId.toInt)(_._2.cash)(_ + _)
+    val firmDebtByBank   = firmRows.groupMapReduce(_._1.bankId.toInt)(_._2.firmLoan)(_ + _)
+    val hhSavingsByBank  = householdRows.groupMapReduce(_._1.bankId.toInt)(_._2.demandDeposit)(_ + _)
+    val hhConsDebtByBank = householdRows.groupMapReduce(_._1.bankId.toInt)(_._2.consumerLoan)(_ + _)
+    val hhMortgageByBank = householdRows.groupMapReduce(_._1.bankId.toInt)(_._2.mortgageLoan)(_ + _)
+
+    bankBalances.zipWithIndex.foreach { case (bank, bankId) =>
+      firmCashByBank.getOrElse(bankId, PLN.Zero) + hhSavingsByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.totalDeposits
+      firmDebtByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.firmLoan
+      hhConsDebtByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.consumerLoan
+      hhMortgageByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.mortgageLoan
+    }
+  }

--- a/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/init/WorldInitSpec.scala
@@ -154,6 +154,7 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
     bankBalances.map(_.consumerLoan) shouldBe targets.consumerLoans
     bankBalances.map(_.mortgageLoan) shouldBe targets.mortgageLoans
     bankBalances.map(_.reserve) shouldBe targets.reserves.getOrElse(fail("Expected reserve targets in complete fixture"))
+    bankBalances.map(_.corpBond) shouldBe targets.corpBonds.getOrElse(fail("Expected corporate-bond targets in complete fixture"))
     bankBalances.map(bank => bank.govBondAfs + bank.govBondHtm).zip(targets.govBonds).foreach { case (actual, expected) =>
       (actual - expected).abs should be <= PLN(1)
     }
@@ -172,4 +173,38 @@ class WorldInitSpec extends AnyFlatSpec with Matchers:
       hhConsDebtByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.consumerLoan
       hhMortgageByBank.getOrElse(bankId, PLN.Zero) shouldBe bank.mortgageLoan
     }
+  }
+
+  it should "reject explicit bank holding vectors whose totals do not match opening sector stocks" in {
+    val init            = WorldInit.initialize(InitRandomness.Contract.fromSeed(42L))
+    val firmStocks      = init.ledgerFinancialState.firms.map(LedgerFinancialState.projectFirmFinancialStocks)
+    val householdStocks = init.ledgerFinancialState.households.map(LedgerFinancialState.projectHouseholdFinancialStocks)
+    val zeroBankRows    = Vector.fill(Banking.DefaultConfigs.length)(PLN.Zero)
+
+    intercept[IllegalArgumentException]:
+      BankInit.create(
+        init.firms,
+        firmStocks,
+        init.households,
+        householdStocks,
+        bankGovBondHoldings = zeroBankRows,
+      )
+
+    intercept[IllegalArgumentException]:
+      BankInit.create(
+        init.firms,
+        firmStocks,
+        init.households,
+        householdStocks,
+        bankReserveHoldings = zeroBankRows,
+      )
+
+    intercept[IllegalArgumentException]:
+      BankInit.create(
+        init.firms,
+        firmStocks,
+        init.households,
+        householdStocks,
+        bankCorpBondHoldings = zeroBankRows,
+      )
   }


### PR DESCRIPTION
## Summary
- add an explicit opening-bank target resolver that distinguishes complete target coverage from the current pending bridge
- add deterministic firm/household routing reconciliation so complete bank profile targets can drive per-bank deposits, firm loans, consumer loans, and mortgages without breaking ledger consistency
- thread explicit government-bond, reserve, corporate-bond, and capital-profile inputs through WorldInit/BankInit while preserving the current fallback when target columns are absent
- add tests for both the current pending bridge and a complete profile fixture used by WorldInit

## Notes
- The committed production bridge remains pending because named-bank stock columns are still empty.
- This does not manufacture bank-level targets from relationship weights; partial target coverage fails fast.

## Validation
- sbt Test/compile
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.config.OpeningBankBalanceProfileBridgeSpec com.boombustgroup.amorfati.init.WorldInitSpec com.boombustgroup.amorfati.engine.economics.banking.BankCapitalSemanticsSpec"
- sbt "testOnly com.boombustgroup.amorfati.agents.BankingSectorSpec com.boombustgroup.amorfati.agents.BankingSectorPropertySpec com.boombustgroup.amorfati.accounting.InitCheckSpec com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec com.boombustgroup.amorfati.diagnostics.OpeningBankBalanceProfileBridgeExportSpec com.boombustgroup.amorfati.engine.economics.BankingEconomicsSpec"
- git diff --check

Closes #852
Closes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for initializing the world from explicit opening bank balance targets.
  * Opening bank balances can now be reconciled more precisely across deposits, loans, reserves, and government bonds.

* **Bug Fixes**
  * Improved consistency between bank-level totals and the underlying firm/household balances during startup.
  * Added validation to catch incomplete or invalid opening balance inputs earlier.

* **Tests**
  * Added coverage for complete and pending opening-balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
