### PR TITLE
Add HH-bank concentration audit diagnostics

### DIFF
--- a/docs/hh-bank-lead-lag-diagnostics.md
+++ b/docs/hh-bank-lead-lag-diagnostics.md
@@ -85,12 +85,14 @@ routing separately.
 one top-bank row per scenario, seed, and concentration metric. It reports the
 peak month, top bank, top share, amount, denominator, consumer-loan exposure
 share, household routing share, RWA share, CAR, effective minimum CAR, and
-capital buffer to RWA.
+capital buffer to RWA. Months with a zero metric denominator are skipped for
+that metric.
 
-Baseline peak metrics include household routing, consumer-loan exposure,
-mortgage exposure, deposits, ordinary consumer-loan default flow, insolvency
-default flow, liquidity-bridge charge-off flow, liquidity shortfall financing
-flow, and RWA share. These are the product-specific inputs needed by baseline
+Baseline peak metrics include household-stage routing, closing household
+routing, consumer-loan exposure, mortgage exposure, deposits, ordinary
+consumer-loan default flow, insolvency default flow, liquidity-bridge charge-off
+flow, liquidity shortfall financing flow, bank capital, bank capital buffer,
+and RWA share. These are the product-specific inputs needed by baseline
 concentration guardrails without mixing bridge/write-off channels into ordinary
 consumer-loan default.
 

--- a/docs/hh-bank-lead-lag-diagnostics.md
+++ b/docs/hh-bank-lead-lag-diagnostics.md
@@ -25,6 +25,7 @@ The task writes:
 <out>/<run-id>/hh-bank-lead-lag-bank-months.tsv
 <out>/<run-id>/hh-bank-lead-lag-correlations.tsv
 <out>/<run-id>/hh-bank-lead-lag-counterfactuals.tsv
