### PR TITLE
Update bank benchmark diagnostics for profiles

### DIFF
--- a/docs/bank-balance-sheet-benchmark.md
+++ b/docs/bank-balance-sheet-benchmark.md
@@ -25,7 +25,8 @@ The task writes:
   semantics.
 - `bank-balance-sheet-bank-rows.tsv`: per-bank capital, funding, credit,
   liquidity, sovereign-portfolio, Polish-bank-levy taxable-asset, and
-  concentration rows.
+  concentration rows, plus source-profile target, target-share, and delta
+  columns where opening bank-profile evidence exists.
 - `bank-balance-sheet-report.md`: human-readable summary.
 
 ## Bank Capital Semantics

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -171,11 +171,15 @@ object BankBalanceSheetBenchmarkExport:
     private def compare(target: Option[PLN], targetShare: Option[BigDecimal], realized: PLN): ProfileStockComparison =
       ProfileStockComparison(target = target, targetShare = target.flatMap(_ => targetShare), delta = target.map(realized - _))
 
-  private final case class SeedContext(seed: Long, init: WorldInit.InitResult)(using p: SimParams):
+  private final case class SeedContext(
+      seed: Long,
+      init: WorldInit.InitResult,
+      openingBankProfileRows: Vector[OpeningBankBalanceProfileBridge.Row],
+  )(using p: SimParams):
     val params: SimParams                                         = p
     val bankBalances: Vector[LedgerFinancialState.BankBalances]   = init.ledgerFinancialState.banks
     val bankStocks: Vector[Banking.BankFinancialStocks]           = bankBalances.map(LedgerFinancialState.projectBankFinancialStocks)
-    val profileRowsByBankId: Map[Int, RuntimeBankProfileEvidence] = runtimeProfileRowsByBankId()
+    val profileRowsByBankId: Map[Int, RuntimeBankProfileEvidence] = runtimeProfileRowsByBankId(openingBankProfileRows)
     val corpBondHoldings: Banking.BankCorpBondHoldings            =
       Banking.bankCorpBondHoldingsFromVector(bankBalances.map(_.corpBond))
     val aggregate: Banking.Aggregate                              =
@@ -591,8 +595,9 @@ object BankBalanceSheetBenchmarkExport:
           results    <- ZIO.foreach(validConfig.seedRange): seed =>
             ZIO
               .attempt:
-                val init = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed))
-                computeSeed(validConfig, seed, init)
+                val openingBankProfileRows = OpeningBankBalanceProfileBridge.Rows
+                val init                   = WorldInit.initialize(InitRandomness.Contract.fromSeed(seed), openingBankProfileRows = openingBankProfileRows)
+                computeSeed(validConfig, seed, init, openingBankProfileRows)
               .mapError(ex => s"Seed $seed crashed during initialization or benchmark computation: ${ex.getMessage}")
           seedMetrics = results.flatMap(_._1)
           bankRows    = results.flatMap(_._2)
@@ -674,8 +679,13 @@ object BankBalanceSheetBenchmarkExport:
         status = status,
       )
 
-  private[diagnostics] def computeSeed(config: Config, seed: Long, init: WorldInit.InitResult)(using SimParams): (Vector[SeedMetric], Vector[BankRow]) =
-    val context = SeedContext(seed, init)
+  private[diagnostics] def computeSeed(
+      config: Config,
+      seed: Long,
+      init: WorldInit.InitResult,
+      openingBankProfileRows: Vector[OpeningBankBalanceProfileBridge.Row] = OpeningBankBalanceProfileBridge.Rows,
+  )(using SimParams): (Vector[SeedMetric], Vector[BankRow]) =
+    val context = SeedContext(seed, init, openingBankProfileRows)
     val metrics = Metrics.map: metric =>
       val value = metric.compute(context)
       SeedMetric(config.runId, seed, metric.target, value, evaluate(value, metric.target))
@@ -1020,8 +1030,8 @@ object BankBalanceSheetBenchmarkExport:
   private def singleBankAssets(row: LedgerFinancialState.BankBalances): PLN =
     row.firmLoan + row.consumerLoan + row.mortgageLoan + row.govBondAfs + row.govBondHtm + row.corpBond + row.reserve + row.interbankLoan.max(PLN.Zero)
 
