### PR TITLE
Add baseline HH credit stress peak guardrails

### DIFF
--- a/docs/household-credit-stress-calibration.md
+++ b/docs/household-credit-stress-calibration.md
@@ -20,8 +20,11 @@ sbt "householdCreditStressCalibration --seeds 5 --months 60 --out target/househo
 The task writes:
 
 - `household-credit-stress-seed-metrics.tsv`: one terminal ratio per seed and
-  metric.
-- `household-credit-stress-summary.tsv`: mean/min/max across seeds, with status.
+  metric, plus path-aware peak monthly and peak rolling 3-month observations.
+  `ObservationMonth` reports the terminal month, peak month, or rolling-window
+  end month.
+- `household-credit-stress-summary.tsv`: mean/min/max across seeds by metric
+  and observation window, with status.
 - `household-credit-stress-targets.tsv`: documented target bands, vintage, and
   semantics.
 - `household-credit-stress-report.md`: human-readable summary.
@@ -43,6 +46,17 @@ ratios are meant to guide follow-up calibration and source-bridge work. A value
 outside the reference band is still reported as `WARN`, but the warning means
 "investigate this channel", not "empirical validation failed".
 
+Seed metrics are long-form by observation window:
+
+- `TERMINAL`: value at the final simulated month for that seed.
+- `PEAK_MONTHLY`: maximum monthly value observed along the simulated path, with
+  the peak month.
+- `PEAK_ROLLING_3`: maximum 3-month rolling average, with the window end month.
+
+The peak rows are path diagnostics. They are especially important for
+consumer-loan defaults and bridge charge-offs because a damaging month can
+capitalise a bank loss before the terminal month ratio returns inside its band.
+
 ## Target Bands
 
 | Metric | Class | Vintage | Band | Unit | Interpretation |
@@ -57,6 +71,7 @@ outside the reference band is still reported as `WARN`, but the warning means
 | `LiquidityBridgeChargeOffToConsumerLoans` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to n/a | monthly ratio | Same-month liquidity bridge write-offs relative to consumer-loan stock. |
 | `LiquidityBridgeChargeOffShareOfHouseholdCreditWriteOff` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `1.00` | share | Share of household credit write-offs that is same-month liquidity bridge charge-off rather than ordinary consumer-loan default. |
 | `MortgageDefaultToMortgageLoans` | `EXPLORATORY_DIAGNOSTIC` | `2026-04-30 model-start baseline` | `0.00` to `0.01` | monthly ratio | Flow/stock stress ratio for mortgage stress; this should later be mapped to arrears/default definitions. |
+| `HouseholdBankruptcyShare` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.00` to `0.01` | monthly share | Baseline personal insolvency can occur, but should not synchronize into monthly waves across a material household share. |
 | `PositiveDepositsToMonthlyIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `1.00` to `8.00` | months of income | Aggregate liquid buffers should be neither exhausted nor implausibly huge relative to household income. |
 | `MedianDepositToMeanMonthlyIncome` | `SOFT_CALIBRATION_WARNING` | `2026-04-30 model-start baseline` | `0.20` to `6.00` | months of mean income | The median household should have some liquidity, but not years of income in demand deposits. |
 | `NegativeDepositShare` | `HARD_INVARIANT` | `2026-04-30 model-start baseline` | `0.00` to `0.00` | share | Demand deposits are non-negative bank liabilities. |

--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -159,8 +159,17 @@ normal-path verdict over:
 - positive GDP proxy direction, with terminal decline reported as a warning
 - total credit to GDP blow-up bounds
 - default/NPL ratio bounds
+- peak and rolling household consumer-default stress on the normal baseline
 - bank-capital and flow-of-funds residual guards relative to annualized GDP
 - household negative-deposit diagnostic counts as warnings
+
+The household peak guard is path-aware: it reads all monthly baseline TSV rows
+and fails the normal-path verdict if peak monthly or peak rolling 3-month
+ordinary consumer-loan default rates exceed the documented `0.03`
+consumer-credit stress band. Liquidity-bridge charge-off, bankruptcy-share, and
+active-distress peaks are included in the health-summary observation string for
+attribution, but the existing `normal.bank_failures` hard fail remains the
+bank-failure invariant.
 
 Hard threshold breaches in normal-validation evidence fail the runner after the
 summary files have been written. Exploratory and stress steps remain visible in

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExport.scala
@@ -36,6 +36,11 @@ object HouseholdCreditStressCalibrationExport:
     case Fail extends Status("FAIL")
     case Info extends Status("INFO")
 
