### PR TITLE
Update repository links after GitHub transfer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "modules/ledger"]
 	path = modules/ledger
-	url = https://github.com/boombustgroup/amor-fati-ledger.git
+	url = https://github.com/amor-fati-systems/amor-fati-ledger.git

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   - given-names: Mateusz
     family-names: Maciaszek
     affiliation: BoomBustGroup
-repository-code: "https://github.com/boombustgroup/amor-fati"
+repository-code: "https://github.com/amor-fati-systems/amor-fati"
 url: "https://www.boombustgroup.com/"
 license: AGPL-3.0-only

--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@
 
 | CI | Coverage | Generated outputs |
 | --- | --- | --- |
-| [![CI](https://github.com/boombustgroup/amor-fati/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/ci.yml) | [![Coverage](https://codecov.io/gh/boombustgroup/amor-fati/graph/badge.svg)](https://codecov.io/gh/boombustgroup/amor-fati) | [![Generated outputs guarded](https://img.shields.io/badge/generated_outputs-guarded-2ea44f.svg)](docs/operations.md#generated-output-guard) |
+| [![CI](https://github.com/amor-fati-systems/amor-fati/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/ci.yml) | [![Coverage](https://codecov.io/gh/amor-fati-systems/amor-fati/graph/badge.svg)](https://codecov.io/gh/amor-fati-systems/amor-fati) | [![Generated outputs guarded](https://img.shields.io/badge/generated_outputs-guarded-2ea44f.svg)](docs/operations.md#generated-output-guard) |
 
 ### Research and Accounting Contract
 
 | Exact SFC identities | Verified ledger | Empirical validation |
 | --- | --- | --- |
-| [![15 exact SFC identities](https://img.shields.io/badge/exact_SFC_identities-15-orange.svg)](docs/sfc-matrix-evidence.md) | [![Verified ledger with Stainless and Z3](https://img.shields.io/badge/verified_ledger-Stainless_%2B_Z3-4B32C3.svg)](https://github.com/boombustgroup/amor-fati-ledger/blob/main/docs/verification.md) | [![Empirical validation snapshot](https://img.shields.io/badge/empirical_validation-snapshot-0A7EA4.svg)](docs/empirical-validation-report.md) |
+| [![15 exact SFC identities](https://img.shields.io/badge/exact_SFC_identities-15-orange.svg)](docs/sfc-matrix-evidence.md) | [![Verified ledger with Stainless and Z3](https://img.shields.io/badge/verified_ledger-Stainless_%2B_Z3-4B32C3.svg)](https://github.com/amor-fati-systems/amor-fati-ledger/blob/main/docs/verification.md) | [![Empirical validation snapshot](https://img.shields.io/badge/empirical_validation-snapshot-0A7EA4.svg)](docs/empirical-validation-report.md) |
 
 ### Operational Diagnostics
 
 | Diagnostics smoke | Diagnostics nightly | Diagnostics extended |
 | --- | --- | --- |
-| [![Diagnostics Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-smoke.yml) | [![Diagnostics Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-nightly.yml) | [![Diagnostics Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/diagnostics-extended.yml) |
+| [![Diagnostics Smoke](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-smoke.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-smoke.yml) | [![Diagnostics Nightly](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-nightly.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-nightly.yml) | [![Diagnostics Extended](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-extended.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/diagnostics-extended.yml) |
 
 | Profiling smoke | Profiling nightly | Profiling extended |
 | --- | --- | --- |
-| [![Hot-Path Profiling Smoke](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-smoke.yml) | [![Hot-Path Profiling Nightly](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-nightly.yml) | [![Hot-Path Profiling Extended](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml/badge.svg?branch=main)](https://github.com/boombustgroup/amor-fati/actions/workflows/hot-path-profiling-extended.yml) |
+| [![Hot-Path Profiling Smoke](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-smoke.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-smoke.yml) | [![Hot-Path Profiling Nightly](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-nightly.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-nightly.yml) | [![Hot-Path Profiling Extended](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-extended.yml/badge.svg?branch=main)](https://github.com/amor-fati-systems/amor-fati/actions/workflows/hot-path-profiling-extended.yml) |
 
 ---
 
@@ -42,7 +42,7 @@ The key design principle is simple:
 
 > **Macro stories can be wrong. The ledger cannot.**
 
-This engine is built on top of the separately verified [amor-fati-ledger](https://github.com/boombustgroup/amor-fati-ledger) flow interpreter, checked out as a Git submodule under `modules/ledger`. The practical consequence is that the strongest invariant in the entire project is not "inflation should look smooth" or "GDP should converge nicely after 10 years". It is this:
+This engine is built on top of the separately verified [amor-fati-ledger](https://github.com/amor-fati-systems/amor-fati-ledger) flow interpreter, checked out as a Git submodule under `modules/ledger`. The practical consequence is that the strongest invariant in the entire project is not "inflation should look smooth" or "GDP should converge nicely after 10 years". It is this:
 
 > **The books must balance to the end of the universe.**
 
@@ -104,7 +104,7 @@ This split is intentional. It keeps rich agent behavior where object-level model
 
 Most macro models treat accounting consistency as a secondary validation step. Amor Fati does not.
 
-The simulation pipeline is anchored to the verified [amor-fati-ledger](https://github.com/boombustgroup/amor-fati-ledger) layer that enforces the project’s stock-flow constraints at runtime. In other words:
+The simulation pipeline is anchored to the verified [amor-fati-ledger](https://github.com/amor-fati-systems/amor-fati-ledger) layer that enforces the project’s stock-flow constraints at runtime. In other words:
 
 - macro behavior is experimental
 - agent rules are revisable

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ as the operational entry point.
 | Canonical reviewer spine | Paper-facing model contract or primary reviewer reference. These files define how the implemented model should be read. |
 | Generated evidence | Committed output produced by a task or exporter. Do not edit by hand; regenerate through the owning command. |
 | Hand-maintained companion to generated evidence | Human-written bridge, index, or workflow note that explains generated evidence and must stay aligned with it. |
-| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. These files do not define parameter governance policy; deeper governance belongs to the [Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27). |
+| Calibration or empirical evidence | Parameter, source, calibration, or empirical-validation evidence. These files do not define parameter governance policy; deeper governance belongs to the [Calibration Governance milestone](https://github.com/amor-fati-systems/amor-fati/milestone/27). |
 | Architecture | Code-facing architecture contract, package-boundary map, runtime-loop explanation, state ownership boundary, or extension guide. |
 | Operational appendix | Commands, CI, validation ownership, scenarios, robustness, and runbook material. Useful, but not the first scientific reading path. |
 | Diagnostics or profiling appendix | Specific diagnostic/profiling methodology, exporter interpretation, or investigation evidence. |

--- a/docs/adr/0001-ledger-first-runtime.md
+++ b/docs/adr/0001-ledger-first-runtime.md
@@ -63,4 +63,4 @@ same-month economics
 - [`FlowSimulation.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala)
 - [`MonthFlowEmitter.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/MonthFlowEmitter.scala)
 - [`RuntimeFlowExecutor.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala)
-- [amor-fati-ledger repository](https://github.com/boombustgroup/amor-fati-ledger)
+- [amor-fati-ledger repository](https://github.com/amor-fati-systems/amor-fati-ledger)

--- a/docs/adr/0003-separate-verified-ledger-repository.md
+++ b/docs/adr/0003-separate-verified-ledger-repository.md
@@ -25,7 +25,7 @@ accounting kernel and which come from Amor Fati's model-specific usage of it.
 ## Decision
 
 The verified accounting kernel lives in the separate
-[amor-fati-ledger](https://github.com/boombustgroup/amor-fati-ledger)
+[amor-fati-ledger](https://github.com/amor-fati-systems/amor-fati-ledger)
 repository. Amor Fati checks that repository out as a Git submodule under
 `modules/ledger` and references it from the root build through an sbt
 `ProjectRef`.
@@ -59,7 +59,7 @@ The Amor Fati engine owns:
 ## References
 
 - [State and ledger boundary](../architecture/state-and-ledger-boundary.md)
-- [amor-fati-ledger repository](https://github.com/boombustgroup/amor-fati-ledger)
+- [amor-fati-ledger repository](https://github.com/amor-fati-systems/amor-fati-ledger)
 - [`AssetOwnershipContract.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala)
 - [`RuntimeFlowProjection.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/RuntimeFlowProjection.scala)
 - [`build.sbt`](../../build.sbt)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -29,7 +29,7 @@ read the nearby package README first, then return here for the system boundary:
 | [agents README](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/README.md) | Autonomous agents, behavioral state, and agent-local module splits. |
 | [init README](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/README.md) | Initial world construction and initialization randomness. |
 | [montecarlo README](../../modules/montecarlo/src/main/scala/com/boombustgroup/amorfati/montecarlo/README.md) | Production Monte Carlo runner, TSV contracts, and seed/month output path. |
-| [amor-fati-ledger repository](https://github.com/boombustgroup/amor-fati-ledger) | Separately verified ledger repository checked out locally under `modules/ledger`; owns the public ledger API. |
+| [amor-fati-ledger repository](https://github.com/amor-fati-systems/amor-fati-ledger) | Separately verified ledger repository checked out locally under `modules/ledger`; owns the public ledger API. |
 
 ## Architecture Scope
 

--- a/docs/data-bridge-national-financial-accounts.md
+++ b/docs/data-bridge-national-financial-accounts.md
@@ -11,7 +11,7 @@ documents current parameter provenance; the empirical validation report
 documents model-output comparisons. This bridge connects both to external data.
 It does not define the long-term parameter governance policy; deeper
 source-of-truth, versioning, and lifecycle decisions belong to the
-[Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27).
+[Calibration Governance milestone](https://github.com/amor-fati-systems/amor-fati/milestone/27).
 
 ## Boundary And Data Roles
 

--- a/docs/model-card.md
+++ b/docs/model-card.md
@@ -87,7 +87,7 @@ modeled economy is behaviorally or empirically correct.
 
 See [SFC matrix evidence](sfc-matrix-evidence.md),
 [engine invariants and semantics](engine-invariants-and-semantics.md), and the
-[ledger verification record](https://github.com/boombustgroup/amor-fati-ledger/blob/main/docs/verification.md).
+[ledger verification record](https://github.com/amor-fati-systems/amor-fati-ledger/blob/main/docs/verification.md).
 
 ## Calibration And Data
 

--- a/docs/model-notation-and-state-vector.md
+++ b/docs/model-notation-and-state-vector.md
@@ -429,7 +429,7 @@ an explicit seed contract.
 
 - This document does not define new equations.
 - This document does not settle calibration governance; that is tracked by
-  the [Calibration Governance milestone](https://github.com/boombustgroup/amor-fati/milestone/27).
+  the [Calibration Governance milestone](https://github.com/amor-fati-systems/amor-fati/milestone/27).
 - This document does not replace generated SFC matrix artifacts.
 - This document intentionally mirrors the current implementation. Future model
   changes should update this notation only when the runtime state boundary or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,7 +46,7 @@ The runtime depends on `amor-fati-ledger`, checked out as the Git submodule at
 Clone with submodules:
 
 ```bash
-git clone --recurse-submodules https://github.com/boombustgroup/amor-fati.git
+git clone --recurse-submodules https://github.com/amor-fati-systems/amor-fati.git
 cd amor-fati
 ```
 
@@ -149,7 +149,7 @@ canonical repository.
 Clone the repository directly:
 
 ```bash
-git clone --recurse-submodules git@github.com:boombustgroup/amor-fati.git
+git clone --recurse-submodules git@github.com:amor-fati-systems/amor-fati.git
 cd amor-fati
 ```
 
@@ -159,7 +159,7 @@ can refresh the baseline when needed:
 ```bash
 git clone --recurse-submodules git@github.com:<user>/amor-fati.git
 cd amor-fati
-git remote add upstream git@github.com:boombustgroup/amor-fati.git
+git remote add upstream git@github.com:amor-fati-systems/amor-fati.git
 git fetch upstream
 ```
 


### PR DESCRIPTION
## Summary

- point the ledger submodule at `amor-fati-systems/amor-fati-ledger`
- update GitHub Actions and Codecov badges
- update CITATION, documentation links, milestones, and clone commands
- retain BoomBustGroup copyright and Scala package namespaces

## Validation

- `git diff --check`
- no tracked references to the former GitHub repository paths remain