-  private def runtimeProfileRowsByBankId()(using p: SimParams): Map[Int, RuntimeBankProfileEvidence] =
-    val runtimeRows = OpeningBankBalanceProfileBridge.Rows.filterNot(_.rowType == "sector_total")
+  private def runtimeProfileRowsByBankId(rows: Vector[OpeningBankBalanceProfileBridge.Row])(using p: SimParams): Map[Int, RuntimeBankProfileEvidence] =
+    val runtimeRows = rows.filterNot(_.rowType == "sector_total")
     require(
       runtimeRows.length == Banking.DefaultConfigs.length,
       s"Bank balance-sheet benchmark requires ${Banking.DefaultConfigs.length} opening bank profile rows, got ${runtimeRows.length}",

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExport.scala
@@ -2,9 +2,10 @@ package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.{Banking, EclStaging}
 import com.boombustgroup.amorfati.agents.banking.PolishBankLevyAssetPerimeter
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{OpeningBankBalanceProfileBridge, SimParams}
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
+import com.boombustgroup.amorfati.fp.FixedPointBase
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
 import com.boombustgroup.amorfati.montecarlo.{DelimitedTextFormat, McTsvFile, McTsvSchema}
 import com.boombustgroup.amorfati.types.*
@@ -88,6 +89,9 @@ object BankBalanceSheetBenchmarkExport:
       capital: PLN,
       assets: PLN,
       deposits: PLN,
+      firmLoans: PLN,
+      consumerLoans: PLN,
+      mortgageLoans: PLN,
       totalCredit: PLN,
       govBondHoldings: PLN,
       govBondShareOfAssets: Share,
@@ -101,6 +105,27 @@ object BankBalanceSheetBenchmarkExport:
       creditShare: BigDecimal,
       depositShare: BigDecimal,
       assetShare: BigDecimal,
+      firmLoanShare: BigDecimal,
+      consumerLoanShare: BigDecimal,
+      mortgageLoanShare: BigDecimal,
+      govBondSectorShare: BigDecimal,
+      profileBridgeStatus: String,
+      relationshipWeightPrior: Option[BigDecimal],
+      profileDepositsTarget: Option[PLN],
+      profileDepositsTargetShare: Option[BigDecimal],
+      profileDepositsDelta: Option[PLN],
+      profileFirmLoansTarget: Option[PLN],
+      profileFirmLoansTargetShare: Option[BigDecimal],
+      profileFirmLoansDelta: Option[PLN],
+      profileConsumerLoansTarget: Option[PLN],
+      profileConsumerLoansTargetShare: Option[BigDecimal],
+      profileConsumerLoansDelta: Option[PLN],
+      profileMortgageLoansTarget: Option[PLN],
+      profileMortgageLoansTargetShare: Option[BigDecimal],
+      profileMortgageLoansDelta: Option[PLN],
+      profileGovBondsTarget: Option[PLN],
+      profileGovBondsTargetShare: Option[BigDecimal],
+      profileGovBondsDelta: Option[PLN],
   )
 
   final case class ExportResult(
@@ -112,13 +137,48 @@ object BankBalanceSheetBenchmarkExport:
 
   private final case class MetricDef(target: TargetBand, compute: SeedContext => ObservedValue)
 
+  private final case class ProfileStockComparison(target: Option[PLN], targetShare: Option[BigDecimal], delta: Option[PLN])
+
+  private final case class RuntimeBankProfileEvidence(
+      bridgeStatus: String,
+      relationshipWeightPrior: Option[BigDecimal],
+      deposits: Option[PLN],
+      depositShare: Option[BigDecimal],
+      firmLoans: Option[PLN],
+      firmLoanShare: Option[BigDecimal],
+      consumerLoans: Option[PLN],
+      consumerLoanShare: Option[BigDecimal],
+      mortgageLoans: Option[PLN],
+      mortgageLoanShare: Option[BigDecimal],
+      govBonds: Option[PLN],
+      govBondShare: Option[BigDecimal],
+  ):
+    def depositsComparison(realized: PLN): ProfileStockComparison =
+      compare(deposits, depositShare, realized)
+
+    def firmLoansComparison(realized: PLN): ProfileStockComparison =
+      compare(firmLoans, firmLoanShare, realized)
+
+    def consumerLoansComparison(realized: PLN): ProfileStockComparison =
+      compare(consumerLoans, consumerLoanShare, realized)
+
+    def mortgageLoansComparison(realized: PLN): ProfileStockComparison =
+      compare(mortgageLoans, mortgageLoanShare, realized)
+
+    def govBondsComparison(realized: PLN): ProfileStockComparison =
+      compare(govBonds, govBondShare, realized)
+
+    private def compare(target: Option[PLN], targetShare: Option[BigDecimal], realized: PLN): ProfileStockComparison =
+      ProfileStockComparison(target = target, targetShare = target.flatMap(_ => targetShare), delta = target.map(realized - _))
+
   private final case class SeedContext(seed: Long, init: WorldInit.InitResult)(using p: SimParams):
-    val params: SimParams                                       = p
-    val bankBalances: Vector[LedgerFinancialState.BankBalances] = init.ledgerFinancialState.banks
-    val bankStocks: Vector[Banking.BankFinancialStocks]         = bankBalances.map(LedgerFinancialState.projectBankFinancialStocks)
-    val corpBondHoldings: Banking.BankCorpBondHoldings          =
+    val params: SimParams                                         = p
+    val bankBalances: Vector[LedgerFinancialState.BankBalances]   = init.ledgerFinancialState.banks
+    val bankStocks: Vector[Banking.BankFinancialStocks]           = bankBalances.map(LedgerFinancialState.projectBankFinancialStocks)
+    val profileRowsByBankId: Map[Int, RuntimeBankProfileEvidence] = runtimeProfileRowsByBankId()
+    val corpBondHoldings: Banking.BankCorpBondHoldings            =
       Banking.bankCorpBondHoldingsFromVector(bankBalances.map(_.corpBond))
-    val aggregate: Banking.Aggregate                            =
+    val aggregate: Banking.Aggregate                              =
       Banking.aggregateFromBankStocks(init.banks, bankStocks, corpBondHoldings)
 
     val annualGdp: PLN        = init.world.flows.monthlyGdpProxy * 12
@@ -159,18 +219,27 @@ object BankBalanceSheetBenchmarkExport:
         throw new IllegalStateException(
           s"Bank balance-sheet benchmark requires aligned bank and ledger rows, got banks=${init.banks.size} bankBalances=${bankBalances.size} bankIds=$bankIds",
         )
-      init.banks
+      val rows = init.banks
         .zip(bankBalances)
         .map: (bank, balances) =>
-          val stocks     = LedgerFinancialState.projectBankFinancialStocks(balances)
-          val corpBond   = corpBondHoldings(bank.id)
-          val credit     = balances.firmLoan + balances.consumerLoan + balances.mortgageLoan
-          val govBonds   = balances.govBondAfs + balances.govBondHtm
-          val bankAssets = singleBankAssets(balances)
-          val levyBase   =
+          val stocks          = LedgerFinancialState.projectBankFinancialStocks(balances)
+          val corpBond        = corpBondHoldings(bank.id)
+          val credit          = balances.firmLoan + balances.consumerLoan + balances.mortgageLoan
+          val bankGovBonds    = balances.govBondAfs + balances.govBondHtm
+          val bankAssets      = singleBankAssets(balances)
+          val profile         = profileRowsByBankId.getOrElse(
+            bank.id.toInt,
+            throw new IllegalStateException(s"Missing opening bank profile benchmark row for BankId ${bank.id.toInt}"),
+          )
+          val depositsProfile = profile.depositsComparison(balances.totalDeposits)
+          val firmLoanProfile = profile.firmLoansComparison(balances.firmLoan)
+          val consumerProfile = profile.consumerLoansComparison(balances.consumerLoan)
+          val mortgageProfile = profile.mortgageLoansComparison(balances.mortgageLoan)
+          val govBondsProfile = profile.govBondsComparison(bankGovBonds)
+          val levyBase        =
             Banking.computePolishBankLevyTaxableAssets(bank, PolishBankLevyAssetPerimeter.fromBankStocks(stocks, corpBond))
-          val car        = rawDecimal(Banking.car(bank, stocks, corpBond).toLong)
-          val minCar     = rawDecimal(Macroprudential.effectiveMinCar(bank.id.toInt, init.world.mechanisms.macropru.ccyb).toLong)
+          val car             = rawDecimal(Banking.car(bank, stocks, corpBond).toLong)
+          val minCar          = rawDecimal(Macroprudential.effectiveMinCar(bank.id.toInt, init.world.mechanisms.macropru.ccyb).toLong)
           BankRow(
             runId = "",
             seed = seed,
@@ -179,9 +248,12 @@ object BankBalanceSheetBenchmarkExport:
             capital = bank.capital,
             assets = bankAssets,
             deposits = balances.totalDeposits,
+            firmLoans = balances.firmLoan,
+            consumerLoans = balances.consumerLoan,
+            mortgageLoans = balances.mortgageLoan,
             totalCredit = credit,
-            govBondHoldings = govBonds,
-            govBondShareOfAssets = finiteShare(govBonds, bankAssets),
+            govBondHoldings = bankGovBonds,
+            govBondShareOfAssets = finiteShare(bankGovBonds, bankAssets),
             polishBankLevyTaxableAssets = levyBase,
             polishBankLevyTaxableAssetsShare = finiteShare(levyBase, bankAssets),
             capitalAdequacyRatio = car,
@@ -192,7 +264,47 @@ object BankBalanceSheetBenchmarkExport:
             creditShare = finiteRatio(credit, totalCredit),
             depositShare = finiteRatio(balances.totalDeposits, deposits),
             assetShare = finiteRatio(bankAssets, assets),
+            firmLoanShare = finiteRatio(balances.firmLoan, firmLoans),
+            consumerLoanShare = finiteRatio(balances.consumerLoan, consumerLoans),
+            mortgageLoanShare = finiteRatio(balances.mortgageLoan, mortgageLoans),
+            govBondSectorShare = finiteRatio(bankGovBonds, govBonds),
+            profileBridgeStatus = profile.bridgeStatus,
+            relationshipWeightPrior = profile.relationshipWeightPrior,
+            profileDepositsTarget = depositsProfile.target,
+            profileDepositsTargetShare = depositsProfile.targetShare,
+            profileDepositsDelta = depositsProfile.delta,
+            profileFirmLoansTarget = firmLoanProfile.target,
+            profileFirmLoansTargetShare = firmLoanProfile.targetShare,
+            profileFirmLoansDelta = firmLoanProfile.delta,
+            profileConsumerLoansTarget = consumerProfile.target,
+            profileConsumerLoansTargetShare = consumerProfile.targetShare,
+            profileConsumerLoansDelta = consumerProfile.delta,
+            profileMortgageLoansTarget = mortgageProfile.target,
+            profileMortgageLoansTargetShare = mortgageProfile.targetShare,
+            profileMortgageLoansDelta = mortgageProfile.delta,
+            profileGovBondsTarget = govBondsProfile.target,
+            profileGovBondsTargetShare = govBondsProfile.targetShare,
+            profileGovBondsDelta = govBondsProfile.delta,
           )
+      requireDerivedMarketShares(rows)
+      rows
+
+    private def requireDerivedMarketShares(rows: Vector[BankRow]): Unit =
+      requireShareSum("creditShare", rows.map(_.creditShare), totalCredit)
+      requireShareSum("depositShare", rows.map(_.depositShare), deposits)
+      requireShareSum("assetShare", rows.map(_.assetShare), assets)
+      requireShareSum("firmLoanShare", rows.map(_.firmLoanShare), firmLoans)
+      requireShareSum("consumerLoanShare", rows.map(_.consumerLoanShare), consumerLoans)
+      requireShareSum("mortgageLoanShare", rows.map(_.mortgageLoanShare), mortgageLoans)
+      requireShareSum("govBondSectorShare", rows.map(_.govBondSectorShare), govBonds)
+
+    private def requireShareSum(label: String, shares: Vector[BigDecimal], denominator: PLN): Unit =
+      if denominator > PLN.Zero then
+        val delta = (shares.sum - BigDecimal(1)).abs
+        require(
+          delta <= BigDecimal("0.000001"),
+          s"Bank balance-sheet benchmark $label must be derived from initialized stocks and sum to one; got sum=${shares.sum}",
+        )
 
   private val RequiredMetricIds: Set[String] = Set(
     "CapitalToAssets",
@@ -696,6 +808,9 @@ object BankBalanceSheetBenchmarkExport:
         "Capital",
         "Assets",
         "Deposits",
+        "FirmLoans",
+        "ConsumerLoans",
+        "MortgageLoans",
         "TotalCredit",
         "GovBondHoldings",
         "GovBondShareOfAssets",
@@ -709,6 +824,27 @@ object BankBalanceSheetBenchmarkExport:
         "CreditShare",
         "DepositShare",
         "AssetShare",
+        "FirmLoanShare",
+        "ConsumerLoanShare",
+        "MortgageLoanShare",
+        "GovBondSectorShare",
+        "ProfileBridgeStatus",
+        "RelationshipWeightPrior",
+        "ProfileDepositsTarget",
+        "ProfileDepositsTargetShare",
+        "ProfileDepositsDelta",
+        "ProfileFirmLoansTarget",
+        "ProfileFirmLoansTargetShare",
+        "ProfileFirmLoansDelta",
+        "ProfileConsumerLoansTarget",
+        "ProfileConsumerLoansTargetShare",
+        "ProfileConsumerLoansDelta",
+        "ProfileMortgageLoansTarget",
+        "ProfileMortgageLoansTargetShare",
+        "ProfileMortgageLoansDelta",
+        "ProfileGovBondsTarget",
+        "ProfileGovBondsTargetShare",
+        "ProfileGovBondsDelta",
       ),
       render = row =>
         DelimitedTextFormat.Tsv.join(
@@ -720,6 +856,9 @@ object BankBalanceSheetBenchmarkExport:
             renderPln(row.capital),
             renderPln(row.assets),
             renderPln(row.deposits),
+            renderPln(row.firmLoans),
+            renderPln(row.consumerLoans),
+            renderPln(row.mortgageLoans),
             renderPln(row.totalCredit),
             renderPln(row.govBondHoldings),
             row.govBondShareOfAssets.format(6),
@@ -733,6 +872,27 @@ object BankBalanceSheetBenchmarkExport:
             renderDecimal(row.creditShare),
             renderDecimal(row.depositShare),
             renderDecimal(row.assetShare),
+            renderDecimal(row.firmLoanShare),
+            renderDecimal(row.consumerLoanShare),
+            renderDecimal(row.mortgageLoanShare),
+            renderDecimal(row.govBondSectorShare),
+            row.profileBridgeStatus,
+            renderOptionalDecimal(row.relationshipWeightPrior),
+            renderOptionalPln(row.profileDepositsTarget),
+            renderOptionalDecimal(row.profileDepositsTargetShare),
+            renderOptionalPln(row.profileDepositsDelta),
+            renderOptionalPln(row.profileFirmLoansTarget),
+            renderOptionalDecimal(row.profileFirmLoansTargetShare),
+            renderOptionalPln(row.profileFirmLoansDelta),
+            renderOptionalPln(row.profileConsumerLoansTarget),
+            renderOptionalDecimal(row.profileConsumerLoansTargetShare),
+            renderOptionalPln(row.profileConsumerLoansDelta),
+            renderOptionalPln(row.profileMortgageLoansTarget),
+            renderOptionalDecimal(row.profileMortgageLoansTargetShare),
+            renderOptionalPln(row.profileMortgageLoansDelta),
+            renderOptionalPln(row.profileGovBondsTarget),
+            renderOptionalDecimal(row.profileGovBondsTargetShare),
+            renderOptionalPln(row.profileGovBondsDelta),
           ),
         ),
     )