+<out>/<run-id>/hh-bank-lead-lag-concentration-peaks.tsv
 <out>/<run-id>/hh-bank-lead-lag-report.md
 ```
 
@@ -47,6 +48,10 @@ Key household-side columns:
   `HhConsumerBankRejectedOrigination`: underwritten household consumer-credit
   origination, total rejected demand, and the bank-side rejected subset.
 - `HhConsumerDebtArrears` and `HhMortgageArrears`: shortfall components.
+- `HhConsumerLoanDefaultShare`, `HhConsumerInsolvencyDefaultShare`,
+  `HhLiquidityBridgeChargeOffShare`, and
+  `HhLiquidityShortfallFinancingShare`: product-specific per-bank flow shares
+  within the same scenario/seed/month.
 
 Key bank-side columns:
 
@@ -56,12 +61,38 @@ Key bank-side columns:
   separate HH metric and as `BankCreditLoss_*` product diagnostics, but the
   same-month bridge settlement does not add a capital loss by default.
 - `BankConsumerNplStock`: closing consumer NPL stock.
+- `BankConsumerLoanShare`, `BankMortgageLoanShare`, and `BankDepositShare`:
+  closing per-bank product stock shares.
+- `BankRwa`, `BankRwaShare`, `BankEffectiveMinCar`, `BankCarBuffer`,
+  `BankCapitalBuffer`, and `BankCapitalBufferToRwa`: closing capital/RWA
+  fragility surface for explaining which bank fails first under a given HH
+  stress path.
 - `BankCapital`, `BankCapitalDelta`, `BankCar`, `BankLcr`: closing bank stress
   state.
 - `BankNewFailure`: 1 when the bank moves from not failed to failed in that
   month.
 - `BankFailureReasonCode`: populated for the first new failure event when the
   aggregate failure diagnostic identifies that bank.
+
+`HouseholdCount` and `HouseholdShare` use household-stage routing, matching the
+route used for that month's HH stress flows. `ClosingHouseholdCount` and
+`ClosingHouseholdShare` expose post-banking reassignment/deposit-mobility
+routing separately.
+
+## Concentration Peaks
+
+`hh-bank-lead-lag-concentration-peaks.tsv` condenses the bank-month rows into
+one top-bank row per scenario, seed, and concentration metric. It reports the
+peak month, top bank, top share, amount, denominator, consumer-loan exposure
+share, household routing share, RWA share, CAR, effective minimum CAR, and
+capital buffer to RWA.
+
+Baseline peak metrics include household routing, consumer-loan exposure,
+mortgage exposure, deposits, ordinary consumer-loan default flow, insolvency
+default flow, liquidity-bridge charge-off flow, liquidity shortfall financing
+flow, and RWA share. These are the product-specific inputs needed by baseline
+concentration guardrails without mixing bridge/write-off channels into ordinary
+consumer-loan default.
 
 ## Correlation Versus Causality
 

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -309,7 +309,8 @@ Recommended steps:
 - robustness report: `--scenario-set core`, 2 seeds, 24 months
 - bank balance-sheet benchmark: 10 seeds
 - household credit-stress calibration: 5 seeds, 60 months
-- HH-bank lead-lag diagnostics: 5 seeds, 60 months, lag max 6
+- HH-bank lead-lag diagnostics: 5 seeds, 60 months, lag max 6, including
+  per-bank household-credit concentration peaks
 - loan-origination quality diagnostics: 2 seeds, 60 months, outcome window 12
 
 Comparison mode:

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
@@ -201,63 +201,87 @@ object HhBankLeadLagDiagnosticsExport:
   private final case class ConcentrationMetric(
       id: String,
       amount: BankMonthRow => BigDecimal,
-      share: BankMonthRow => BigDecimal,
+      share: (BankMonthRow, BigDecimal) => BigDecimal,
       interpretation: String,
   )
+
+  private def observedShare(accessor: BankMonthRow => BigDecimal): (BankMonthRow, BigDecimal) => BigDecimal =
+    (row, _) => accessor(row)
+
+  private def denominatorShare(amount: BankMonthRow => BigDecimal): (BankMonthRow, BigDecimal) => BigDecimal =
+    (row, denominator) => if denominator > BigDecimal(0) then amount(row) / denominator else BigDecimal(0)
 
   private val ConcentrationMetrics: Vector[ConcentrationMetric] = Vector(
     ConcentrationMetric(
       id = "HouseholdRoutingShare",
       amount = row => BigDecimal(row.householdCount),
-      share = _.householdShare,
+      share = observedShare(_.householdShare),
       interpretation = "Share of household-stage routed households assigned to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "ClosingHouseholdRoutingShare",
+      amount = row => BigDecimal(row.closingHouseholdCount),
+      share = observedShare(_.closingHouseholdShare),
+      interpretation = "Share of post-banking closing household assignments carried by the top bank.",
     ),
     ConcentrationMetric(
       id = "ConsumerLoanExposureShare",
       amount = _.bankConsumerLoanStock,
-      share = _.bankConsumerLoanShare,
+      share = observedShare(_.bankConsumerLoanShare),
       interpretation = "Share of closing unsecured consumer-loan stock held by the top bank.",
     ),
     ConcentrationMetric(
       id = "MortgageExposureShare",
       amount = _.bankMortgageLoanStock,
-      share = _.bankMortgageLoanShare,
+      share = observedShare(_.bankMortgageLoanShare),
       interpretation = "Share of closing mortgage-loan stock mirrored to the top bank.",
     ),
     ConcentrationMetric(
       id = "DepositShare",
       amount = _.bankDeposits,
-      share = _.bankDepositShare,
+      share = observedShare(_.bankDepositShare),
       interpretation = "Share of closing customer deposits assigned to the top bank.",
     ),
     ConcentrationMetric(
       id = "ConsumerLoanDefaultFlowShare",
       amount = _.hhConsumerLoanDefault,
-      share = _.hhConsumerLoanDefaultShare,
+      share = observedShare(_.hhConsumerLoanDefaultShare),
       interpretation = "Share of ordinary consumer-loan default flow routed to the top bank.",
     ),
     ConcentrationMetric(
       id = "ConsumerInsolvencyDefaultFlowShare",
       amount = _.hhConsumerInsolvencyDefault,
-      share = _.hhConsumerInsolvencyDefaultShare,
+      share = observedShare(_.hhConsumerInsolvencyDefaultShare),
       interpretation = "Share of personal-insolvency consumer default flow routed to the top bank.",
     ),
     ConcentrationMetric(
       id = "LiquidityBridgeChargeOffFlowShare",
       amount = _.hhLiquidityBridgeChargeOff,
-      share = _.hhLiquidityBridgeChargeOffShare,
+      share = observedShare(_.hhLiquidityBridgeChargeOffShare),
       interpretation = "Share of same-month liquidity-bridge charge-off flow routed to the top bank.",
     ),
     ConcentrationMetric(
       id = "LiquidityShortfallFinancingFlowShare",
       amount = _.hhLiquidityShortfallFinancing,
-      share = _.hhLiquidityShortfallFinancingShare,
+      share = observedShare(_.hhLiquidityShortfallFinancingShare),
       interpretation = "Share of same-month liquidity shortfall financing routed to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "CapitalShare",
+      amount = _.bankCapital,
+      share = observedShare(_.bankCapitalShare),
+      interpretation = "Share of closing bank capital carried by the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "CapitalBufferShare",
+      amount = _.bankCapitalBuffer,
+      share = denominatorShare(_.bankCapitalBuffer),
+      interpretation = "Share of aggregate capital buffer carried by the top bank.",
     ),
     ConcentrationMetric(
       id = "RwaShare",
       amount = _.bankRwa,
-      share = _.bankRwaShare,
+      share = observedShare(_.bankRwaShare),
       interpretation = "Share of inferred bank RWA denominator carried by the top bank.",
     ),
   )
@@ -568,7 +592,7 @@ object HhBankLeadLagDiagnosticsExport:
               peakMonth = row.month,
               bankId = row.bankId,
               bankName = row.bankName,
-              topShare = metric.share(row),
+              topShare = metric.share(row, denominator),
               amount = amount,
               denominator = denominator,
               bankConsumerLoanShare = row.bankConsumerLoanShare,
@@ -591,10 +615,11 @@ object HhBankLeadLagDiagnosticsExport:
       .toVector
       .flatMap: (_, monthRows) =>
         val denominator = monthRows.map(metric.amount).sum
-        monthRows.map(row => (row, metric.amount(row), denominator))
+        if denominator > BigDecimal(0) then monthRows.map(row => (row, metric.amount(row), denominator))
+        else Vector.empty
 
-    candidates.maxByOption: (row, amount, _) =>
-      (metric.share(row), amount, -row.month, -row.bankId)
+    candidates.maxByOption: (row, amount, denominator) =>
+      (metric.share(row, denominator), amount, -row.month, -row.bankId)
 
   private[diagnostics] def pearson(pairs: Vector[(BigDecimal, BigDecimal)]): Option[BigDecimal] =
     if pairs.length < 2 then None
@@ -937,7 +962,7 @@ object HhBankLeadLagDiagnosticsExport:
     if rows.isEmpty then "No baseline first-failure rows in the observed horizon."
     else
       val header =
-        "| Seed | Month | Bank | Reason | Consumer Default Share | Bridge Charge-Off Share | Consumer Loan Share | RWA Share | CAR | Min CAR | Capital Buffer / RWA |"
+        "| Seed | Month | Bank | Reason | HhConsumerLoanDefaultShare | Bridge Charge-Off Share | Consumer Loan Share | RWA Share | CAR | Min CAR | Capital Buffer / RWA |"
       val sep    = "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
       val body   = rows.map: row =>
         s"| ${row.seed} | ${row.month} | ${row.bankId} ${row.bankName} | ${row.bankFailureReasonCode} | ${renderDecimal(row.hhConsumerLoanDefaultShare)} | ${renderDecimal(row.hhLiquidityBridgeChargeOffShare)} | ${renderDecimal(row.bankConsumerLoanShare)} | ${renderDecimal(row.bankRwaShare)} | ${renderDecimal(row.bankCar)} | ${renderDecimal(row.bankEffectiveMinCar)} | ${renderDecimal(row.bankCapitalBufferToRwa)} |"

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExport.scala
@@ -3,6 +3,7 @@ package com.boombustgroup.amorfati.diagnostics
 import com.boombustgroup.amorfati.agents.Banking
 import com.boombustgroup.amorfati.config.{HhBankLeadLagScenarios, SimParams}
 import com.boombustgroup.amorfati.engine.ledger.{CorporateBondOwnership, LedgerFinancialState}
+import com.boombustgroup.amorfati.engine.mechanisms.Macroprudential
 import com.boombustgroup.amorfati.fp.FixedPointBase
 import com.boombustgroup.amorfati.montecarlo.{McDiagnosticRunner, McSeedMonth, McTsvFile, McTsvSchema}
 import com.boombustgroup.amorfati.types.*
@@ -40,6 +41,9 @@ object HhBankLeadLagDiagnosticsExport:
       bankId: Int,
       bankName: String,
       householdCount: Int,
+      householdShare: BigDecimal,
+      closingHouseholdCount: Int,
+      closingHouseholdShare: BigDecimal,
       hhMonthlyIncome: BigDecimal,
       hhConsumerLoanDefault: BigDecimal,
       hhConsumerInsolvencyDefault: BigDecimal,
@@ -52,12 +56,28 @@ object HhBankLeadLagDiagnosticsExport:
       hhConsumerBankRejectedOrigination: BigDecimal,
       hhConsumerDebtArrears: BigDecimal,
       hhMortgageArrears: BigDecimal,
+      hhConsumerLoanDefaultShare: BigDecimal,
+      hhConsumerInsolvencyDefaultShare: BigDecimal,
+      hhLiquidityBridgeChargeOffShare: BigDecimal,
+      hhLiquidityShortfallFinancingShare: BigDecimal,
       bankConsumerLoanStock: BigDecimal,
+      bankConsumerLoanShare: BigDecimal,
+      bankMortgageLoanStock: BigDecimal,
+      bankMortgageLoanShare: BigDecimal,
+      bankDeposits: BigDecimal,
+      bankDepositShare: BigDecimal,
       bankConsumerNplStock: BigDecimal,
       bankConsumerNplLoss: BigDecimal,
+      bankRwa: BigDecimal,
+      bankRwaShare: BigDecimal,
       bankCapital: BigDecimal,
+      bankCapitalShare: BigDecimal,
       bankCapitalDelta: BigDecimal,
+      bankEffectiveMinCar: BigDecimal,
       bankCar: BigDecimal,
+      bankCarBuffer: BigDecimal,
+      bankCapitalBuffer: BigDecimal,
+      bankCapitalBufferToRwa: BigDecimal,
       bankLcr: BigDecimal,
       bankFailed: Int,
       bankNewFailure: Int,
@@ -95,11 +115,35 @@ object HhBankLeadLagDiagnosticsExport:
       interpretation: String,
   )
 
+  final case class ConcentrationPeakResult(
+      runId: String,
+      scenarioId: String,
+      scenarioLabel: String,
+      seed: Long,
+      metric: String,
+      peakMonth: Int,
+      bankId: Int,
+      bankName: String,
+      topShare: BigDecimal,
+      amount: BigDecimal,
+      denominator: BigDecimal,
+      bankConsumerLoanShare: BigDecimal,
+      householdShare: BigDecimal,
+      bankRwaShare: BigDecimal,
+      bankCapitalBufferToRwa: BigDecimal,
+      bankCar: BigDecimal,
+      bankEffectiveMinCar: BigDecimal,
+      bankNewFailure: Int,
+      bankFailed: Int,
+      interpretation: String,
+  )
+
   final case class ExportResult(
       paths: Vector[Path],
       bankMonthRows: Vector[BankMonthRow],
       correlations: Vector[CorrelationResult],
       counterfactuals: Vector[CounterfactualResult],
+      concentrationPeaks: Vector[ConcentrationPeakResult],
   )
 
   private final class HhBankTotals:
@@ -154,6 +198,70 @@ object HhBankLeadLagDiagnosticsExport:
     "BankNewFailure"      -> (row => BigDecimal(row.bankNewFailure)),
   )
 
+  private final case class ConcentrationMetric(
+      id: String,
+      amount: BankMonthRow => BigDecimal,
+      share: BankMonthRow => BigDecimal,
+      interpretation: String,
+  )
+
+  private val ConcentrationMetrics: Vector[ConcentrationMetric] = Vector(
+    ConcentrationMetric(
+      id = "HouseholdRoutingShare",
+      amount = row => BigDecimal(row.householdCount),
+      share = _.householdShare,
+      interpretation = "Share of household-stage routed households assigned to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "ConsumerLoanExposureShare",
+      amount = _.bankConsumerLoanStock,
+      share = _.bankConsumerLoanShare,
+      interpretation = "Share of closing unsecured consumer-loan stock held by the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "MortgageExposureShare",
+      amount = _.bankMortgageLoanStock,
+      share = _.bankMortgageLoanShare,
+      interpretation = "Share of closing mortgage-loan stock mirrored to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "DepositShare",
+      amount = _.bankDeposits,
+      share = _.bankDepositShare,
+      interpretation = "Share of closing customer deposits assigned to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "ConsumerLoanDefaultFlowShare",
+      amount = _.hhConsumerLoanDefault,
+      share = _.hhConsumerLoanDefaultShare,
+      interpretation = "Share of ordinary consumer-loan default flow routed to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "ConsumerInsolvencyDefaultFlowShare",
+      amount = _.hhConsumerInsolvencyDefault,
+      share = _.hhConsumerInsolvencyDefaultShare,
+      interpretation = "Share of personal-insolvency consumer default flow routed to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "LiquidityBridgeChargeOffFlowShare",
+      amount = _.hhLiquidityBridgeChargeOff,
+      share = _.hhLiquidityBridgeChargeOffShare,
+      interpretation = "Share of same-month liquidity-bridge charge-off flow routed to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "LiquidityShortfallFinancingFlowShare",
+      amount = _.hhLiquidityShortfallFinancing,
+      share = _.hhLiquidityShortfallFinancingShare,
+      interpretation = "Share of same-month liquidity shortfall financing routed to the top bank.",
+    ),
+    ConcentrationMetric(
+      id = "RwaShare",
+      amount = _.bankRwa,
+      share = _.bankRwaShare,
+      interpretation = "Share of inferred bank RWA denominator carried by the top bank.",
+    ),
+  )
+
   def main(args: Array[String]): Unit =
     parseArgs(args.toVector) match
       case Left(err)     =>
@@ -191,8 +299,9 @@ object HhBankLeadLagDiagnosticsExport:
         .map(_.result())
       correlations    = computeCorrelations(validConfig, bankRows)
       counterfactuals = summarizeCounterfactuals(validConfig, bankRows)
-      paths          <- writeArtifactsZIO(validConfig, correlations, counterfactuals)
-    yield ExportResult(paths, bankRows, correlations, counterfactuals)
+      peaks           = summarizeConcentrationPeaks(validConfig, bankRows)
+      paths          <- writeArtifactsZIO(validConfig, bankRows, correlations, counterfactuals, peaks)
+    yield ExportResult(paths, bankRows, correlations, counterfactuals, peaks)
 
   def parseArgs(args: Vector[String]): Either[String, Config] =
     def missingValue(flag: String): Left[String, Config] = Left(s"Missing value for $flag")
@@ -273,7 +382,8 @@ object HhBankLeadLagDiagnosticsExport:
       s"HH-bank diagnostics require aligned opening and closing bank rows, got ${seedMonth.openingState.banks.length} opening banks and $nBanks closing banks",
     )
 
-    val hhTotals = Array.tabulate(nBanks)(_ => HhBankTotals())
+    val hhTotals               = Array.tabulate(nBanks)(_ => HhBankTotals())
+    val closingHouseholdCounts = Array.fill(nBanks)(0)
     seedMonth.householdSnapshotState.households
       .zip(seedMonth.householdMonthlyFlows)
       .foreach: (household, flow) =>
@@ -285,22 +395,47 @@ object HhBankLeadLagDiagnosticsExport:
         require(bankId >= 0 && bankId < nBanks, s"Household ${household.id.toInt} references invalid bank id $bankId for $nBanks banks")
         hhTotals(bankId).add(flow)
 
-    val bankStocks        = seedMonth.state.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
-    val failureDiagnostic = seedMonth.state.world.flows.bankFailure
-    val unemployment      = fixed(seedMonth.state.world.unemploymentRate(seedMonth.state.householdAggregates.employed).toLong)
-    val inflation         = fixed(seedMonth.state.world.inflation.toLong)
-    val monthlyGdp        = pln(seedMonth.state.world.cachedMonthlyGdpProxy)
+    seedMonth.state.households.foreach: household =>
+      val bankId = household.bankId.toInt
+      require(bankId >= 0 && bankId < nBanks, s"Closing household ${household.id.toInt} references invalid bank id $bankId for $nBanks banks")
+      closingHouseholdCounts(bankId) += 1
+
+    val bankStocks                       = seedMonth.state.ledgerFinancialState.banks.map(LedgerFinancialState.projectBankFinancialStocks)
+    val corpBondHoldings                 = seedMonth.state.banks.map(bank => CorporateBondOwnership.bankHolderFor(seedMonth.state.ledgerFinancialState, bank.id))
+    val bankRwas                         = seedMonth.state.banks
+      .zip(bankStocks)
+      .zip(corpBondHoldings)
+      .map { case ((bank, stocks), corpBond) => inferredRwa(bank, stocks, corpBond) }
+    val totalHouseholds                  = seedMonth.householdSnapshotState.households.length
+    val totalClosingHh                   = seedMonth.state.households.length
+    val totalConsumerLoanDefault         = hhTotals.iterator.map(_.consumerLoanDefault).sumPln
+    val totalConsumerInsolvencyDefault   = hhTotals.iterator.map(_.consumerInsolvencyDefault).sumPln
+    val totalLiquidityBridgeChargeOff    = hhTotals.iterator.map(_.liquidityBridgeChargeOff).sumPln
+    val totalLiquidityShortfallFinancing = hhTotals.iterator.map(_.liquidityShortfallFinancing).sumPln
+    val totalConsumerLoans               = bankStocks.map(_.consumerLoan).sumPln
+    val totalMortgageLoans               = bankStocks.map(_.mortgageLoan).sumPln
+    val totalDeposits                    = bankStocks.map(_.totalDeposits).sumPln
+    val totalBankRwa                     = bankRwas.sumPln
+    val totalBankCapital                 = seedMonth.state.banks.map(_.capital).sumPln
+    val failureDiagnostic                = seedMonth.state.world.flows.bankFailure
+    val unemployment                     = fixed(seedMonth.state.world.unemploymentRate(seedMonth.state.householdAggregates.employed).toLong)
+    val inflation                        = fixed(seedMonth.state.world.inflation.toLong)
+    val monthlyGdp                       = pln(seedMonth.state.world.cachedMonthlyGdpProxy)
 
     seedMonth.state.banks.zipWithIndex.map: (bank, idx) =>
       val stocks            = bankStocks(idx)
       val openingBank       = seedMonth.openingState.banks(idx)
-      val corpBondHoldings  = CorporateBondOwnership.bankHolderFor(seedMonth.state.ledgerFinancialState, bank.id)
       val totals            = hhTotals(idx)
       val bankConsumerLoss  = consumerNplLoss(totals.consumerLoanDefault, totals.consumerInsolvencyDefault)
       val newFailure        = if !openingBank.failed && bank.failed then 1 else 0
       val failureReasonCode =
         if newFailure == 1 && failureDiagnostic.firstNewBankId == bank.id.toInt then failureDiagnostic.firstNewReasonCode
         else 0
+      val corpBond          = corpBondHoldings(idx)
+      val bankRwa           = bankRwas(idx)
+      val bankCar           = Banking.car(bank, stocks, corpBond)
+      val effectiveMinCar   = Macroprudential.effectiveMinCar(bank.id.toInt, seedMonth.state.world.mechanisms.macropru.ccyb)
+      val capitalBuffer     = bank.capital - (bankRwa * effectiveMinCar)
       BankMonthRow(
         runId = config.runId,
         scenarioId = scenario.id,
@@ -310,6 +445,9 @@ object HhBankLeadLagDiagnosticsExport:
         bankId = bank.id.toInt,
         bankName = bankName(idx),
         householdCount = totals.householdCount,
+        householdShare = countRatio(totals.householdCount, totalHouseholds),
+        closingHouseholdCount = closingHouseholdCounts(idx),
+        closingHouseholdShare = countRatio(closingHouseholdCounts(idx), totalClosingHh),
         hhMonthlyIncome = pln(totals.monthlyIncome),
         hhConsumerLoanDefault = pln(totals.consumerLoanDefault),
         hhConsumerInsolvencyDefault = pln(totals.consumerInsolvencyDefault),
@@ -322,12 +460,28 @@ object HhBankLeadLagDiagnosticsExport:
         hhConsumerBankRejectedOrigination = pln(totals.consumerBankRejectedOrigination),
         hhConsumerDebtArrears = pln(totals.consumerDebtArrears),
         hhMortgageArrears = pln(totals.mortgageArrears),
+        hhConsumerLoanDefaultShare = finiteRatio(totals.consumerLoanDefault, totalConsumerLoanDefault),
+        hhConsumerInsolvencyDefaultShare = finiteRatio(totals.consumerInsolvencyDefault, totalConsumerInsolvencyDefault),
+        hhLiquidityBridgeChargeOffShare = finiteRatio(totals.liquidityBridgeChargeOff, totalLiquidityBridgeChargeOff),
+        hhLiquidityShortfallFinancingShare = finiteRatio(totals.liquidityShortfallFinancing, totalLiquidityShortfallFinancing),
         bankConsumerLoanStock = pln(stocks.consumerLoan),
+        bankConsumerLoanShare = finiteRatio(stocks.consumerLoan, totalConsumerLoans),
+        bankMortgageLoanStock = pln(stocks.mortgageLoan),
+        bankMortgageLoanShare = finiteRatio(stocks.mortgageLoan, totalMortgageLoans),
+        bankDeposits = pln(stocks.totalDeposits),
+        bankDepositShare = finiteRatio(stocks.totalDeposits, totalDeposits),
         bankConsumerNplStock = pln(bank.consumerNpl),
         bankConsumerNplLoss = pln(bankConsumerLoss),
+        bankRwa = pln(bankRwa),
+        bankRwaShare = finiteRatio(bankRwa, totalBankRwa),
         bankCapital = pln(bank.capital),
+        bankCapitalShare = finiteRatio(bank.capital, totalBankCapital),
         bankCapitalDelta = pln(bank.capital - openingBank.capital),
-        bankCar = fixed(Banking.car(bank, stocks, corpBondHoldings).toLong),
+        bankEffectiveMinCar = fixed(effectiveMinCar.toLong),
+        bankCar = fixed(bankCar.toLong),
+        bankCarBuffer = fixed((bankCar - effectiveMinCar).toLong),
+        bankCapitalBuffer = pln(capitalBuffer),
+        bankCapitalBufferToRwa = finiteRatio(capitalBuffer, bankRwa),
         bankLcr = fixed(Banking.lcr(stocks).toLong),
         bankFailed = if bank.failed then 1 else 0,
         bankNewFailure = newFailure,
@@ -396,6 +550,52 @@ object HhBankLeadLagDiagnosticsExport:
         interpretation = scenario.interpretation,
       )
 
+  private[diagnostics] def summarizeConcentrationPeaks(config: Config, rows: Vector[BankMonthRow]): Vector[ConcentrationPeakResult] =
+    val byScenarioSeed = rows.groupBy(row => (row.scenarioId, row.scenarioLabel, row.seed))
+    byScenarioSeed.toVector
+      .sortBy { case ((scenarioId, _, seed), _) => (scenarioId, seed) }
+      .flatMap: (key, seedRows) =>
+        val (scenarioId, scenarioLabel, seed) = key
+        ConcentrationMetrics.flatMap: metric =>
+          peakForMetric(seedRows, metric).map: peak =>
+            val (row, amount, denominator) = peak
+            ConcentrationPeakResult(
+              runId = config.runId,
+              scenarioId = scenarioId,
+              scenarioLabel = scenarioLabel,
+              seed = seed,
+              metric = metric.id,
+              peakMonth = row.month,
+              bankId = row.bankId,
+              bankName = row.bankName,
+              topShare = metric.share(row),
+              amount = amount,
+              denominator = denominator,
+              bankConsumerLoanShare = row.bankConsumerLoanShare,
+              householdShare = row.householdShare,
+              bankRwaShare = row.bankRwaShare,
+              bankCapitalBufferToRwa = row.bankCapitalBufferToRwa,
+              bankCar = row.bankCar,
+              bankEffectiveMinCar = row.bankEffectiveMinCar,
+              bankNewFailure = row.bankNewFailure,
+              bankFailed = row.bankFailed,
+              interpretation = metric.interpretation,
+            )
+
+  private def peakForMetric(
+      rows: Vector[BankMonthRow],
+      metric: ConcentrationMetric,
+  ): Option[(BankMonthRow, BigDecimal, BigDecimal)] =
+    val candidates = rows
+      .groupBy(_.month)
+      .toVector
+      .flatMap: (_, monthRows) =>
+        val denominator = monthRows.map(metric.amount).sum
+        monthRows.map(row => (row, metric.amount(row), denominator))
+
+    candidates.maxByOption: (row, amount, _) =>
+      (metric.share(row), amount, -row.month, -row.bankId)
+
   private[diagnostics] def pearson(pairs: Vector[(BigDecimal, BigDecimal)]): Option[BigDecimal] =
     if pairs.length < 2 then None
     else
@@ -412,18 +612,22 @@ object HhBankLeadLagDiagnosticsExport:
 
   private def writeArtifactsZIO(
       config: Config,
+      bankRows: Vector[BankMonthRow],
       correlations: Vector[CorrelationResult],
       counterfactuals: Vector[CounterfactualResult],
+      concentrationPeaks: Vector[ConcentrationPeakResult],
   ): ZIO[Any, String, Vector[Path]] =
     val bankRowsPath        = config.runRoot.resolve("hh-bank-lead-lag-bank-months.tsv")
     val correlationsPath    = config.runRoot.resolve("hh-bank-lead-lag-correlations.tsv")
     val counterfactualsPath = config.runRoot.resolve("hh-bank-lead-lag-counterfactuals.tsv")
+    val concentrationPath   = config.runRoot.resolve("hh-bank-lead-lag-concentration-peaks.tsv")
     val reportPath          = config.runRoot.resolve("hh-bank-lead-lag-report.md")
     for
       _ <- McTsvFile.writeAll(correlationsPath, correlations, CorrelationTsvSchema)(DiagnosticIo.outputFailure)
       _ <- McTsvFile.writeAll(counterfactualsPath, counterfactuals, CounterfactualTsvSchema)(DiagnosticIo.outputFailure)
-      _ <- DiagnosticIo.writeText(reportPath, renderReport(config, correlations, counterfactuals))
-    yield Vector(bankRowsPath, correlationsPath, counterfactualsPath, reportPath)
+      _ <- McTsvFile.writeAll(concentrationPath, concentrationPeaks, ConcentrationPeakTsvSchema)(DiagnosticIo.outputFailure)
+      _ <- DiagnosticIo.writeText(reportPath, renderReport(config, bankRows, correlations, counterfactuals, concentrationPeaks))
+    yield Vector(bankRowsPath, correlationsPath, counterfactualsPath, concentrationPath, reportPath)
 
   private val BankMonthTsvSchema: McTsvSchema[BankMonthRow] =
     val header = McTsvSchema.header(
@@ -435,6 +639,9 @@ object HhBankLeadLagDiagnosticsExport:
       "BankId",
       "BankName",
       "HouseholdCount",
+      "HouseholdShare",
+      "ClosingHouseholdCount",
+      "ClosingHouseholdShare",
       "HhMonthlyIncome",
       "HhConsumerLoanDefault",
       "HhConsumerInsolvencyDefault",
@@ -447,12 +654,28 @@ object HhBankLeadLagDiagnosticsExport:
       "HhConsumerBankRejectedOrigination",
       "HhConsumerDebtArrears",
       "HhMortgageArrears",
+      "HhConsumerLoanDefaultShare",
+      "HhConsumerInsolvencyDefaultShare",
+      "HhLiquidityBridgeChargeOffShare",
+      "HhLiquidityShortfallFinancingShare",
       "BankConsumerLoanStock",
+      "BankConsumerLoanShare",
+      "BankMortgageLoanStock",
+      "BankMortgageLoanShare",
+      "BankDeposits",
+      "BankDepositShare",
       "BankConsumerNplStock",
       "BankConsumerNplLoss",
+      "BankRwa",
+      "BankRwaShare",
       "BankCapital",
+      "BankCapitalShare",
       "BankCapitalDelta",
+      "BankEffectiveMinCar",
       "BankCar",
+      "BankCarBuffer",
+      "BankCapitalBuffer",
+      "BankCapitalBufferToRwa",
       "BankLcr",
       "BankFailed",
       "BankNewFailure",
@@ -518,6 +741,56 @@ object HhBankLeadLagDiagnosticsExport:
         ).map(tsv).mkString("\t"),
     )
 
+  private val ConcentrationPeakTsvSchema: McTsvSchema[ConcentrationPeakResult] =
+    val header = McTsvSchema.header(
+      "RunId",
+      "ScenarioId",
+      "ScenarioLabel",
+      "Seed",
+      "Metric",
+      "PeakMonth",
+      "BankId",
+      "BankName",
+      "TopShare",
+      "Amount",
+      "Denominator",
+      "BankConsumerLoanShare",
+      "HouseholdShare",
+      "BankRwaShare",
+      "BankCapitalBufferToRwa",
+      "BankCar",
+      "BankEffectiveMinCar",
+      "BankNewFailure",
+      "BankFailed",
+      "Interpretation",
+    )
+    McTsvSchema(
+      header,
+      row =>
+        Vector(
+          row.runId,
+          row.scenarioId,
+          row.scenarioLabel,
+          row.seed.toString,
+          row.metric,
+          row.peakMonth.toString,
+          row.bankId.toString,
+          row.bankName,
+          renderDecimal(row.topShare),
+          renderDecimal(row.amount),
+          renderDecimal(row.denominator),
+          renderDecimal(row.bankConsumerLoanShare),
+          renderDecimal(row.householdShare),
+          renderDecimal(row.bankRwaShare),
+          renderDecimal(row.bankCapitalBufferToRwa),
+          renderDecimal(row.bankCar),
+          renderDecimal(row.bankEffectiveMinCar),
+          row.bankNewFailure.toString,
+          row.bankFailed.toString,
+          row.interpretation,
+        ).map(tsv).mkString("\t"),
+    )
+
   private def renderBankMonthRow(row: BankMonthRow): String =
     Vector(
       row.runId,
@@ -528,6 +801,9 @@ object HhBankLeadLagDiagnosticsExport:
       row.bankId.toString,
       row.bankName,
       row.householdCount.toString,
+      renderDecimal(row.householdShare),
+      row.closingHouseholdCount.toString,
+      renderDecimal(row.closingHouseholdShare),
       renderDecimal(row.hhMonthlyIncome),
       renderDecimal(row.hhConsumerLoanDefault),
       renderDecimal(row.hhConsumerInsolvencyDefault),
@@ -540,12 +816,28 @@ object HhBankLeadLagDiagnosticsExport:
       renderDecimal(row.hhConsumerBankRejectedOrigination),
       renderDecimal(row.hhConsumerDebtArrears),
       renderDecimal(row.hhMortgageArrears),
+      renderDecimal(row.hhConsumerLoanDefaultShare),
+      renderDecimal(row.hhConsumerInsolvencyDefaultShare),
+      renderDecimal(row.hhLiquidityBridgeChargeOffShare),
+      renderDecimal(row.hhLiquidityShortfallFinancingShare),
       renderDecimal(row.bankConsumerLoanStock),
+      renderDecimal(row.bankConsumerLoanShare),
+      renderDecimal(row.bankMortgageLoanStock),
+      renderDecimal(row.bankMortgageLoanShare),
+      renderDecimal(row.bankDeposits),
+      renderDecimal(row.bankDepositShare),
       renderDecimal(row.bankConsumerNplStock),
       renderDecimal(row.bankConsumerNplLoss),
+      renderDecimal(row.bankRwa),
+      renderDecimal(row.bankRwaShare),
       renderDecimal(row.bankCapital),
+      renderDecimal(row.bankCapitalShare),
       renderDecimal(row.bankCapitalDelta),
+      renderDecimal(row.bankEffectiveMinCar),
       renderDecimal(row.bankCar),
+      renderDecimal(row.bankCarBuffer),
+      renderDecimal(row.bankCapitalBuffer),
+      renderDecimal(row.bankCapitalBufferToRwa),
       renderDecimal(row.bankLcr),
       row.bankFailed.toString,
       row.bankNewFailure.toString,
@@ -555,14 +847,26 @@ object HhBankLeadLagDiagnosticsExport:
       renderDecimal(row.monthlyGdpProxy),
     ).map(tsv).mkString("\t")
 
-  private def renderReport(config: Config, correlations: Vector[CorrelationResult], counterfactuals: Vector[CounterfactualResult]): String =
-    val baseline = counterfactuals.find(_.scenarioId == "baseline")
-    val noHit    = counterfactuals.find(_.scenarioId == "no-consumer-npl-capital-hit")
-    val topCorr  = correlations
+  private def renderReport(
+      config: Config,
+      bankRows: Vector[BankMonthRow],
+      correlations: Vector[CorrelationResult],
+      counterfactuals: Vector[CounterfactualResult],
+      concentrationPeaks: Vector[ConcentrationPeakResult],
+  ): String =
+    val baseline      = counterfactuals.find(_.scenarioId == "baseline")
+    val noHit         = counterfactuals.find(_.scenarioId == "no-consumer-npl-capital-hit")
+    val topCorr       = correlations
       .filter(row => row.scenarioId == "baseline" && row.lagMonths > 0 && row.correlation.isDefined)
       .sortBy(row => -row.correlation.get.abs)
       .take(10)
-    val command  =
+    val baselinePeaks = concentrationPeaks
+      .filter(_.scenarioId == "baseline")
+      .sortBy(row => (row.seed, row.metric))
+    val firstFailures = bankRows
+      .filter(row => row.scenarioId == "baseline" && row.bankNewFailure > 0)
+      .sortBy(row => (row.seed, row.month, row.bankId))
+    val command       =
       s"""sbt "hhBankLeadLagDiagnostics --seed-start ${config.seedStart} --seeds ${config.seeds} --months ${config.months} --lag-max ${config.lagMax} --out ${config.out} --run-id ${config.runId}""""
     Vector(
       "# HH-to-Bank Lead-Lag Diagnostics",
@@ -579,6 +883,8 @@ object HhBankLeadLagDiagnosticsExport:
       "bank consumer-credit loss, capital, CAR, LCR, and failure outcomes. The",
       "correlation table is descriptive lead-lag evidence; the counterfactual table",
       "tests whether the direct consumer NPL capital-hit channel is necessary in this fixture.",
+      "Concentration shares make the household-to-bank routing and product-specific",
+      "consumer-credit flow concentration directly visible before failures occur.",
       "",
       "## Counterfactual Summary",
       "",
@@ -591,6 +897,14 @@ object HhBankLeadLagDiagnosticsExport:
       "## Strongest Positive-Lag Baseline Correlations",
       "",
       correlationTable(topCorr),
+      "",
+      "## Baseline Concentration Peaks",
+      "",
+      concentrationTable(baselinePeaks),
+      "",
+      "## Baseline First Failure Rows",
+      "",
+      firstFailureTable(firstFailures),
       "",
     ).mkString("\n")
 
@@ -610,6 +924,25 @@ object HhBankLeadLagDiagnosticsExport:
         s"| ${row.lagMonths} | ${row.hhMetric} | ${row.bankMetric} | ${row.observations} | ${row.correlation.map(renderDecimal).getOrElse("NA")} |"
       (header +: sep +: body).mkString("\n")
 
+  private def concentrationTable(rows: Vector[ConcentrationPeakResult]): String =
+    if rows.isEmpty then "No baseline concentration peak rows."
+    else
+      val header = "| Seed | Metric | Month | Bank | Top Share | Amount | Denominator | Consumer Loan Share | RWA Share | Capital Buffer / RWA |"
+      val sep    = "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+      val body   = rows.map: row =>
+        s"| ${row.seed} | ${row.metric} | ${row.peakMonth} | ${row.bankId} ${row.bankName} | ${renderDecimal(row.topShare)} | ${renderDecimal(row.amount)} | ${renderDecimal(row.denominator)} | ${renderDecimal(row.bankConsumerLoanShare)} | ${renderDecimal(row.bankRwaShare)} | ${renderDecimal(row.bankCapitalBufferToRwa)} |"
+      (header +: sep +: body).mkString("\n")
+
+  private def firstFailureTable(rows: Vector[BankMonthRow]): String =
+    if rows.isEmpty then "No baseline first-failure rows in the observed horizon."
+    else
+      val header =
+        "| Seed | Month | Bank | Reason | Consumer Default Share | Bridge Charge-Off Share | Consumer Loan Share | RWA Share | CAR | Min CAR | Capital Buffer / RWA |"
+      val sep    = "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+      val body   = rows.map: row =>
+        s"| ${row.seed} | ${row.month} | ${row.bankId} ${row.bankName} | ${row.bankFailureReasonCode} | ${renderDecimal(row.hhConsumerLoanDefaultShare)} | ${renderDecimal(row.hhLiquidityBridgeChargeOffShare)} | ${renderDecimal(row.bankConsumerLoanShare)} | ${renderDecimal(row.bankRwaShare)} | ${renderDecimal(row.bankCar)} | ${renderDecimal(row.bankEffectiveMinCar)} | ${renderDecimal(row.bankCapitalBufferToRwa)} |"
+      (header +: sep +: body).mkString("\n")
+
   private def causalReading(baseline: Option[CounterfactualResult], noHit: Option[CounterfactualResult]): String =
     (baseline, noHit) match
       case (Some(base), Some(counter)) =>
@@ -619,11 +952,25 @@ object HhBankLeadLagDiagnosticsExport:
       case _                           =>
         "Counterfactual rows are incomplete; counterfactual reading unavailable."
 
+  private def inferredRwa(bank: Banking.BankState, stocks: Banking.BankFinancialStocks, corpBondHoldings: PLN)(using p: SimParams): PLN =
+    val car      = Banking.car(bank, stocks, corpBondHoldings)
+    val baseRwa  = Banking.riskWeightedAssets(stocks, corpBondHoldings)
+    val ratioRwa =
+      if car > Multiplier.Zero && bank.capital > PLN.Zero then bank.capital / car
+      else PLN.Zero
+    ratioRwa.max(baseRwa)
+
   private def pln(value: PLN)(using p: SimParams): BigDecimal =
     fixed(polandScale(value).toLong)
 
   private def polandScale(value: PLN)(using p: SimParams): PLN =
     if p.gdpRatio > Scalar.Zero then value / p.gdpRatio.toMultiplier else value
+
+  private def finiteRatio(numerator: PLN, denominator: PLN): BigDecimal =
+    if denominator > PLN.Zero then fixed(numerator.ratioTo(denominator).toLong) else BigDecimal(0)
+
+  private def countRatio(numerator: Int, denominator: Int): BigDecimal =
+    if denominator > 0 then BigDecimal(numerator) / BigDecimal(denominator) else BigDecimal(0)
 
   private def fixed(raw: Long): BigDecimal =
     BigDecimal(raw) / BigDecimal(FixedPointBase.Scale)
@@ -661,5 +1008,6 @@ object HhBankLeadLagDiagnosticsExport:
       |- hh-bank-lead-lag-bank-months.tsv
       |- hh-bank-lead-lag-correlations.tsv
       |- hh-bank-lead-lag-counterfactuals.tsv
+      |- hh-bank-lead-lag-concentration-peaks.tsv
       |- hh-bank-lead-lag-report.md
       |""".stripMargin

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
@@ -72,6 +72,24 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
     summary.find(_.scenarioId == "no-consumer-npl-capital-hit").value.failedSeeds shouldBe 0
   }
 
+  "HhBankLeadLagDiagnosticsExport.summarizeConcentrationPeaks" should "locate peak per-bank household default-flow concentration" in {
+    val rows = Vector(
+      row(month = 1, bankId = 0, hhConsumerLoanDefault = BigDecimal(10), hhConsumerLoanDefaultShare = BigDecimal("0.25"), bankConsumerNplLoss = BigDecimal(8)),
+      row(month = 1, bankId = 1, hhConsumerLoanDefault = BigDecimal(30), hhConsumerLoanDefaultShare = BigDecimal("0.75"), bankConsumerNplLoss = BigDecimal(24)),
+      row(month = 2, bankId = 0, hhConsumerLoanDefault = BigDecimal(45), hhConsumerLoanDefaultShare = BigDecimal("0.90"), bankConsumerNplLoss = BigDecimal(36)),
+      row(month = 2, bankId = 1, hhConsumerLoanDefault = BigDecimal(5), hhConsumerLoanDefaultShare = BigDecimal("0.10"), bankConsumerNplLoss = BigDecimal(4)),
+    )
+
+    val peaks = HhBankLeadLagDiagnosticsExport.summarizeConcentrationPeaks(HhBankLeadLagDiagnosticsExport.Config(seeds = 1, months = 2), rows)
+    val peak  = peaks.find(_.metric == "ConsumerLoanDefaultFlowShare").value
+
+    peak.peakMonth shouldBe 2
+    peak.bankId shouldBe 0
+    peak.topShare shouldBe BigDecimal("0.90")
+    peak.amount shouldBe BigDecimal(45)
+    peak.denominator shouldBe BigDecimal(50)
+  }
+
   private def row(
       scenarioId: String = "baseline",
       scenarioLabel: String = "Baseline",
@@ -79,6 +97,7 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
       month: Int,
       bankId: Int = 0,
       hhConsumerLoanDefault: BigDecimal,
+      hhConsumerLoanDefaultShare: BigDecimal = BigDecimal(1),
       bankConsumerNplLoss: BigDecimal,
       bankNewFailure: Int = 0,
       bankFailed: Int = 0,
@@ -92,6 +111,9 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
       bankId = bankId,
       bankName = s"Bank-$bankId",
       householdCount = 1,
+      householdShare = BigDecimal(1),
+      closingHouseholdCount = 1,
+      closingHouseholdShare = BigDecimal(1),
       hhMonthlyIncome = BigDecimal(100),
       hhConsumerLoanDefault = hhConsumerLoanDefault,
       hhConsumerInsolvencyDefault = BigDecimal(0),
@@ -104,12 +126,28 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
       hhConsumerBankRejectedOrigination = BigDecimal(0),
       hhConsumerDebtArrears = BigDecimal(0),
       hhMortgageArrears = BigDecimal(0),
+      hhConsumerLoanDefaultShare = hhConsumerLoanDefaultShare,
+      hhConsumerInsolvencyDefaultShare = BigDecimal(0),
+      hhLiquidityBridgeChargeOffShare = BigDecimal(0),
+      hhLiquidityShortfallFinancingShare = BigDecimal(0),
       bankConsumerLoanStock = BigDecimal(1000),
+      bankConsumerLoanShare = BigDecimal(1),
+      bankMortgageLoanStock = BigDecimal(0),
+      bankMortgageLoanShare = BigDecimal(0),
+      bankDeposits = BigDecimal(1000),
+      bankDepositShare = BigDecimal(1),
       bankConsumerNplStock = BigDecimal(0),
       bankConsumerNplLoss = bankConsumerNplLoss,
+      bankRwa = BigDecimal(1000),
+      bankRwaShare = BigDecimal(1),
       bankCapital = BigDecimal(100),
+      bankCapitalShare = BigDecimal(1),
       bankCapitalDelta = -bankConsumerNplLoss,
+      bankEffectiveMinCar = BigDecimal("0.08"),
       bankCar = BigDecimal("0.1"),
+      bankCarBuffer = BigDecimal("0.02"),
+      bankCapitalBuffer = BigDecimal(20),
+      bankCapitalBufferToRwa = BigDecimal("0.02"),
       bankLcr = BigDecimal("1.0"),
       bankFailed = bankFailed,
       bankNewFailure = bankNewFailure,

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HhBankLeadLagDiagnosticsExportSpec.scala
@@ -74,10 +74,38 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
 
   "HhBankLeadLagDiagnosticsExport.summarizeConcentrationPeaks" should "locate peak per-bank household default-flow concentration" in {
     val rows = Vector(
-      row(month = 1, bankId = 0, hhConsumerLoanDefault = BigDecimal(10), hhConsumerLoanDefaultShare = BigDecimal("0.25"), bankConsumerNplLoss = BigDecimal(8)),
-      row(month = 1, bankId = 1, hhConsumerLoanDefault = BigDecimal(30), hhConsumerLoanDefaultShare = BigDecimal("0.75"), bankConsumerNplLoss = BigDecimal(24)),
-      row(month = 2, bankId = 0, hhConsumerLoanDefault = BigDecimal(45), hhConsumerLoanDefaultShare = BigDecimal("0.90"), bankConsumerNplLoss = BigDecimal(36)),
-      row(month = 2, bankId = 1, hhConsumerLoanDefault = BigDecimal(5), hhConsumerLoanDefaultShare = BigDecimal("0.10"), bankConsumerNplLoss = BigDecimal(4)),
+      row(
+        month = 1,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(10),
+        hhConsumerLoanDefaultShare = BigDecimal("0.25"),
+        bankConsumerNplLoss = BigDecimal(8),
+      ),
+      row(
+        month = 1,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(30),
+        hhConsumerLoanDefaultShare = BigDecimal("0.75"),
+        bankConsumerNplLoss = BigDecimal(24),
+      ),
+      row(
+        month = 2,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(45),
+        hhConsumerLoanDefaultShare = BigDecimal("0.90"),
+        bankConsumerNplLoss = BigDecimal(36),
+      ),
+      row(
+        month = 2,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(5),
+        hhConsumerLoanDefaultShare = BigDecimal("0.10"),
+        bankConsumerNplLoss = BigDecimal(4),
+      ),
     )
 
     val peaks = HhBankLeadLagDiagnosticsExport.summarizeConcentrationPeaks(HhBankLeadLagDiagnosticsExport.Config(seeds = 1, months = 2), rows)
@@ -90,18 +118,147 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
     peak.denominator shouldBe BigDecimal(50)
   }
 
+  it should "skip zero-denominator months and use deterministic concentration tie-breaks" in {
+    val rows = Vector(
+      row(
+        month = 1,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(0),
+        hhConsumerLoanDefaultShare = BigDecimal(1),
+        bankConsumerNplLoss = BigDecimal(0),
+        bankDeposits = BigDecimal(0),
+        bankDepositShare = Some(BigDecimal(0)),
+      ),
+      row(
+        month = 1,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(0),
+        hhConsumerLoanDefaultShare = BigDecimal(1),
+        bankConsumerNplLoss = BigDecimal(0),
+        bankDeposits = BigDecimal(0),
+        bankDepositShare = Some(BigDecimal(0)),
+      ),
+      row(
+        month = 2,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(50),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(40),
+        bankDeposits = BigDecimal(10),
+        bankDepositShare = Some(BigDecimal("0.25")),
+      ),
+      row(
+        month = 2,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(50),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(40),
+        bankDeposits = BigDecimal(30),
+        bankDepositShare = Some(BigDecimal("0.75")),
+      ),
+      row(
+        month = 4,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(75),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(60),
+        bankDeposits = BigDecimal(20),
+        bankDepositShare = Some(BigDecimal("0.50")),
+        bankCapitalBuffer = BigDecimal(30),
+      ),
+      row(
+        month = 4,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(75),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(60),
+        bankDeposits = BigDecimal(20),
+        bankDepositShare = Some(BigDecimal("0.50")),
+        bankCapitalBuffer = BigDecimal(10),
+      ),
+      row(
+        month = 5,
+        bankId = 0,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(75),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(60),
+        bankDeposits = BigDecimal(20),
+        bankDepositShare = Some(BigDecimal("0.50")),
+        bankCapitalBuffer = BigDecimal(20),
+      ),
+      row(
+        month = 5,
+        bankId = 1,
+        bankCount = 2,
+        hhConsumerLoanDefault = BigDecimal(75),
+        hhConsumerLoanDefaultShare = BigDecimal("0.50"),
+        bankConsumerNplLoss = BigDecimal(60),
+        bankDeposits = BigDecimal(20),
+        bankDepositShare = Some(BigDecimal("0.50")),
+        bankCapitalBuffer = BigDecimal(20),
+      ),
+    )
+
+    val peaks       = HhBankLeadLagDiagnosticsExport.summarizeConcentrationPeaks(HhBankLeadLagDiagnosticsExport.Config(seeds = 1, months = 5), rows)
+    val defaultPeak = peaks.find(_.metric == "ConsumerLoanDefaultFlowShare").value
+
+    defaultPeak.peakMonth shouldBe 4
+    defaultPeak.bankId shouldBe 0
+    defaultPeak.topShare shouldBe BigDecimal("0.50")
+    defaultPeak.amount shouldBe BigDecimal(75)
+    defaultPeak.denominator shouldBe BigDecimal(150)
+
+    val depositPeak = peaks.find(_.metric == "DepositShare").value
+    depositPeak.peakMonth shouldBe 2
+    depositPeak.bankId shouldBe 1
+    depositPeak.topShare shouldBe BigDecimal("0.75")
+    depositPeak.amount shouldBe BigDecimal(30)
+    depositPeak.denominator shouldBe BigDecimal(40)
+
+    val bufferPeak = peaks.find(_.metric == "CapitalBufferShare").value
+    bufferPeak.peakMonth shouldBe 4
+    bufferPeak.bankId shouldBe 0
+    bufferPeak.topShare shouldBe BigDecimal("0.75")
+    bufferPeak.amount shouldBe BigDecimal(30)
+    bufferPeak.denominator shouldBe BigDecimal(40)
+  }
+
   private def row(
       scenarioId: String = "baseline",
       scenarioLabel: String = "Baseline",
       seed: Long = 1L,
       month: Int,
       bankId: Int = 0,
+      bankCount: Int = 1,
       hhConsumerLoanDefault: BigDecimal,
       hhConsumerLoanDefaultShare: BigDecimal = BigDecimal(1),
       bankConsumerNplLoss: BigDecimal,
       bankNewFailure: Int = 0,
       bankFailed: Int = 0,
+      householdCount: Int = 1,
+      closingHouseholdCount: Int = 1,
+      householdShare: Option[BigDecimal] = None,
+      closingHouseholdShare: Option[BigDecimal] = None,
+      bankConsumerLoanStock: BigDecimal = BigDecimal(1000),
+      bankConsumerLoanShare: Option[BigDecimal] = None,
+      bankDeposits: BigDecimal = BigDecimal(1000),
+      bankDepositShare: Option[BigDecimal] = None,
+      bankRwa: BigDecimal = BigDecimal(1000),
+      bankRwaShare: Option[BigDecimal] = None,
+      bankCapital: BigDecimal = BigDecimal(100),
+      bankCapitalShare: Option[BigDecimal] = None,
+      bankCapitalBuffer: BigDecimal = BigDecimal(20),
   ): HhBankLeadLagDiagnosticsExport.BankMonthRow =
+    require(bankCount > 0, "bankCount must be positive")
+    val equalBankShare     = BigDecimal(1) / BigDecimal(bankCount)
+    val capitalBufferToRwa = if bankRwa > BigDecimal(0) then bankCapitalBuffer / bankRwa else BigDecimal(0)
     HhBankLeadLagDiagnosticsExport.BankMonthRow(
       runId = "test",
       scenarioId = scenarioId,
@@ -110,10 +267,10 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
       month = month,
       bankId = bankId,
       bankName = s"Bank-$bankId",
-      householdCount = 1,
-      householdShare = BigDecimal(1),
-      closingHouseholdCount = 1,
-      closingHouseholdShare = BigDecimal(1),
+      householdCount = householdCount,
+      householdShare = householdShare.getOrElse(equalBankShare),
+      closingHouseholdCount = closingHouseholdCount,
+      closingHouseholdShare = closingHouseholdShare.getOrElse(equalBankShare),
       hhMonthlyIncome = BigDecimal(100),
       hhConsumerLoanDefault = hhConsumerLoanDefault,
       hhConsumerInsolvencyDefault = BigDecimal(0),
@@ -130,24 +287,24 @@ class HhBankLeadLagDiagnosticsExportSpec extends AnyFlatSpec with Matchers with 
       hhConsumerInsolvencyDefaultShare = BigDecimal(0),
       hhLiquidityBridgeChargeOffShare = BigDecimal(0),
       hhLiquidityShortfallFinancingShare = BigDecimal(0),
-      bankConsumerLoanStock = BigDecimal(1000),
-      bankConsumerLoanShare = BigDecimal(1),
+      bankConsumerLoanStock = bankConsumerLoanStock,
+      bankConsumerLoanShare = bankConsumerLoanShare.getOrElse(equalBankShare),
       bankMortgageLoanStock = BigDecimal(0),
       bankMortgageLoanShare = BigDecimal(0),
-      bankDeposits = BigDecimal(1000),
-      bankDepositShare = BigDecimal(1),
+      bankDeposits = bankDeposits,
+      bankDepositShare = bankDepositShare.getOrElse(equalBankShare),
       bankConsumerNplStock = BigDecimal(0),
       bankConsumerNplLoss = bankConsumerNplLoss,
-      bankRwa = BigDecimal(1000),
-      bankRwaShare = BigDecimal(1),
-      bankCapital = BigDecimal(100),
-      bankCapitalShare = BigDecimal(1),
+      bankRwa = bankRwa,
+      bankRwaShare = bankRwaShare.getOrElse(equalBankShare),
+      bankCapital = bankCapital,
+      bankCapitalShare = bankCapitalShare.getOrElse(equalBankShare),
       bankCapitalDelta = -bankConsumerNplLoss,
       bankEffectiveMinCar = BigDecimal("0.08"),
       bankCar = BigDecimal("0.1"),
       bankCarBuffer = BigDecimal("0.02"),
-      bankCapitalBuffer = BigDecimal(20),
-      bankCapitalBufferToRwa = BigDecimal("0.02"),
+      bankCapitalBuffer = bankCapitalBuffer,
+      bankCapitalBufferToRwa = capitalBufferToRwa,
       bankLcr = BigDecimal("1.0"),
       bankFailed = bankFailed,
       bankNewFailure = bankNewFailure,


### PR DESCRIPTION
## Summary
- extend HH-bank lead-lag diagnostics with per-bank exposure, default-flow, bridge-flow, RWA, and capital-buffer concentration shares
- emit hh-bank-lead-lag-concentration-peaks.tsv and surface baseline peak/first-failure tables in the report
- document the new #873 audit surface and nightly profile contract

## Verification
- sbt scalafmtAll
- sbt "testOnly com.boombustgroup.amorfati.diagnostics.HhBankLeadLagDiagnosticsExportSpec com.boombustgroup.amorfati.diagnostics.NightlyDiagnosticsProfileRunnerSpec"
- git diff --check
- local seed005 M17 HH-bank audit under target/hh-bank-lead-lag/issue873-seed005-m17

Closes #873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostics export for concentration peaks, with a dedicated TSV file and report section.
  * Expanded bank-month diagnostics with more detailed household flow, product-share, and capital buffer metrics.
  * Added clearer peak-concentration reporting for product closing shares and stress/failure indicators.

* **Documentation**
  * Updated nightly and diagnostics docs to reflect the new export and expanded metric descriptions.

* **Tests**
  * Added coverage for concentration-peak calculations and related output fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->