+  enum ObservationWindow(val token: String):
+    case Terminal     extends ObservationWindow("TERMINAL")
+    case PeakMonthly  extends ObservationWindow("PEAK_MONTHLY")
+    case PeakRolling3 extends ObservationWindow("PEAK_ROLLING_3")
+
   enum ObservedValue:
     case Finite(value: BigDecimal)
     case PositiveInfinity
@@ -62,6 +67,8 @@ object HouseholdCreditStressCalibrationExport:
       runId: String,
       seed: Long,
       months: Int,
+      observationWindow: ObservationWindow,
+      observationMonth: Int,
       target: TargetBand,
       value: ObservedValue,
       status: Status,
@@ -71,6 +78,7 @@ object HouseholdCreditStressCalibrationExport:
       runId: String,
       months: Int,
       seeds: Int,
+      observationWindow: ObservationWindow,
       target: TargetBand,
       mean: ObservedValue,
       min: Option[BigDecimal],
@@ -80,15 +88,16 @@ object HouseholdCreditStressCalibrationExport:
 
   final case class ExportResult(paths: Vector[Path], seedMetrics: Vector[SeedMetric], summary: Vector[SummaryMetric])
 
-  private final case class SeedContext(terminal: McSeedMonth):
-    val terminalRow: Array[MetricValue] = terminal.row
-    val terminalState                   = terminal.state
-    val householdCount: Int             = terminalState.households.size
+  private final case class SeedContext(month: McSeedMonth):
+    val monthlyRow: Array[MetricValue] = month.row
+    val monthlyState                   = month.state
+    val householdCount: Int            = monthlyState.households.size
+    val monthNumber: Int               = month.executionMonth.toInt
 
     def col(name: String): BigDecimal =
       decimal(McTimeseriesSchema.colNames.indexOf(name) match
         case -1      => throw new IllegalArgumentException(s"Missing Monte Carlo column: $name")
-        case ordinal => terminalRow(ordinal).toLong)
+        case ordinal => monthlyRow(ordinal).toLong)
 
     def ratioColumn(numerator: String, denominator: String): ObservedValue =
       ratio(col(numerator), col(denominator))
@@ -100,6 +109,7 @@ object HouseholdCreditStressCalibrationExport:
       ratioRaw(BigDecimal(numerator.toLong), denominatorRaw)
 
   private final case class MetricDef(target: TargetBand, compute: SeedContext => ObservedValue)