@@ -860,6 +1020,56 @@ object BankBalanceSheetBenchmarkExport:
   private def singleBankAssets(row: LedgerFinancialState.BankBalances): PLN =
     row.firmLoan + row.consumerLoan + row.mortgageLoan + row.govBondAfs + row.govBondHtm + row.corpBond + row.reserve + row.interbankLoan.max(PLN.Zero)
 
+  private def runtimeProfileRowsByBankId()(using p: SimParams): Map[Int, RuntimeBankProfileEvidence] =
+    val runtimeRows = OpeningBankBalanceProfileBridge.Rows.filterNot(_.rowType == "sector_total")
+    require(
+      runtimeRows.length == Banking.DefaultConfigs.length,
+      s"Bank balance-sheet benchmark requires ${Banking.DefaultConfigs.length} opening bank profile rows, got ${runtimeRows.length}",
+    )
+    val byId        = runtimeRows
+      .map: row =>
+        val bankId = parseBankId(row)
+        bankId -> RuntimeBankProfileEvidence(
+          bridgeStatus = row.bridgeStatus,
+          relationshipWeightPrior = row.relationshipWeightPrior,
+          deposits = profileTarget(row.depositsMPln),
+          depositShare = row.depositShare,
+          firmLoans = profileTarget(row.firmLoansMPln),
+          firmLoanShare = row.firmLoanShare,
+          consumerLoans = profileTarget(row.consumerLoansMPln),
+          consumerLoanShare = row.consumerLoanShare,
+          mortgageLoans = profileTarget(row.mortgageLoansMPln),
+          mortgageLoanShare = row.mortgageLoanShare,
+          govBonds = profileTarget(row.govBondsMPln),
+          govBondShare = row.govBondShare,
+        )
+      .toMap
+    require(byId.size == runtimeRows.length, "Bank balance-sheet benchmark requires unique opening bank profile bank_id values")
+    Banking.DefaultConfigs.foreach: config =>
+      val row = runtimeRows
+        .find(parseBankId(_) == config.id.toInt)
+        .getOrElse:
+          throw new IllegalStateException(s"Missing opening bank profile row for BankId ${config.id.toInt}")
+      require(
+        row.runtimeBankName == config.name,
+        s"Opening bank profile row ${config.id.toInt} names ${row.runtimeBankName}, expected ${config.name}",
+      )
+    byId
+
+  private def parseBankId(row: OpeningBankBalanceProfileBridge.Row): Int =
+    Try(row.bankId.toInt)
+      .getOrElse(throw new IllegalStateException(s"Opening bank profile row has non-integer bank_id='${row.bankId}'"))
+
+  private def profileTarget(value: Option[BigDecimal])(using SimParams): Option[PLN] =
+    value.map(mPlnToRuntime)
+
+  private def mPlnToRuntime(value: BigDecimal)(using p: SimParams): PLN =
+    val pln = value * BigDecimal(1000000L)
+    val raw = (pln * FixedPointBase.ScaleDecimal)
+      .setScale(0, RoundingMode.HALF_EVEN)
+      .toLongExact
+    PLN.fromRaw(raw) * p.gdpRatio
+
   private def ratioRaw(numerator: BigDecimal, denominator: BigDecimal): ObservedValue =
     if denominator == BigDecimal(0) then
       if numerator == BigDecimal(0) then ObservedValue.Finite(BigDecimal(0))
