### PR TITLE
Define research platform and target core roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ inventory below, so new documentation cannot silently become orphaned.
 | Proposed population, baseline, and representation scale | [Population and representation RFC](rfc/0001-population-and-representation.md) |
 | Proposed public Research API and notebook runtime | [Research API and notebook runtime RFC](rfc/0002-research-api-and-notebook-runtime.md) |
 | Proposed model ontology and state architecture | [Model ontology and state architecture RFC](rfc/0003-model-ontology-and-state-architecture.md) |
+| Proposed JVM, JIT, GC, and worker-runtime policy | [JVM runtime, JIT, and garbage collection policy RFC](rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md) |
 | Code architecture and extension paths | [Architecture documentation](architecture/index.md) |
 | Commands, CI, diagnostics, scenarios, and local outputs | [Operations appendix index](operations.md#operational-appendix-index) |
 
@@ -73,6 +74,7 @@ as the operational entry point.
 | [docs/rfc/0001-population-and-representation.md](rfc/0001-population-and-representation.md) | Design proposal / RFC | Draft population specialization for reference-economy compilation, statistical units, representation scale, population storage, firms, migration, tourism, and opening population relationships. |
 | [docs/rfc/0002-research-api-and-notebook-runtime.md](rfc/0002-research-api-and-notebook-runtime.md) | Design proposal / RFC | Draft public Research API, experiment lifecycle, result-query, reproducibility, committed-notebook, and managed Almond/Jupyter runtime contract. |
 | [docs/rfc/0003-model-ontology-and-state-architecture.md](rfc/0003-model-ontology-and-state-architecture.md) | Design proposal / RFC | Draft model-wide ontology and state architecture for units, relationships, instruments, assets, representation resolution, state lifetimes, and data-oriented storage. |
+| [docs/rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md](rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md) | Design proposal / RFC | Draft supported JDK, worker-process, JIT, GC-profile, heap, runtime-provenance, and qualification-evidence policy. |
 | [docs/stochastic-processes-and-replay.md](stochastic-processes-and-replay.md) | Canonical reviewer spine | Publication-facing randomness, seed, stream, replay, validation, and stochastic-limitation contract. |
 | [README.md](../README.md) | Canonical reviewer spine | Repository front door, status overview, model identity, and top-level documentation entry. |
 | [docs/architecture/extension-points.md](architecture/extension-points.md) | Architecture | Code-facing recipes for adding flow mechanisms, same-month economics stages, agents/sectors, scenarios, diagnostics, output columns, and tests. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ inventory below, so new documentation cannot silently become orphaned.
 | Sector equations and decision rules | [Model specification source map](model-specification.md#source-map) |
 | SFC matrix and ledger-derived evidence | [SFC matrix evidence](sfc-matrix-evidence.md) and [model equations to SFC map](model-equations-to-sfc-map.md) |
 | Calibration and empirical validation | [Calibration register](calibration-register.md), [data bridge](data-bridge-national-financial-accounts.md), and [empirical validation report](empirical-validation-report.md) |
+| Proposed population, baseline, and representation scale | [Population and representation RFC](rfc/0001-population-and-representation.md) |
+| Proposed public Research API and notebook runtime | [Research API and notebook runtime RFC](rfc/0002-research-api-and-notebook-runtime.md) |
+| Proposed model ontology and state architecture | [Model ontology and state architecture RFC](rfc/0003-model-ontology-and-state-architecture.md) |
 | Code architecture and extension paths | [Architecture documentation](architecture/index.md) |
 | Commands, CI, diagnostics, scenarios, and local outputs | [Operations appendix index](operations.md#operational-appendix-index) |
 
@@ -42,6 +45,7 @@ as the operational entry point.
 | Diagnostics or profiling appendix | Specific diagnostic/profiling methodology, exporter interpretation, or investigation evidence. |
 | ADR or decision record | Durable architectural or semantic decision record. Preserve history unless superseded explicitly. |
 | Background / reading map | Orientation material for readers who need conceptual routing before the model specification, without defining model behavior. |
+| Design proposal / RFC | Proposed model or architecture contract under review. It is not canonical behavior or an accepted decision until promoted explicitly. |
 
 ## Complete Inventory
 
@@ -62,9 +66,13 @@ as the operational entry point.
 | [docs/institutional-sector-equations.md](institutional-sector-equations.md) | Canonical reviewer spine | Paper-facing public, monetary, external, insurance, NBFI, TFI, quasi-fiscal, and JST equations. |
 | [docs/model-card.md](model-card.md) | Canonical reviewer spine | Intended use, uses outside scope, evidence status, known limitations, reproducibility, and responsible interpretation. |
 | [docs/model-notation-and-state-vector.md](model-notation-and-state-vector.md) | Canonical reviewer spine | Canonical notation, state-vector definitions, symbols, ownership boundaries, and implementation anchors. |
+| [docs/rfc/README.md](rfc/README.md) | Design proposal / RFC | Index and lifecycle policy for active, implemented, and superseded RFCs. |
 | [docs/model-specification.md](model-specification.md) | Canonical reviewer spine | Canonical publication-facing model specification, reviewer reading path, and first scientific entry point. |
 | [docs/monthly-transition-function.md](monthly-transition-function.md) | Canonical reviewer spine | Formal monthly transition contract from pre-boundary state through same-month economics, ledger execution, SFC validation, and next-pre materialization. |
 | [docs/odd-model-documentation.md](odd-model-documentation.md) | Canonical reviewer spine | ODD/ODD+D model documentation for ABM structure, scheduling, entities, observations, and decision-making. |
+| [docs/rfc/0001-population-and-representation.md](rfc/0001-population-and-representation.md) | Design proposal / RFC | Draft population specialization for reference-economy compilation, statistical units, representation scale, population storage, firms, migration, tourism, and opening population relationships. |
+| [docs/rfc/0002-research-api-and-notebook-runtime.md](rfc/0002-research-api-and-notebook-runtime.md) | Design proposal / RFC | Draft public Research API, experiment lifecycle, result-query, reproducibility, committed-notebook, and managed Almond/Jupyter runtime contract. |
+| [docs/rfc/0003-model-ontology-and-state-architecture.md](rfc/0003-model-ontology-and-state-architecture.md) | Design proposal / RFC | Draft model-wide ontology and state architecture for units, relationships, instruments, assets, representation resolution, state lifetimes, and data-oriented storage. |
 | [docs/stochastic-processes-and-replay.md](stochastic-processes-and-replay.md) | Canonical reviewer spine | Publication-facing randomness, seed, stream, replay, validation, and stochastic-limitation contract. |
 | [README.md](../README.md) | Canonical reviewer spine | Repository front door, status overview, model identity, and top-level documentation entry. |
 | [docs/architecture/extension-points.md](architecture/extension-points.md) | Architecture | Code-facing recipes for adding flow mechanisms, same-month economics stages, agents/sectors, scenarios, diagnostics, output columns, and tests. |
@@ -77,6 +85,11 @@ as the operational entry point.
 | [docs/adr/0003-separate-verified-ledger-repository.md](adr/0003-separate-verified-ledger-repository.md) | ADR or decision record | Decision record for keeping the verified accounting kernel in the separate `amor-fati-ledger` repository, checked out under `modules/ledger`. |
 | [docs/adr/0004-ledger-owned-financial-state.md](adr/0004-ledger-owned-financial-state.md) | ADR or decision record | Decision record for keeping supported ledger-backed financial stocks in `LedgerFinancialState`. |
 | [docs/adr/0005-fixed-point-domain-numerics.md](adr/0005-fixed-point-domain-numerics.md) | ADR or decision record | Decision record for using Long-backed fixed-point opaque types for domain numerics instead of untyped floating-point values. |
+| [docs/adr/0006-data-oriented-high-cardinality-state.md](adr/0006-data-oriented-high-cardinality-state.md) | ADR or decision record | Decision record for columnar high-cardinality runtime state with typed control and observation boundaries. |
+| [docs/adr/0007-controlled-model-core-replacement.md](adr/0007-controlled-model-core-replacement.md) | ADR or decision record | Decision record for replacing the stateful model core on the target ontology while preserving verified accounting and scientific infrastructure. |
+| [docs/adr/0008-explicit-reference-population-and-representation-scale.md](adr/0008-explicit-reference-population-and-representation-scale.md) | ADR or decision record | Proposed decision separating a versioned reference population from explicit run-level representation scale and weights. |
+| [docs/adr/0009-research-api-as-supported-scientific-interface.md](adr/0009-research-api-as-supported-scientific-interface.md) | ADR or decision record | Proposed decision establishing the versioned Research API as the supported programmatic scientific interface. |
+| [docs/adr/0010-managed-almond-jupyter-runtime-and-committed-notebooks.md](adr/0010-managed-almond-jupyter-runtime-and-committed-notebooks.md) | ADR or decision record | Proposed decision for a managed Almond/Jupyter environment and committed executable research notebooks. |
 | [docs/adr/README.md](adr/README.md) | ADR or decision record | Index and format note for architecture decision records. |
 | [docs/bank-balance-sheet-benchmark.md](bank-balance-sheet-benchmark.md) | Diagnostics or profiling appendix | Bank balance-sheet benchmark diagnostic and bank-capital source interpretation. |
 | [docs/bank-failure-ablations.md](bank-failure-ablations.md) | Diagnostics or profiling appendix | Bank-failure ablation diagnostic methodology and interpretation. |

--- a/docs/adr/0006-data-oriented-high-cardinality-state.md
+++ b/docs/adr/0006-data-oriented-high-cardinality-state.md
@@ -1,0 +1,109 @@
+# ADR-0006: Data-Oriented High-Cardinality State
+
+Status: Accepted
+
+Date: 2026-07-15
+
+## Context
+
+Amor Fati currently stores household, firm, and persistent financial rows
+primarily as immutable vectors of per-entity case classes. This representation
+is readable and type-safe, but population passes allocate and copy complete
+objects even when a mechanism consumes only a few fields.
+
+The model ontology redesign introduces distinct persons, households,
+enterprises, institutions, relationships, contracts, instruments, positions,
+networks, real assets, and representation weights at different resolutions.
+The population redesign is the first high-cardinality specialization. Creating
+those families first as a larger immutable object graph would establish a
+storage boundary that would need another structural migration before supporting
+substantially different representation scales or more resolved contracts.
+
+The verified ledger library already demonstrates a narrower data-oriented
+boundary: its production state stores one primitive balance array for each
+entity-sector and asset pair, while commands and reference semantics remain
+typed values. Amor Fati should use the same separation of dense runtime data
+from control-plane objects without treating the current monthly ledger delta
+shell as a complete persistent simulation-state design.
+
+## Decision
+
+High-cardinality persistent runtime state is stored in dedicated
+data-oriented tables. Persons, households, ordinary enterprises,
+high-cardinality relationships, networks, financial contracts, positions, real
+assets when resolved, and persisted financial balances use structure-of-arrays
+storage backed by primitive arrays or equally compact typed columns.
+
+This decision does not prohibit case classes. Immutable typed values remain the
+default for configuration, reference-economy manifests, scenarios, validated
+commands, aggregate and low-cardinality state, public results, diagnostic
+views, and pure reference semantics.
+
+The data-oriented boundary has the following contracts:
+
+- Raw mutable columns remain encapsulated inside their owning package.
+- Domain transitions update related columns together and enforce cross-column
+  invariants.
+- Stable typed entity IDs are distinct from dense runtime row indices.
+- Dynamic membership uses a controlled allocator with liveness protection and
+  deterministic transition-boundary behavior.
+- The explicit monthly boundary remains authoritative. Current-month kernels
+  cannot observe partially written next-month state; dynamic columns use
+  current/next buffers, validated change sets, or an equivalent mechanism.
+- Variable-degree relationships use compact indexed relationship or adjacency
+  tables rather than nested per-agent collections.
+- Persistent financial principal has one authoritative owner. Contract terms
+  and ledger balances must not become independently mutable copies.
+- Row views and immutable snapshots are materialized on demand for tests,
+  diagnostics, export, and research-facing APIs, not as the default monthly
+  storage representation.
+- Large transient per-entity workspaces may use the same columnar and indexed
+  techniques, but remain monthly workspace rather than persistent economic
+  state.
+- Amor Fati uses dedicated domain tables rather than introducing a generic
+  entity-component-system framework.
+
+Exact column encodings, slot-allocation algorithms, compaction policy, and the
+set of double-buffered columns are implementation details governed by the
+model-wide ontology RFC and its population specialization. They may evolve
+without superseding this ADR as long as the boundary above remains intact.
+
+## Consequences
+
+- The population compiler should emit the target columnar population directly,
+  rather than building `Vector[Person]` or `Vector[Household]` as persistent
+  runtime state.
+- New high-cardinality state should not extend the existing per-agent case-class
+  representation.
+- Existing household, firm, labor-market, relationship, and financial-state
+  code is replaced or selectively reused through the controlled core strategy
+  recorded by ADR-0007.
+- Existing monthly economics outputs that copy complete entity vectors should
+  be replaced by table views, workspaces, change sets, or requested snapshots
+  according to their state lifetime.
+- Domain APIs must compensate for the weaker structural guarantees of separate
+  columns by centralizing transitions and validating table-wide invariants.
+- Tests should cover row alignment, ID resolution, liveness, month-boundary
+  isolation, deterministic replay, and equivalence between row views and
+  columnar state.
+- Diagnostics and scientific exports retain readable typed schemas even though
+  the runtime storage is columnar.
+- The proposed Research API defines the supported observation boundary and
+  informs indexes and projections without exposing their physical layout.
+- Low-cardinality and control-plane code does not need a data-oriented rewrite
+  merely for consistency of style.
+- The storage layout supports larger and differently weighted populations, but
+  performance claims still require profiling and scale-robustness evidence.
+
+## References
+
+- [Model ontology and state architecture RFC](../rfc/0003-model-ontology-and-state-architecture.md)
+- [Population and representation RFC](../rfc/0001-population-and-representation.md#population-storage-profile)
+- [ADR-0009: Research API as the Supported Scientific Interface](0009-research-api-as-supported-scientific-interface.md)
+- [ADR-0007: Controlled Model-Core Replacement](0007-controlled-model-core-replacement.md)
+- [ADR-0002: Explicit Month Boundary](0002-explicit-month-boundary.md)
+- [ADR-0004: Ledger-Owned Financial State](0004-ledger-owned-financial-state.md)
+- [State and ledger boundary](../architecture/state-and-ledger-boundary.md)
+- [`Household.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala)
+- [`LedgerFinancialState.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala)
+- [`RuntimeFlowExecutor.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala)

--- a/docs/adr/0007-controlled-model-core-replacement.md
+++ b/docs/adr/0007-controlled-model-core-replacement.md
@@ -1,0 +1,162 @@
+# ADR-0007: Controlled Model-Core Replacement
+
+Status: Accepted
+
+Date: 2026-07-15
+
+## Context
+
+The current Amor Fati model core encodes several foundational concepts in a
+state shape that conflicts with the target ontology:
+
+- `Household.State` is simultaneously a worker, household consumption unit,
+  financial owner, bank customer, migrant marker, and social-network node;
+- `FirmState` embeds ownership classification, bank routing, production-network
+  links, operational state, and real assets in one copied row;
+- employment, household membership, enterprise ownership, accounts, and credit
+  are fields or aggregates rather than independently identified relationships;
+- persistent micro and financial state is primarily stored as immutable vectors
+  of object rows; and
+- same-month economics passes updated populations through large result DTOs.
+
+Correcting these boundaries in place would require the old and new
+representations to coexist across much of the month pipeline. Production
+adapters would need to translate persons back into household-worker rows,
+contracts back into `bankId`, tables back into copied vectors, and ledger-backed
+balances back into object-row state. That transitional architecture would be
+large, would constrain the target design, and would create persistent risk of
+dual state ownership.
+
+Amor Fati has no external users or compatibility commitments that justify
+preserving the current agent-state API. It does, however, have substantial
+assets that must not be discarded: the verified ledger, fixed-point domain
+types, explicit month semantics, random-stream ownership, economic equations,
+flow vocabulary, SFC validation, calibration evidence, scenarios, diagnostics,
+and tests.
+
+## Decision
+
+Amor Fati will replace its stateful model core with a new implementation built
+natively on the accepted model ontology and data-oriented storage boundary.
+This is a controlled core replacement, not a clean-room rewrite of the system.
+
+The replacement is developed in the existing repository. It preserves and
+reuses components whose semantics remain valid, including:
+
+- the `amor-fati-ledger` library and ledger-first accounting path;
+- fixed-point domain numerics and semantically valid typed IDs;
+- explicit month-boundary and random-stream contracts;
+- pure economic equations and mechanisms after dependency review;
+- aggregate market, policy, fiscal, monetary, and external state whose ontology
+  remains valid;
+- flow, SFC, reconciliation, scenario, diagnostic, and evidence infrastructure;
+  and
+- existing tests and fixed-seed runs after classifying them as behavioral,
+  accounting, scientific, or obsolete storage-shape evidence.
+
+The replacement may break the internal API of the current model core. It will
+replace:
+
+- population initialization and scaling;
+- persistent person, household, enterprise, relationship, contract, network,
+  and high-cardinality financial storage;
+- agent kernels whose behavior is coupled to whole-row copying or conflated
+  state;
+- current root ownership of high-cardinality month-boundary state; and
+- same-month DTOs that duplicate complete persistent populations.
+
+The current engine is frozen as a behavioral and accounting oracle during
+development. It is not a production compatibility layer. Test-only fixtures,
+projections, and differential harnesses may compare old and new mechanisms on
+controlled inputs. A production month must never translate persistent state
+through both cores or allow both cores to own the same balance or entity state.
+
+The new core must first complete a thin end-to-end month using its native state:
+
+```text
+baseline and compiled population
+        -> labor and wages
+        -> household income and consumption
+        -> enterprise production and decisions
+        -> active financial flows
+        -> ledger execution and SFC validation
+        -> atomic next-month state
+```
+
+The new core becomes the default runtime only after satisfying the cutover gates
+defined by the model ontology RFC. These include population and opening-balance
+reconciliation, accounting identities, deterministic replay, controlled-input
+mechanism evidence, lifecycle integrity, multi-month stability, scenario
+directionality, evidence-schema availability, and single runtime ownership.
+
+Full time-series equality with the old engine is not required where corrected
+population, relationship, contract, or scaling semantics intentionally change
+the modeled economy. Every intentional behavioral difference must instead be
+identified, justified, and validated.
+
+## Consequences
+
+- The target architecture is not constrained by compatibility with
+  `Household.State`, `FirmState`, current object-row financial state, copied
+  population vectors, or overloaded `bankId` routing.
+- Development temporarily contains two implementations, but only in branch and
+  test contexts. There is no supported dual-engine production mode.
+- Existing mechanisms are reviewed and selectively reused rather than copied
+  indiscriminately or discarded wholesale.
+- Test effort shifts from preserving object shape to proving equations,
+  accounting, replay, invariants, empirical reconciliation, and scenario
+  behavior.
+- The first end-to-end slice must include ledger and SFC execution. A population
+  prototype disconnected from accounting is insufficient evidence for the
+  replacement.
+- Optional ontology resolution, such as individual dwellings, insurers, bank
+  shareholders, JST units, or foreign enterprises, remains outside the
+  foundational replacement unless separately promoted by research and evidence
+  requirements.
+- The old core is removed after cutover. It is not retained as a permanent
+  fallback, compatibility mode, or alternate scientific model.
+- A pre-release Research API and notebook pilot may execute the current engine
+  to validate scientific workflows before DOD implementation. This does not
+  make current internal types a compatibility target or the old engine a
+  production adapter after target-core cutover.
+- Canonical model and architecture documentation changes only as new slices
+  become implemented and authoritative; draft RFCs continue to distinguish
+  target design from current behavior.
+
+## Alternatives Considered
+
+### In-place vertical migration
+
+Introduce target tables one family at a time under the current runtime and
+transfer ownership gradually. Rejected because the current conflations cross
+population, economics, banking, ledger projection, and month-closing boundaries.
+The required compatibility and dual-representation code would be extensive and
+would shape the new architecture around temporary constraints.
+
+### Clean-room system rewrite
+
+Reimplement the complete model, accounting, orchestration, diagnostics, and
+scientific infrastructure without treating current code as reusable. Rejected
+because the absence of external users removes API compatibility pressure, not
+the value of verified accounting, domain types, equations, calibration,
+scenarios, and evidence.
+
+### Preserve the current core
+
+Add population weights and incremental fields to the current household and firm
+rows. Rejected because it would preserve the person-household conflation,
+overloaded relationships, opaque scale mapping, object-row storage, and
+aggregate financial routing that motivated the ontology redesign.
+
+## References
+
+- [Model ontology and state architecture RFC](../rfc/0003-model-ontology-and-state-architecture.md#core-migration-strategy)
+- [Population and representation RFC](../rfc/0001-population-and-representation.md#implementation-boundary)
+- [ADR-0008: Explicit Reference Population and Representation Scale](0008-explicit-reference-population-and-representation-scale.md)
+- [ADR-0009: Research API as the Supported Scientific Interface](0009-research-api-as-supported-scientific-interface.md)
+- [ADR-0010: Managed Almond/Jupyter Runtime and Committed Notebooks](0010-managed-almond-jupyter-runtime-and-committed-notebooks.md)
+- [ADR-0002: Explicit Month Boundary](0002-explicit-month-boundary.md)
+- [ADR-0004: Ledger-Owned Financial State](0004-ledger-owned-financial-state.md)
+- [ADR-0005: Fixed-Point Domain Numerics](0005-fixed-point-domain-numerics.md)
+- [ADR-0006: Data-Oriented High-Cardinality State](0006-data-oriented-high-cardinality-state.md)
+- [State and ledger boundary](../architecture/state-and-ledger-boundary.md)

--- a/docs/adr/0008-explicit-reference-population-and-representation-scale.md
+++ b/docs/adr/0008-explicit-reference-population-and-representation-scale.md
@@ -1,0 +1,113 @@
+# ADR-0008: Explicit Reference Population and Representation Scale
+
+Status: Proposed
+
+Date: 2026-07-17
+
+## Context
+
+The current Amor Fati initialization derives the number of household agents
+from realized firm worker slots, configured unemployment, and initial
+immigration. `firmsCount`, `workersPerFirm`, and `gdpRatio` consequently serve
+several different purposes: runtime population size, production normalization,
+and translation between agent-scale and Polish macroeconomic values.
+
+That coupling obscures what a simulation represents. Changing the number of
+simulated rows can change economic meaning rather than only representation
+resolution. Persons and households are also conflated, economically inactive
+residents are absent as agents, retirement is partly aggregate, and firm
+attributes do not yet reproduce a controlled joint empirical population.
+
+Researchers need to distinguish the empirical economy from the number of
+simulated units used to represent it. This distinction must be resolved before
+the Research API can offer an intuitive population control and before the
+data-oriented core fixes its population tables.
+
+## Decision
+
+A run represents a versioned **reference economy** with an explicit reference
+population and opening institutional controls. Representation scale is a
+separate run-level choice describing how many empirical units are represented
+by each simulated unit or relationship.
+
+The target population contract has these properties:
+
+- the baseline identifies its geography, reference period, source vintages,
+  statistical-unit definitions, classifications, and true-scale controls;
+- persons and households are distinct units linked by explicit membership;
+- labor-force status belongs to persons, while pooled consumption, housing,
+  and most retail-finance relationships belong to households;
+- ordinary enterprises are synthetic units constrained jointly by empirical
+  sector, size, region, ownership, and employment controls;
+- representation weights are explicit, typed, reported, and reconciled;
+- named systemic institutions can remain represented at `1:1` while ordinary
+  populations are weighted;
+- population compilation jointly creates units and the opening relationships
+  required by the selected baseline; and
+- `gdpRatio` is not the target mechanism for expressing representation scale.
+
+A researcher selects a baseline, a supported representation policy such as
+`1:1000`, and a seed. The population compiler derives the compatible simulated
+population and emits a manifest containing represented and simulated counts,
+weights, controls, residuals, exceptions, and provenance. Researchers do not
+coordinate independent firm, worker, household, and macro-scaling parameters
+to approximate a population size.
+
+Exact Polish baseline controls, weight-transition rules, compiler algorithms,
+and storage encodings remain unresolved in RFC-0001. This ADR remains Proposed
+until that RFC's acceptance criteria and first implementation scope are agreed.
+
+## Consequences
+
+- Baseline calibration and representation scale become different versioned
+  concepts. A scale change does not silently select a different economy.
+- Aggregate stocks and flows must reconcile to true-scale controls within
+  declared tolerances across supported representation scales.
+- Person, household, enterprise, membership, and employment populations require
+  explicit identities and weight semantics.
+- Economic inactivity, retirement, migration history, residency, and financial
+  distress cannot remain one overloaded household status.
+- Firm initialization must control a joint empirical population rather than
+  independently sampling weakly related marginals.
+- The Research API can expose one population representation choice and a
+  population manifest instead of implementation-shaped count knobs.
+- Data-oriented population tables are designed after the statistical units and
+  dominant Research API queries are known.
+- Existing calibrations and equations that depend on `workersPerFirm` or
+  `gdpRatio` require classification as economic parameters, numerical
+  normalization, or obsolete representation coupling.
+- Dynamic entry, exit, births, deaths, household changes, and migration require
+  weight-preserving lifecycle rules before they are implemented.
+
+## Alternatives Considered
+
+### Keep household-agent count implicit
+
+Continue deriving household agents from firms and unemployment, then scale
+macroeconomic values through `gdpRatio`. Rejected because the empirical economy,
+statistical population, and computational resolution remain entangled.
+
+### Make every represented family use one global weight
+
+Apply a uniform `1:N` weight to persons, households, firms, banks, and public
+institutions. Rejected because household composition, enterprise size,
+relationship quantities, and named systemic institutions require different but
+reconciled representation policies.
+
+### Require `1:1` simulation
+
+Represent every empirical person, household, and enterprise individually.
+Rejected as the sole supported policy because scientific meaning should not
+depend on one computational resolution. A `1:1` profile can remain a supported
+special case when validated and operationally feasible.
+
+## References
+
+- [RFC-0001: Population and Representation](../rfc/0001-population-and-representation.md)
+- [RFC-0002: Research API and Notebook Runtime](../rfc/0002-research-api-and-notebook-runtime.md)
+- [RFC-0003: Model Ontology and State Architecture](../rfc/0003-model-ontology-and-state-architecture.md)
+- [ADR-0006: Data-Oriented High-Cardinality State](0006-data-oriented-high-cardinality-state.md)
+- [ADR-0007: Controlled Model-Core Replacement](0007-controlled-model-core-replacement.md)
+- [`PopulationConfig.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationConfig.scala)
+- [`SimParams.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala)
+- [`WorldInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala)

--- a/docs/adr/0009-research-api-as-supported-scientific-interface.md
+++ b/docs/adr/0009-research-api-as-supported-scientific-interface.md
@@ -1,0 +1,113 @@
+# ADR-0009: Research API as the Supported Scientific Interface
+
+Status: Proposed
+
+Date: 2026-07-17
+
+## Context
+
+Amor Fati currently exposes useful capabilities through internal initialization
+and month-step methods, Monte Carlo runners, CLI commands, and specialized
+diagnostic exporters. These entry points reflect implementation ownership rather
+than one coherent scientific workflow. A researcher cannot yet construct,
+validate, execute, inspect, compare, and reproduce experiments through a stable
+programmatic contract.
+
+The target core will replace current high-cardinality state and internal agent
+APIs. Exposing `FlowSimulation.SimState`, current agent case classes, or future
+primitive data-oriented columns would couple scientific work to a storage shape
+that is intentionally changing. Conversely, designing storage without first
+observing real research queries risks optimizing the wrong access patterns.
+
+Notebook integration provides the first concrete external-style consumer, but
+the scientific interface must survive replacement of Almond, Jupyter, the CLI,
+and the internal simulation core.
+
+## Decision
+
+Amor Fati provides a versioned **Research API** as the supported programmatic
+interface for scientific experiment construction, execution, observation,
+comparison, and reproducibility.
+
+The Research API:
+
+- accepts immutable, typed, and validated experiment specifications;
+- makes baseline identity, representation policy, scenario, seed, horizon,
+  requested evidence, and resource profile explicit;
+- owns lifecycle operations such as prepare, start, step, run, cancel,
+  checkpoint, fork, seed ensemble, and close;
+- publishes immutable results, manifests, validation reports, aggregate time
+  series, controlled snapshots, and bounded micro views;
+- uses economic domain names and stable selectors rather than storage indices;
+- preserves the explicit month boundary and cannot publish a partially closed
+  month;
+- records enough configuration and software provenance to reproduce a run; and
+- remains independent of Almond, Jupyter, terminal rendering, charting, and
+  future transport protocols.
+
+CLI experiment commands, committed notebooks, and future service adapters use
+the same application-level experiment services. They may provide different
+presentation and operational behavior, but they do not implement separate model
+execution semantics.
+
+The public contract does not expose current internal state, primitive DOD
+columns, allocator slots, buffer swaps, or ledger implementation indices.
+Researcher-facing row values and result tables may use immutable typed objects
+because they are bounded observations, not authoritative persistent state.
+
+The first API remains explicitly pre-release until RFC-0002's acceptance
+criteria are met against the target core. A pilot facade may execute the current
+engine to validate workflows, but current internal signatures are not a
+compatibility requirement for the replacement core.
+
+## Consequences
+
+- Notebook and CLI work become consumers of one contract rather than parallel
+  wrappers around internal methods.
+- The target DOD layout can change without rewriting scientific notebooks when
+  public semantics remain stable.
+- Result queries and evidence requests must declare retention and resource cost;
+  aggregate series cannot require unconditional full microstate snapshots.
+- Every completed, cancelled, or failed run requires a machine-readable manifest
+  and explicit validation status independent of visible notebook output.
+- Checkpoint compatibility, result-schema evolution, cancellation, and API
+  versioning become supported system concerns.
+- Current CLI and Monte Carlo paths require convergence on Research API
+  application services where they represent the same experiment lifecycle.
+- Internal package APIs remain free to change under ADR-0007 until the Research
+  API is promoted.
+- Future enterprise adapters can build on the same boundary without making the
+  notebook adapter an enterprise architecture dependency.
+
+## Alternatives Considered
+
+### Treat CLI commands as the public interface
+
+Keep scientific workflows as command invocations plus TSV parsing. Rejected
+because interactive composition, typed validation, checkpoint control, bounded
+queries, and in-process result inspection would remain fragmented or require a
+second semantic layer.
+
+### Expose the simulation state directly
+
+Let researchers import `SimState` or target core tables. Rejected because it
+freezes internal storage, permits invariant-breaking mutation, and makes
+notebooks depend on object-row or primitive-column details.
+
+### Make the notebook adapter the API
+
+Put experiment lifecycle and result semantics directly into Almond-specific
+helpers. Rejected because CLI, unattended runs, and future service adapters
+would either depend on Jupyter or reimplement the same behavior.
+
+## References
+
+- [RFC-0002: Research API and Notebook Runtime](../rfc/0002-research-api-and-notebook-runtime.md)
+- [RFC-0001: Population and Representation](../rfc/0001-population-and-representation.md)
+- [RFC-0003: Model Ontology and State Architecture](../rfc/0003-model-ontology-and-state-architecture.md)
+- [ADR-0006: Data-Oriented High-Cardinality State](0006-data-oriented-high-cardinality-state.md)
+- [ADR-0007: Controlled Model-Core Replacement](0007-controlled-model-core-replacement.md)
+- [ADR-0010: Managed Almond/Jupyter Runtime and Committed Notebooks](0010-managed-almond-jupyter-runtime-and-committed-notebooks.md)
+- [`FlowSimulation.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala)
+- [`McRunner.scala`](../../modules/montecarlo/src/main/scala/com/boombustgroup/amorfati/montecarlo/runner/McRunner.scala)
+- [`ScenarioRunExport.scala`](../../modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala)

--- a/docs/adr/0010-managed-almond-jupyter-runtime-and-committed-notebooks.md
+++ b/docs/adr/0010-managed-almond-jupyter-runtime-and-committed-notebooks.md
@@ -1,0 +1,120 @@
+# ADR-0010: Managed Almond/Jupyter Runtime and Committed Notebooks
+
+Status: Proposed
+
+Date: 2026-07-17
+
+## Context
+
+Amor Fati aims to become a research system used and cited by scientists, but
+its current entry paths assume familiarity with the repository, sbt tasks, CLI
+exports, and internal model structure. Scala gives researchers direct access to
+the system's typed domain, yet a generic Scala kernel would still require them
+to assemble compatible compiler, JVM, classpath, baseline, and dependency
+versions.
+
+Amor Fati is distributed as a complete system rather than as a library that
+researchers install into arbitrary applications. The notebook experience must
+preserve that model while lowering the cost of exploratory work. It must also
+exercise the Research API without coupling the simulation core to Jupyter.
+
+Almond provides a Scala kernel for Jupyter, configurable kernel identity,
+launcher command, arguments, and predef behavior, plus APIs for rich notebook
+display. Notebook execution remains arbitrary local code execution and is not a
+security boundary.
+
+## Decision
+
+Amor Fati supplies a managed Almond-based Jupyter kernel and a small set of
+committed, editable Scala notebooks as the first interactive scientific
+environment for the Research API.
+
+The system-owned environment:
+
+- exposes a dedicated kernel identity, provisionally `Amor Fati (Scala)`;
+- pins and tests one compatible Amor Fati, Scala, JVM, Almond, Jupyter, model,
+  baseline, and notebook-adapter combination per supported release;
+- launches through an Amor Fati-owned command or environment entry point;
+- provides the compiled internal classpath and a minimal predef for Research
+  API imports and renderers;
+- validates version compatibility at startup and reports the resolved
+  environment;
+- does not require publishing Amor Fati as a Maven package, `$ivy` resolution,
+  or a researcher-managed classpath; and
+- keeps Almond and Jupyter dependencies outside the simulation core and
+  Research API.
+
+Canonical notebooks are committed as executable research workflows. They run
+from a fresh kernel in top-to-bottom order, use bounded CI configurations,
+contain no machine-specific paths or credentials, and store clean outputs by
+default. Run evidence is persisted through Research API result bundles and
+manifests rather than relying on mutable notebook state or visible cell output.
+
+The initial pilot contains at least baseline inspection and scenario comparison
+against the pre-release Research API before DOD layout is finalized. The
+notebooks record API friction and dominant queries that inform the target state
+design. The environment is promoted as supported only after the target core,
+deterministic replay, cancellation, resource cleanup, manifests, and canonical
+notebook suite pass together.
+
+The managed local kernel is trusted code execution. Remote, shared, or
+multi-tenant hosting requires a separate decision covering authentication,
+isolation, network policy, quotas, secrets, audit, and tenancy.
+
+## Consequences
+
+- Researchers receive an editable, typed environment without assembling Amor
+  Fati as a package dependency.
+- Canonical notebooks become executable acceptance tests for Research API
+  ergonomics and release compatibility.
+- Scala, JVM, or Almond upgrades require the notebook suite to pass against a
+  newly pinned compatibility matrix.
+- Notebook state, hidden cell order, and rendered output are not sufficient run
+  provenance; manifests and result bundles remain authoritative.
+- Large outputs, checkpoints, generated plots, and data extracts are not
+  committed beside notebook source by default.
+- The adapter owns rich display, progress integration, and kernel-specific
+  cancellation while core results retain useful non-Jupyter representations.
+- Cooperative cancellation must preserve the explicit month boundary and may
+  initially limit a kernel to one active run.
+- Replacing Almond later can supersede this ADR without changing ADR-0009 or
+  the Research API contract.
+- Hosted enterprise notebooks are explicitly outside the initial security and
+  operational scope.
+
+## Alternatives Considered
+
+### Require researchers to use sbt and CLI exports
+
+Keep the existing operational entry points as the only supported workflow.
+Rejected because they impose avoidable repository and build-tool knowledge and
+do not provide an interactive typed research surface.
+
+### Publish Amor Fati as a notebook dependency
+
+Ask notebooks to resolve a published or local Amor Fati artifact. Rejected
+because it contradicts the system distribution model and makes researchers
+responsible for assembling compatible runtime, baseline, and dependency
+versions.
+
+### Use uncommitted example notebooks
+
+Treat notebooks as local demonstrations outside version control and CI.
+Rejected because they would neither define a reproducible entry path nor test
+the Research API against releases.
+
+### Couple the Research API to Almond
+
+Expose Jupyter display and kernel lifecycle types from the scientific API.
+Rejected because CLI, batch, and future service adapters must remain independent
+of the selected notebook technology.
+
+## References
+
+- [RFC-0002: Research API and Notebook Runtime](../rfc/0002-research-api-and-notebook-runtime.md)
+- [ADR-0009: Research API as the Supported Scientific Interface](0009-research-api-as-supported-scientific-interface.md)
+- [ADR-0002: Explicit Month Boundary](0002-explicit-month-boundary.md)
+- [ADR-0007: Controlled Model-Core Replacement](0007-controlled-model-core-replacement.md)
+- [Almond installation options](https://almond.sh/docs/install-options)
+- [Almond advanced installation](https://almond.sh/docs/next/install-advanced)
+- [Almond Jupyter API](https://almond.sh/docs/api-jupyter)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,8 +1,10 @@
 # Architecture Decision Records
 
-This directory stores durable architecture decision records. ADRs preserve
-accepted trade-offs and their consequences. They are not living tutorials; the
-current architecture narrative lives in [docs/architecture](../architecture/).
+This directory stores durable architecture decision records. Proposed ADRs make
+a candidate decision explicit while its owning RFC remains under review;
+accepted ADRs preserve the chosen trade-off and its consequences. They are not
+living tutorials; the current architecture narrative lives in
+[docs/architecture](../architecture/).
 
 ADR-0001 through ADR-0005 are retroactive records for decisions already
 embedded in the codebase before this ADR series was started. Later ADRs should
@@ -18,13 +20,18 @@ historical anchor date, not the date the ADR text was written.
 
 ## Records
 
-| ADR | Decision |
-| --- | --- |
-| [ADR-0001](0001-ledger-first-runtime.md) | Runtime monetary flows execute through the ledger-first path. |
-| [ADR-0002](0002-explicit-month-boundary.md) | `FlowSimulation.SimState` and explicit month randomness define the public month boundary. |
-| [ADR-0003](0003-separate-verified-ledger-repository.md) | The verified accounting kernel lives in the separate `amor-fati-ledger` repository, checked out as `modules/ledger`. |
-| [ADR-0004](0004-ledger-owned-financial-state.md) | Supported ledger-backed financial stocks live in `LedgerFinancialState`. |
-| [ADR-0005](0005-fixed-point-domain-numerics.md) | Domain numerics use Long-backed fixed-point opaque types instead of untyped floating-point values. |
+| ADR | Status | Decision |
+| --- | --- | --- |
+| [ADR-0001](0001-ledger-first-runtime.md) | Accepted | Runtime monetary flows execute through the ledger-first path. |
+| [ADR-0002](0002-explicit-month-boundary.md) | Accepted | `FlowSimulation.SimState` and explicit month randomness define the public month boundary. |
+| [ADR-0003](0003-separate-verified-ledger-repository.md) | Accepted | The verified accounting kernel lives in the separate `amor-fati-ledger` repository, checked out as `modules/ledger`. |
+| [ADR-0004](0004-ledger-owned-financial-state.md) | Accepted | Supported ledger-backed financial stocks live in `LedgerFinancialState`. |
+| [ADR-0005](0005-fixed-point-domain-numerics.md) | Accepted | Domain numerics use Long-backed fixed-point opaque types instead of untyped floating-point values. |
+| [ADR-0006](0006-data-oriented-high-cardinality-state.md) | Accepted | High-cardinality runtime state uses data-oriented tables while typed objects remain at control and observation boundaries. |
+| [ADR-0007](0007-controlled-model-core-replacement.md) | Accepted | The stateful model core is replaced natively on the target ontology while verified accounting and scientific infrastructure are preserved. |
+| [ADR-0008](0008-explicit-reference-population-and-representation-scale.md) | Proposed | Runs separate a versioned reference population from their explicit representation scale and weights. |
+| [ADR-0009](0009-research-api-as-supported-scientific-interface.md) | Proposed | A versioned Research API is the supported programmatic scientific interface across adapters. |
+| [ADR-0010](0010-managed-almond-jupyter-runtime-and-committed-notebooks.md) | Proposed | Amor Fati supplies a managed Almond/Jupyter kernel and committed executable notebooks. |
 
 ## Format
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -15,6 +15,9 @@ equation, SFC, calibration, validation, and diagnostics documents linked from
 | System map and package responsibilities | [Architecture overview](overview.md) |
 | One-month runtime execution path | [Runtime loop](runtime-loop.md) |
 | State ownership and ledger-backed financial stocks | [State and ledger boundary](state-and-ledger-boundary.md) |
+| Proposed population compiler and representation scale | [Population and representation RFC](../rfc/0001-population-and-representation.md) |
+| Proposed public Research API and notebook runtime | [Research API and notebook runtime RFC](../rfc/0002-research-api-and-notebook-runtime.md) |
+| Proposed model-wide ontology and target state architecture | [Model ontology and state architecture RFC](../rfc/0003-model-ontology-and-state-architecture.md) |
 | How to add mechanisms, sectors, scenarios, diagnostics, or output columns | [Extension points](extension-points.md) |
 | Durable architectural decisions | [ADR index](../adr/) |
 
@@ -42,6 +45,11 @@ The current architecture spine covers four contracts:
    and which financial stocks are ledger-owned.
 4. Extension workflow: where to wire new mechanisms and which tests or docs
    must move with the code.
+
+The population, Research API and notebook, and model-wide ontology RFCs describe
+proposed target boundaries, not current implementation. They remain design
+proposals until their decisions are accepted, implemented, and promoted into
+the canonical architecture spine.
 
 Architectural history belongs in [docs/adr](../adr/). ADRs are intentionally
 short records of accepted decisions, not living design tutorials.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -52,8 +52,10 @@ RFCs describe proposed target boundaries, not current implementation. They
 remain design proposals until their decisions are accepted, implemented, and
 promoted into the canonical architecture spine.
 
-Architectural history belongs in [docs/adr](../adr/). ADRs are intentionally
-short records of accepted decisions, not living design tutorials.
+Architectural history belongs in [docs/adr](../adr/). A proposed ADR records a
+candidate decision while its owning RFC remains under review. Only accepted
+ADRs enter the canonical architecture history as durable decisions. ADRs are
+intentionally short decision records, not living design tutorials.
 
 ## Maintenance Rule
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -18,6 +18,7 @@ equation, SFC, calibration, validation, and diagnostics documents linked from
 | Proposed population compiler and representation scale | [Population and representation RFC](../rfc/0001-population-and-representation.md) |
 | Proposed public Research API and notebook runtime | [Research API and notebook runtime RFC](../rfc/0002-research-api-and-notebook-runtime.md) |
 | Proposed model-wide ontology and target state architecture | [Model ontology and state architecture RFC](../rfc/0003-model-ontology-and-state-architecture.md) |
+| Proposed JVM, JIT, GC, and worker-runtime policy | [JVM runtime, JIT, and garbage collection policy RFC](../rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md) |
 | How to add mechanisms, sectors, scenarios, diagnostics, or output columns | [Extension points](extension-points.md) |
 | Durable architectural decisions | [ADR index](../adr/) |
 
@@ -46,10 +47,10 @@ The current architecture spine covers four contracts:
 4. Extension workflow: where to wire new mechanisms and which tests or docs
    must move with the code.
 
-The population, Research API and notebook, and model-wide ontology RFCs describe
-proposed target boundaries, not current implementation. They remain design
-proposals until their decisions are accepted, implemented, and promoted into
-the canonical architecture spine.
+The population, Research API and notebook, model-wide ontology, and JVM runtime
+RFCs describe proposed target boundaries, not current implementation. They
+remain design proposals until their decisions are accepted, implemented, and
+promoted into the canonical architecture spine.
 
 Architectural history belongs in [docs/adr](../adr/). ADRs are intentionally
 short records of accepted decisions, not living design tutorials.

--- a/docs/rfc/0001-population-and-representation.md
+++ b/docs/rfc/0001-population-and-representation.md
@@ -263,6 +263,11 @@ while typed batches and pure reference semantics remain object-based. Amor Fati
 should reuse this architectural principle without treating the current ledger
 implementation as a complete population or world-state design.
 
+In this example, `Array[Long]` is raw backing storage for fixed-point monetary
+values, not an untyped integer domain model. Amor Fati accessors and projections
+must expose `PLN` or the project's equivalent opaque fixed-point monetary type;
+the raw representation remains encapsulated inside the storage boundary.
+
 ### Column schemas
 
 An entity table stores one column per state dimension. For example, a person
@@ -273,7 +278,7 @@ labor state should not be stored as an allocated enum payload such as
 labourStatus       Array[Byte]
 employerIndex      Array[Int]
 sectorIndex        Array[Byte]
-wage               Array[Long]
+wageRaw            Array[Long]  // fixed-point PLN backing units; exposed as PLN
 unemployedMonths   Array[Int]
 retrainingProgram  Array[Int]
 representationWeight Array[Long]
@@ -450,11 +455,16 @@ are intensive values and are not multiplied by representation scale. Monetary
 stocks and flows posted to the economy-wide ledger are extensive values and
 must equal the represented amount.
 
+Every monetary value and account balance, whether intensive or extensive, must
+use `PLN` or an equivalent opaque fixed-point domain type at domain boundaries.
+`Double` and `Float` are not valid monetary or accounting representations.
+
 For a weighted household cohort, underwriting may use per-household income,
 debt, and debt-service values, while the ledger contract carries the weighted
-exposure. The implementation must make that projection explicit. It must not
-silently apply `gdpRatio` to some stocks while treating other agent values as
-already scaled.
+exposure. Both sides remain fixed-point monetary values, and weighting must use
+a checked domain operation with explicit rounding and overflow behavior. The
+implementation must make that projection explicit. It must not silently apply
+`gdpRatio` to some stocks while treating other agent values as already scaled.
 
 Changing `residentsPerAgent` should preserve controlled aggregate opening
 stocks and flows within documented rounding tolerances. It may change finite

--- a/docs/rfc/0001-population-and-representation.md
+++ b/docs/rfc/0001-population-and-representation.md
@@ -1,0 +1,698 @@
+# RFC-0001: Population and Representation
+
+Status: Draft for decision
+Scope: Reference population, representation scale, population storage profile,
+firm population, migration, tourism, and opening population relationships
+Performance: Deliberately out of scope for this design pass
+
+## Purpose
+
+Amor Fati currently derives its household population from firm employment and
+then maps agent-scale monetary flows to Polish macro aggregates through
+`gdpRatio`. This makes a run possible, but it leaves three different concepts
+entangled:
+
+1. the empirical economy being represented;
+2. the statistical units and relationships present in that economy; and
+3. the number of simulated agents used to represent those units.
+
+The target design separates those concepts. A researcher should select a
+versioned reference economy, a representation scale such as `1:1000`, and a
+seed. The population compiler should derive a balanced synthetic population
+and report exactly what it created. Researchers should not need to coordinate
+independent `firmsCount`, `workersPerFirm`, and household-count parameters.
+
+This RFC is the first decision stage for the target core. It owns the
+statistical population, its compiler, and the population-facing part of the
+storage profile. Its accepted semantics become inputs to the
+[Research API and notebook runtime RFC](0002-research-api-and-notebook-runtime.md)
+and the later model-wide
+[Model ontology and state architecture RFC](0003-model-ontology-and-state-architecture.md).
+It does not define the full ontology of public and financial institutions, real
+assets, securities, insurance, interbank exposures, markets, policy state, or
+monthly execution evidence.
+
+This RFC records the intended population model, not the current implementation.
+Its durable separation of reference population from representation scale is
+extracted as proposed
+[ADR-0008](../adr/0008-explicit-reference-population-and-representation-scale.md).
+That ADR can become accepted, and canonical model documentation can change,
+only after this RFC's open decisions are resolved. The narrower runtime-storage
+boundary is already accepted in
+[ADR-0006](../adr/0006-data-oriented-high-cardinality-state.md); the population
+ontology and compiler details remain under review here.
+
+## Proposed Decisions
+
+1. A run represents a versioned **reference economy**. Representation scale is
+   a property of the simulation, not a calibration of the economy itself.
+2. `Person` and `Household` become distinct units. Labor supply belongs to
+   persons; consumption, pooled finances, housing, and most bank relationships
+   belong to households.
+3. Employment, unemployment, economic inactivity, retirement, and financial
+   bankruptcy are not interchangeable statuses.
+4. Immigration is a residency transition and migration history attached to a
+   person. It is not a separate kind of household.
+5. Inbound tourists are temporary non-residents and do not enter the resident
+   population. Tourism remains aggregate by default, with an optional visitor
+   cohort module when a research question needs micro-level tourism.
+6. Ordinary firms are synthetic but empirically constrained jointly by sector,
+   size, region, ownership, and employment. Named systemic institutions may be
+   represented at `1:1`.
+7. Employment and opening financial relationships become explicit links or
+   contracts. A single `bankId` must not stand for every account and credit
+   product. The model-wide RFC owns the final contract and instrument schemas.
+8. `gdpRatio` is not the target representation mechanism. Agent weights and a
+   true-scale reference-economy balance sheet should make the mapping from
+   simulated units to aggregates explicit.
+9. High-cardinality population state uses data-oriented, columnar storage.
+   Scala `case class` values remain appropriate for configuration, manifests,
+   aggregate state, validated commands, results, and diagnostic views. The
+   model-wide RFC owns the storage boundary outside the population domain.
+
+## Terminology
+
+The following terms are normative for this design:
+
+| Term | Meaning |
+| --- | --- |
+| Resident | A person included in the reference economy's usual-residence population. Citizenship and country of birth are separate attributes. |
+| Immigrant | A resident with an inward residency transition or relevant migration history. This does not imply current foreign citizenship, permanent wage discount, or permanent remittance behavior. |
+| Emigrant | A person whose usual residence moves out of the reference economy. Temporary outbound tourism is not emigration. |
+| Labor force | Employed plus unemployed persons under the baseline's statistical definition. |
+| Unemployed | A person in the labor force without employment and available for or seeking work under the selected definition. |
+| Economically inactive | A person outside the labor force. Reasons include education, retirement, care, disability or long-term sickness, and other inactivity. |
+| Pension recipient | A person receiving a pension. This is not identical to economic inactivity because pension recipients may work. |
+| Household | A co-resident economic unit that pools at least part of consumption, housing, income, assets, or liabilities. |
+| Firm | The modeled enterprise unit. Establishments and local units require an explicit extension rather than being silently treated as enterprises. |
+| Tourist or visitor | A temporary non-resident visitor, or a resident temporarily travelling abroad. Neither event changes usual residence. |
+| Representation weight | The number of empirical units represented by a simulated unit or relationship. |
+
+The word `inactive` should describe labor-force status only. It should not be
+used as a synonym for a household skipped by an execution stage, a bankrupt
+borrower, an unemployed person, or a retired person.
+
+## Current Amor Fati State
+
+The current implementation already contains useful pieces, but it does not yet
+implement the ontology above.
+
+| Area | Implemented state | Consequence |
+| --- | --- | --- |
+| Person and household | `Household.State` is simultaneously a worker, a consumption unit, and a financial owner. | Individual labor status and multi-person household finances cannot be represented separately. |
+| Employment | `HhStatus` contains `Employed`, `Unemployed`, `Retraining`, and `Bankrupt`. | Retraining and bankruptcy are mixed into an employment/activity status even though they belong to program and financial-distress dimensions. |
+| Initial population | Firm worker slots create employed household agents; initial unemployment adds agents outside those slots. | Actual household-agent count depends on realized firm sizes and unemployment, not on one authoritative resident-population control. |
+| Economic inactivity | No resident inactive-person population exists. | Students, carers, disabled or long-term sick people, and other inactive residents are absent as agents. |
+| Retirement | `DemographicsState` carries an aggregate retiree stock used by ZUS and NFZ. Household agents have neither age nor a retired status. | Retirement is currently a fiscal/demographic proxy, not an agent transition. Growing the retiree stock does not remove or reclassify a represented worker. |
+| Immigration | Initial and monthly immigrants are created as household agents with `isImmigrant = true`; return migrants are removed; remittances are modeled. | Migration is substantially more developed than retirement, but a permanent Boolean conflates residency history, integration, citizenship, and remittance propensity. |
+| Tourism | Inbound receipts and outbound expenditure are aggregate GDP-linked flows with seasonality, exchange-rate response, trend, and shocks. | Tourism exists, but there are no visitor agents, stays, origin markets, destinations, or tourism-firm capacity constraints. |
+| Firms | Sector counts are controlled; size, region, and ownership attributes are then sampled in separate passes, with some ownership probabilities conditional on sector. | The population reflects selected empirical marginals but not a controlled joint distribution of sector, size, region, ownership, and employment. |
+| Banks | A household or firm has one `bankId`; household deposits, mortgages, consumer credit, interest, and most flows use it. | Aggregate multi-bank routing is explicit, but product-level bilateral contracts are not. |
+| Scale | Defaults declare 10,000 firms and use `workersPerFirm` as a population and GDP normalizer. `gdpRatio` scales many macro stocks. | Population representation, firm production, and monetary calibration are coupled. A scale change is not a transparent `1:N` sampling decision. |
+| Runtime data layout | Agent state and persistent financial state are primarily `Vector` collections of per-entity case classes. The ledger library executes batches against columnar `Array[Long]` stores, but Amor Fati currently creates an empty execution state for monthly deltas and snapshots the result to a `Map`. | The ledger execution kernel is data-oriented, but the persistent simulation state is not. Population passes still allocate and copy object rows, and the ledger layout is not yet the single persistent layout of financial state. |
+
+Two opening stocks expose the population mismatch directly. Initial
+`workingAgePop` is the length of the population actually created from realized
+firm job slots, unemployment, and initial immigration. Initial retirees are
+instead configured as `firmsCount * workersPerFirm / 3`. Monthly retirement
+then increases the external retiree stock without reclassifying or removing a
+household agent. The resulting values can support fiscal-flow experiments, but
+they do not form a closed demographic accounting system.
+
+Relevant implementation anchors include:
+
+- [`Household.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala)
+  for household state and `HhStatus`;
+- [`SocialSecurity.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/SocialSecurity.scala)
+  for the external retiree stock;
+- [`Immigration.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/Immigration.scala)
+  and [`ImmigrantInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/ImmigrantInit.scala)
+  for migrant creation and removal;
+- [`HouseholdFinancialEconomics.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/economics/HouseholdFinancialEconomics.scala)
+  and [`TourismConfig.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/TourismConfig.scala)
+  for aggregate tourism;
+- [`FirmInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/FirmInit.scala)
+  for the current firm generator; and
+- [`PopulationConfig.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationConfig.scala)
+  and [`SimParams.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala)
+  for current population and `gdpRatio` coupling;
+- [`LedgerFinancialState.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala)
+  for the current object-row persistent financial state; and
+- [`RuntimeFlowExecutor.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/RuntimeFlowExecutor.scala)
+  for the current monthly delta execution boundary.
+
+## Target Entity Model
+
+### Person
+
+A person is the demographic and labor-market unit. The minimum target state is:
+
+- `personId` and `householdId`;
+- age or age cohort;
+- region of usual residence;
+- residency status and migration history;
+- labor-force status: employed, unemployed, or inactive with a reason;
+- optional employment-contract link;
+- education, skill, and health or work-capacity attributes;
+- pension eligibility and receipt, separate from labor-force status; and
+- labor-market program state such as retraining, separate from employment.
+
+Children and other dependants are persons even when they have no independent
+economic decision rule. Collective-household residents may be represented by a
+dedicated household type rather than dropped from the population.
+
+### Household
+
+A household is the primary consumption and retail-finance unit. It contains:
+
+- member links and household type;
+- dwelling tenure, region, housing cost, and dependent composition;
+- pooled disposable income and consumption rules;
+- deposit accounts and securities holdings;
+- mortgage and consumer-credit contracts; and
+- household-level distress and insolvency state.
+
+An employment loss changes a person's labor state and then the income of their
+household. Personal insolvency changes household finances; it does not make a
+person economically inactive.
+
+### Firm
+
+A firm is an enterprise or explicit enterprise archetype. It contains sector,
+size class, region, ownership class, legal form where relevant, production and
+capital state, and financial contracts. Employment is linked through explicit
+person-to-firm relationships or weighted job allocations.
+
+The baseline must declare whether a row represents an enterprise, local unit,
+or establishment. Mixing those universes produces invalid firm counts and
+employment ratios.
+
+### Financial Institution
+
+Banks, the central bank, funds, insurers, and other financial institutions keep
+their institutional identity. Because the number of systemically relevant
+institutions is small and their heterogeneity matters, named banks can remain
+`1:1` even when household and ordinary-firm populations are sampled.
+
+This section defines only how population compilation references those
+institutions when assigning accounts, credit, or employment. Their complete
+ontology, consolidation, contracts, instruments, positions, and runtime state
+belong to the model-wide ontology RFC.
+
+### Visitor Cohort
+
+The default model has no visitor agents. If tourism microstructure is activated,
+it should create temporary `VisitorCohort` units with origin, destination,
+arrival month, nights, party size, and expenditure basket. Their representation
+weight contributes to visitor nights and expenditure, never to resident
+population or labor-force denominators.
+
+## Population Storage Profile
+
+The population ontology and its storage layout should be designed together.
+Amor Fati should not first introduce millions of `Person`, `Household`,
+`Enterprise`, membership, employment, and opening-relationship objects and then
+replace them with a columnar representation in a second migration.
+
+Data-Oriented Design in this RFC means arranging high-cardinality population
+state by the fields consumed together by model kernels. It does not mean
+removing every `case class`, exposing mutable arrays throughout the codebase,
+or introducing a generic entity-component-system framework.
+
+### Storage boundary
+
+The compiler-owned population slice has the following conceptual shape. It is
+embedded in, but does not redefine, the full `SimulationState` described by the
+model-wide ontology RFC:
+
+```text
+CompiledPopulation
+|-- PersonTable                       columnar person state
+|-- HouseholdTable                    columnar household state
+|-- EnterpriseTable                   columnar ordinary-enterprise state
+|-- HouseholdMembershipTable          person-to-household relationships
+|-- EmploymentTable                   person-to-enterprise relationships
+|-- PopulationNetworkStore            compact social and production graphs
+|-- OpeningRelationshipAssignments    typed account, credit, tenure, and ownership inputs
+`-- PopulationManifest                weights, controls, residuals, and provenance
+```
+
+`OpeningRelationshipAssignments` is compiler output, not a generic persistent
+contract table. The target deposit-account, credit-contract, security-position,
+enterprise-ownership, insurance, pension, and interbank schemas are defined in
+the model-wide RFC. The compiler materializes only the families enabled by the
+selected baseline and hands their balances to the authoritative ledger
+initialization boundary.
+
+The ownership rule is:
+
+| State family | Default representation |
+| --- | --- |
+| Persons, households, ordinary enterprises | Dedicated structure-of-arrays tables backed by primitive arrays or equally compact typed columns. |
+| Employment and membership | Dedicated relationship tables with indexed party columns and represented quantities. |
+| Opening account, credit, tenure, and ownership assignments | Typed compiler output validated against the model-wide relationship and contract schemas. |
+| Social and production networks | Compact adjacency storage such as offsets plus neighbor indices, not one neighbor-array object per agent. |
+| Financial balances | Persistent columnar ledger storage owned outside this population slice; compiler DTOs must not become a second owner. |
+| Named institutions referenced by the population | Stable typed IDs and immutable profiles supplied by the selected baseline. |
+| Configuration, population manifests, aggregates, commands, and results | Immutable typed values and case classes. |
+| Tests, diagnostics, and exports | On-demand immutable row views or snapshots derived from the columnar source. |
+
+The ledger library already demonstrates the intended split. Its production
+`MutableWorldState` stores one `Array[Long]` per entity-sector and asset pair,
+while typed batches and pure reference semantics remain object-based. Amor Fati
+should reuse this architectural principle without treating the current ledger
+implementation as a complete population or world-state design.
+
+### Column schemas
+
+An entity table stores one column per state dimension. For example, a person
+labor state should not be stored as an allocated enum payload such as
+`Employed(firmId, sectorIdx, wage)`. Its runtime representation may use:
+
+```text
+labourStatus       Array[Byte]
+employerIndex      Array[Int]
+sectorIndex        Array[Byte]
+wage               Array[Long]
+unemployedMonths   Array[Int]
+retrainingProgram  Array[Int]
+representationWeight Array[Long]
+```
+
+The exact primitive encoding is an implementation decision, but raw columns
+must remain package-private. Domain transitions such as `setEmployed`,
+`setUnemployed`, `retire`, `immigrate`, and `emigrate` update every dependent
+column together and enforce the same invariants that an algebraic data type
+would otherwise make visible.
+
+Columnar storage is not permission to replace domain types with unlabelled
+integers at API boundaries. Opaque IDs, typed column accessors, validated
+commands, and explicit transition methods should preserve Scala's type safety.
+
+### Stable identity and dense indices
+
+A stable entity ID is not an array position. Every high-cardinality entity
+family needs:
+
+- a stable typed ID used by manifests, diagnostics, replay, and external
+  references;
+- a dense runtime row index used for array access;
+- an ID-to-row resolution boundary where dynamic lookup is required; and
+- generation or liveness protection so a removed row cannot be mistaken for a
+  newly allocated entity.
+
+Births, deaths, immigration, emigration, household formation, firm entry, and
+firm exit change table membership through a controlled allocator. Slot reuse,
+compaction, and relationship rewrites may occur only at a declared transition
+boundary and must preserve replay determinism.
+
+### Month boundary and mutation
+
+The current explicit monthly transition remains a semantic requirement. DOD
+must not turn the model into globally mutable state with order-dependent reads.
+
+Static columns are shared across months. Dynamic columns use explicit current
+and next buffers, a change set, or another mechanism that guarantees that a
+stage reads the declared opening state and that the completed month becomes
+visible atomically. Scratch columns for income, consumption, matching, or flow
+amounts may be reused within a month but are not persistent state.
+
+The preferred default for entity-resolved state is double buffering of the
+columns whose opening and closing values must coexist. The runtime swaps those
+buffers only after validation and ledger reconciliation. Full immutable object
+graphs should be materialized only for requested snapshots, not for every
+month.
+
+### Relationship and contract tables
+
+Population relationships are data, not fields overloaded with several
+meanings:
+
+- a person-to-household membership column handles the common one-household
+  relation;
+- employment links connect person rows to firm rows and carry represented job
+  quantities where weights require them;
+- the compiler emits validated opening assignments for accounts, loans, tenure,
+  and ownership using the model-wide schemas; and
+- variable-degree relationships use indexed adjacency or relationship tables
+  rather than nested collections.
+
+Financial principal must have one persistent owner. A contract schema may own
+parties and contractual terms while the ledger owns the balance, but Amor Fati
+must not keep independently mutable principal columns in both places. Deposit,
+credit, security, ownership, insurance, pension, and interbank schemas remain
+separate as specified by the model-wide ontology RFC.
+
+### Research and diagnostic interface
+
+Researchers should not need to understand the column encoding. Public model
+configuration uses the baseline, representation policy, seed, and scenarios.
+Diagnostics and exporters receive stable typed read views, iterators, aggregate
+queries, or explicit snapshots.
+
+This preserves a readable research interface while allowing the engine to
+process large populations without making per-agent case classes the permanent
+storage format.
+
+## Reference Economy
+
+A reference-economy bundle is a versioned, immutable input to population
+compilation. It should contain:
+
+- country and territorial coverage;
+- reference period and source-vintage metadata;
+- resident population controls by age, region, household type, and relevant
+  labor-force dimensions;
+- household controls for size, composition, tenure, income, and financial
+  products;
+- enterprise controls by sector, size, region, ownership, and employment;
+- an explicit sector-classification bridge into Amor Fati sectors;
+- named or archetypal financial institutions and their opening profiles;
+- national-accounts and financial-accounts totals; and
+- migration, births, deaths, pension receipt, and tourism control series.
+
+The first target bundle represents Poland in `2026-Q1` using information
+available by `2026-04-30`. These are different temporal concepts:
+
+| Field | Initial target meaning |
+| --- | --- |
+| `referencePeriod` | `2026-Q1`: the principal completed-quarter economic state represented by the baseline. |
+| `valuationDate` | `2026-04-30`: the point-in-time date for market prices and stocks where a valid observation is available. |
+| `informationCutoff` | `2026-04-30`: no source release published after this date belongs to this baseline vintage. |
+| `sourceObservationPeriod` | The actual date, month, quarter, or year observed by each individual source series. |
+| `sourceReleaseDate` | The publication date of the exact source vintage used. |
+
+April 30 is in the second calendar quarter; it must not be used as evidence
+that the reference period is `2026-Q2`. Conversely, calling the bundle
+`2026-Q1` does not make every input a Q1 observation. Older annual, monthly, or
+quarterly inputs remain admissible only when their dates and transformations
+are explicit.
+
+The bundle may combine sources observed on different dates, but every series
+must retain its observation date, release vintage, transformation, and
+reconciliation rule. A proposed identifier such as
+`pl-2026q1-cutoff-2026-04-30-v1` identifies the compiled bundle, not an
+unsupported claim that every source describes the same day.
+
+The existing Amor Fati calibration is the starting evidence for this bundle,
+not yet proof of a fully reconciled reference economy. Aggregate GDP, public,
+banking, external, and financial stocks may be calibrated while the joint
+population of persons, households, and firms remains only partially empirical.
+The baseline compiler must preserve valid existing bridges and make the sector,
+population, and ownership gaps explicit rather than treating all current
+defaults as equally calibrated.
+
+## Representation Scale
+
+### Researcher-facing meaning
+
+`1:N` means that one ordinary simulated resident unit represents approximately
+`N` empirical residents in the same controlled stratum. At `1:1`, Amor Fati
+would create a synthetic unit for each in-scope empirical unit; it would not
+claim to reconstruct real identities.
+
+The primary user setting should therefore be residents per agent, not raw agent
+counts:
+
+```yaml
+baseline: pl-2026q1-cutoff-2026-04-30-v1
+representation:
+  residentsPerAgent: 1000
+  enterprisePolicy: stratified
+  systemicInstitutions: census
+  rareStrata: preserve
+seed: 42
+```
+
+The population compiler derives household, person, firm, and relationship
+counts. A scenario may change empirical controls; a scale setting may not.
+
+### Weights and exceptions
+
+A single scale label does not require every entity type to have the same
+weight:
+
+- synthetic households and their member records normally carry a household
+  representation weight close to the requested population scale;
+- ordinary firms carry stratum-specific enterprise weights so weighted firm
+  counts and employment both reconcile;
+- rare strata may use smaller weights to avoid disappearance;
+- named banks and systemic or otherwise indispensable institutions may have
+  weight one; and
+- every non-default weight and preservation rule is reported in the manifest.
+
+Agent count is never used as an economic count without applying weights.
+
+### Money and the ledger
+
+Rates, prices, propensities, and per-person or per-household decision variables
+are intensive values and are not multiplied by representation scale. Monetary
+stocks and flows posted to the economy-wide ledger are extensive values and
+must equal the represented amount.
+
+For a weighted household cohort, underwriting may use per-household income,
+debt, and debt-service values, while the ledger contract carries the weighted
+exposure. The implementation must make that projection explicit. It must not
+silently apply `gdpRatio` to some stocks while treating other agent values as
+already scaled.
+
+Changing `residentsPerAgent` should preserve controlled aggregate opening
+stocks and flows within documented rounding tolerances. It may change finite
+population variance and network realization; those effects belong in scale
+robustness evidence.
+
+## Population Compiler
+
+Population initialization becomes a deterministic compiler from a baseline,
+representation policy, and random seed:
+
+1. Load and schema-validate the reference-economy bundle.
+2. Reconcile source universes, dates, classifications, and accounting totals.
+3. Construct joint control tables rather than a collection of unrelated
+   marginal probabilities.
+4. Generate weighted synthetic households and their person members using
+   constrained synthesis that satisfies both household-level and person-level
+   controls.
+5. Generate the firm population from joint sector, size, region, ownership,
+   and employment controls.
+6. Match employed persons to weighted firm job positions; keep unemployed and
+   inactive populations distinct.
+7. Assign deposit accounts, mortgages, consumer loans, firm loans, and other
+   financial contracts using product-specific empirical controls.
+8. Reconcile the micro holdings to national and financial accounts and create
+   ledger opening balances.
+9. Validate hard invariants and emit the compiled population plus a manifest.
+
+The random seed selects a reproducible micro-realization inside the empirical
+constraints. It must not alter controlled totals such as resident population,
+labor force, sector employment, or opening deposit stock beyond declared
+rounding tolerance.
+
+## Firm Population Policy
+
+The correct default is neither an arbitrary random firm population nor an
+attempt to reproduce every actual Polish company.
+
+Ordinary firms should be synthetic and disclosure-safe, but the weighted joint
+population must reproduce the reference economy. Size should be conditional on
+sector and region; ownership should be conditional where the data supports it;
+and weighted job capacity must reconcile with employment. Independent draws
+from national sector, size, and region marginals are insufficient because they
+can create combinations that do not resemble the empirical economy.
+
+Named firms should be included only when their individual identity is necessary
+for the research question and supported by reliable public data. Named or
+explicit archetypal banks are a stronger default because bank concentration,
+balance sheets, and failure propagation are central mechanisms and the
+institution count is small.
+
+## Bilateral Relationships
+
+The population compiler replaces overloaded routing fields with explicit
+opening relations:
+
+```text
+Person --member-of--> Household
+Person --employment-contract--> Firm
+Household --deposit-account--> Bank
+Household --mortgage-contract--> Bank
+Household --consumer-loan-contract--> Bank
+Firm --deposit-account--> Bank
+Firm --loan-contract--> Bank
+```
+
+A household may use different banks for deposits, mortgages, and consumer
+credit. A firm may likewise have multiple banking relationships. Each contract
+has an owner or borrower, a financial institution, a product, an outstanding
+balance, contractual terms, and a representation weight or represented amount.
+
+These examples do not exhaust the model-wide relationship ontology. Enterprise
+ownership, securities, insurance, pensions, interbank exposures, tenancy,
+collateral, and supply networks are governed by the model-wide RFC. This RFC is
+responsible for compiling only the population-linked opening rows requested by
+the selected baseline.
+
+Banks do not need a separate copy of household state. They observe the
+information allowed by an application or servicing relationship and obtain
+their exposures by aggregating the same ledger contracts. This creates a
+bilateral micro link while preserving one accounting source of truth.
+
+## Demographic and External Transitions
+
+### Inactivity and retirement
+
+At minimum, inactivity reasons should distinguish retirement, education, care,
+disability or long-term sickness, and other inactivity. Pension receipt remains
+a separate flag or benefit contract so working pension recipients are valid.
+
+A retirement event must update the relevant person's activity, employment, and
+pension states and the household's income. It may not only increment an
+external retiree counter. The aggregate retiree count becomes a derived
+validation output rather than an independently evolving population.
+
+### Migration
+
+Immigration adds residents and emigration removes residents according to the
+baseline's usual-residence convention. The transition updates person,
+household, labor, housing, and financial relations together. Migration history
+may influence labor matching and remittances, but those effects should decay or
+depend on explicit attributes rather than a permanent universal discount.
+
+Amor Fati's existing immigrant spawning, return migration, and remittance logic
+is a useful behavioral starting point. It should be re-homed under the common
+population compiler and demographic-transition contract rather than discarded.
+
+### Tourism
+
+Tourism is already present as aggregate inbound receipts and outbound resident
+expenditure. That is the correct default granularity for monetary-policy,
+fiscal, banking, and general macro scenarios unless visitor composition,
+regional destinations, accommodation capacity, or tourism-specific shocks are
+causal mechanisms in the experiment.
+
+If micro tourism is enabled, inbound visitor cohorts transact with domestic
+firms and the foreign sector but never join domestic households. Outbound trips
+belong to resident households and create import expenditure without changing
+their residency.
+
+## Required Manifest
+
+Every run should persist a machine-readable population manifest containing at
+least:
+
+- reference-economy ID, digest, and source vintages;
+- population-compiler version;
+- requested representation scale and seed;
+- simulated and weighted counts by entity type;
+- weight distribution and preserved rare strata;
+- controlled totals and achieved residuals;
+- person and household counts by age, region, activity, employment, and
+  migration dimensions;
+- firm counts and employment by sector, size, region, and ownership;
+- bank and product relationship counts and opening balances;
+- resident migration flows and visitor/tourism flows separately; and
+- all reconciliation tolerances and warnings.
+
+The manifest, not a comment in `PopulationConfig`, is the authority for what a
+specific run represented.
+
+## Hard Invariants
+
+The compiler and monthly transition must enforce:
+
+1. Labor force equals employed plus unemployed represented persons.
+2. Economically inactive persons are excluded from the labor-force denominator.
+3. Pension receipt does not by itself imply inactivity.
+4. Each resident person belongs to exactly one household or declared collective
+   household at a month boundary.
+5. Weighted employed persons equal weighted filled job positions within an
+   explicit tolerance.
+6. Resident population evolves through births, deaths, immigration, and
+   emigration; tourism never changes it.
+7. Every employment or financial contract references live entities and a valid
+   represented amount.
+8. Product-level household and firm positions reconcile to bank and
+   economy-wide ledger positions.
+9. Firm and household joint controls meet their declared tolerances.
+10. Changing representation scale does not change reference-economy controls or
+    true-scale opening balance sheets.
+11. Seed changes alter only the admissible micro-realization, not hard controls.
+12. No aggregate retiree, migrant, or inactive stock evolves independently of
+    the represented entities from which it is defined.
+13. All columns in an entity table have the same logical row count, and every
+    live stable ID resolves to exactly one live row.
+14. Current-month kernels cannot observe partially written next-month entity
+    state.
+15. Persistent financial principal has one authoritative storage owner.
+
+## Implementation Boundary
+
+The target population is implemented natively inside the controlled model-core
+replacement accepted by
+[ADR-0007](../adr/0007-controlled-model-core-replacement.md). The current runtime
+remains a behavioral and accounting comparison oracle, not the production host
+for the new population. Test-only projections may create matched fixtures, but
+the target runtime must not translate persistent state through
+`Household.State`, `FirmState`, or a second financial-state owner.
+
+A practical sequence is:
+
+1. Define the baseline schema, representation weights, compiler manifest,
+   population-table schemas, stable-ID policy, and invariants consistently with
+   the model-wide ontology RFC.
+2. Build the constrained firm and household/person compiler so its native
+   output is the target columnar population, then validate it offline against
+   the baseline.
+3. Build the new core's month-boundary state directly from the compiled tables
+   and opening ledger balances.
+4. Implement a thin end-to-end month over native population tables, covering
+   labor, household income and consumption, enterprise activity, financial
+   flows, ledger execution, SFC validation, and atomic closing.
+5. Port retirement, migration, population lifecycle, and active behavioral
+   mechanisms without preserving the old agent API as a compatibility target.
+6. Replace single-bank routing with model-wide product-level account and credit
+   contracts backed by the ledger for every currently active product family.
+7. Remove population meaning from `gdpRatio`; retain any independent numerical
+   unit normalization only if it is explicit and economically neutral.
+8. Add optional visitor cohorts only when a validated research requirement
+   justifies them.
+
+The data-oriented storage boundary is recorded in
+[ADR-0006](../adr/0006-data-oriented-high-cardinality-state.md). The full state
+taxonomy and non-population stores are proposed in the
+[model-wide ontology RFC](0003-model-ontology-and-state-architecture.md). Their
+individual column encodings may evolve without changing model semantics or
+superseding the ADR.
+
+Runtime optimization follows the accepted semantics. It must not decide the
+statistical units, delete inactive residents, or collapse product-level
+relationships before the reference model is defined.
+
+The next design stage is the
+[Research API and notebook runtime RFC](0002-research-api-and-notebook-runtime.md).
+It turns the population semantics accepted here into researcher-facing
+experiment, query, and evidence requirements. The model-wide ontology and state
+RFC then uses both documents to finalize physical state, indexes, views, and
+the data-oriented implementation boundary.
+
+## Open Decisions
+
+The following decisions remain before this RFC can become an ADR:
+
+1. Exact baseline IDs, reference periods, and source-vintage policy.
+2. The statistical definition and age range used for labor force and
+   inactivity controls.
+3. The minimum household/person joint control table supported in the first
+   compiler version.
+4. Whether rare and systemic non-bank firms are preserved automatically or
+   only by baseline declaration.
+5. The representation-weight policy for firm entry, firm death, household
+   splitting, births, and deaths during a run.
+6. The first population-linked account and credit families emitted by the
+   compiler; the model-wide promotion order remains an ontology-RFC decision.
+7. Whether aggregate tourism remains the only supported mode in the first
+   population redesign release.
+8. The concrete stable-ID, slot-allocation, and compaction policy for dynamic
+   populations.
+9. Which dynamic columns require double buffering and which may use validated
+   in-place transitions or change sets.

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -137,8 +137,9 @@ runtime ledger indices, and future primitive columns remain internal.
 8. Public queries use economic domain names, stable selectors, and controlled
    tabular or typed views. They never expose raw high-cardinality storage,
    allocator slots, buffer swaps, or ledger implementation indices.
-9. Every execution emits a machine-readable run manifest and validation status.
-   A notebook file or visible cell output is not sufficient provenance.
+9. Every execution that reaches a controlled terminal state emits a
+   machine-readable run manifest and validation status. A notebook file or
+   visible cell output is not sufficient provenance.
 10. Canonical notebooks are committed, editable examples. Their stored outputs
     are cleared by default, and representative notebooks execute headlessly in
     CI against the release environment.
@@ -389,8 +390,9 @@ cell outputs and execution against an unsupported kernel.
 The Research API defines a run-manifest contract inside the result-bundle
 contract. The Research API, result bundle, and run manifest are separately
 versioned so that artifact or manifest evolution does not silently change the
-programmatic API. Every completed or failed run emits a manifest containing at
-least:
+programmatic API. Every run that reaches a controlled terminal state --
+successful completion, cooperative cancellation, or a captured failure -- emits
+a manifest containing at least:
 
 - Amor Fati release and Git commit, including dirty-worktree status;
 - Research API, result-bundle schema, and run-manifest schema versions;
@@ -401,9 +403,17 @@ least:
 - Scala, JVM, Almond, and notebook-adapter versions;
 - notebook digest when execution originated from a notebook;
 - requested and retained evidence policy;
-- start, completion, cancellation, or failure status;
+- start, completion, cancellation, or captured-failure status;
 - validation and reconciliation results; and
 - hashes of canonical output artifacts.
+
+Abrupt JVM or host termination, process kill, and out-of-memory failure are
+outside that terminal-manifest guarantee. After such an interruption, the
+durable run representation is the last atomically committed checkpoint at an
+accepted month boundary, if one exists. Atomically completed artifacts written
+after that checkpoint may instead be exposed only through a result bundle
+explicitly marked `INCOMPLETE`; that bundle must identify the last accepted
+boundary and must not claim successful completion or complete validation.
 
 The existing `EmpiricalValidationExport.ModelRunManifestTsvSchema` and
 `docs/empirical-validation/model-run-manifest.tsv` are a partial legacy export,
@@ -441,7 +451,9 @@ Interactive execution requires explicit operational behavior:
 - progress is observable without retaining unbounded event history;
 - cancellation is checked at defined safe points;
 - an interrupted month does not publish closing state or a successful result;
-- out-of-memory and kernel termination leave completed artifact writes atomic;
+- abrupt out-of-memory or kernel termination does not promise a terminal
+  manifest; completed artifact writes remain atomic and recovery exposes only
+  the last committed checkpoint or an explicitly incomplete bundle;
 - temporary work directories are run-scoped and recoverable; and
 - parallel seed execution preserves the deterministic seed schedule.
 
@@ -556,7 +568,8 @@ The first supported notebook interface is complete when:
    bottom;
 3. the same experiment specification produces equivalent scientific results
    through notebook and unattended CLI execution;
-4. every run produces a complete manifest and explicit validation status;
+4. every run that reaches a controlled terminal state produces a complete
+   manifest and explicit validation status;
 5. canonical results can be queried without importing engine-internal state;
 6. representation scale and weighted counts are visible and unambiguous;
 7. requested micro evidence is bounded and declared before execution;

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -386,10 +386,14 @@ cell outputs and execution against an unsupported kernel.
 
 ## Reproducibility and Evidence
 
-Every completed or failed run emits a manifest containing at least:
+The Research API defines a run-manifest contract inside the result-bundle
+contract. The Research API, result bundle, and run manifest are separately
+versioned so that artifact or manifest evolution does not silently change the
+programmatic API. Every completed or failed run emits a manifest containing at
+least:
 
 - Amor Fati release and Git commit, including dirty-worktree status;
-- Research API and result-schema versions;
+- Research API, result-bundle schema, and run-manifest schema versions;
 - baseline ID, source vintage, and content digest;
 - population compiler and representation manifest;
 - complete validated experiment specification;
@@ -400,6 +404,14 @@ Every completed or failed run emits a manifest containing at least:
 - start, completion, cancellation, or failure status;
 - validation and reconciliation results; and
 - hashes of canonical output artifacts.
+
+The existing `EmpiricalValidationExport.ModelRunManifestTsvSchema` and
+`docs/empirical-validation/model-run-manifest.tsv` are a partial legacy export,
+not the complete Research API manifest. Their current seven-column record is a
+useful empirical-validation snapshot locator, but it lacks the baseline,
+representation, contract-version, evidence-policy, validation, reconciliation,
+and canonical-artifact-hash fields required above. It may remain as a
+compatibility artifact until the versioned result-bundle manifest supersedes it.
 
 Notebook source is contextual evidence, not the run record. A modified notebook
 can be reproduced only when its executed specification and environment are

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -1,0 +1,585 @@
+# RFC-0002: Research API and Notebook Runtime
+
+Status: Draft for decision
+Scope: Public research workflows, experiment lifecycle, result queries,
+reproducibility manifests, committed notebooks, and the managed Almond/Jupyter
+runtime
+Performance: Resource controls are in scope; engine optimization is not
+
+## Purpose
+
+Amor Fati is a complete research system, not a library that researchers are
+expected to assemble into their own applications. Its current executable
+surfaces are nevertheless implementation-oriented: initialization, monthly
+execution, Monte Carlo orchestration, scenario exports, and diagnostics are
+available through internal Scala entry points or dedicated CLI commands. A
+researcher cannot yet open an interactive environment, construct a documented
+experiment, inspect typed results, modify a scenario, and rerun it through a
+stable public contract.
+
+This RFC defines that contract before the target data-oriented core is built.
+Committed Scala notebooks become the first external-style consumers of Amor
+Fati and expose missing abstractions while those abstractions can still be
+changed. Almond supplies the Scala kernel for Jupyter, but Almond is an adapter
+technology rather than the public API itself.
+
+The design deliberately preserves Amor Fati's system distribution model. It
+does not require publishing the model as a Maven artifact or asking researchers
+to reconstruct a compatible classpath with notebook-local dependency
+directives. Amor Fati owns and launches a tested notebook environment containing
+the engine, Research API, baseline assets, Scala, JVM, Almond, and Jupyter
+components required by a release.
+
+## Decision Order
+
+This RFC is the second decision stage in the target-core design:
+
+1. [Population and representation RFC](0001-population-and-representation.md)
+   defines what the reference economy, represented units, weights, and opening
+   population relationships mean.
+2. This RFC defines what a researcher can configure, execute, observe, compare,
+   and reproduce using those semantics.
+3. [Model ontology and state architecture RFC](0003-model-ontology-and-state-architecture.md)
+   uses the accepted population semantics and research access patterns to
+   complete the state model, indexes, views, and data-oriented storage design.
+
+The documents have different scopes rather than a class-inheritance hierarchy.
+The model-wide RFC may constrain which observations can be authoritative, but
+it must not redesign accepted population meaning or force researchers to
+configure storage details.
+
+The Research API contract should be resolved before the data-oriented state
+layout is finalized. A pilot implementation may run against the current engine
+to validate ergonomics. The target core then replaces that engine behind the
+same conceptual boundary; compatibility with current internal classes is not a
+goal.
+
+Two proposed decision records extract the independently durable parts of this
+RFC:
+
+- [ADR-0009](../adr/0009-research-api-as-supported-scientific-interface.md)
+  makes the Research API the supported scientific programmatic boundary; and
+- [ADR-0010](../adr/0010-managed-almond-jupyter-runtime-and-committed-notebooks.md)
+  selects the managed Almond/Jupyter runtime and committed notebook policy.
+
+Both remain Proposed until the relevant open decisions and acceptance criteria
+in this RFC are resolved.
+
+## Goals
+
+1. Make a first scientifically meaningful Amor Fati experiment executable and
+   inspectable from a committed notebook.
+2. Give researchers typed domain operations rather than access to engine
+   internals or primitive storage.
+3. Make baseline, scale, scenario, seed, requested evidence, and software
+   provenance explicit in every run.
+4. Use the same application-level contract for notebooks, CLI workflows, and
+   future service adapters.
+5. Support interactive exploration without weakening deterministic batch runs,
+   accounting validation, or the explicit month boundary.
+6. Make canonical notebooks executable contract tests for API ergonomics and
+   release compatibility.
+7. Keep the engine and Research API independent of Almond and Jupyter.
+
+## Non-Goals
+
+This RFC does not:
+
+- turn Amor Fati into a general-purpose Scala package;
+- expose mutable data-oriented columns as a public microdata API;
+- define the final visualization library or publication style;
+- make a notebook the authoritative storage format for run evidence;
+- provide a hosted multi-tenant notebook service;
+- treat notebook execution as a security sandbox;
+- replace CLI and unattended batch execution with an interactive kernel; or
+- settle the population, contract, or state semantics owned by the preceding
+  and following RFCs.
+
+## Current Amor Fati Surface
+
+Useful execution capabilities already exist, but they are not one coherent
+research interface:
+
+- `WorldInit.initialize` constructs the current world;
+- `FlowSimulation.step` exposes the current explicit one-month transition;
+- `McRunner` owns production Monte Carlo orchestration;
+- `ScenarioRunExport` executes registry scenarios and writes tabular artifacts;
+- diagnostic exporters create specialized evidence bundles; and
+- generated manifests already capture parts of configuration, calibration, and
+  version provenance.
+
+These are implementation anchors and evidence sources. They do not become the
+public Research API by being renamed or imported into a notebook. In
+particular, `FlowSimulation.SimState`, current agent `case class` collections,
+runtime ledger indices, and future primitive columns remain internal.
+
+## Proposed Decisions
+
+1. Amor Fati introduces a versioned **Research API** as the sole supported
+   programmatic boundary for scientific experiment construction, execution,
+   observation, and comparison.
+2. The Research API is independent of Almond, Jupyter, terminal rendering, and
+   any particular charting library.
+3. CLI experiment commands and the notebook adapter converge on the same
+   application services. They may format results differently but must not
+   implement separate simulation semantics.
+4. Amor Fati supplies a managed Almond-based kernel with a release-pinned and
+   tested Scala, JVM, Almond, Jupyter, model, baseline, and adapter combination.
+5. Researchers launch the managed system environment. Canonical notebooks do
+   not resolve Amor Fati through `$ivy`, publish-local conventions, or an
+   independently assembled classpath.
+6. Experiment configuration is immutable, typed, validated, and complete before
+   execution. Interactive convenience builds new specifications; it does not
+   silently mutate a running experiment's provenance.
+7. A run owns its mutable execution lifecycle. Results, snapshots, manifests,
+   and researcher-facing views are immutable observations of accepted month
+   boundaries.
+8. Public queries use economic domain names, stable selectors, and controlled
+   tabular or typed views. They never expose raw high-cardinality storage,
+   allocator slots, buffer swaps, or ledger implementation indices.
+9. Every execution emits a machine-readable run manifest and validation status.
+   A notebook file or visible cell output is not sufficient provenance.
+10. Canonical notebooks are committed, editable examples. Their stored outputs
+    are cleared by default, and representative notebooks execute headlessly in
+    CI against the release environment.
+11. Notebook interruption is cooperative cancellation at defined execution
+    boundaries. A cancelled or failed month cannot publish a partially closed
+    simulation state.
+12. The kernel is trusted local code execution. Hosted or multi-user deployment
+    requires a separate isolation and tenancy design.
+
+## Architecture Boundary
+
+The target dependency direction is:
+
+```text
+                              +----------------------+
+                              | CLI and batch tools  |
+                              +----------+-----------+
+                                         |
++------------------+          +----------v-----------+
+| Almond/Jupyter   +----------> Research API         |
+| adapter          |          | experiment services |
++------------------+          +----------+-----------+
+                                         |
+                              +----------v-----------+
+                              | Simulation core      |
+                              | and population core  |
+                              +----------+-----------+
+                                         |
+                              +----------v-----------+
+                              | Verified ledger      |
+                              +----------------------+
+```
+
+The core does not import Almond or Jupyter APIs. Rich display, progress cells,
+and kernel-specific cancellation belong to the adapter. A future HTTP or
+enterprise adapter can use the Research API without depending on notebook code.
+
+The exact sbt project split remains an implementation decision, but the logical
+owners are distinct:
+
+| Boundary | Responsibility |
+| --- | --- |
+| Simulation core | Baseline compilation, model state, monthly transition, accounting, deterministic execution. |
+| Research API | Experiment specifications, validation, lifecycle, queries, result bundles, comparison, provenance. |
+| Notebook adapter | Almond predef, rich display, progress integration, notebook-friendly rendering and launch diagnostics. |
+| CLI adapter | Commands, unattended execution, filesystem destinations, terminal progress and exit status. |
+
+## Research API Contract
+
+### Experiment specification
+
+An experiment specification contains at least:
+
+- baseline identity and source-vintage digest;
+- representation scale and any declared `1:1` exceptions;
+- scenario identity plus typed, validated overrides;
+- master seed and deterministic stream policy;
+- start boundary and horizon;
+- requested aggregate, snapshot, event, trace, and diagnostic evidence;
+- execution profile and resource limits; and
+- Research API version.
+
+Population size is not inferred from unrelated firm or worker parameters.
+Baseline and representation semantics come directly from the accepted
+population RFC.
+
+Conceptually, notebook code should read like:
+
+```scala
+val experiment = AmorFati.experiment(
+  baseline = Baseline.poland("2026-Q1"),
+  representation = Representation.oneTo(1000),
+  seed = Seed(42)
+)
+
+val result = experiment
+  .withScenario(Scenario.monetaryTightening(/* typed changes */))
+  .run(months = 60)
+
+result.series(Measure.RealGdp)
+result.series(Measure.UnemploymentRate)
+result.snapshot(Month(12)).households.sample(1000)
+result.manifest
+```
+
+Names in this example are illustrative rather than accepted Scala signatures.
+The final API should optimize for discoverability, compiler assistance, and
+scientific meaning rather than minimizing character count.
+
+### Commands and lifecycle
+
+The public lifecycle distinguishes specification from execution:
+
+```text
+ExperimentSpec
+      |
+      v validate and compile
+PreparedExperiment
+      |
+      v start
+SimulationHandle ---- step / run / cancel / checkpoint
+      |
+      v close successfully
+RunResult + RunManifest + ValidationReport
+```
+
+The supported lifecycle should include:
+
+- validate and prepare without running;
+- execute one or many explicit months;
+- run to a horizon;
+- inspect progress and the latest accepted boundary;
+- request cooperative cancellation;
+- create a checkpoint at an accepted boundary;
+- fork a new experiment from a supported checkpoint;
+- run a deterministic seed ensemble; and
+- close resources explicitly or through a scoped API.
+
+Notebook cell order cannot redefine these semantics. Re-executing a cell may
+create a new handle, but it cannot retroactively change the manifest of an
+existing run.
+
+### Results and queries
+
+The initial observation surface should provide:
+
+- aggregate time series with units and definitions;
+- validation, SFC, ledger, and reconciliation status;
+- population and representation summaries;
+- controlled snapshots at requested month boundaries;
+- filtered or sampled immutable micro views where enabled;
+- scenario and seed-ensemble comparisons;
+- warnings, omissions, and aggregate-only representation declarations; and
+- export into canonical result-bundle formats.
+
+Queries declare their evidence cost. A request for a GDP series must not force
+retention of all person columns for every month. Micro snapshots, event traces,
+and decision traces are opt-in and carry explicit cadence, selection, and size
+limits.
+
+Typed row views may use Scala `case class` values. This does not conflict with
+data-oriented persistent storage because views are bounded observations rather
+than the authoritative high-cardinality state.
+
+### Mutation policy
+
+Researchers modify experiments through validated domain operations:
+
+- baseline selection;
+- scenario composition;
+- typed parameter patches;
+- evidence requests;
+- representation choices; and
+- checkpoint forks.
+
+The API does not support `state.copy(...)`, mutation of raw arrays, direct
+balance replacement, or bypassing the monthly ledger and closing boundary.
+Experimental interventions that alter state during a run require an explicit,
+manifested intervention command with defined timing and validation rules.
+
+## Managed Almond Runtime
+
+### System-owned kernel
+
+Amor Fati provides a dedicated kernel identity, provisionally displayed as
+`Amor Fati (Scala)`. A system command such as `./amor-fati notebook` installs or
+selects the release-compatible kernel and launches the supported Jupyter
+environment.
+
+The kernel definition owns:
+
+- the Java command and JVM options;
+- the compiled Amor Fati classpath;
+- the Scala and Almond versions;
+- a small predef importing the Research API and notebook renderers;
+- baseline and result-directory discovery;
+- startup validation and a visible environment summary; and
+- any resource defaults required for safe local execution.
+
+The exact command name and packaging mechanism remain open until the repository
+distribution path is selected. The invariant is that a researcher launches an
+Amor Fati environment rather than manually constructing a generic Scala kernel.
+
+### Compatibility matrix
+
+Almond's ability to launch Scala kernels does not by itself prove compatibility
+with Amor Fati's compiler, TASTy, JVM, and dependency combination. Every Amor
+Fati release that advertises notebook support records and tests one exact
+combination. Upgrading Scala or Almond requires executing the canonical notebook
+suite before promotion.
+
+The notebook startup cell or predef exposes the resolved environment versions
+and fails clearly if the kernel does not match the checked-out system release.
+Silent fallback to another Scala version is not permitted.
+
+### Kernel state
+
+A Jupyter kernel is stateful, but scientific runs remain explicitly identified:
+
+- each started run receives a unique run ID;
+- active handles are listed and can be closed;
+- restarting the kernel invalidates in-memory handles but not completed result
+  bundles or explicit checkpoints;
+- hidden cell history is not treated as provenance; and
+- canonical notebooks execute correctly from a fresh kernel in top-to-bottom
+  order.
+
+## Committed Notebook Policy
+
+The initial canonical notebook set should remain small and workflow-oriented:
+
+```text
+notebooks/
+|-- 01-baseline-overview.ipynb
+|-- 02-first-scenario.ipynb
+|-- 03-scenario-comparison.ipynb
+|-- 04-seed-ensemble.ipynb
+`-- 05-microdata-inspection.ipynb
+```
+
+The exact filenames may change during implementation. Each canonical notebook:
+
+1. states its required Amor Fati and Research API compatibility;
+2. starts from a fresh managed kernel;
+3. contains no machine-specific paths or credentials;
+4. uses a bounded configuration suitable for CI;
+5. demonstrates one coherent research workflow rather than serving as general
+   product documentation;
+6. persists evidence through the result-bundle API rather than notebook output;
+7. has outputs cleared before commit unless a small output is explicitly
+   accepted as documentation evidence; and
+8. is executed headlessly in CI at an appropriate cadence.
+
+Large run outputs, checkpoints, generated plots, and data extracts are not
+committed beside notebook source by default. CI should reject accidental large
+cell outputs and execution against an unsupported kernel.
+
+## Reproducibility and Evidence
+
+Every completed or failed run emits a manifest containing at least:
+
+- Amor Fati release and Git commit, including dirty-worktree status;
+- Research API and result-schema versions;
+- baseline ID, source vintage, and content digest;
+- population compiler and representation manifest;
+- complete validated experiment specification;
+- seed and random-stream policy;
+- Scala, JVM, Almond, and notebook-adapter versions;
+- notebook digest when execution originated from a notebook;
+- requested and retained evidence policy;
+- start, completion, cancellation, or failure status;
+- validation and reconciliation results; and
+- hashes of canonical output artifacts.
+
+Notebook source is contextual evidence, not the run record. A modified notebook
+can be reproduced only when its executed specification and environment are
+captured independently of mutable kernel history.
+
+## Rich Display
+
+The notebook adapter may provide rich representations for:
+
+- experiment specifications and validation errors;
+- population and baseline manifests;
+- progress and cancellation status;
+- time-series and scenario-comparison tables;
+- validation and reconciliation reports; and
+- bounded microdata views.
+
+Rich rendering consumes public result values. Core result classes must retain a
+useful text representation and machine-readable export without Jupyter. A
+charting failure cannot invalidate or change a simulation result.
+
+## Resources, Cancellation, and Failure
+
+Interactive execution requires explicit operational behavior:
+
+- representation scale, horizon, seed count, snapshot cadence, and trace volume
+  are validated against the selected execution profile;
+- progress is observable without retaining unbounded event history;
+- cancellation is checked at defined safe points;
+- an interrupted month does not publish closing state or a successful result;
+- out-of-memory and kernel termination leave completed artifact writes atomic;
+- temporary work directories are run-scoped and recoverable; and
+- parallel seed execution preserves the deterministic seed schedule.
+
+The first release may support only one active local run per kernel if concurrent
+handles would complicate memory ownership or output routing. This is preferable
+to implicit contention.
+
+## Security Boundary
+
+A notebook executes arbitrary Scala, Java, native-library, and operating-system
+code with the permissions of its process. The managed kernel is not a sandbox.
+Canonical notebooks must not embed credentials, and the launcher must not
+inject unrelated secrets into the environment.
+
+Remote, shared, or enterprise notebook hosting requires a separate design for
+authentication, process and filesystem isolation, network policy, quotas,
+secret handling, audit, and tenancy. Those requirements must not leak into the
+local Research API prematurely.
+
+## API and Notebook Versioning
+
+The Research API is versioned with Amor Fati releases even though it is not
+published as a standalone package. A result manifest records the API version,
+and every canonical notebook declares the supported version or release range.
+
+Before the first supported Research API release, signatures may change freely
+with the committed notebooks in the same change. After promotion:
+
+- incompatible semantic or signature changes require an explicit API-version
+  transition;
+- result schemas evolve through documented, machine-readable versions;
+- deprecations state a removal release or migration path; and
+- canonical notebooks for a release remain reproducible from that release's
+  managed environment.
+
+Internal core and DOD layouts are not covered by this compatibility policy.
+
+## Implementation Sequence
+
+### Phase 0: resolve population semantics
+
+Accept the initial population and representation decisions required for
+baseline selection, scale, weights, population summaries, and opening
+relationships. Research API names must not conceal unresolved statistical
+meaning.
+
+### Phase 1: define the research contract
+
+1. Specify the initial experiment, lifecycle, manifest, result, query, and
+   error types without Almond dependencies.
+2. Map existing initialization, scenario, Monte Carlo, manifest, and exporter
+   capabilities to that boundary.
+3. Implement a narrow pre-release Research API facade over the current engine.
+   Current internal engine types do not enter its public signatures.
+4. Keep the contract explicitly pre-release so notebook evidence can correct it
+   before the target state design is fixed.
+
+### Phase 2: deliver the pilot notebook environment
+
+1. Pin a development compatibility matrix and provide the minimal system-owned
+   Almond launcher, kernelspec, and predef.
+2. Commit baseline-overview and scenario-comparison notebooks against the
+   pre-release Research API.
+3. Execute both notebooks from a fresh kernel in CI with bounded workloads and
+   clean stored outputs.
+4. Record every awkward internal escape, expensive query, missing selector, and
+   ambiguous population concept exposed by those workflows.
+
+The pilot is a real usable notebook surface, not a mock-up. It is not yet the
+supported long-term API, and fidelity to current internal engine classes is not
+a compatibility requirement for the target core.
+
+### Phase 3: complete the target state design
+
+Use the accepted population semantics and observed query patterns to complete
+the model-wide ontology and state RFC. Define indexes, projections, snapshot
+costs, stable views, and evidence retention before fixing DOD table layouts.
+
+### Phase 4: implement the target core behind the boundary
+
+Implement the native population compiler and thin end-to-end target-core month.
+Move Research API services to the target core without a public dependency on
+old agent classes or new primitive storage. API changes remain possible while
+the Research API is explicitly pre-release.
+
+Harden the pilot environment while the target core grows:
+
+1. expand and release-pin the kernel compatibility matrix;
+2. complete the system-owned launcher, predef, renderers, cancellation, and
+   resource cleanup;
+3. expand the canonical notebook set with clean outputs;
+4. retain fresh-kernel, top-to-bottom CI execution and add output-size checks;
+   and
+5. document local operational recovery without making notebooks the only
+   supported execution mode.
+
+### Phase 5: promote the supported interface
+
+Promote a Research API version only after canonical notebooks, CLI runs,
+deterministic replay, manifests, resource cleanup, cancellation, and target-core
+validation pass together. Future enterprise adapters build on this promoted
+boundary rather than on notebook internals.
+
+## Acceptance Criteria
+
+The first supported notebook interface is complete when:
+
+1. a researcher can launch the managed environment through one Amor Fati
+   command without publishing or locally installing Amor Fati as a package;
+2. a fresh kernel can execute the baseline and scenario notebooks from top to
+   bottom;
+3. the same experiment specification produces equivalent scientific results
+   through notebook and unattended CLI execution;
+4. every run produces a complete manifest and explicit validation status;
+5. canonical results can be queried without importing engine-internal state;
+6. representation scale and weighted counts are visible and unambiguous;
+7. requested micro evidence is bounded and declared before execution;
+8. cancellation cannot publish a partially closed month;
+9. kernel restart and stale-handle failures are clear and recoverable; and
+10. the notebook suite passes against the pinned Scala, JVM, Almond, and Amor
+    Fati combination in CI.
+
+## Open Decisions
+
+The following decisions remain before this RFC can become an ADR:
+
+1. The exact first-version Research API type and package names.
+2. Whether a pilot Research API over the current engine is shipped or remains a
+   test-only ergonomics harness until the target core is available.
+3. The exact result-table interchange type and its unit/metadata representation.
+4. The checkpoint serialization format and compatibility policy.
+5. Which micro queries and snapshot cadences are supported in the first release.
+6. Whether one or multiple concurrent run handles are allowed per kernel.
+7. The managed distribution mechanism and final notebook launch command.
+8. The tested Scala, JVM, Almond, and Jupyter compatibility matrix.
+9. Whether canonical `.ipynb` files remain the sole notebook source or gain a
+   paired text representation for reviewable diffs.
+10. The CI cadence for lightweight notebooks and heavier scientific examples.
+11. The first visualization and tabular renderers included in the adapter.
+12. The Research API compatibility and deprecation policy after its first
+    supported release.
+
+## Implementation Anchors
+
+- [`WorldInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala)
+  for current world initialization;
+- [`FlowSimulation.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala)
+  for the current explicit month transition;
+- [`McRunner.scala`](../../modules/montecarlo/src/main/scala/com/boombustgroup/amorfati/montecarlo/runner/McRunner.scala)
+  for current seed-ensemble orchestration; and
+- [`ScenarioRunExport.scala`](../../modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala)
+  for current registry-scenario execution and artifact export.
+
+Almond capability references:
+
+- [Almond installation options](https://almond.sh/docs/install-options) for
+  kernel identity, display name, command, arguments, and predef configuration;
+- [Almond advanced installation](https://almond.sh/docs/next/install-advanced)
+  for launcher and Scala-kernel installation behavior; and
+- [Almond Jupyter API](https://almond.sh/docs/api-jupyter) for adapter-owned rich
+  display and notebook integration.

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -321,6 +321,9 @@ The kernel definition owns:
 The exact command name and packaging mechanism remain open until the repository
 distribution path is selected. The invariant is that a researcher launches an
 Amor Fati environment rather than manually constructing a generic Scala kernel.
+JDK selection, kernel/worker process ownership, JIT, GC, heap, and runtime
+qualification belong to
+[RFC-0004](0004-jvm-runtime-jit-and-garbage-collection-policy.md).
 
 ### Compatibility matrix
 
@@ -329,6 +332,11 @@ with Amor Fati's compiler, TASTy, JVM, and dependency combination. Every Amor
 Fati release that advertises notebook support records and tests one exact
 combination. Upgrading Scala or Almond requires executing the canonical notebook
 suite before promotion.
+
+The exact JVM distribution and runtime profile are qualified through
+[RFC-0004](0004-jvm-runtime-jit-and-garbage-collection-policy.md). The notebook
+matrix must distinguish the Almond kernel JVM from any separately launched
+simulation-worker JVM.
 
 The notebook startup cell or predef exposes the resolved environment versions
 and fails clearly if the kernel does not match the checked-out system release.
@@ -481,8 +489,9 @@ meaning.
 
 ### Phase 2: deliver the pilot notebook environment
 
-1. Pin a development compatibility matrix and provide the minimal system-owned
-   Almond launcher, kernelspec, and predef.
+1. Pin a development compatibility matrix using the provisional control runtime
+   qualified by RFC-0004, and provide the minimal system-owned Almond launcher,
+   kernelspec, and predef.
 2. Commit baseline-overview and scenario-comparison notebooks against the
    pre-release Research API.
 3. Execute both notebooks from a fresh kernel in CI with bounded workloads and

--- a/docs/rfc/0003-model-ontology-and-state-architecture.md
+++ b/docs/rfc/0003-model-ontology-and-state-architecture.md
@@ -486,6 +486,14 @@ risk state, aggregate metric, diagnostic projection, or known unsupported
 ownership family. A field must not enter the ledger merely because it has
 currency units.
 
+Fixed-point money is a hard target invariant across every classification. All
+monetary values, flows, stocks, and account balances use `PLN` or the project's
+equivalent opaque fixed-point domain types, never `Double` or `Float`. A
+continuous calculation may enter accounting or ledger state only through a
+checked conversion with explicit scale, rounding, and overflow behavior that
+preserves SFC identities, including deterministic residual allocation where
+rounding requires it.
+
 ## Flows and Events
 
 Flows record activity over a period. Events record a discrete transition. The
@@ -561,11 +569,21 @@ The monthly execution path additionally owns non-boundary data:
 MonthExecution
 |-- MonthWorkspace        reusable scratch columns and matching buffers
 |-- CommandsAndChangeSets validated proposed transitions
-|-- FlowBatches           ledger inputs and executed-flow evidence
+|-- BatchedFlows           typed BatchedFlow commands and executed-flow evidence
+|-- RuntimeLedgerExecution topology, imperative-interpreter result, and deltas
+|-- AccountingStockProjection supported executed deltas projected into closing stocks
 |-- Events                defaults, failures, migration, entry, exit
 |-- Observations          aggregates and requested snapshots
 `-- Trace                 replay and diagnostic evidence
 ```
+
+Production monthly monetary execution emits `BatchedFlow` values through
+`MonthFlowEmitter`, executes them against `RuntimeLedgerTopology` through
+`ImperativeInterpreter`, and projects the supported executed deltas into the
+accounting-controlled `LedgerFinancialState` slice before publishing closing
+state. Legacy flat `Flow` emitters and `RuntimeLedgerTopology.toFlatFlows` are
+restricted to tests, diagnostics, and explicit compatibility paths; they are
+not production month-execution inputs.
 
 None of these families becomes persistent merely because it appears in a step
 output. Only validated closing state is published as the next boundary.
@@ -650,6 +668,21 @@ workspace buffers, change sets, or snapshots according to their lifetime.
 
 ## Month-Boundary Rules
 
+Signal timing follows three distinct stages for execution month `T`:
+
+- **Stage A -- pre-signal:** opening state and inherited `T - 1`
+  `DecisionSignals` form the pre-decision surface.
+- **Stage B -- same-month:** a decision may consume only Stage A and explicitly
+  ordered same-month state or `OperationalSignals` produced before that
+  decision. It cannot consume a downstream or closing outcome from Stage C.
+- **Stage C -- post-outcome:** realized end-of-month outcomes are closing
+  evidence and may become behavioral input only through `SeedOut` at the
+  `T + 1` boundary.
+
+The pre-signal, same-month, and post-outcome surfaces remain strictly distinct.
+This timing asymmetry prevents a realized outcome from causally feeding a
+decision that helped produce it in the same month.
+
 1. Stable IDs and dense row indices are distinct.
 2. Opening state is read-only to same-month kernels.
 3. Dynamic fields use current/next buffers, validated change sets, or an
@@ -687,14 +720,16 @@ The target architecture must enforce at least:
 9. Secured credit collateral references a valid real asset or an explicitly
    aggregate collateral pool.
 10. Persistent financial principal and balances have one authoritative owner.
-11. Aggregate market or institutional projections identify their source and do
+11. Every monetary value and account balance uses an opaque fixed-point domain
+    type; floating-point values cannot enter accounting or ledger state.
+12. Aggregate market or institutional projections identify their source and do
     not independently drift from authoritative micro or ledger state.
-12. Execution and settlement shells cannot survive as end-of-month owners.
-13. Current-month workspaces and observations cannot silently become behavioral
+13. Execution and settlement shells cannot survive as end-of-month owners.
+14. Current-month workspaces and observations cannot silently become behavioral
     memory.
-14. A change of representation resolution preserves controlled true-scale
+15. A change of representation resolution preserves controlled true-scale
     stocks and flows within declared tolerances.
-15. All state publication is atomic at the explicit month boundary.
+16. All state publication is atomic at the explicit month boundary.
 
 ## Research-Facing Contract
 

--- a/docs/rfc/0003-model-ontology-and-state-architecture.md
+++ b/docs/rfc/0003-model-ontology-and-state-architecture.md
@@ -1,0 +1,877 @@
+# RFC-0003: Model Ontology and State Architecture
+
+Status: Draft for decision
+Scope: Economic units, relationships, instruments, real assets, representation
+resolution, persistent state, monthly workspace, evidence boundaries, and
+data-oriented storage
+Performance: Storage shape is in scope; performance claims and tuning are not
+
+## Purpose
+
+Amor Fati contains more economic structure than its current top-level runtime
+state makes explicit. Persons and households are conflated, employment and bank
+relationships are embedded in agent fields, firm ownership is represented by
+Booleans, and several financial instruments are stored as balances by owner
+rather than as bilateral contracts or holder-resolved positions. At the same
+time, the model already contains named banks, public institutions, social funds,
+financial markets, foreign-sector proxies, real assets, networks, and a verified
+ledger boundary.
+
+This RFC defines the target ontology and state architecture for the whole model.
+It answers four separate questions:
+
+1. What economic units, assets, claims, and relationships exist in the model?
+2. At what resolution is each family represented in a particular baseline?
+3. Which state is persistent at a month boundary, and which state is temporary
+   calculation, flow, event, or observation data?
+4. Which high-cardinality families require data-oriented storage?
+
+The answers must remain separate. An entity can belong to the ontology while
+remaining an aggregate singleton. A monthly result can require a columnar batch
+without becoming a persistent economic entity. A small named population can
+remain a typed Scala structure without disappearing from the ontology.
+
+## Relationship to Other Documents
+
+This RFC is the model-wide integration design, but it is the third decision
+stage for the target core. Population meaning and researcher-facing access
+patterns are resolved first; this RFC then completes the ontology and translates
+those requirements into authoritative state, indexes, views, and storage
+boundaries. Related documents have narrower responsibilities:
+
+- [Population and representation RFC](0001-population-and-representation.md)
+  defines the reference economy, statistical population, representation scale,
+  synthetic-population compiler, migration, and tourism policy.
+- [Research API and notebook runtime RFC](0002-research-api-and-notebook-runtime.md)
+  defines experiment construction, execution lifecycle, result queries,
+  evidence manifests, committed notebooks, and the managed Almond/Jupyter
+  adapter.
+- [ADR-0006](../adr/0006-data-oriented-high-cardinality-state.md) records the
+  accepted storage principle for high-cardinality persistent state.
+- [ADR-0007](../adr/0007-controlled-model-core-replacement.md) records the accepted
+  strategy for replacing the stateful core without preserving its internal API
+  or rewriting the verified accounting and scientific infrastructure.
+- [ADR-0004](../adr/0004-ledger-owned-financial-state.md) records the single-owner
+  rule for supported ledger-backed financial stocks.
+- [State and ledger boundary](../architecture/state-and-ledger-boundary.md)
+  documents the currently implemented ownership boundary.
+- [Model notation and state vector](../model-notation-and-state-vector.md) remains
+  the canonical description of implemented state, not of this proposed target.
+
+This RFC must not be read as a claim that the target ontology is already
+implemented. When accepted and implemented, canonical model and architecture
+documentation must be updated separately.
+
+## Proposed Decisions
+
+1. Amor Fati has one explicit model ontology covering institutional units, real
+   assets, relationships, financial instruments and positions, classifications,
+   events, and aggregate market or policy state.
+2. Every baseline declares the representation resolution of each ontological
+   family. `1:1`, weighted synthetic units, cohorts, aggregate singletons, and
+   intentionally absent families are distinct modes.
+3. Ontological identity is not inferred from a Scala class or ledger sector.
+   Stable typed IDs identify units, contracts, instruments, positions, and
+   relationships across month boundaries and evidence exports.
+4. High-cardinality homogeneous state and large batch workspaces use dedicated
+   data-oriented storage. Low-cardinality institutional, policy, market, and
+   control state remains typed.
+5. Relationships that have independent economic meaning or lifecycle are state,
+   not overloaded entity fields. Employment, ownership, accounts, credit,
+   positions, tenure, and variable-degree networks receive explicit schemas.
+6. A generic `FinancialContractTable` is not the target. Deposits, credit,
+   securities, ownership stakes, insurance claims, pension claims, and
+   interbank exposures have separate semantic schemas even where they share
+   infrastructure.
+7. Contract and instrument tables own identity, parties, terms, and lifecycle.
+   The ledger owns supported financial principal and balances. The same stock
+   must not have two independently mutable owners.
+8. Markets, mechanisms, and `engine.economics` step outputs are not
+   automatically entities. Their persistent state, transient workspace,
+   commands, events, and observations are classified explicitly.
+9. The explicit monthly transition remains authoritative. Data-oriented storage
+   must preserve opening-state isolation, deterministic replay, atomic closing,
+   and reconciliation before state publication.
+10. Public research interfaces expose typed views, queries, manifests, and
+    exports. Researchers do not configure primitive column layouts.
+11. The target is delivered through the controlled model-core replacement
+    recorded by ADR-0007. Compatibility with the current internal agent-state
+    API is not a design requirement.
+
+## Core Migration Strategy
+
+[ADR-0007](../adr/0007-controlled-model-core-replacement.md) accepts a controlled
+replacement of the stateful model core. This avoids designing the target around
+temporary compatibility with `Household.State`, `FirmState`, copied entity
+vectors, overloaded `bankId` routing, or object-row financial state.
+
+The replacement is not a clean-room rewrite of Amor Fati. The boundary is:
+
+| Preserve and reuse | Replace in the new core |
+| --- | --- |
+| Verified ledger library and ledger-first execution | Population initialization and compilation |
+| Fixed-point domain numerics and typed identifiers where semantically valid | Household/person and enterprise persistent object rows |
+| Random-stream ownership and deterministic seed schedule | Root ownership of high-cardinality state |
+| Explicit month-boundary semantics | Embedded membership, employment, ownership, bank, and network relationships |
+| Economic equations and pure mechanisms after dependency review | Agent-oriented kernels tied to whole-row copying and `copy` transitions |
+| Flow vocabulary, SFC projection, reconciliation, and accounting invariants | Object-row `LedgerFinancialState` storage and aggregate-only routing where contracts are required |
+| Aggregate market, policy, fiscal, monetary, and external state where ontology remains valid | Same-month DTOs that duplicate complete persistent populations |
+| Calibration evidence, scenario definitions, diagnostics, and scientific exports where their meaning remains valid | Initialization controls whose population or scaling meaning is invalidated by the new baseline compiler |
+| Existing tests as behavioral evidence after classification | Tests that merely encode an obsolete storage shape or conflated ontology |
+
+The current engine is frozen as a behavioral and accounting oracle. It is not a
+production compatibility layer for the new core. Test-only fixtures, projections,
+or adapters may feed comparable inputs into both engines, but no production
+month executes by translating persistent state back and forth.
+
+The replacement follows these constraints:
+
+1. The new core is developed in this repository so history, domain code,
+   calibration, tests, and the ledger remain directly reusable.
+2. The new core owns its ontology, tables, contracts, workspace, and monthly
+   closing state natively from its first end-to-end execution.
+3. Old APIs are reused only when their semantics remain correct. API
+   compatibility is not a goal.
+4. Porting is selective. A pure equation or mechanism is reused or moved; code
+   whose behavior depends on the obsolete state shape is reimplemented against
+   the new tables.
+5. At no point may the old and new cores jointly own one production state.
+6. Fixed-seed differential tests compare mechanisms on controlled inputs.
+   Full-run time-series equality is not required where the corrected population
+   ontology intentionally changes outcomes.
+7. Aggregate, accounting, directional scenario, replay, and invariant evidence
+   must pass the cutover gates before the new core replaces the old runtime.
+8. Aggregate families remain aggregate unless a separately justified research
+   requirement and empirical bridge require greater resolution.
+
+The intended path is:
+
+```text
+freeze current engine as oracle
+              |
+              v
+build native target core -> thin end-to-end month -> port active mechanisms
+              |                                      |
+              `---------- differential harness ------'
+                                     |
+                                     v
+                              satisfy cutover gates
+                                     |
+                                     v
+                    replace old core and remove oracle path
+```
+
+This strategy deliberately accepts a temporary second implementation in a
+development and test context. It rejects permanent dual runtime, compatibility
+architecture, and piecemeal production ownership split across old and new state.
+
+## Delivery Scope
+
+The complete ontology is deliberately larger than the first implementation
+slice. Every family belongs to one of three delivery classes.
+
+### Mandatory foundation
+
+The first target foundation contains only the state required to correct
+population meaning, representation scale, and currently active bilateral
+behavior:
+
+- baseline manifest, classification catalogs, representation modes, weights,
+  and stable-ID policy;
+- `PersonTable`, `HouseholdTable`, and `EnterpriseTable`;
+- household membership and employment relations;
+- existing social and production networks in compact indexed storage;
+- explicit opening deposit-account and credit-contract assignments for the
+  products already active in the model;
+- the existing named bank population and other required institutional IDs;
+- a persistent columnar ledger projection with one authoritative balance owner;
+  and
+- typed views, change sets, and equivalence evidence for migrated kernels.
+
+This foundation does not require resolved dwellings, individual insurers,
+security-by-security bond books, bank shareholders, or individual local
+governments.
+
+### Initially aggregate
+
+The following families remain typed aggregate singletons, small named
+populations, weighted cohorts, or diagnostic projections in the initial target
+unless a narrower design decision promotes them:
+
+- NBP, central government, consolidated JST, ZUS/FUS, NFZ, PPK, and earmarked
+  funds;
+- insurers, NBFIs, investment funds, and quasi-fiscal vehicles;
+- regional housing markets and aggregate dwelling wealth;
+- foreign trade partner and sector cohorts;
+- aggregate insurance reserves and pension or fund claims;
+- government, corporate, and quasi-fiscal security portfolios at their current
+  holder resolution; and
+- market, policy, expectations, fiscal, monetary, and external-sector state.
+
+Their representation mode and known loss of heterogeneity are recorded in the
+manifest. They remain part of the ontology without becoming DOD populations.
+
+### Optional future resolution
+
+The following are extension paths, not prerequisites for the population and DOD
+migration:
+
+- individual dwellings, landlords, tenancy contracts, and collateral links;
+- individual insurers, policies, beneficiaries, and claims;
+- person-level pension entitlements and fund-unit positions;
+- security-by-security government and corporate bond instruments;
+- explicit bank shareholders and holder-resolved bank equity;
+- individual JST units and their debt holders;
+- named or synthetic foreign enterprises and counterparties; and
+- micro-level visitor cohorts.
+
+Promotion from aggregate to resolved state requires a research question,
+empirical controls, reconciliation rules, lifecycle semantics, and validation
+evidence. Architectural possibility alone is insufficient.
+
+## Ontology and Storage Are Different
+
+The ontology describes economic meaning. Storage describes an implementation
+strategy. The following distinctions are normative:
+
+| Concept | Question answered | Example |
+| --- | --- | --- |
+| Institutional unit | Who can make decisions, own assets, incur liabilities, or receive flows? | Household, enterprise, bank, NBP, central government. |
+| Real asset | What non-financial object or stock is produced, used, occupied, or owned? | Dwelling, inventory, physical capital. |
+| Relationship | Which independently meaningful link connects units or assets? | Membership, employment, ownership, tenancy, supply link. |
+| Contract or instrument | What enforceable or accounting claim connects issuer, borrower, lender, or holder? | Mortgage, deposit account, bond, equity position. |
+| Market or policy state | What aggregate price, rule, signal, or institutional regime persists? | Yield curve, policy rate, housing price index. |
+| Event or flow | What occurred during a period? | Origination, default, migration, tax payment. |
+| Observation or evidence | What is derived for validation, diagnostics, or export? | Gini coefficient, SFC residual, decision trace. |
+| Storage family | How is a high-cardinality set processed efficiently? | Structure-of-arrays person table or indexed edge store. |
+
+No rule requires one class per ontological concept or one table per class. No
+rule permits an economic relationship to remain semantically ambiguous merely
+because it is currently encoded as a scalar field.
+
+## Representation Resolution
+
+Every baseline manifest must classify each ontological family using one of the
+following representation modes:
+
+| Mode | Meaning |
+| --- | --- |
+| Named census unit | A known institution represented individually with weight one, such as a systemically relevant bank. |
+| Synthetic micro unit | A disclosure-safe generated unit representing one empirical unit. |
+| Weighted synthetic unit | A generated unit representing multiple empirical units in a controlled stratum. |
+| Weighted cohort | A group represented by common state and a weight where individual identity is not behaviorally required. |
+| Aggregate singleton | One consolidated state representing an entire institutional sector, market, fund, or mechanism. |
+| Diagnostic projection | A derived view of authoritative state, not an independently evolving unit. |
+| Not represented | A family deliberately outside the baseline, with the omission declared. |
+
+Representation mode is baseline metadata, not a permanent property of the
+ontology. For example, JST can be one aggregate singleton in the first Poland
+baseline and later become a population of local-government units without
+redefining what local government means. Foreign trade partners can remain
+sector-partner cohorts while domestic enterprises use weighted synthetic units.
+
+Each represented family declares:
+
+- statistical or legal unit definition;
+- institutional sector and relevant classifications;
+- stable-ID namespace;
+- representation mode and weight semantics;
+- opening controls and reconciliation tolerances;
+- lifecycle rules;
+- authoritative state owner; and
+- whether a row is an economic unit, cohort, contract, position, or diagnostic
+  projection.
+
+## Classifications and Reference Catalogs
+
+Classifications are versioned reference data, not scattered enums or implicit
+integer meanings. The target reference state includes at least:
+
+- institutional sectors and subsectors;
+- modeled entity and relationship types;
+- industry classification plus the bridge to Amor Fati production sectors;
+- geography, residency, and territorial coverage;
+- enterprise size, legal form, listing status, and ownership or control class;
+- labor-force, employment-contract, education, activity, and program status;
+- account, credit, security, insurance, pension, and collateral product types;
+- currency, valuation basis, maturity, seniority, and accounting classification;
+  and
+- representation mode, weight unit, aggregation, and consolidation policy.
+
+Runtime codes can use compact numeric encodings, but the baseline manifest must
+bind every code to a stable catalog version and human-readable meaning. A code
+change cannot silently reinterpret a persisted population or result bundle.
+
+## Economic Units
+
+### Persons and households
+
+`Person` is the demographic, residency, education, health, labor-supply, and
+pension-eligibility unit. `Household` is the co-resident consumption, pooled
+finance, housing, and retail-credit unit. Membership is an explicit relation.
+The detailed statistical definitions belong to the population RFC.
+
+### Non-financial enterprises
+
+`Enterprise` is the default firm unit. A baseline must not silently mix legal
+enterprises, enterprise groups, establishments, and local units. Establishments
+or local units become separate units only when regional production, site-level
+employment, or capacity is behaviorally required.
+
+Enterprise state includes operational status, sector, size, region, technology,
+production, inventories, capital, pricing, distress, and lifecycle. Employment,
+ownership, banking, securities issuance, and supply-network links remain
+separate relations or contracts.
+
+### Financial corporations
+
+The ontology distinguishes:
+
+- commercial banks and other deposit-taking institutions;
+- the central bank;
+- insurers;
+- investment funds and fund managers where the distinction matters;
+- non-bank credit providers;
+- pension or retirement-savings vehicles; and
+- resolution or deposit-guarantee institutions where modeled as balance-sheet
+  owners rather than policy mechanisms.
+
+Their first implementation may remain low-cardinality or consolidated. Named
+banks can use weight one while insurers or NBFIs remain aggregate singletons.
+
+### General government and public institutions
+
+The ontology distinguishes central government, local government, social
+security, healthcare funds, earmarked funds, and any public corporation or
+quasi-fiscal vehicle. Consolidation rules must be explicit. A treasury
+settlement account is not automatically the same unit as central government,
+and an execution shell is not an institutional owner.
+
+The currently aggregate ZUS/FUS, NFZ, PPK, FP, PFRON, FGSP, JST, BGK/PFR-like
+quasi-fiscal state belongs in this institutional map even where no individual
+agent population exists.
+
+### Rest of the world
+
+The foreign sector distinguishes foreign institutional owners, trade partner
+or foreign-firm cohorts, external investors, visitors, and settlement
+counterparties. The current GVC rows are sector-partner proxies, not claims to
+represent individual foreign companies. Runtime trade, income, capital, or
+transfer settlement shells are not persistent foreign units.
+
+## Real Assets and Non-financial Stocks
+
+The ontology includes real assets even when their first representation remains
+an aggregate stock:
+
+- dwellings or housing cohorts, with region and tenure-relevant attributes;
+- enterprise physical capital;
+- green capital;
+- inventories;
+- productive technology or intangible-capital state where economically
+  distinct; and
+- collateral links between a real asset and a secured credit contract.
+
+A scalar enterprise capital stock can remain an enterprise column until asset
+vintage or individual-asset heterogeneity affects behavior. A regional housing
+stock can remain an aggregate market state until ownership, tenancy, collateral,
+construction capacity, or household mobility requires resolved dwellings. The
+ontology records the missing resolution rather than pretending that an
+aggregate price index is a dwelling population.
+
+## Relationships
+
+The target relationship families are:
+
+| Relationship | Parties | Minimum semantic state |
+| --- | --- | --- |
+| Household membership | Person to household | Role, start/end boundary, represented quantity where weighted. |
+| Employment | Person or labor cohort to enterprise or establishment | Contract type, job quantity, wage terms, sector, start/end, status. |
+| Residency and migration episode | Person to geography | Usual-residence status, origin, destination, start/end, migration reason where modeled. |
+| Tenure or occupancy | Household to dwelling or housing cohort | Owner/tenant/other tenure, housing cost, start/end. |
+| Enterprise ownership | Owner unit to enterprise | Stake or control share, ownership class, listed/private status, start/end. |
+| Deposit service | Household or enterprise to bank | Account identity, product, currency, status, terms, ledger balance key. |
+| Credit | Borrower to lender, optionally collateral | Product, origination, maturity, rate terms, status, ledger balance key. |
+| Security issuance | Issuer to instrument | Instrument terms, issue and maturity state. |
+| Security holding | Holder to instrument | Position identity, quantity or represented holding, valuation basis, ledger balance key. |
+| Insurance | Policyholder or beneficiary to insurer | Product, coverage, premium terms, claim or reserve relation. |
+| Pension or fund entitlement | Person or household to scheme | Contribution and entitlement status, fund position where resolved. |
+| Fiscal entitlement or obligation | Person, household, or enterprise to public institution | Program or tax type, eligibility or liability interval, represented amount where persisted. |
+| Interbank exposure | Lender bank to borrower bank | Instrument, amount, maturity, seniority or recovery class. |
+| Production or supply link | Enterprise to enterprise or foreign cohort | Input class, weight or capacity, active interval. |
+| Social link | Person or household to peer | Network type, weight where required, active interval. |
+
+Common one-to-one or many-to-one links may use a foreign-key column when the
+relationship has no independent attributes or lifecycle. Variable-degree links
+and economically meaningful contracts use dedicated indexed stores. The choice
+must be justified by semantics first and access pattern second.
+
+## Financial Instruments, Contracts, and Positions
+
+The financial model requires distinct schemas rather than one universal row.
+The initial target families are:
+
+### Deposit accounts
+
+`DepositAccountTable` links an account holder to a deposit-taking institution
+and stores product, currency, contractual status, and a ledger balance key.
+Demand and term deposits can share infrastructure while preserving different
+terms and liquidity behavior.
+
+### Credit contracts
+
+`CreditContractTable` owns borrower, lender, product, origination, maturity,
+rate convention, amortization, collateral reference, performance stage, and
+contract status. Product-specific extension columns or tables cover mortgages,
+consumer credit, firm credit, NBFI credit, and quasi-fiscal lending without
+forcing every kernel through irrelevant fields.
+
+Principal and accrued financial balances remain ledger-owned. Risk state such
+as arrears, non-performance, staging, and recovery belongs to the contract or a
+contract-indexed risk table, not only to aggregate bank buckets.
+
+### Securities and ownership
+
+`SecurityInstrumentTable` owns issuer and instrument terms for government
+bonds, corporate bonds, quasi-fiscal bonds, fund units, and listed equity where
+resolved. `SecurityPositionTable` links holders to instruments. Issuance and
+holder positions reconcile to the ledger and to market valuation state.
+
+`EnterpriseOwnershipTable` covers control and beneficial ownership of listed
+and unlisted enterprises. It replaces `foreignOwned` and `stateOwned` Booleans
+with explicit owners or owner classes and shares. Listed equity ownership and
+enterprise-control classification must reconcile but are not assumed to be
+identical concepts.
+
+### Insurance, pension, and reserve claims
+
+Policy or entitlement tables are introduced only at the resolution needed by a
+research question. Until then, technical reserves and fund positions remain
+declared aggregate or household-distributed projections. A projection used to
+balance a sector is labeled as such and does not imply that individual policy
+contracts have been modeled.
+
+### Interbank instruments
+
+Net interbank position per bank is insufficient for bilateral default
+propagation. An `InterbankExposureTable` or a small dense bank-by-bank matrix
+owns lender-borrower exposure. Its row count is small today, so semantic
+clarity, not DOD performance, determines the representation.
+
+### Net worth, ownership equity, and regulatory capital
+
+Accounting net worth, a transferable equity instrument, enterprise control, and
+regulatory bank capital are different concepts:
+
+- enterprise ownership records who controls or beneficially owns an enterprise;
+- listed or otherwise transferable equity is an instrument with issuer and
+  holder positions;
+- accounting net worth is a balance-sheet residual or institutional state; and
+- regulatory bank capital is the capital buffer used for prudential ratios,
+  loss absorption, failure, and resolution.
+
+The current `BankState.capital` is persistent regulatory and accounting state,
+not a holder-resolved bank-equity position. It remains valid institutional state
+while outside the transferable ledger slice. Adding bank shareholders later
+requires an explicit bank-equity instrument and holder positions reconciled to,
+but not confused with, regulatory capital. The same distinction applies to
+private-enterprise ownership and firm equity balances.
+
+Every stock-like family must therefore be classified as one of: supported
+ledger-owned balance, contract or instrument state, institutional accounting or
+risk state, aggregate metric, diagnostic projection, or known unsupported
+ownership family. A field must not enter the ledger merely because it has
+currency units.
+
+## Flows and Events
+
+Flows record activity over a period. Events record a discrete transition. The
+ontology includes, at minimum:
+
+- births, deaths, household formation or dissolution, immigration, emigration,
+  and residency changes;
+- hiring, separation, retirement, retraining entry or completion, and contract
+  changes;
+- enterprise entry, exit, ownership change, technology adoption, investment,
+  and bankruptcy;
+- account opening or closing, origination, issuance, purchase, sale,
+  amortization, maturity, delinquency, default, restructuring, recovery, and
+  write-off;
+- bank failure, bail-in, resolution, and counterparty-loss propagation;
+- tax, contribution, benefit, pension, healthcare, insurance, and quasi-fiscal
+  payments; and
+- domestic trade, imports, exports, tourism, remittances, income flows, capital
+  flows, and valuation changes.
+
+An event can update several authoritative stores atomically. A flow that does
+not survive closing remains executed-flow evidence. A receivable, payable,
+arrears balance, or other claim that survives closing must be promoted to an
+explicit contract, position, ledger balance, or declared institutional state.
+
+## Target State Architecture
+
+The target month-boundary state has the following conceptual shape:
+
+```text
+SimulationState
+|-- ReferenceState
+|   |-- classification catalogs
+|   |-- baseline and representation manifest
+|   `-- immutable entity profiles
+|-- PopulationState
+|   |-- PersonTable
+|   |-- HouseholdTable
+|   `-- EnterpriseTable
+|-- InstitutionalState
+|   |-- FinancialInstitutionState
+|   |-- PublicInstitutionState
+|   `-- ForeignCohortState
+|-- RelationshipState
+|   |-- HouseholdMembershipTable
+|   |-- EmploymentTable
+|   |-- EnterpriseOwnershipTable
+|   |-- ResidencyAndTenureTables
+|   `-- NetworkStore
+|-- ContractAndInstrumentState
+|   |-- DepositAccountTable
+|   |-- CreditContractTable
+|   |-- SecurityInstrumentTable
+|   |-- SecurityPositionTable
+|   |-- InsuranceAndPensionTables
+|   `-- InterbankExposureStore
+|-- RealAssetState
+|   |-- HousingOrDwellingState
+|   `-- EnterpriseAssetState
+|-- LedgerState
+|-- MarketPolicyAndMacroState
+`-- BoundaryMetadata
+```
+
+This is a semantic ownership tree, not a requirement for one giant case class.
+Packages may expose narrower state handles. A table may share an allocator or
+column infrastructure with another table while retaining a distinct domain
+schema.
+
+The monthly execution path additionally owns non-boundary data:
+
+```text
+MonthExecution
+|-- MonthWorkspace        reusable scratch columns and matching buffers
+|-- CommandsAndChangeSets validated proposed transitions
+|-- FlowBatches           ledger inputs and executed-flow evidence
+|-- Events                defaults, failures, migration, entry, exit
+|-- Observations          aggregates and requested snapshots
+`-- Trace                 replay and diagnostic evidence
+```
+
+None of these families becomes persistent merely because it appears in a step
+output. Only validated closing state is published as the next boundary.
+
+## Data-Oriented Storage Boundary
+
+### Required data-oriented families
+
+The following are high-cardinality or naturally batch-processed and should use
+structure-of-arrays, compact typed columns, or indexed edge storage:
+
+- persons, households, and ordinary enterprises;
+- household membership, employment, and enterprise ownership;
+- deposit accounts, credit contracts, and security positions when resolved;
+- social, production, and other variable-degree networks;
+- high-cardinality real assets when enabled;
+- persistent ledger balances; and
+- large per-entity monthly workspaces, deltas, and requested event buffers.
+
+### Conditional data-oriented families
+
+Banks, insurers, funds, local governments, securities, dwellings, foreign
+counterparties, and visitor units use DOD when their resolved population or hot
+access pattern justifies it. Their ontology does not depend on that choice.
+
+### Typed low-cardinality families
+
+Typed immutable values remain the default for:
+
+- aggregate market and policy state;
+- a small named bank or institutional population where row processing is not a
+  bottleneck;
+- configuration, classifications, baseline metadata, and manifests;
+- commands, validated transitions, and public results;
+- aggregate diagnostics and SFC validation results; and
+- on-demand row views used by tests, diagnostics, and researchers.
+
+Raw arrays are package-private. Domain APIs use typed IDs, validated accessors,
+and explicit transition methods. Separate columns do not weaken economic
+invariants.
+
+## Persistent State, Workspace, and Evidence
+
+Every state-bearing field must be classified as one of:
+
+| Class | Lifetime | Rule |
+| --- | --- | --- |
+| Reference | Baseline lifetime | Immutable input or classification. |
+| Persistent micro state | Across month boundaries | Authoritative entity, relationship, contract, or real-asset state. |
+| Persistent aggregate state | Across month boundaries | Market, policy, institutional, or lagged macro state. |
+| Monthly workspace | Within one execution month | Reusable calculations; never published as independent state. |
+| Change set or command | Until validation and closing | Proposed transition applied atomically. |
+| Flow or event | Occurrence during one period | Append-only evidence or immediate input to accounting and closing. |
+| Observation | Derived on demand or at configured cadence | Must not feed behavior unless promoted explicitly to lagged state. |
+
+This classification prevents monthly `StepOutput` DTOs from becoming a second
+state owner. In particular, vectors of updated firms, households, balances, or
+per-entity flows in `engine.economics` should migrate toward table handles,
+workspace buffers, change sets, or snapshots according to their lifetime.
+
+## Current Implementation Mapping
+
+| Current representation | Target interpretation |
+| --- | --- |
+| `FlowSimulation.SimState` | Existing month-boundary root; will reference the target stores without changing explicit month semantics. |
+| `Household.State` | Temporary conflation to split across person, household, membership, employment, network, and relationship state. |
+| `FirmState` | Enterprise row plus embedded bank routing, ownership classification, and network links to extract. |
+| `Banking.BankState` and `Banking.MarketState` | Small bank population and aggregate banking-market state; contracts and exposures are separate. |
+| `World` and its segments | Typed persistent aggregate, institutional, market, policy, and mechanism state. |
+| `LedgerFinancialState` owner rows | Current authoritative financial-stock slice; migrate to persistent columnar ledger state and more resolved contract keys. |
+| `AssetOwnershipContract` | Current owner-sector and asset-family registry; a basis for, not a replacement for, instrument and position ontology. |
+| `HousingMarket.State` | Aggregate or regional housing-market and mortgage projection; no resolved dwelling population yet. |
+| `GvcTrade.ForeignFirm` | Foreign sector-partner cohort or proxy, not a named foreign enterprise. |
+| Interbank exposure matrix | Bilateral exposure relation, semantically valid even while stored as a small dense matrix. |
+| `PipelineState`, `MonthlyCalculus`, and economics `StepOutput` | Lagged signals, monthly calculation transcripts, workspaces, and observations; not new economic units. |
+| Runtime ledger shells | Execution or settlement counterparties; never persistent institutional owners. |
+
+## Month-Boundary Rules
+
+1. Stable IDs and dense row indices are distinct.
+2. Opening state is read-only to same-month kernels.
+3. Dynamic fields use current/next buffers, validated change sets, or an
+   equivalent isolation mechanism.
+4. Entry, exit, birth, death, migration, contract origination, maturity,
+   default, and resolution update all affected stores at a declared transition
+   boundary.
+5. Relationship and contract references are validated against live IDs before
+   closing.
+6. Ledger execution and stock-flow reconciliation complete before closing state
+   is published.
+7. Slot reuse or compaction occurs only at a deterministic boundary and updates
+   every dependent index.
+8. Requested observations are derived from one coherent boundary or explicitly
+   identified same-month evidence.
+
+## Hard Invariants
+
+The target architecture must enforce at least:
+
+1. Every live entity, relationship, contract, instrument, and position has one
+   stable typed ID in its namespace.
+2. Every relationship references live, type-correct parties at a boundary.
+3. Representation weights are positive and their unit meaning is declared.
+4. Person, household, employment, and population controls satisfy the
+   population RFC invariants.
+5. Enterprise ownership shares and classifications reconcile within declared
+   tolerances.
+6. Every credit or account contract has a valid institution and borrower or
+   holder.
+7. Instrument issuance reconciles to holder positions plus explicitly declared
+   residual or aggregate holdings.
+8. Bilateral interbank assets reconcile to counterpart liabilities and bank net
+   positions.
+9. Secured credit collateral references a valid real asset or an explicitly
+   aggregate collateral pool.
+10. Persistent financial principal and balances have one authoritative owner.
+11. Aggregate market or institutional projections identify their source and do
+    not independently drift from authoritative micro or ledger state.
+12. Execution and settlement shells cannot survive as end-of-month owners.
+13. Current-month workspaces and observations cannot silently become behavioral
+    memory.
+14. A change of representation resolution preserves controlled true-scale
+    stocks and flows within declared tolerances.
+15. All state publication is atomic at the explicit month boundary.
+
+## Research-Facing Contract
+
+A researcher configures a baseline, representation policy, scenarios, seed,
+requested evidence, and optional resolution modules. The run manifest reports:
+
+- every ontological family and its representation mode;
+- simulated and represented counts;
+- institutional consolidation choices;
+- enabled contract, asset, and network resolution;
+- aggregate-only and diagnostic-only families;
+- omitted families;
+- opening reconciliation residuals;
+- table and schema versions; and
+- requested snapshots or event evidence.
+
+The researcher-facing API uses domain names and typed selectors. Primitive
+encodings, row compaction, buffer swaps, and ledger indices remain internal.
+The complete public lifecycle, query, reproducibility, notebook, and adapter
+contract belongs to the
+[Research API and notebook runtime RFC](0002-research-api-and-notebook-runtime.md).
+
+## Implementation Sequence
+
+### Phase 0: freeze semantics and evidence
+
+1. Complete the population and representation decisions required by the first
+   target-core slice.
+2. Complete the Research API decisions that define experiment lifecycle,
+   public observations, evidence retention, and dominant access patterns.
+3. Freeze the remaining ontology vocabulary, delivery classes, representation modes,
+   stable-ID namespaces, state-lifetime taxonomy, and manifest schema.
+4. Identify the existing tests, fixed-seed runs, ledger identities, SFC checks,
+   aggregates, and diagnostics that form the comparison oracle for each future
+   slice.
+5. Record current behavior where coverage is insufficient before changing state
+   ownership.
+
+### Phase 1: build the native foundation
+
+1. Translate the accepted population and Research API contracts into the native
+   foundation without exposing storage internals through the public boundary.
+2. Make the population compiler emit native person, household, enterprise,
+   membership, and employment tables plus a reconciliation manifest.
+3. Introduce typed entity-reference, relationship, allocator, table-view,
+   workspace, and change-set infrastructure without introducing a generic ECS.
+4. Introduce deposit-account and credit-contract schemas for the products
+   required by the first end-to-end execution.
+5. Build the new root state and explicit monthly closing boundary over these
+   stores.
+6. Validate the compiled opening state against empirical controls and opening
+   ledger identities before implementing behavioral progression.
+
+### Phase 2: complete a thin end-to-end month
+
+Implement the smallest scientifically coherent execution:
+
+```text
+baseline and compiled population
+        -> labor and wages
+        -> household income and consumption
+        -> enterprise production and decisions
+        -> active financial flows
+        -> ledger execution and SFC validation
+        -> atomic next-month state
+```
+
+This path uses native target tables from initialization through closing. It may
+reuse pure equations and aggregate institutional state, but it must not execute
+through the old `Household.State` or `FirmState` runtime.
+
+### Phase 3: port the active model surface
+
+1. Port remaining household, labor, enterprise, entry, exit, migration,
+   retirement, network, and distress mechanisms against the new stores.
+2. Port active deposit, mortgage, consumer-credit, firm-credit, default,
+   amortization, risk, and bank-aggregation mechanisms against explicit
+   contracts.
+3. Re-key ledger balances where required while preserving ADR-0004 single
+   ownership and existing SFC semantics.
+4. Reuse aggregate fiscal, monetary, housing, financial-market, and
+   external-sector mechanisms where their state meaning remains valid.
+5. Replace copied per-entity vectors with table views, reusable workspace,
+   change sets, and cadence-controlled evidence as each mechanism is ported.
+6. Maintain a test-only differential harness using matched fixtures and
+   controlled inputs. Do not add a production old-to-new state adapter.
+
+### Phase 4: qualify and cut over
+
+1. Satisfy every cutover gate below on the new core.
+2. Make the new core the only production runtime and default command path.
+3. Remove the old agent core, old economics orchestration paths, comparison-only
+   production wiring, and obsolete storage-shape tests.
+4. Retain only intentionally reusable mechanisms, historical evidence, and the
+   minimal test harness needed to explain validated behavioral differences.
+5. Profile after semantic qualification. Performance evidence may select
+   encodings but may not redefine ontology or timing.
+
+### Phase 5: promote optional resolution only by evidence
+
+Introduce security instruments and positions, interbank contracts, enterprise
+owners, insurance claims, pension entitlements, dwellings, JST units, or foreign
+counterparties only through separate decisions satisfying the promotion
+criteria in this RFC. They are not part of the foundational migration merely
+because their schemas are anticipated.
+
+At every phase, update canonical model, state-vector, ODD, architecture,
+validation, and model-card documentation only for the implemented slice that has
+become authoritative.
+
+## Cutover Gates
+
+The new core may replace the current engine only when all gates pass:
+
+1. **Population reconciliation:** compiled weighted persons, households,
+   enterprises, employment, activity, migration, and opening relationships meet
+   baseline controls within declared tolerances.
+2. **Opening balance reconciliation:** contract and holder balances reconcile to
+   institutional balance sheets and the ledger without undisclosed residuals.
+3. **Accounting:** all applicable ledger conservation, SFC, balance-sheet, and
+   stock-flow identities pass.
+4. **Determinism and replay:** identical baseline, configuration, seed, and
+   requested evidence produce identical results on repeated runs.
+5. **Mechanism evidence:** preserved equations and mechanisms agree on
+   controlled inputs, or every intentional difference is documented and
+   validated.
+6. **Lifecycle integrity:** entry, exit, birth, death, migration, employment,
+   origination, default, maturity, and resolution preserve stable-ID and
+   relationship invariants.
+7. **Multi-month stability:** the qualification profiles complete their declared
+   horizons and seeds without invariant failure, numerical corruption, or
+   unexplained stock drift.
+8. **Scenario directionality:** accepted policy and shock scenarios preserve
+   expected causal direction or carry a documented scientific explanation for
+   a changed response.
+9. **Evidence contract:** required manifests, aggregates, diagnostics, traces,
+   and scientific exports are available with explicit schema versions.
+10. **Single runtime ownership:** no production path depends on translating
+    persistent state through the old core or maintaining duplicate balances.
+
+## Open Decisions
+
+1. Exact stable-ID namespaces and whether heterogeneous parties use a typed
+   tagged reference or table-specific party columns.
+2. Shared table infrastructure and allocator APIs that preserve domain-specific
+   schemas without becoming a generic ECS.
+3. First financial families to become contract- and holder-resolved.
+4. Whether private enterprise ownership is represented by explicit owner units,
+   owner cohorts, ownership classes, or a mixed policy in the first baseline.
+5. Minimum security-instrument granularity for government and corporate bonds.
+6. Initial boundary between individual credit contracts and weighted credit
+   cohorts.
+7. Whether housing begins with household-to-regional-cohort tenure links or
+   resolved dwelling units.
+8. Which public and financial institutions remain aggregate singletons in the
+   first Poland baseline.
+9. Which monthly event families are persisted and which are retained only when
+   explicitly requested.
+10. Which high-cardinality dynamic columns use double buffering, change sets, or
+    validated in-place mutation.
+11. Snapshot cadence and query APIs that support scientific use without
+    materializing the full object graph every month.
+12. Promotion criteria for replacing an aggregate projection with a resolved
+    entity, relationship, contract, or position population.
+
+## Implementation Anchors
+
+- [`FlowSimulation.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/flows/FlowSimulation.scala)
+  for the current month-boundary root and step evidence.
+- [`World.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/World.scala)
+  and [`WorldStateSegments.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/WorldStateSegments.scala)
+  for current aggregate, institutional, market, and mechanism state.
+- [`Household.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/Household.scala)
+  and [`FirmModel.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/firm/FirmModel.scala)
+  for currently embedded units and relationships.
+- [`Banking.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/Banking.scala)
+  and [`InterbankContagion.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/agents/InterbankContagion.scala)
+  for the bank population, aggregate financial rows, and bilateral exposure
+  matrix.
+- [`LedgerFinancialState.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/LedgerFinancialState.scala)
+  and [`AssetOwnershipContract.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/ledger/AssetOwnershipContract.scala)
+  for current financial-stock ownership and supported asset families.
+- [`HousingMarket.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/markets/HousingMarket.scala)
+  and [`GvcTrade.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/markets/GvcTrade.scala)
+  for current aggregate real-asset and foreign-cohort representations.
+- [`engine/economics`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/engine/economics/)
+  for same-month calculation outputs that must be classified as state,
+  workspace, change set, event, or observation during migration.

--- a/docs/rfc/0003-model-ontology-and-state-architecture.md
+++ b/docs/rfc/0003-model-ontology-and-state-architecture.md
@@ -46,6 +46,9 @@ boundaries. Related documents have narrower responsibilities:
   defines experiment construction, execution lifecycle, result queries,
   evidence manifests, committed notebooks, and the managed Almond/Jupyter
   adapter.
+- [JVM runtime, JIT, and garbage collection policy RFC](0004-jvm-runtime-jit-and-garbage-collection-policy.md)
+  defines the managed process topology, runtime profiles, provenance, and
+  evidence used to qualify the target DOD allocation and live-set behavior.
 - [ADR-0006](../adr/0006-data-oriented-high-cardinality-state.md) records the
   accepted storage principle for high-cardinality persistent state.
 - [ADR-0007](../adr/0007-controlled-model-core-replacement.md) records the accepted
@@ -603,6 +606,11 @@ Typed immutable values remain the default for:
 Raw arrays are package-private. Domain APIs use typed IDs, validated accessors,
 and explicit transition methods. Separate columns do not weaken economic
 invariants.
+
+Collector or JIT evidence may select column encodings, buffer-reuse policy, and
+capacity strategy only after semantic and month-boundary requirements are met.
+The runtime RFC owns those measurements; no GC preference can expose storage or
+redefine the ontology.
 
 ## Persistent State, Workspace, and Evidence
 

--- a/docs/rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md
+++ b/docs/rfc/0004-jvm-runtime-jit-and-garbage-collection-policy.md
@@ -1,0 +1,577 @@
+# RFC-0004: JVM Runtime, JIT, and Garbage Collection Policy
+
+Status: Draft for decision
+
+Scope: Supported JDK and distribution, process topology, JIT compiler, garbage
+collector profiles, heap policy, runtime provenance, and qualification evidence
+
+Performance: Selection methodology is in scope; no candidate is selected by
+uncontrolled timing evidence
+
+## Purpose
+
+Amor Fati is a JVM system, but its current runtime policy is implicit. The Nix
+development shell and CI use JDK 21 and configure G1 with an 8 GiB maximum heap.
+The repository-level `.jvmopts` also selects G1 but uses a 4 GiB maximum heap.
+Runs outside the managed shell can use whichever `java` executable happens to
+be installed. Build, test, assembled-CLI, diagnostics, and future notebook
+processes therefore do not yet share one explicit runtime contract.
+
+The target population and data-oriented core will materially change the heap:
+many immutable object rows and copied vectors will become fewer long-lived
+primitive columns, current/next buffers, indexed relationships, and reusable
+workspaces. The managed Almond environment will also introduce a long-lived
+compiler kernel with different allocation and responsiveness requirements from
+a batch simulation. A garbage collector selected from current-engine timing or
+from generic reputation would not be a defensible system decision.
+
+This RFC defines how Amor Fati selects, launches, observes, qualifies, and
+records its JVM runtime. It separates the JDK, VM, JIT compiler, garbage
+collector, process topology, and heap policy. It names candidates and a
+provisional control configuration, but it does not accept a final JDK, JIT, or
+collector before compatibility and target-core evidence exist.
+
+## Relationship to Other Decisions
+
+This RFC is deliberately opened before the target state layout is implemented
+and closed after a representative target-core slice exists:
+
+1. [RFC-0001](0001-population-and-representation.md) defines supported
+   representation scales and the population workloads that runtime profiles
+   must execute.
+2. [RFC-0002](0002-research-api-and-notebook-runtime.md) defines the managed
+   notebook environment, experiment lifecycle, cancellation, and result
+   contract. This RFC owns the JVM process and runtime policy beneath it.
+3. This RFC provisionally qualifies a JDK, control collector, and process
+   topology for the notebook pilot.
+4. [RFC-0003](0003-model-ontology-and-state-architecture.md) implements the thin
+   target-core month and exposes the representative DOD allocation and live-set
+   profile.
+5. This RFC then compares collectors and JITs on that target workload before
+   proposing any runtime ADR.
+
+[ADR-0006](../adr/0006-data-oriented-high-cardinality-state.md) decides the
+encapsulation and storage principle, not the garbage collector. Collector
+results may select an encoding within the ADR boundary but cannot redefine
+economic ontology, expose raw columns, or restore object-row state merely to
+improve a benchmark.
+
+[ADR-0007](../adr/0007-controlled-model-core-replacement.md) permits a current
+engine oracle and a target core during development. Runtime comparison may
+execute both, but the old engine is not the workload on which the final
+collector is selected.
+
+## Terminology
+
+| Term | Meaning in this RFC |
+| --- | --- |
+| JDK | Java development and runtime distribution, including version, vendor build, VM, tools, and security-update line. |
+| JVM or VM | Managed runtime executing bytecode. The primary candidate family is OpenJDK HotSpot. |
+| JIT | Runtime compiler translating hot bytecode to machine code, such as HotSpot C2 or Graal JIT. |
+| GC | Garbage collector and its memory-management barriers, threads, pause behavior, and heap ergonomics. |
+| Native Image | GraalVM ahead-of-time native executable and runtime. It is not interchangeable with Graal JIT on HotSpot. |
+| Kernel JVM | Long-lived process hosting Almond, Scala compilation, notebook state, and notebook adapter code. |
+| Worker JVM | Process owning one simulation execution context, heap, core state, and result publication lifecycle. |
+| Runtime profile | Amor Fati-owned, versioned selection of JDK, VM, JIT, GC, heap, and operational flags for a declared workload. |
+| Control configuration | Stable comparison runtime used to determine whether another candidate improves an explicit objective. |
+
+## Goals
+
+1. Make every supported run use an identifiable and reproducible JVM runtime.
+2. Separate notebook-kernel requirements from simulation-worker requirements.
+3. Select runtime defaults from Amor Fati workloads rather than generic JVM
+   recommendations.
+4. Optimize the primary research objective, time to a valid result, while
+   retaining explicit memory, pause, startup, and interactive-responsiveness
+   constraints.
+5. Keep scientific results invariant across qualified runtime profiles.
+6. Preserve JFR, GC logging, crash diagnostics, and operational observability.
+7. Support the repository's declared operating systems and architectures
+   without pretending that every experimental collector is portable.
+8. Permit later enterprise runtime profiles without making current research
+   users configure raw JVM flags.
+
+## Non-Goals
+
+This RFC does not:
+
+- tune individual economic kernels or replace the DOD design;
+- promise that one GC is best for batch, notebook, and future service workloads;
+- make low pause time the primary scientific objective by default;
+- expose JVM flags as part of the economic experiment specification;
+- use GitHub-hosted runner timings as decisive cross-collector evidence;
+- select GraalVM Native Image as the primary notebook or simulation runtime;
+- define remote worker scheduling, multi-tenancy, or distributed Monte Carlo;
+- require every evaluated JIT and collector to become a supported profile; or
+- create an ADR before the qualification gates in this RFC pass.
+
+## Current Runtime Contract
+
+The implemented runtime has the following pieces:
+
+| Surface | Current behavior | Gap |
+| --- | --- | --- |
+| Nix development shell | `pkgs.jdk21`, `JAVA_HOME`, `SBT_OPTS=-Xmx8G -XX:+UseG1GC`, and an `amor-fati-java` wrapper with the same application options. | JDK major and GC are pinned, but vendor identity and rationale are not a run-level contract. |
+| GitHub Actions | Enters the Nix shell and checks that `java -version` reports major version 21. | It validates the major version, not the complete runtime profile. |
+| Repository `.jvmopts` | `-Xmx4G -XX:+UseG1GC`. | Heap differs from the Nix/CI profile, and the file configures sbt rather than a separately owned worker. |
+| Assembled diagnostics | Can use `amor-fati-java` and `AMOR_FATI_JAVA_OPTS`. | Ordinary commands do not yet have one mandatory system launcher. |
+| Profiling | JFR, unified GC logs, allocation views, GC pause views, runtime metadata, and coarse MXBean GC counters exist. | The comparison policy lacks collector, JIT, allocation-rate, RSS, pause-distribution, and canonical-hardware qualification. |
+| Run evidence | Diagnostics report JVM metadata and performance telemetry. | Every scientific result bundle does not yet record the complete runtime and effective flags. |
+| Notebook runtime | Not implemented. | Kernel and simulation memory ownership have not been separated. |
+
+The operations documentation currently describes the CI baseline as Temurin,
+while CI actually consumes the JDK supplied by the pinned Nix package set. The
+qualification harness must record the resolved vendor, build, VM, and flags
+rather than infer them from a documentation label.
+
+## Candidate Runtime Families
+
+### OpenJDK 21 control
+
+JDK 21 with HotSpot C2 and G1 is the implemented control. It remains the
+compatibility reference until another JDK passes the full build, test, ledger,
+profiling, CLI, and notebook gates. Existing evidence is not a final endorsement
+because it was not produced as a controlled runtime comparison.
+
+### OpenJDK 25 candidate baseline
+
+JDK 25 is the candidate supported baseline for the target research platform:
+
+- it is the current post-JDK-21 LTS line from most vendors;
+- Scala 3.8 supports compilation and execution on JDK 25;
+- non-generational ZGC has been removed, leaving generational ZGC;
+- Generational Shenandoah is a product feature; and
+- its JFR and runtime capabilities are appropriate for a new long-lived
+  platform baseline.
+
+Candidate status is not acceptance. The exact vendor distribution, Nix package,
+security-update policy, supported operating systems, Almond compatibility,
+Stainless workflow, and ledger verification must be tested. A JDK 25 build that
+improves execution but breaks the reproducible development or verification
+toolchain is not qualified.
+
+### GraalVM on HotSpot
+
+GraalVM running JVM bytecode with Graal JIT is a JIT candidate, not a synonym
+for Native Image and not automatically a different GC decision. It may improve
+hot Scala code through inlining, escape analysis, and allocation elimination,
+but it also changes compilation warmup, CPU consumption, code cache, failure
+diagnostics, distribution, and support requirements.
+
+Graal JIT is evaluated only after a stable HotSpot C2 control exists. The first
+comparison uses the same collector and heap policy where the distributions
+support that comparison. The RFC does not require a full Cartesian product of
+every JIT and collector.
+
+### GraalVM Native Image
+
+Native Image uses a different ahead-of-time build and runtime model. It is
+outside the initial supported notebook and simulation-worker candidates because:
+
+- Almond and interactive Scala compilation require a normal JVM process;
+- Scala and dependencies can require closed-world reflection and resource
+  configuration;
+- Native Image exposes a different collector set and memory behavior;
+- it weakens direct comparability with existing JFR and HotSpot diagnostics; and
+- fast startup is not by itself the primary objective of a multi-minute or
+  long-horizon scientific run.
+
+A future small CLI launcher or isolated deployment worker may justify a separate
+Native Image RFC. It is not selected indirectly by choosing to benchmark Graal
+JIT.
+
+## Garbage Collector Candidates
+
+### G1
+
+G1 is the control collector. It targets a balance of throughput, bounded pause
+goals, and large-heap operation and is HotSpot's default. Amor Fati will first
+run G1 with minimal tuning: an explicit maximum heap and diagnostic flags, not
+a collection of inherited folklore flags. Further tuning requires a traceable
+observation such as evacuation failure, humongous-object pressure, or a missed
+pause objective.
+
+The target DOD design creates large primitive arrays. G1 classifies sufficiently
+large allocations as humongous objects relative to its region size, so repeated
+buffer allocation, resizing, and retention must be visible in the evidence.
+This is not a reason to avoid DOD or G1; it is a reason to benchmark the actual
+table lifecycle.
+
+### Parallel GC
+
+Parallel GC is a first-class candidate for unattended research batch runs. Its
+stop-the-world collections can produce long pauses, but total time to a valid
+result may be better when latency is irrelevant and sufficient heap headroom is
+available. Excluding it would silently optimize a batch simulator for a service
+latency objective it does not yet have.
+
+Parallel GC cannot become the notebook default solely by winning throughput. It
+must also satisfy kernel or worker isolation, cancellation, memory, and maximum
+pause constraints for the profile in which it is used.
+
+### Generational ZGC
+
+ZGC is a candidate for large heaps, strict pause constraints, and any in-process
+interactive execution that cannot isolate simulation pauses from the kernel.
+Its concurrent work can trade throughput and CPU for very small pauses. A ZGC
+profile must therefore improve a declared pause or responsiveness objective
+without unacceptable time-to-result, RSS, or CPU cost.
+
+On the JDK 25 candidate line, `-XX:+UseZGC` means generational ZGC; the removed
+non-generational mode is not a separate candidate.
+
+### Generational Shenandoah
+
+Generational Shenandoah is an evaluation candidate on JDK 25. The generational
+mode is a product feature but is not the default Shenandoah mode in JDK 25, so
+the profile must request and record it explicitly. Availability and behavior
+must be verified on each supported vendor, operating system, and architecture.
+
+Shenandoah is promoted only if it offers a material advantage over G1 or ZGC
+for an Amor Fati profile. Collector diversity is not itself a product feature.
+
+## Proposed Runtime Architecture
+
+The target system separates control-plane processes from the memory-intensive
+simulation worker:
+
+```text
+                           +--------------------+
+                           | CLI or scheduler   |
+                           +---------+----------+
+                                     |
++-------------------+      +---------v----------+
+| Almond kernel JVM +------> Research API       |
+| Scala + renderers |      | local coordinator |
++-------------------+      +---------+----------+
+                                     |
+                           +---------v----------+
+                           | simulation worker  |
+                           | JVM + target core  |
+                           +---------+----------+
+                                     |
+                           +---------v----------+
+                           | atomic result      |
+                           | bundle/checkpoint  |
+                           +--------------------+
+```
+
+The CLI and Almond adapter may use the same local coordinator. The simulation
+worker owns its heap, runtime profile, active model state, month transition,
+ledger execution, and atomic result publication. The kernel owns interactive
+Scala state and bounded result views, not the complete mutable simulation heap.
+
+This process boundary provides:
+
+- a collector and heap policy chosen for the simulation rather than compiler
+  allocations;
+- hard process termination after cooperative cancellation fails;
+- OOM isolation from the research notebook;
+- explicit lifecycle and cleanup for repeated experiments;
+- identical worker execution from CLI and notebooks; and
+- a future local-to-remote boundary without changing scientific API semantics.
+
+The notebook pilot may use an in-process backend temporarily only if the
+Research API abstracts execution ownership and the pilot records the limitation.
+An in-process shortcut cannot become the public result or state contract.
+
+## Runtime Profiles
+
+Researchers select an Amor Fati execution intent or accept a documented
+default. They do not assemble JVM flags. The provisional profile vocabulary is:
+
+| Profile | Objective | Initial candidate |
+| --- | --- | --- |
+| `control` | Reproducible compatibility and comparison | HotSpot C2, G1, explicit fixed heap |
+| `research-batch` | Minimum time and resource cost to a valid result | Compare G1 and Parallel GC first |
+| `large-population` | Complete a large live-set run with bounded pauses and sufficient headroom | Compare G1, ZGC, and Generational Shenandoah |
+| `notebook-kernel` | Interactive compilation, rendering, and coordinator responsiveness | Separate non-worker profile; G1 control initially |
+| `jit-evaluation` | Measure Graal JIT against C2 without conflating collector changes | Same qualified GC where supported |
+
+Names and membership remain open until implementation. A profile is versioned
+system configuration, not a behavioral model parameter. Changing a runtime
+profile must not change the simulated economy or stochastic schedule.
+
+Unsupported raw JVM overrides may remain available for developers and runtime
+experiments, but they mark a result as non-qualified and record every effective
+flag. A researcher should never need an override for a documented normal run.
+
+## Heap and Resource Policy
+
+One global `-Xmx` value is not sufficient for build, kernel, smoke, batch, and
+large-population workloads. Each qualified profile declares:
+
+- maximum and optional initial Java heap;
+- expected non-heap and native-memory headroom;
+- minimum host or container memory;
+- CPU availability and collector-thread policy where constrained;
+- maximum representation scale, seed concurrency, trace volume, and snapshot
+  cadence validated for that resource envelope;
+- behavior when required memory is unavailable; and
+- whether multiple workers may execute concurrently.
+
+The launcher validates obvious mismatches before population compilation. An 8
+GiB heap does not imply that an 8 GiB container or host is sufficient, because
+JIT code cache, thread stacks, direct buffers, memory-mapped artifacts, native
+libraries, and collector metadata consume memory outside the Java heap.
+
+Fixed heaps improve benchmark comparability. Percentage-based sizing may be
+appropriate for deployment profiles, but the resolved byte sizes and container
+limits must enter the manifest. The system must not silently increase scale to
+fill available memory.
+
+## Scientific Determinism
+
+A qualified change of JDK, vendor build, JIT, collector, heap, worker count, or
+operating system must preserve the scientific contract:
+
+- identical baseline, experiment specification, seed, and requested evidence
+  produce identical canonical result hashes where bitwise identity is promised;
+- ledger conservation, SFC reconciliation, lifecycle invariants, and validation
+  status remain identical;
+- seed assignment and result ordering do not depend on thread scheduling or
+  worker completion order;
+- cancellation and failure never publish a successful or partially closed
+  month; and
+- any intentionally non-bitwise metric has a documented numerical tolerance and
+  reason independent of performance.
+
+If a runtime candidate changes results, it fails qualification until the source
+is understood. A faster runtime does not justify accepting unexplained
+scientific divergence.
+
+## Runtime Manifest
+
+Every supported result bundle records at least:
+
+- runtime-profile ID and version;
+- JDK vendor, distribution, feature version, security version, and complete
+  build string;
+- VM name, version, mode, and architecture;
+- JIT identity and relevant compiler configuration;
+- GC identity and generational mode;
+- effective JVM arguments and environment-owned overrides;
+- initial, maximum, and observed heap;
+- host/container CPU and memory limits visible to the process;
+- operating system and architecture;
+- worker process count and seed-concurrency policy;
+- JFR/GC-log availability and artifact hashes when captured; and
+- qualified, experimental, or unsupported runtime status.
+
+The manifest captures resolved runtime facts from the executing worker, not
+only requested launcher settings.
+
+## Qualification Workloads
+
+Runtime candidates execute the same versioned workload bundle:
+
+1. **Cold start:** launcher to validated no-op or prepared experiment.
+2. **Notebook control:** fresh kernel startup, imports, baseline inspection, and
+   one bounded scenario execution.
+3. **Short simulation:** one seed over a CI-scale horizon.
+4. **Canonical research run:** five seeds over 60 months.
+5. **Long horizon:** enough months to expose promotion, retained state, leaks,
+   checkpoint, and compaction behavior.
+6. **Scale ladder:** identical economics across multiple supported
+   representation scales.
+7. **Evidence pressure:** controlled aggregate-only, snapshot, event, and trace
+   retention profiles.
+8. **Failure paths:** cancellation, worker termination, OOM boundary, invalid
+   configuration, and artifact-write failure.
+
+The current engine runs establish tooling and migration controls. The decisive
+collector and JIT comparison uses the target population compiler, persistent
+DOD state, representative relationships, ledger, full month closing, and result
+publication. A synthetic allocation benchmark or isolated arithmetic loop is
+diagnostic evidence only.
+
+## Measurement Protocol
+
+### Environment control
+
+Decisive comparisons run on named, dedicated hardware with fixed CPU governor,
+core allocation, memory, operating system, JDK build, workload inputs, output
+filesystem, and background-load policy. GitHub-hosted runners provide
+compatibility and regression signals, not final runtime selection evidence.
+
+At least one canonical Linux deployment machine owns performance qualification.
+Every supported Nix operating-system and architecture combination runs
+functional and determinism gates. A local Apple Silicon notebook profile may
+have separate performance evidence without redefining canonical batch claims.
+
+### Repetition and warmup
+
+- Cold-start and steady-state measurements are reported separately.
+- Each candidate receives equivalent warmup or starts from an explicitly cold
+  process according to the workload contract.
+- Candidate order is randomized or rotated to reduce thermal and temporal bias.
+- Enough repetitions are collected to report median, dispersion, and tail
+  behavior; one fastest run is never evidence.
+- JFR overhead is measured and either held constant or reported separately.
+- Heap size, worker concurrency, and evidence policy remain fixed within a
+  collector comparison.
+
+### Required metrics
+
+| Category | Required observations |
+| --- | --- |
+| Correctness | Result hashes, validation verdicts, ledger/SFC identities, deterministic replay. |
+| Time | Cold startup, preparation, wall time, CPU time, seed-month throughput, checkpoint and export time. |
+| Allocation | Allocated bytes, allocation rate, top classes/sites, promotion behavior, large-array lifecycle. |
+| Heap | Live set after closing boundaries, peak used/committed heap, headroom, full-collection behavior. |
+| Process memory | Peak and steady RSS, non-heap, direct/native memory where observable. |
+| GC | Collection count, concurrent CPU, total GC time, pause median/p95/p99/max, allocation stalls and failure modes. |
+| JIT | Compilation time, compiler CPU, code-cache use, warmup trajectory, deoptimizations and failures. |
+| Operations | Cancellation latency, worker cleanup, artifact atomicity, diagnostics quality, platform availability. |
+
+Primary selection uses time to a successfully validated canonical result under
+the profile's resource and pause constraints. A candidate cannot win by omitting
+evidence, reducing scale, changing seed concurrency, or consuming unbounded
+memory.
+
+## Candidate Promotion Rules
+
+A runtime candidate becomes a supported default only when:
+
+1. build, format, unit, heavy, integration, ledger, CLI, notebook, and
+   profiling workflows pass on its exact distribution;
+2. canonical outputs satisfy the determinism and accounting gates;
+3. its improvement is repeatable on controlled hardware and material for the
+   declared profile objective;
+4. peak RSS, heap headroom, pause behavior, CPU, startup, and diagnostics remain
+   within documented limits;
+5. all required target operating systems have either the same supported profile
+   or an explicit compatible fallback;
+6. security updates and patch upgrades have a tested maintenance path;
+7. the launcher, manifests, operations documentation, and failure messages
+   expose the resolved runtime clearly; and
+8. an ADR records the selected baseline or profile and the evidence bundle that
+   justified it.
+
+Failure to beat the control is a valid result. Amor Fati does not support extra
+collectors or JITs merely because they were benchmarked.
+
+## Implementation and Evidence Sequence
+
+### Phase 0: make the current runtime observable
+
+1. Reconcile `.jvmopts`, Nix, CI, assembled-runner, and documentation claims.
+2. Capture complete JDK, VM, JIT, GC, heap, container, OS, and architecture
+   metadata in profiling artifacts.
+3. Add allocation rate, process RSS, pause distribution, and JIT observations to
+   the controlled evidence where current tooling lacks them.
+4. Freeze a current-engine workload bundle to validate the harness.
+
+### Phase 1: qualify the notebook-pilot baseline
+
+1. Test JDK 25 with Scala, sbt, ZIO, Almond, Stainless, ledger verification,
+   assembly, tests, and all Nix systems.
+2. Use HotSpot C2 and G1 as the initial control unless evidence exposes a
+   blocker.
+3. Implement the Amor Fati launcher and explicit kernel/worker runtime metadata.
+4. Decide whether the pilot worker is out-of-process or a documented temporary
+   in-process backend behind the Research API.
+
+### Phase 2: establish the target allocation profile
+
+Run the target population compiler and thin end-to-end DOD month with realistic
+weights, table capacities, current/next state, relationships, workspaces,
+ledger execution, validation, and bounded results. Remove accidental allocations
+identified by profiling before comparing collectors.
+
+### Phase 3: compare collectors and JITs
+
+1. Compare G1 and Parallel GC for the canonical research-batch objective.
+2. Compare G1, ZGC, and Generational Shenandoah for large-population and
+   pause-constrained objectives.
+3. Compare Graal JIT with HotSpot C2 using a qualified collector and identical
+   workload.
+4. Re-run finalists across the scale, horizon, evidence, cancellation, and
+   supported-platform gates.
+
+### Phase 4: record accepted runtime decisions
+
+Only after the evidence is reviewable, extract separate ADRs where independence
+matters:
+
+- supported JDK/distribution and update line;
+- kernel and simulation-worker process topology;
+- default and optional GC profiles; and
+- Graal JIT adoption, if it independently qualifies.
+
+Native Image requires a later RFC rather than an incidental ADR from this
+comparison.
+
+## Acceptance Criteria
+
+This RFC can close only when:
+
+1. the system launcher, not ambient `java`, owns supported runtime selection;
+2. build, kernel, and worker JVM responsibilities are explicit;
+3. a JDK/distribution passes the complete compatibility matrix;
+4. the target-core benchmark bundle represents real population, DOD, ledger,
+   evidence, and month-closing behavior;
+5. collector and JIT comparisons are reproducible on controlled hardware;
+6. scientific outputs and invariants are unchanged across qualified profiles;
+7. one default research-batch profile and one notebook-kernel profile are
+   selected, with any large-population profile justified separately;
+8. effective runtime facts appear in every result manifest;
+9. resource validation, cancellation, OOM isolation, and artifact atomicity are
+   tested; and
+10. accepted choices are extracted into one or more ADRs with evidence links.
+
+## Open Decisions
+
+1. The exact JDK major, vendor distribution, Nix attribute, and patch-update
+   policy.
+2. Whether JDK 21 remains a supported fallback after JDK 25 qualification.
+3. Whether the notebook pilot starts with an out-of-process worker or a
+   temporary in-process backend.
+4. The local worker protocol and checkpoint/result transport boundary.
+5. Canonical Linux qualification hardware and operating-system image.
+6. Supported performance evidence for Apple Silicon and other Nix systems.
+7. Initial heap and host-memory envelopes for kernel, CI, research batch, and
+   scale-ladder profiles.
+8. The exact canonical horizons, scales, seed counts, and evidence policies.
+9. Statistical repetition count and material-improvement thresholds.
+10. Whether G1, Parallel, ZGC, or Generational Shenandoah qualifies for each
+    supported worker profile.
+11. Whether Graal JIT provides a material target-core advantage over C2.
+12. Which runtime overrides mark a run experimental versus unsupported.
+13. Runtime-profile compatibility and deprecation rules across releases.
+14. Which JFR and native-memory observations are always on versus profiling-only.
+
+## Implementation Anchors
+
+- [`flake.nix`](../../flake.nix) for the current JDK 21, G1, heap, and
+  `amor-fati-java` wrapper;
+- [`.jvmopts`](../../.jvmopts) for the current local sbt heap and G1 selection;
+- [CI workflow](../../.github/workflows/ci.yml) for the current major-version
+  check and Nix-owned build/test environment;
+- [Operations](../operations.md#requirements) for the implemented toolchain
+  contract;
+- [Hot-path profiling](../hot-path-profiling.md) for JFR, allocation, GC, and
+  JVM-flag artifacts;
+- [Performance regression budgets](../performance-regression-budgets.md) for
+  current soft duration, throughput, heap, and GC-time comparisons;
+- [`profile-jvm-process.sh`](../../scripts/profile-jvm-process.sh) for the
+  assembled-process JFR and unified-GC-log harness; and
+- [`NightlyDiagnosticsProfileRunner.scala`](../../modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala)
+  for current JVM, heap, GC, and step-throughput telemetry.
+
+External capability references:
+
+- [OpenJDK 25](https://openjdk.org/projects/jdk/25/) and
+  [JEPs integrated since JDK 21](https://openjdk.org/projects/jdk/25/jeps-since-jdk-21)
+  for the candidate JDK line and collector changes;
+- [Scala JDK compatibility](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html)
+  for Scala 3.8 support on JDK 21 and JDK 25;
+- [JDK 25 HotSpot GC tuning guide](https://docs.oracle.com/en/java/javase/25/gctuning/)
+  for G1, Parallel, and ZGC behavior and tuning guidance;
+- [JEP 521: Generational Shenandoah](https://openjdk.org/jeps/521) for its JDK 25
+  product status and explicit mode behavior;
+- [GraalVM as a JVM](https://www.graalvm.org/jdk25/reference-manual/java/) and
+  [Graal JIT operations](https://www.graalvm.org/jdk25/reference-manual/compiler/operations/)
+  for the JVM/JIT distinction; and
+- [GraalVM Native Image memory management](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/)
+  for its distinct runtime and collector model.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -13,23 +13,29 @@ architecture documentation.
 | [RFC-0001: Population and representation](0001-population-and-representation.md) | Draft for decision | Reference economy, population compiler, representation scale, population storage, migration, tourism, and opening relationships. |
 | [RFC-0002: Research API and notebook runtime](0002-research-api-and-notebook-runtime.md) | Draft for decision | Public experiment lifecycle, result queries, reproducibility, committed notebooks, and the managed Almond/Jupyter environment. |
 | [RFC-0003: Model ontology and state architecture](0003-model-ontology-and-state-architecture.md) | Draft for decision | Model-wide units, relationships, instruments, assets, state lifetimes, representation resolution, and target core architecture. |
+| [RFC-0004: JVM runtime, JIT, and garbage collection policy](0004-jvm-runtime-jit-and-garbage-collection-policy.md) | Draft for decision | Supported JDK and distribution, process topology, JIT and GC profiles, heap policy, runtime provenance, and qualification evidence. |
 
-## Decision Order
+## Decision and Evidence Order
 
-Resolve the active RFCs in this order:
+The active RFCs have one evidence loop rather than a strictly linear resolution
+order:
 
 1. **Population and representation:** define the empirical economy, statistical
    units, representation scale, weights, and opening population relationships.
 2. **Research API and notebook runtime:** define how researchers configure,
    execute, observe, compare, and reproduce experiments using those semantics.
-3. **Model ontology and state architecture:** complete the model-wide state
+3. **JVM runtime provisional baseline:** qualify the JDK, process topology, and
+   control runtime needed by the notebook pilot without selecting a final GC.
+4. **Model ontology and state architecture:** complete the model-wide state
    design and translate the accepted semantics and access patterns into
    data-oriented storage, indexes, views, and migration boundaries.
+5. **JVM runtime final qualification:** use the representative target-core DOD
+   allocation and live-set profile to select any supported JIT and GC profiles.
 
 RFC numbers are stable document identities, following the repository's ADR
-convention. For RFC-0001 through RFC-0003 they also reflect the accepted
-decision order. Once assigned, a number is never changed; later dependency
-changes are recorded in this index rather than by renumbering files.
+convention, not dependency or implementation positions. Once assigned, a number
+is never changed; dependency changes and evidence loops are recorded in this
+index rather than by renumbering files.
 
 ## Lifecycle
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -1,0 +1,46 @@
+# Request for Comments Index
+
+This directory contains proposed Amor Fati model and architecture contracts.
+RFCs describe target semantics, unresolved design choices, and implementation
+boundaries. They do not describe canonical runtime behavior until the relevant
+decisions are accepted, implemented, and promoted into the canonical model and
+architecture documentation.
+
+## Active RFCs
+
+| RFC | Status | Scope |
+| --- | --- | --- |
+| [RFC-0001: Population and representation](0001-population-and-representation.md) | Draft for decision | Reference economy, population compiler, representation scale, population storage, migration, tourism, and opening relationships. |
+| [RFC-0002: Research API and notebook runtime](0002-research-api-and-notebook-runtime.md) | Draft for decision | Public experiment lifecycle, result queries, reproducibility, committed notebooks, and the managed Almond/Jupyter environment. |
+| [RFC-0003: Model ontology and state architecture](0003-model-ontology-and-state-architecture.md) | Draft for decision | Model-wide units, relationships, instruments, assets, state lifetimes, representation resolution, and target core architecture. |
+
+## Decision Order
+
+Resolve the active RFCs in this order:
+
+1. **Population and representation:** define the empirical economy, statistical
+   units, representation scale, weights, and opening population relationships.
+2. **Research API and notebook runtime:** define how researchers configure,
+   execute, observe, compare, and reproduce experiments using those semantics.
+3. **Model ontology and state architecture:** complete the model-wide state
+   design and translate the accepted semantics and access patterns into
+   data-oriented storage, indexes, views, and migration boundaries.
+
+RFC numbers are stable document identities, following the repository's ADR
+convention. For RFC-0001 through RFC-0003 they also reflect the accepted
+decision order. Once assigned, a number is never changed; later dependency
+changes are recorded in this index rather than by renumbering files.
+
+## Lifecycle
+
+1. A draft RFC records proposed semantics and lists its open decisions.
+2. Durable accepted decisions are captured in an ADR and linked from the RFC.
+3. The RFC remains active while implementation and unresolved design work
+   continue.
+4. Once the target is implemented, canonical model, ODD, state-vector,
+   architecture, validation, and model-card documentation is updated.
+5. The RFC is then marked `Implemented` or `Superseded` and retained as design
+   history rather than deleted.
+
+An accepted ADR does not automatically make an entire RFC canonical. It accepts
+only the decision within the ADR's stated scope.


### PR DESCRIPTION
## Summary

- add RFC-0001 through RFC-0003 for population semantics, the Research API and managed notebook runtime, and the target ontology/DOD core
- record the accepted data-oriented state and controlled core-replacement decisions in ADR-0006 and ADR-0007
- add proposed ADR-0008 through ADR-0010 for explicit representation scale, the supported Research API boundary, and managed Almond notebooks
- add RFC-0004 for JVM, worker-process, JIT, GC, heap, provenance, and qualification policy without selecting a final runtime
- update the RFC, ADR, architecture, and documentation indexes

## Validation

- `python3 scripts/check-docs.py` (62 Markdown files)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the docs “Start Here,” architecture reading path, and inventory listings to include additional RFC/ADR artifacts.
  * Added RFC drafts covering population & representation, the versioned Research API with a managed notebook runtime, model ontology & month-boundary state architecture, and JVM/JIT/GC runtime policy.
  * Added ADRs detailing high-cardinality state storage, controlled model-core replacement, explicit reference economy vs representation scale, Research API as the scientific interface, and a managed Almond/Jupyter delivery approach.
  * Updated ADR index conventions to distinguish proposed vs accepted decisions and improve status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->