+  private final case class MetricObservation(month: Int, value: ObservedValue)
 
   private val RequiredMetricIds: Set[String] = Set(
     "ConsumerLoansToGdp",
@@ -112,6 +122,7 @@ object HouseholdCreditStressCalibrationExport:
     "LiquidityBridgeChargeOffToConsumerLoans",
     "LiquidityBridgeChargeOffShareOfHouseholdCreditWriteOff",
     "MortgageDefaultToMortgageLoans",
+    "HouseholdBankruptcyShare",
     "PositiveDepositsToMonthlyIncome",
     "MedianDepositToMeanMonthlyIncome",
     "NegativeDepositShare",
@@ -239,6 +250,18 @@ object HouseholdCreditStressCalibrationExport:
       interpretation = "Mortgage stress should be rarer than unsecured consumer-credit stress in the baseline.",
     ),
     TargetBand(
+      id = "HouseholdBankruptcyShare",
+      label = "Personal insolvencies / households",
+      unit = "monthly share",
+      guardrailClass = GuardrailClass.SoftCalibrationWarning,
+      vintage = BaselineVintage,
+      lower = Some(BigDecimal("0.00")),
+      upper = Some(BigDecimal("0.01")),
+      sourceNote =
+        "Issue #871 stylized baseline path cap for monthly household personal-insolvency incidence after replacing the deterministic insolvency cliff.",
+      interpretation = "Baseline personal insolvency can occur, but should not synchronize into monthly waves across a material household share.",
+    ),
+    TargetBand(
       id = "PositiveDepositsToMonthlyIncome",
       label = "Positive demand deposits / monthly household income",
       unit = "months of income",
@@ -355,16 +378,16 @@ object HouseholdCreditStressCalibrationExport:
     metric("ConsumerLoansToGdp")(ctx => ObservedValue.Finite(ctx.col("ConsumerLoansToGdp"))),
     metric("MortgageLoansToGdp")(ctx => ObservedValue.Finite(ctx.col("MortgageToGdp"))),
     metric("ConsumerDebtServiceToIncome")(ctx =>
-      ctx.householdRatio(ctx.terminalState.householdAggregates.totalConsumerDebtService, ctx.terminalState.householdAggregates.totalIncome),
+      ctx.householdRatio(ctx.monthlyState.householdAggregates.totalConsumerDebtService, ctx.monthlyState.householdAggregates.totalIncome),
     ),
     metric("MortgageDebtServiceToIncome")(ctx =>
-      ctx.householdRatio(ctx.terminalState.householdAggregates.totalDebtService, ctx.terminalState.householdAggregates.totalIncome),
+      ctx.householdRatio(ctx.monthlyState.householdAggregates.totalDebtService, ctx.monthlyState.householdAggregates.totalIncome),
     ),
     metric("MortgagePrincipalToIncome")(ctx =>
-      ctx.householdRatio(ctx.terminalState.householdAggregates.totalMortgagePrincipal, ctx.terminalState.householdAggregates.totalIncome),
+      ctx.householdRatio(ctx.monthlyState.householdAggregates.totalMortgagePrincipal, ctx.monthlyState.householdAggregates.totalIncome),
     ),
     metric("MortgageInterestToIncome")(ctx =>
-      ctx.householdRatio(ctx.terminalState.householdAggregates.totalMortgageInterest, ctx.terminalState.householdAggregates.totalIncome),
+      ctx.householdRatio(ctx.monthlyState.householdAggregates.totalMortgageInterest, ctx.monthlyState.householdAggregates.totalIncome),
     ),
     metric("ConsumerDefaultToConsumerLoans")(ctx => ctx.ratioColumn("ConsumerLoanDefault", "ConsumerLoans")),
     metric("LiquidityBridgeChargeOffToConsumerLoans")(ctx => ctx.ratioColumn("LiquidityBridgeChargeOff", "ConsumerLoans")),
@@ -373,47 +396,48 @@ object HouseholdCreditStressCalibrationExport:
       ratioRaw(bridge, bridge + ctx.col("ConsumerLoanDefault")),
     ),
     metric("MortgageDefaultToMortgageLoans")(ctx => ctx.ratioColumn("MortgageDefault", "MortgageStock")),
+    metric("HouseholdBankruptcyShare")(ctx => ObservedValue.Finite(ctx.col("HouseholdDistress_BankruptcyShare"))),
     metric("PositiveDepositsToMonthlyIncome")(ctx =>
       ctx.householdRatio(
-        ctx.terminalState.ledgerFinancialState.households.map(h => h.demandDeposit).sumPln,
-        ctx.terminalState.householdAggregates.totalIncome,
+        ctx.monthlyState.ledgerFinancialState.households.map(h => h.demandDeposit).sumPln,
+        ctx.monthlyState.householdAggregates.totalIncome,
       ),
     ),
     metric("MedianDepositToMeanMonthlyIncome")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       if ctx.householdCount <= 0 then ObservedValue.NotAvailable
       else ctx.householdRatio(agg.medianSavings, BigDecimal(agg.totalIncome.toLong) / BigDecimal(ctx.householdCount)),
     ),
     metric("NegativeDepositShare")(ctx => ObservedValue.Finite(ctx.col("HouseholdLiquidity_NegativeDepositShare"))),
     metric("DebtArrearsToShortfall")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(
         agg.totalRentArrears + agg.totalMortgageArrears + agg.totalConsumerDebtArrears,
         agg.totalLiquidityShortfallFinancing,
       ),
     ),
     metric("UnmetBasicConsumptionToIncome")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalUnmetBasicConsumption, agg.totalIncome),
     ),
     metric("DiscretionaryConsumptionCompressionToIncome")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalDiscretionaryConsumptionCompression, agg.totalIncome),
     ),
     metric("ShortfallToIncome")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalLiquidityShortfallFinancing, agg.totalIncome),
     ),
     metric("ShortfallToApprovedOrigination")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalLiquidityShortfallFinancing, agg.totalConsumerApprovedOrigination),
     ),
     metric("RejectedConsumerCreditDemandToApprovedOrigination")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalConsumerRejectedOrigination, agg.totalConsumerApprovedOrigination),
     ),
     metric("RejectedConsumerCreditDemandToShortfall")(ctx =>
-      val agg = ctx.terminalState.householdAggregates
+      val agg = ctx.monthlyState.householdAggregates
       ctx.householdRatio(agg.totalConsumerRejectedOrigination, agg.totalLiquidityShortfallFinancing),
     ),
   )