@@ -877,6 +1087,12 @@ object BankBalanceSheetBenchmarkExport:
 
   private def renderPln(value: PLN): String =
     renderDecimal(rawDecimal(value.toLong))
+
+  private def renderOptionalPln(value: Option[PLN]): String =
+    value.map(renderPln).getOrElse("")
+
+  private def renderOptionalDecimal(value: Option[BigDecimal]): String =
+    value.map(renderDecimal).getOrElse("")
 
   private def renderDecimal(value: BigDecimal): String =
     value.setScale(6, RoundingMode.HALF_UP).bigDecimal.stripTrailingZeros.toPlainString

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
@@ -85,28 +85,7 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
       SeedMetric("bank-spec", 2L, target, ObservedValue.Finite(BigDecimal("0.000")), Status.Warn),
     )
     val summary = summarize(Config(runId = "bank-spec", seeds = 2), rows)
-    val bankRow = BankRow(
-      runId = "bank-spec",
-      seed = 1L,
-      bankId = 0,
-      bankName = "PKO BP",
-      capital = PLN(10),
-      assets = PLN(100),
-      deposits = PLN(80),
-      totalCredit = PLN(50),
-      govBondHoldings = PLN(20),
-      govBondShareOfAssets = Share.decimal(20, 2),
-      polishBankLevyTaxableAssets = PLN(30),
-      polishBankLevyTaxableAssetsShare = Share.decimal(30, 2),
-      capitalAdequacyRatio = BigDecimal("0.20"),
-      effectiveMinCar = BigDecimal("0.125"),
-      carBuffer = BigDecimal("0.075"),
-      lcr = BigDecimal("1.20"),
-      nsfr = BigDecimal("1.10"),
-      creditShare = BigDecimal("0.25"),
-      depositShare = BigDecimal("0.30"),
-      assetShare = BigDecimal("0.20"),
-    )
+    val bankRow = sampleBankRow()
 
     val seedTsv   = renderSeedMetricsTsv(rows)
     val sumTsv    = renderSummaryTsv(summary)
@@ -157,6 +136,9 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
         "Capital",
         "Assets",
         "Deposits",
+        "FirmLoans",
+        "ConsumerLoans",
+        "MortgageLoans",
         "TotalCredit",
         "GovBondHoldings",
         "GovBondShareOfAssets",
@@ -170,6 +152,27 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
         "CreditShare",
         "DepositShare",
         "AssetShare",
+        "FirmLoanShare",
+        "ConsumerLoanShare",
+        "MortgageLoanShare",
+        "GovBondSectorShare",
+        "ProfileBridgeStatus",
+        "RelationshipWeightPrior",
+        "ProfileDepositsTarget",
+        "ProfileDepositsTargetShare",
+        "ProfileDepositsDelta",
+        "ProfileFirmLoansTarget",
+        "ProfileFirmLoansTargetShare",
+        "ProfileFirmLoansDelta",
+        "ProfileConsumerLoansTarget",
+        "ProfileConsumerLoansTargetShare",
+        "ProfileConsumerLoansDelta",
+        "ProfileMortgageLoansTarget",
+        "ProfileMortgageLoansTargetShare",
+        "ProfileMortgageLoansDelta",
+        "ProfileGovBondsTarget",
+        "ProfileGovBondsTargetShare",
+        "ProfileGovBondsDelta",
       )
     bankTsv should include("PKO BP")
     report should include("--seed-start 2")