@@ -509,34 +533,63 @@ object HouseholdCreditStressCalibrationExport:
           case GuardrailClass.ExploratoryDiagnostic  => Status.Warn
 
   private def computeSeedMetricsZIO(config: Config, seed: Long, months: ZStream[Any, String, McSeedMonth]): ZIO[Any, String, Vector[SeedMetric]] =
-    months.runLast.flatMap:
-      case Some(terminal) => ZIO.succeed(computeSeedMetrics(config, seed, terminal))
-      case None           => ZIO.fail("household credit-stress run produced no monthly rows")
+    months.runCollect.flatMap: collected =>
+      val monthly = collected.toVector
+      if monthly.nonEmpty then ZIO.succeed(computeSeedMetrics(config, seed, monthly))
+      else ZIO.fail("household credit-stress run produced no monthly rows")
 
-  private def computeSeedMetrics(config: Config, seed: Long, terminal: McSeedMonth): Vector[SeedMetric] =
-    val context = SeedContext(terminal)
-    Metrics.map: metric =>
-      val value = metric.compute(context)
-      SeedMetric(config.runId, seed, config.months, metric.target, value, evaluate(value, metric.target))
+  private def computeSeedMetrics(config: Config, seed: Long, months: Vector[McSeedMonth]): Vector[SeedMetric] =
+    Metrics.flatMap: metric =>
+      val observations = months.map: month =>
+        val context = SeedContext(month)
+        MetricObservation(context.monthNumber, metric.compute(context))
+      val terminal     = observations.last
+      val peakMonthly  = peakObservation(observations)
+      val peakRolling3 = peakRollingObservation(observations, windowSize = 3)
+      Vector(
+        seedMetric(config, seed, metric.target, ObservationWindow.Terminal, terminal),
+        seedMetric(config, seed, metric.target, ObservationWindow.PeakMonthly, peakMonthly),
+        seedMetric(config, seed, metric.target, ObservationWindow.PeakRolling3, peakRolling3),
+      )
+
+  private def seedMetric(
+      config: Config,
+      seed: Long,
+      target: TargetBand,
+      window: ObservationWindow,
+      observation: MetricObservation,
+  ): SeedMetric =
+    SeedMetric(
+      runId = config.runId,
+      seed = seed,
+      months = config.months,
+      observationWindow = window,
+      observationMonth = observation.month,
+      target = target,
+      value = observation.value,
+      status = evaluate(observation.value, target),
+    )
 
   private[diagnostics] def summarize(config: Config, rows: Vector[SeedMetric]): Vector[SummaryMetric] =
-    Targets.map: target =>
-      val metricRows = rows.filter(_.target.id == target.id)
-      val finite     = metricRows.flatMap(_.value.finite)
-      val mean       =
-        if metricRows.exists(_.value == ObservedValue.PositiveInfinity) then ObservedValue.PositiveInfinity
-        else if finite.nonEmpty then ObservedValue.Finite(finite.sum / BigDecimal(finite.size))
-        else ObservedValue.NotAvailable
-      SummaryMetric(
-        runId = config.runId,
-        months = config.months,
-        seeds = config.seeds,
-        target = target,
-        mean = mean,
-        min = if finite.nonEmpty then Some(finite.min) else None,
-        max = if finite.nonEmpty then Some(finite.max) else None,
-        status = evaluate(mean, target),
-      )
+    Targets.flatMap: target =>
+      ObservationWindow.values.toVector.map: window =>
+        val metricRows = rows.filter(row => row.target.id == target.id && row.observationWindow == window)
+        val finite     = metricRows.flatMap(_.value.finite)
+        val mean       =
+          if metricRows.exists(_.value == ObservedValue.PositiveInfinity) then ObservedValue.PositiveInfinity
+          else if finite.nonEmpty then ObservedValue.Finite(finite.sum / BigDecimal(finite.size))
+          else ObservedValue.NotAvailable
+        SummaryMetric(
+          runId = config.runId,
+          months = config.months,
+          seeds = config.seeds,
+          observationWindow = window,
+          target = target,
+          mean = mean,
+          min = if finite.nonEmpty then Some(finite.min) else None,
+          max = if finite.nonEmpty then Some(finite.max) else None,
+          status = worstStatus(evaluate(mean, target) +: metricRows.map(_.status)),
+        )
 
   private def writeArtifactsZIO(config: Config, summary: Vector[SummaryMetric]): ZIO[Any, String, Vector[Path]] =
     val seedMetricsPath = config.runRoot.resolve("household-credit-stress-seed-metrics.tsv")