@@ -196,27 +199,9 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
     val targetTsv = renderTargetsTsv(Vector(target))
     val bankTsv   = renderBankRowsTsv(
       Vector(
-        BankRow(
+        sampleBankRow(
           runId = "run\t\"id\"",
-          seed = 1L,
-          bankId = 0,
           bankName = "Bank\t\"Name\"\nSA",
-          capital = PLN(10),
-          assets = PLN(100),
-          deposits = PLN(80),
-          totalCredit = PLN(50),
-          govBondHoldings = PLN(20),
-          govBondShareOfAssets = Share.decimal(20, 2),
-          polishBankLevyTaxableAssets = PLN(30),
-          polishBankLevyTaxableAssetsShare = Share.decimal(30, 2),
-          capitalAdequacyRatio = BigDecimal("0.20"),
-          effectiveMinCar = BigDecimal("0.125"),
-          carBuffer = BigDecimal("0.075"),
-          lcr = BigDecimal("1.20"),
-          nsfr = BigDecimal("1.10"),
-          creditShare = BigDecimal("0.25"),
-          depositShare = BigDecimal("0.30"),
-          assetShare = BigDecimal("0.20"),
         ),
       ),
     )
@@ -253,6 +238,85 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
     metricValue(metrics, "CapitalToAssets") shouldBe ObservedValue.Finite(BigDecimal(aggregate.capital.toLong) / BigDecimal(totalAssets.toLong))
     metricValue(metrics, "AggregateCar") shouldBe ObservedValue.Finite(BigDecimal(aggregate.car.toLong) / BigDecimal(FixedPointBase.Scale))
   }
+
+  it should "derive market-share columns from initialized bank stocks" in {
+    given SimParams = SimParams.defaults
+
+    val init           = WorldInit.initialize(InitRandomness.Contract.fromSeed(1L))
+    val (_, bankRows)  = computeSeed(Config(runId = "bank-spec", seeds = 1), 1L, init)
+    val totalCredit    = bankRows.map(_.totalCredit).sumPln
+    val totalDeposits  = bankRows.map(_.deposits).sumPln
+    val totalAssets    = bankRows.map(_.assets).sumPln
+    val totalFirmLoans = bankRows.map(_.firmLoans).sumPln
+    val totalConsumer  = bankRows.map(_.consumerLoans).sumPln
+    val totalMortgages = bankRows.map(_.mortgageLoans).sumPln
+    val totalGovBonds  = bankRows.map(_.govBondHoldings).sumPln
+    val pekao          = bankRows.find(_.bankName == "Pekao").getOrElse(fail("Missing Pekao benchmark row"))
+    val bpsCoop        = bankRows.find(_.bankName == "BPS/Coop").getOrElse(fail("Missing BPS/Coop benchmark row"))
+
+    bankRows.foreach: row =>
+      row.creditShare shouldBe BigDecimal(row.totalCredit.toLong) / BigDecimal(totalCredit.toLong)
+      row.depositShare shouldBe BigDecimal(row.deposits.toLong) / BigDecimal(totalDeposits.toLong)
+      row.assetShare shouldBe BigDecimal(row.assets.toLong) / BigDecimal(totalAssets.toLong)
+      row.firmLoanShare shouldBe BigDecimal(row.firmLoans.toLong) / BigDecimal(totalFirmLoans.toLong)
+      row.consumerLoanShare shouldBe BigDecimal(row.consumerLoans.toLong) / BigDecimal(totalConsumer.toLong)
+      row.mortgageLoanShare shouldBe BigDecimal(row.mortgageLoans.toLong) / BigDecimal(totalMortgages.toLong)
+      row.govBondSectorShare shouldBe BigDecimal(row.govBondHoldings.toLong) / BigDecimal(totalGovBonds.toLong)
+
+    pekao.profileBridgeStatus shouldBe "SOURCE_BACKED_PARTIAL_EVIDENCE"
+    pekao.profileDepositsTarget.get should be > PLN.Zero
+    pekao.profileDepositsDelta shouldBe pekao.profileDepositsTarget.map(pekao.deposits - _)
+    bpsCoop.profileConsumerLoansTarget shouldBe None
+    bpsCoop.profileConsumerLoansDelta shouldBe None
+  }
+
+  private def sampleBankRow(runId: String = "bank-spec", seed: Long = 1L, bankId: Int = 0, bankName: String = "PKO BP"): BankRow =
+    BankRow(
+      runId = runId,
+      seed = seed,
+      bankId = bankId,
+      bankName = bankName,
+      capital = PLN(10),
+      assets = PLN(100),
+      deposits = PLN(80),
+      firmLoans = PLN(20),
+      consumerLoans = PLN(10),
+      mortgageLoans = PLN(20),
+      totalCredit = PLN(50),
+      govBondHoldings = PLN(20),
+      govBondShareOfAssets = Share.decimal(20, 2),
+      polishBankLevyTaxableAssets = PLN(30),
+      polishBankLevyTaxableAssetsShare = Share.decimal(30, 2),
+      capitalAdequacyRatio = BigDecimal("0.20"),
+      effectiveMinCar = BigDecimal("0.125"),
+      carBuffer = BigDecimal("0.075"),
+      lcr = BigDecimal("1.20"),
+      nsfr = BigDecimal("1.10"),
+      creditShare = BigDecimal("0.25"),
+      depositShare = BigDecimal("0.30"),
+      assetShare = BigDecimal("0.20"),
+      firmLoanShare = BigDecimal("0.10"),
+      consumerLoanShare = BigDecimal("0.15"),
+      mortgageLoanShare = BigDecimal("0.20"),
+      govBondSectorShare = BigDecimal("0.25"),
+      profileBridgeStatus = "SOURCE_BACKED_PARTIAL_EVIDENCE",
+      relationshipWeightPrior = Some(BigDecimal("0.175")),
+      profileDepositsTarget = Some(PLN(75)),
+      profileDepositsTargetShare = Some(BigDecimal("0.29")),
+      profileDepositsDelta = Some(PLN(5)),
+      profileFirmLoansTarget = Some(PLN(19)),
+      profileFirmLoansTargetShare = Some(BigDecimal("0.18")),
+      profileFirmLoansDelta = Some(PLN(1)),
+      profileConsumerLoansTarget = Some(PLN(12)),
+      profileConsumerLoansTargetShare = Some(BigDecimal("0.16")),
+      profileConsumerLoansDelta = Some(PLN(-2)),
+      profileMortgageLoansTarget = Some(PLN(17)),
+      profileMortgageLoansTargetShare = Some(BigDecimal("0.14")),
+      profileMortgageLoansDelta = Some(PLN(3)),
+      profileGovBondsTarget = None,
+      profileGovBondsTargetShare = None,
+      profileGovBondsDelta = None,
+    )
 
   private def metricValue(rows: Vector[SeedMetric], id: String): ObservedValue =
     rows.find(_.target.id == id).map(_.value).getOrElse(fail(s"Missing metric $id"))

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/BankBalanceSheetBenchmarkExportSpec.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.agents.Banking
-import com.boombustgroup.amorfati.config.SimParams
+import com.boombustgroup.amorfati.config.{OpeningBankBalanceProfileBridge, SimParams}
 import com.boombustgroup.amorfati.engine.ledger.LedgerFinancialState
 import com.boombustgroup.amorfati.fp.FixedPointBase
 import com.boombustgroup.amorfati.init.{InitRandomness, WorldInit}