@@ -564,6 +617,8 @@ object HouseholdCreditStressCalibrationExport:
         "RunId",
         "Seed",
         "Months",
+        "ObservationWindow",
+        "ObservationMonth",
         "Metric",
         "Label",
         "Value",
@@ -581,6 +636,8 @@ object HouseholdCreditStressCalibrationExport:
           row.runId,
           row.seed.toString,
           row.months.toString,
+          row.observationWindow.token,
+          row.observationMonth.toString,
           row.target.id,
           row.target.label,
           renderValue(row.value),
@@ -601,6 +658,7 @@ object HouseholdCreditStressCalibrationExport:
         "RunId",
         "Months",
         "Seeds",
+        "ObservationWindow",
         "Metric",
         "Label",
         "Mean",
@@ -620,6 +678,7 @@ object HouseholdCreditStressCalibrationExport:
           row.runId,
           row.months.toString,
           row.seeds.toString,
+          row.observationWindow.token,
           row.target.id,
           row.target.label,
           renderValue(row.mean),
@@ -675,6 +734,7 @@ object HouseholdCreditStressCalibrationExport:
       markdownRow(
         Vector(
           row.target.id,
+          row.observationWindow.token,
           renderValue(row.mean),
           row.min.map(renderDecimal).getOrElse("n/a"),
           row.max.map(renderDecimal).getOrElse("n/a"),
@@ -706,14 +766,45 @@ object HouseholdCreditStressCalibrationExport:
         "",
         "## Summary",
         "",
-        markdownRow(Vector("Metric", "Mean", "Min", "Max", "Status")),
-        markdownRow(Vector("---", "---", "---", "---", "---")),
+        markdownRow(Vector("Metric", "Window", "Mean", "Min", "Max", "Status")),
+        markdownRow(Vector("---", "---", "---", "---", "---", "---")),
       ) ++ summaryRows
     lines.mkString("\n") + "\n"
 
   private def metric(id: String)(compute: SeedContext => ObservedValue): MetricDef =
     val target = Targets.find(_.id == id).getOrElse(throw new IllegalArgumentException(s"Missing target band: $id"))
     MetricDef(target, compute)
+
+  private def peakObservation(observations: Vector[MetricObservation]): MetricObservation =
+    observations.maxBy(observation => (valueRank(observation.value), -observation.month))
+
+  private def peakRollingObservation(observations: Vector[MetricObservation], windowSize: Int): MetricObservation =
+    val windows =
+      if observations.length >= windowSize then observations.sliding(windowSize).toVector
+      else Vector(observations)
+    windows
+      .map(window => MetricObservation(window.last.month, rollingValue(window.map(_.value))))
+      .maxBy(observation => (valueRank(observation.value), -observation.month))
+
+  private def rollingValue(values: Vector[ObservedValue]): ObservedValue =
+    if values.exists(_ == ObservedValue.PositiveInfinity) then ObservedValue.PositiveInfinity
+    else
+      val finite = values.flatMap(_.finite)
+      if finite.length == values.length then ObservedValue.Finite(finite.sum / BigDecimal(finite.length))
+      else ObservedValue.NotAvailable
+
+  private def valueRank(value: ObservedValue): (Int, BigDecimal) =
+    value match
+      case ObservedValue.PositiveInfinity => 2 -> BigDecimal(0)
+      case ObservedValue.Finite(v)        => 1 -> v
+      case ObservedValue.NotAvailable     => 0 -> BigDecimal(0)
+
+  private def worstStatus(statuses: Vector[Status]): Status =
+    statuses.maxBy:
+      case Status.Fail => 3
+      case Status.Warn => 2
+      case Status.Pass => 1
+      case Status.Info => 0
 
   private def ratio(numerator: BigDecimal, denominator: BigDecimal): ObservedValue =
     ratioRaw(numerator, denominator)

--- a/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyHealthSummary.scala
+++ b/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyHealthSummary.scala
@@ -23,12 +23,14 @@ private[diagnostics] object NightlyHealthSummary:
   private val HealthJsonName = "health-summary.json"
   private val HealthMdName   = "health-summary.md"
 
-  private val BaselineStepId              = "baseline-monte-carlo"
-  private val NormalCreditToGdpLowerBound = BigDecimal(0)
-  private val NormalCreditToGdpUpperBound = BigDecimal(10)
-  private val ResidualToGdpUpperBound     = BigDecimal("0.001")
-  private val RatioLowerBound             = BigDecimal(0)
-  private val RatioUpperBound             = BigDecimal(1)
+  private val BaselineStepId                        = "baseline-monte-carlo"
+  private val NormalCreditToGdpLowerBound           = BigDecimal(0)
+  private val NormalCreditToGdpUpperBound           = BigDecimal(10)
+  private val ResidualToGdpUpperBound               = BigDecimal("0.001")
+  private val RatioLowerBound                       = BigDecimal(0)
+  private val RatioUpperBound                       = BigDecimal(1)
+  private val BaselineConsumerDefaultPeakUpperBound = BigDecimal("0.03")
+  private val HouseholdStressRollingWindowMonths    = 3
 
   private val RequiredBaselineColumns: Vector[String] = Vector(
     "Month",
@@ -46,8 +48,11 @@ private[diagnostics] object NightlyHealthSummary:
     "BankCreditLoss_FirmDefaultRate",
     "BankCreditLoss_MortgageDefaultRate",
     "BankCreditLoss_ConsumerLoanDefaultRate",
+    "BankCreditLoss_LiquidityBridgeChargeOffRate",
     "BankCreditLoss_CorpBondDefaultRate",
     "ConsumerCredit_NplRatioGross",
+    "HouseholdDistress_BankruptcyShare",
+    "HouseholdDistress_ActiveShare",
     "HouseholdLiquidity_NegativeDepositCount",
     "HouseholdLiquidity_NegativeDepositShare",
   )
@@ -186,6 +191,7 @@ private[diagnostics] object NightlyHealthSummary:
                 gdpMetric(series),
                 creditToGdpMetric(series),
                 lossRatesMetric(series),
+                householdCreditStressPeakMetric(series),
                 residualMetric(series),
                 negativeStockMetric(series),
               )