@@ -268,6 +268,26 @@ class BankBalanceSheetBenchmarkExportSpec extends AnyFlatSpec with Matchers:
     pekao.profileDepositsDelta shouldBe pekao.profileDepositsTarget.map(pekao.deposits - _)
     bpsCoop.profileConsumerLoansTarget shouldBe None
     bpsCoop.profileConsumerLoansDelta shouldBe None
+  }
+
+  it should "use the opening profile rows supplied with the initialized world" in {
+    given SimParams = SimParams.defaults
+
+    val customRows = OpeningBankBalanceProfileBridge.Rows.map:
+      case row if row.runtimeBankName == "Pekao" =>
+        row.copy(
+          bridgeStatus = "CUSTOM_PROFILE_EVIDENCE",
+          depositsMPln = Some(BigDecimal("1")),
+          depositShare = Some(BigDecimal("0.000001")),
+        )
+      case row                                   => row
+    val init       = WorldInit.initialize(InitRandomness.Contract.fromSeed(1L), openingBankProfileRows = customRows)
+    val (_, rows)  = computeSeed(Config(runId = "bank-spec", seeds = 1), 1L, init, customRows)
+    val pekao      = rows.find(_.bankName == "Pekao").getOrElse(fail("Missing Pekao benchmark row"))
+
+    pekao.profileBridgeStatus shouldBe "CUSTOM_PROFILE_EVIDENCE"
+    pekao.profileDepositsTargetShare shouldBe Some(BigDecimal("0.000001"))
+    pekao.profileDepositsDelta shouldBe pekao.profileDepositsTarget.map(pekao.deposits - _)
   }
 
   private def sampleBankRow(runId: String = "bank-spec", seed: Long = 1L, bankId: Int = 0, bankName: String = "PKO BP"): BankRow =


### PR DESCRIPTION
## Summary
- extend `bank-balance-sheet-bank-rows.tsv` with realized stock columns, realized market shares, opening profile targets, target shares, and realized-minus-target deltas
- add fail-fast share-sum checks and tests proving benchmark market shares are derived from initialized stocks
- update the benchmark doc to describe the profile target/delta columns

## Diagnostics
- `bankBalanceSheetBenchmark --seed-start 1 --seeds 10 --out target/bank-balance-sheet-benchmark --run-id issue-849-bank-benchmark`: no WARN/FAIL; hard and soft guardrails pass, exploratory rows remain INFO
- `bankFailureAblations --seed-start 1 --seeds 1 --months 60 --out target/bank-failure-ablations --run-id issue-849-seed1-60`: baseline first failure month 44; `no-realized-credit-loss-capital-hit` and `initial-capital-150pct` prevent failures in this fixture
- `bankFailureAblations --seed-start 1 --seeds 5 --months 60 --out target/bank-failure-ablations --run-id issue-849-seeds5-60`: baseline fails 5/5 seeds, mean first failure month 46.8, mean terminal failures 2.6; `no-realized-credit-loss-capital-hit` prevents failures in 5/5; `initial-capital-150pct` reduces failures to 3/5; `no-resolution-feedback` does not delay first failure
- HH-bank lead-lag was not re-run because the ablation surface already isolates the remaining red flag to realized credit-loss capital hits; #845 owns the implementation-grade repair pass for private-credit loss dynamics

## Validation
- `sbt scalafmtAll`
- `sbt "testOnly com.boombustgroup.amorfati.diagnostics.BankBalanceSheetBenchmarkExportSpec"`
- `sbt "bankBalanceSheetBenchmark --seed-start 1 --seeds 10 --out target/bank-balance-sheet-benchmark --run-id issue-849-bank-benchmark"`
- `sbt "bankFailureAblations --seed-start 1 --seeds 1 --months 60 --out target/bank-failure-ablations --run-id issue-849-seed1-60"`
- `sbt "bankFailureAblations --seed-start 1 --seeds 5 --months 60 --out target/bank-failure-ablations --run-id issue-849-seeds5-60"`
- `bash scripts/check-generated-outputs.sh`
- `git diff --check`

Closes #849
Refs #845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bank balance sheet benchmark exports now include additional loan breakdowns and sector-share columns.
  * Rows with opening profile evidence now also show profile comparison details, including targets, shares, and deltas.

* **Documentation**
  * Clarified which extra columns appear in the bank-rows TSV output and when they are included.

* **Bug Fixes**
  * Improved consistency checks for derived share columns in benchmark output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->