@@ -275,6 +281,34 @@ private[diagnostics] object NightlyHealthSummary:
       threshold = s"All monitored default/NPL ratios must satisfy $RatioLowerBound <= value <= $RatioUpperBound.",
       source = "baseline Monte Carlo seed TSVs",
       details = "Positive defaults are allowed; impossible negative or above-100% rates are not.",
+    )
+
+  private def householdCreditStressPeakMetric(series: BaselineSeries): Metric =
+    val consumerDefaultPeak  = series.maxLocated("BankCreditLoss_ConsumerLoanDefaultRate")
+    val consumerDefaultRoll3 = series.maxRolling("BankCreditLoss_ConsumerLoanDefaultRate", HouseholdStressRollingWindowMonths)
+    val bridgePeak           = series.maxLocated("BankCreditLoss_LiquidityBridgeChargeOffRate")
+    val insolvencyPeak       = series.maxLocated("HouseholdDistress_BankruptcyShare")
+    val activeDistressPeak   = series.maxLocated("HouseholdDistress_ActiveShare")
+    val failed               =
+      consumerDefaultPeak.value > BaselineConsumerDefaultPeakUpperBound ||
+        consumerDefaultRoll3.exists(_.value > BaselineConsumerDefaultPeakUpperBound)
+    metric(
+      id = "normal.hh_credit_stress_peaks",
+      label = "Household credit-stress path peaks",
+      status = if failed then MetricStatus.Fail else MetricStatus.Pass,
+      hard = true,
+      observed = Vector(
+        s"consumer_loan_default_rate_peak=${renderLocated(consumerDefaultPeak)}",
+        s"consumer_loan_default_rate_rolling_${HouseholdStressRollingWindowMonths}m_peak=${consumerDefaultRoll3.map(renderLocated).getOrElse("n/a")}",
+        s"liquidity_bridge_chargeoff_rate_peak=${renderLocated(bridgePeak)}",
+        s"household_bankruptcy_share_peak=${renderLocated(insolvencyPeak)}",
+        s"household_active_distress_share_peak=${renderLocated(activeDistressPeak)}",
+      ).mkString("; "),
+      threshold =
+        s"Peak and rolling ${HouseholdStressRollingWindowMonths}-month ordinary consumer-loan default rates must be <= $BaselineConsumerDefaultPeakUpperBound on normal baseline paths.",
+      source = "baseline Monte Carlo seed TSVs",
+      details =
+        "This path-aware guard catches damaging household consumer-default spikes that can disappear by the terminal month; bridge charge-off and distress shares are reported for attribution.",
     )
 
   private def residualMetric(series: BaselineSeries): Metric =
@@ -373,9 +407,36 @@ private[diagnostics] object NightlyHealthSummary:
     def countWhere(column: String)(predicate: BigDecimal => Boolean): Int =
       values(column).count(predicate)
 
+    def maxLocated(column: String): LocatedValue =
+      rows
+        .map(row => LocatedValue(row.decimal(column), row.file, row.rowNumber, row.month))
+        .maxBy(value => (value.value, -value.month, value.file.toString, -value.rowNumber))
+
+    def maxRolling(column: String, windowMonths: Int): Option[LocatedValue] =
+      rows
+        .groupBy(_.file)
+        .toVector
+        .sortBy((file, _) => file.toString)
+        .flatMap: (_, fileRows) =>
+          val ordered = fileRows.sortBy(_.rowNumber)
+          val windows =
+            if ordered.length >= windowMonths then ordered.sliding(windowMonths).toVector
+            else Vector(ordered)
+          windows.collect:
+            case window if window.nonEmpty =>
+              val value = window.map(_.decimal(column)).sum / BigDecimal(window.length)
+              val last  = window.last
+              LocatedValue(value, last.file, last.rowNumber, last.month)
+        .maxByOption(value => (value.value, -value.month, value.file.toString, -value.rowNumber))
+
   private final case class BaselineRow(file: Path, rowNumber: Int, values: Map[String, BigDecimal]):
     def decimal(column: String): BigDecimal =
       values.getOrElse(column, throw IllegalStateException(s"Missing parsed column '$column' in ${file.getFileName}:$rowNumber"))
+
+    def month: Int =
+      decimal("Month").toInt
+
+  private final case class LocatedValue(value: BigDecimal, file: Path, rowNumber: Int, month: Int)
 
   private def loadBaseline(step: ManifestStep): Either[String, BaselineSeries] =
     for
@@ -490,6 +551,9 @@ private[diagnostics] object NightlyHealthSummary:
 
   private def markdownCell(value: String): String =
     value.replace("|", "\\|").replace("\n", " ").trim
+
+  private def renderLocated(value: LocatedValue): String =
+    s"${value.value} at month=${value.month}, file=${value.file.getFileName}, row=${value.rowNumber}"
 
   private def renderObject(fields: Vector[(String, String)]): String =
     fields.map((key, value) => s"${json(key)}:$value").mkString("{", ",", "}")

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/HouseholdCreditStressCalibrationExportSpec.scala
@@ -29,6 +29,7 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
       "LiquidityBridgeChargeOffToConsumerLoans",
       "LiquidityBridgeChargeOffShareOfHouseholdCreditWriteOff",
       "MortgageDefaultToMortgageLoans",
+      "HouseholdBankruptcyShare",
       "PositiveDepositsToMonthlyIncome",
       "MedianDepositToMeanMonthlyIncome",
       "NegativeDepositShare",
@@ -62,8 +63,11 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
   it should "render seed and summary TSV artifacts with calibration metadata" in {
     val target  = Targets.find(_.id == "ShortfallToIncome").get
     val rows    = Vector(
-      SeedMetric("stress-spec", 1L, 60, target, ObservedValue.Finite(BigDecimal("0.02")), Status.Pass),
-      SeedMetric("stress-spec", 2L, 60, target, ObservedValue.Finite(BigDecimal("0.08")), Status.Warn),
+      SeedMetric("stress-spec", 1L, 60, ObservationWindow.Terminal, 60, target, ObservedValue.Finite(BigDecimal("0.02")), Status.Pass),
+      SeedMetric("stress-spec", 1L, 60, ObservationWindow.PeakMonthly, 13, target, ObservedValue.Finite(BigDecimal("0.08")), Status.Warn),
+      SeedMetric("stress-spec", 2L, 60, ObservationWindow.Terminal, 60, target, ObservedValue.Finite(BigDecimal("0.01")), Status.Pass),
+      SeedMetric("stress-spec", 2L, 60, ObservationWindow.PeakMonthly, 17, target, ObservedValue.Finite(BigDecimal("0.03")), Status.Pass),
+      SeedMetric("stress-spec", 2L, 60, ObservationWindow.PeakRolling3, 18, target, ObservedValue.Finite(BigDecimal("0.025")), Status.Pass),
     )
     val summary = summarize(Config(runId = "stress-spec", seeds = 2, months = 60), rows)
     val seedTsv = renderSeedMetricsTsv(rows)
@@ -74,6 +78,8 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
       "RunId",
       "Seed",
       "Months",
+      "ObservationWindow",
+      "ObservationMonth",
       "Metric",
       "Label",
       "Value",
@@ -87,11 +93,13 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
       "Interpretation",
     )
     seedTsv should include("ShortfallToIncome")
+    seedTsv should include("PEAK_MONTHLY\t13")
     seedTsv should include("2026-04-30 model-start baseline")
     sumTsv.linesIterator.next() shouldBe tsv(
       "RunId",
       "Months",
       "Seeds",
+      "ObservationWindow",
       "Metric",
       "Label",
       "Mean",
@@ -107,6 +115,7 @@ class HouseholdCreditStressCalibrationExportSpec extends AnyFlatSpec with Matche
       "Interpretation",
     )
     sumTsv should include("SOFT_CALIBRATION_WARNING")
+    sumTsv should include("PEAK_ROLLING_3")
     report should include("--seed-start 2")
   }
 

--- a/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -207,6 +207,23 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     Files.readString(result.jsonPath) should include(""""status":"FAIL"""")
   }
 
+  it should "fail on peak household consumer-default stress even when the terminal month passes" in {
+    val ctx = context("smoke", tempOut("health-hh-peak-fail"), runId = "health-hh-peak-fail")
+    writeBaselineSeedTsv(
+      ctx,
+      seed = 1,
+      rows = healthyRows(months = 12).updated(5, healthyRow(month = 6, consumerLoanDefaultRate = "0.04")),
+    )
+
+    val result = DiagnosticIo.unsafeRun(NightlyHealthSummary.write(ctx, succeededSteps(ctx))).value
+    val json   = Files.readString(result.jsonPath)
+
+    result.status shouldBe NightlyHealthSummary.HealthStatus.Failed
+    result.hardFailureCount should be > 0
+    json should include(""""id":"normal.hh_credit_stress_peaks"""")
+    json should include("consumer_loan_default_rate_peak=0.04 at month=6")
+  }
+
   it should "warn without hard-failing on household negative-deposit diagnostics" in {
     val ctx = context("smoke", tempOut("health-warning"), runId = "health-warning")
     writeBaselineSeedTsv(
@@ -329,6 +346,10 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       month: Int,
       bankFailures: Int = 0,
       newFailures: Int = 0,
+      consumerLoanDefaultRate: String = "0.01",
+      liquidityBridgeChargeOffRate: String = "0",
+      householdBankruptcyShare: String = "0",
+      householdActiveDistressShare: String = "0.01",
       negativeDepositCount: Int = 0,
       negativeDepositShare: String = "0",
   ): String =
@@ -347,9 +368,12 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "0",
       "0.01",
       "0.02",
-      "0.03",
+      consumerLoanDefaultRate,
+      liquidityBridgeChargeOffRate,
       "0.04",
       "0.05",
+      householdBankruptcyShare,
+      householdActiveDistressShare,
       negativeDepositCount.toString,
       negativeDepositShare,
     ).mkString("\t")
@@ -371,8 +395,11 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "BankCreditLoss_FirmDefaultRate",
       "BankCreditLoss_MortgageDefaultRate",
       "BankCreditLoss_ConsumerLoanDefaultRate",
+      "BankCreditLoss_LiquidityBridgeChargeOffRate",
       "BankCreditLoss_CorpBondDefaultRate",
       "ConsumerCredit_NplRatioGross",
+      "HouseholdDistress_BankruptcyShare",
+      "HouseholdDistress_ActiveShare",
       "HouseholdLiquidity_NegativeDepositCount",
       "HouseholdLiquidity_NegativeDepositShare",
     ).mkString("\t")


### PR DESCRIPTION
## Summary
- add terminal, peak monthly, and peak rolling 3-month windows to household credit-stress seed/summary exports
- add normal-path health guardrail for peak/rolling ordinary consumer-loan default stress while preserving bank failures as hard fail
- document path-aware HH distress guardrails and add regression coverage

## Verification
- sbt scalafmtAll
- not run: focused tests, per request to avoid heating the local machine

Stacked on `issue-872-hh-baseline-bank-failure` so this PR contains only #871 changes.

Closes #871
Refs #872