### PR TITLE
Add legacy baseline catalog

### DIFF
--- a/docs/rfc/0002-research-api-contract.md
+++ b/docs/rfc/0002-research-api-contract.md
@@ -1,7 +1,7 @@
 # RFC-0002 Companion: Research API Contract
 
 Status: Draft for decision
-Audit base: `main` at `ed6f4e95`
+Audit base: `main` at `5b17597e`
 Owning RFC: [RFC-0002](0002-research-api-and-notebook-runtime.md)
 
 ## Purpose
@@ -24,6 +24,10 @@ The current configuration surface cannot yet satisfy this contract:
 
 - `SimParams.defaults` is the one code-defined production parameterization and
   still describes the existing `2026-04-30` model-start calibration;
+- `BaselineCatalog` now exposes that calibration through the exact legacy ID
+  `pl-2026-04-30-legacy-v1`, verifies an in-memory payload digest and required
+  model contract, and keeps `SimParams` config-private; it is not yet a public
+  Research API, persisted bundle loader, or `pl-2026q2-v1` implementation;
 - the `SimConfigSpec` and `SimConfigPropertySpec` test names refer to
   `SimParams`; there is no separately loadable `SimConfig` baseline contract;
 - `ScenarioRegistry` builds every scenario from a private
@@ -362,6 +366,11 @@ that historical bundles already exist:
 The legacy provider must not be advertised as a canonical scientific baseline.
 Its ID and manifest must make its migration-only status visible.
 
+The first two boundaries now exist as the internal `BaselineCatalog` kernel.
+It verifies the legacy `SimParams.defaults` payload and model-contract marker
+before preparation, but has no public Research API facade, filesystem bundle
+format, or real Q2 baseline. The remaining steps above remain required.
+
 ## Decision Register
 
 | ID | Decision | Proposed resolution | State |
@@ -399,6 +408,8 @@ boundary, the design needs:
 
 - [`SimParams.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/SimParams.scala)
   for the current code-defined parameter root;
+- [`BaselineCatalog.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala)
+  for the current internal catalog, legacy provider, and preparation checks;
 - [`ScenarioRegistry.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala)
   for current full-configuration scenario materialization and provenance;
 - [`WorldInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala)

--- a/docs/rfc/0002-research-api-contract.md
+++ b/docs/rfc/0002-research-api-contract.md
@@ -25,9 +25,10 @@ The current configuration surface cannot yet satisfy this contract:
 - `SimParams.defaults` is the one code-defined production parameterization and
   still describes the existing `2026-04-30` model-start calibration;
 - `BaselineCatalog` now exposes that calibration through the exact legacy ID
-  `pl-2026-04-30-legacy-v1`, verifies an in-memory payload digest and required
-  model contract, and keeps `SimParams` config-private; it is not yet a public
-  Research API, persisted bundle loader, or `pl-2026q2-v1` implementation;
+  `pl-2026-04-30-legacy-v1`, verifies the compiled payload against a reviewed,
+  pinned digest and required model contract, and keeps `SimParams`
+  config-private; it is not yet a public Research API, persisted bundle loader,
+  or `pl-2026q2-v1` implementation;
 - the `SimConfigSpec` and `SimConfigPropertySpec` test names refer to
   `SimParams`; there is no separately loadable `SimConfig` baseline contract;
 - `ScenarioRegistry` builds every scenario from a private
@@ -367,9 +368,10 @@ The legacy provider must not be advertised as a canonical scientific baseline.
 Its ID and manifest must make its migration-only status visible.
 
 The first two boundaries now exist as the internal `BaselineCatalog` kernel.
-It verifies the legacy `SimParams.defaults` payload and model-contract marker
-before preparation, but has no public Research API facade, filesystem bundle
-format, or real Q2 baseline. The remaining steps above remain required.
+It verifies the legacy `SimParams.defaults` payload against a reviewed pinned
+digest and model-contract marker before preparation, but has no public Research
+API facade, filesystem bundle format, or real Q2 baseline. The remaining steps
+above remain required.
 
 ## Decision Register
 

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
@@ -22,6 +22,11 @@ final case class BaselineDigest private (value: String):
   override def toString: String = value
 
 object BaselineDigest:
+  def fromSha256Hex(value: String): BaselineDigest =
+    val normalized = Option(value).fold("")(_.trim.toLowerCase)
+    require(normalized.matches("[0-9a-f]{64}"), "baseline digest must be a 64-character SHA-256 hex value")
+    BaselineDigest(normalized)
+
   def sha256Utf8(value: String): BaselineDigest =
     val digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8))
     val hex    = digest.iterator.map(byte => f"${byte & 0xff}%02x").mkString
@@ -116,6 +121,10 @@ final class BaselineCatalog private[config] (
 object BaselineCatalog:
   val LegacyDefaultsId: BaselineId = BaselineId.from("pl-2026-04-30-legacy-v1").fold(error => throw IllegalStateException(error), identity)
 
+  /** Reviewed digest of the complete legacy SimParams.defaults payload. */
+  private val LegacyDefaultsPayloadDigest =
+    BaselineDigest.fromSha256Hex("ce7d73afff381af8e9eb97647680b9d576e610af2f2d4866580364090de4d8e9")
+
   private object LegacyDefaultsProvider extends BaselineProvider:
     private val params = SimParams.defaults
 
@@ -127,7 +136,7 @@ object BaselineCatalog:
         openingBoundary = LocalDate.of(2026, 4, 30),
         baselineSchemaVersion = 1,
         requiredModelContract = ModelContractVersion.LegacySimParamsV1,
-        contentDigest = legacyPayloadDigest(params),
+        contentDigest = LegacyDefaultsPayloadDigest,
         description = "Migration-only provider over SimParams.defaults; not the pl-2026q2-v1 reference-economy bundle.",
       )
 

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
@@ -1,0 +1,149 @@
+package com.boombustgroup.amorfati.config
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.LocalDate
+
+/** Immutable researcher-facing identity for a reference-economy baseline. */
+final case class BaselineId private (value: String):
+  override def toString: String = value
+
+object BaselineId:
+  def from(value: String): Either[String, BaselineId] =
+    val normalized = Option(value).fold("")(_.trim)
+    if normalized.isEmpty then Left("baseline ID must be non-blank")
+    else Right(BaselineId(normalized))
+
+/** Immutable selector used by future Research API experiment specifications. */
+final case class BaselineRef(id: BaselineId)
+
+/** SHA-256 digest of the exact baseline payload selected for preparation. */
+final case class BaselineDigest private (value: String):
+  override def toString: String = value
+
+object BaselineDigest:
+  def sha256Utf8(value: String): BaselineDigest =
+    val digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8))
+    val hex    = digest.iterator.map(byte => f"${byte & 0xff}%02x").mkString
+    BaselineDigest(hex)
+
+/** Qualification status shown by the baseline catalog. */
+enum BaselineQualification:
+  case Canonical
+  case Experimental
+  case Legacy
+  case Superseded
+
+/** Version of the model-side contract required to compile a baseline. */
+final case class ModelContractVersion private (value: String):
+  override def toString: String = value
+
+object ModelContractVersion:
+  val LegacySimParamsV1: ModelContractVersion = ModelContractVersion("legacy-simparams-v1")
+
+  def from(value: String): ModelContractVersion =
+    require(value != null && value.trim.nonEmpty, "model contract version must be non-blank")
+    ModelContractVersion(value.trim)
+
+/** Descriptive and integrity metadata for one immutable baseline provider. */
+final case class BaselineManifest(
+    id: BaselineId,
+    displayName: String,
+    qualification: BaselineQualification,
+    openingBoundary: LocalDate,
+    baselineSchemaVersion: Int,
+    requiredModelContract: ModelContractVersion,
+    contentDigest: BaselineDigest,
+    description: String,
+)
+
+enum BaselineLoadError:
+  case InvalidId(input: String, reason: String)
+  case UnknownBaseline(requested: BaselineId, available: Vector[BaselineId])
+  case IncompatibleModel(
+      baseline: BaselineId,
+      required: ModelContractVersion,
+      current: ModelContractVersion,
+  )
+  case IntegrityMismatch(baseline: BaselineId, expected: BaselineDigest, actual: BaselineDigest)
+
+/** Immutable prepared baseline. Its engine configuration remains
+  * config-private.
+  */
+final class ResolvedBaseline private[config] (
+    val manifest: BaselineManifest,
+    private[config] val params: SimParams,
+)
+
+/** Internal source of a baseline payload. Disk-backed bundles replace this seam
+  * later.
+  */
+private[config] trait BaselineProvider:
+  def manifest: BaselineManifest
+  def compile(): SimParams
+
+/** Exact baseline resolution and verification for the current model contract.
+  */
+final class BaselineCatalog private[config] (
+    val modelContract: ModelContractVersion,
+    providers: Vector[BaselineProvider],
+):
+  private val providersById = providers.map(provider => provider.manifest.id -> provider).toMap
+
+  require(
+    providersById.size == providers.size,
+    "baseline catalog cannot contain duplicate baseline IDs",
+  )
+
+  def list: Vector[BaselineManifest] = providers.map(_.manifest)
+
+  def resolve(input: String): Either[BaselineLoadError, ResolvedBaseline] =
+    BaselineId.from(input).left.map(reason => BaselineLoadError.InvalidId(input, reason)).flatMap(id => resolve(BaselineRef(id)))
+
+  def resolve(ref: BaselineRef): Either[BaselineLoadError, ResolvedBaseline] =
+    providersById
+      .get(ref.id)
+      .toRight(BaselineLoadError.UnknownBaseline(ref.id, list.map(_.id)))
+      .flatMap: provider =>
+        val manifest = provider.manifest
+        if manifest.requiredModelContract != modelContract then Left(BaselineLoadError.IncompatibleModel(ref.id, manifest.requiredModelContract, modelContract))
+        else
+          val params = provider.compile()
+          val actual = BaselineCatalog.legacyPayloadDigest(params)
+          if actual != manifest.contentDigest then Left(BaselineLoadError.IntegrityMismatch(ref.id, manifest.contentDigest, actual))
+          else Right(ResolvedBaseline(manifest, params))
+
+object BaselineCatalog:
+  val LegacyDefaultsId: BaselineId = BaselineId.from("pl-2026-04-30-legacy-v1").fold(error => throw IllegalStateException(error), identity)
+
+  private object LegacyDefaultsProvider extends BaselineProvider:
+    private val params = SimParams.defaults
+
+    val manifest: BaselineManifest =
+      BaselineManifest(
+        id = LegacyDefaultsId,
+        displayName = "Poland 2026-04-30 legacy defaults",
+        qualification = BaselineQualification.Legacy,
+        openingBoundary = LocalDate.of(2026, 4, 30),
+        baselineSchemaVersion = 1,
+        requiredModelContract = ModelContractVersion.LegacySimParamsV1,
+        contentDigest = legacyPayloadDigest(params),
+        description = "Migration-only provider over SimParams.defaults; not the pl-2026q2-v1 reference-economy bundle.",
+      )
+
+    def compile(): SimParams = params
+
+  val legacy: BaselineCatalog =
+    new BaselineCatalog(ModelContractVersion.LegacySimParamsV1, Vector(LegacyDefaultsProvider))
+
+  private[config] def forTesting(
+      modelContract: ModelContractVersion,
+      providers: Vector[BaselineProvider],
+  ): BaselineCatalog =
+    new BaselineCatalog(modelContract, providers)
+
+  /** Legacy-only structural fingerprint. A persisted baseline bundle must
+    * replace this with canonical hashes of its schema-validated artifacts.
+    */
+  private[config] def legacyPayloadDigest(params: SimParams): BaselineDigest =
+    BaselineDigest.sha256Utf8(s"legacy-simparams-v1\n$params")

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
@@ -1,0 +1,92 @@
+package com.boombustgroup.amorfati.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
+
+class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
+
+  private object DefaultsProvider extends BaselineProvider:
+    private val params = SimParams.defaults
+
+    val manifest: BaselineManifest =
+      BaselineManifest(
+        id = BaselineCatalog.LegacyDefaultsId,
+        displayName = "Test legacy defaults",
+        qualification = BaselineQualification.Legacy,
+        openingBoundary = LocalDate.of(2026, 4, 30),
+        baselineSchemaVersion = 1,
+        requiredModelContract = ModelContractVersion.LegacySimParamsV1,
+        contentDigest = BaselineCatalog.legacyPayloadDigest(params),
+        description = "Test fixture.",
+      )
+
+    def compile(): SimParams = params
+
+  "BaselineCatalog" should "list and resolve the exact legacy baseline" in {
+    val catalog = BaselineCatalog.legacy
+
+    catalog.list.map(_.id) shouldBe Vector(BaselineCatalog.LegacyDefaultsId)
+
+    val resolved = catalog.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
+    resolved.manifest.id shouldBe BaselineCatalog.LegacyDefaultsId
+    resolved.manifest.qualification shouldBe BaselineQualification.Legacy
+    resolved.params shouldBe SimParams.defaults
+  }
+
+  it should "reject an unknown baseline identity" in {
+    val requested = BaselineId.from("pl-2019q4-v1").fold(error => fail(error), identity)
+
+    BaselineCatalog.legacy.resolve(BaselineRef(requested)) shouldBe
+      Left(BaselineLoadError.UnknownBaseline(requested, Vector(BaselineCatalog.LegacyDefaultsId)))
+  }
+
+  it should "reject a blank baseline identity before catalog lookup" in {
+    BaselineCatalog.legacy.resolve("  ") shouldBe
+      Left(BaselineLoadError.InvalidId("  ", "baseline ID must be non-blank"))
+  }
+
+  it should "reject a payload whose digest no longer matches its manifest" in {
+    val tampered = new BaselineProvider:
+      val manifest: BaselineManifest = DefaultsProvider.manifest.copy(
+        contentDigest = BaselineDigest.sha256Utf8("tampered"),
+      )
+
+      def compile(): SimParams = SimParams.defaults
+
+    val catalog  = BaselineCatalog.forTesting(ModelContractVersion.LegacySimParamsV1, Vector(tampered))
+    val expected = tampered.manifest.contentDigest
+    val actual   = BaselineCatalog.legacyPayloadDigest(SimParams.defaults)
+
+    catalog.resolve(BaselineRef(BaselineCatalog.LegacyDefaultsId)) shouldBe
+      Left(BaselineLoadError.IntegrityMismatch(BaselineCatalog.LegacyDefaultsId, expected, actual))
+  }
+
+  it should "reject a baseline compiled for a different model contract" in {
+    val incompatibleContract = ModelContractVersion.from("target-core-v1")
+    val incompatible         = new BaselineProvider:
+      val manifest: BaselineManifest = DefaultsProvider.manifest.copy(requiredModelContract = incompatibleContract)
+
+      def compile(): SimParams = SimParams.defaults
+
+    val catalog = BaselineCatalog.forTesting(ModelContractVersion.LegacySimParamsV1, Vector(incompatible))
+
+    catalog.resolve(BaselineRef(BaselineCatalog.LegacyDefaultsId)) shouldBe
+      Left(
+        BaselineLoadError.IncompatibleModel(
+          BaselineCatalog.LegacyDefaultsId,
+          incompatibleContract,
+          ModelContractVersion.LegacySimParamsV1,
+        ),
+      )
+  }
+
+  it should "keep resolved legacy parameters immutable across preparations" in {
+    val first   = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
+    val changed = first.params.copy(pop = first.params.pop.copy(firmsCount = first.params.pop.firmsCount + 1))
+    val second  = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
+
+    changed.pop.firmsCount shouldBe first.params.pop.firmsCount + 1
+    second.params.pop.firmsCount shouldBe first.params.pop.firmsCount
+  }

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
@@ -7,6 +7,9 @@ import java.time.LocalDate
 
 class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
 
+  private val PinnedLegacyPayloadDigest =
+    BaselineDigest.fromSha256Hex("ce7d73afff381af8e9eb97647680b9d576e610af2f2d4866580364090de4d8e9")
+
   private object DefaultsProvider extends BaselineProvider:
     private val params = SimParams.defaults
 
@@ -18,7 +21,7 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
         openingBoundary = LocalDate.of(2026, 4, 30),
         baselineSchemaVersion = 1,
         requiredModelContract = ModelContractVersion.LegacySimParamsV1,
-        contentDigest = BaselineCatalog.legacyPayloadDigest(params),
+        contentDigest = PinnedLegacyPayloadDigest,
         description = "Test fixture.",
       )
 
@@ -32,6 +35,7 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
     val resolved = catalog.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
     resolved.manifest.id shouldBe BaselineCatalog.LegacyDefaultsId
     resolved.manifest.qualification shouldBe BaselineQualification.Legacy
+    resolved.manifest.contentDigest shouldBe PinnedLegacyPayloadDigest
     resolved.params shouldBe SimParams.defaults
   }
 
@@ -47,20 +51,18 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
       Left(BaselineLoadError.InvalidId("  ", "baseline ID must be non-blank"))
   }
 
-  it should "reject a payload whose digest no longer matches its manifest" in {
-    val tampered = new BaselineProvider:
-      val manifest: BaselineManifest = DefaultsProvider.manifest.copy(
-        contentDigest = BaselineDigest.sha256Utf8("tampered"),
-      )
+  it should "reject a changed legacy payload against the pinned digest" in {
+    val changedParams = SimParams.defaults.copy(pop = SimParams.defaults.pop.copy(firmsCount = SimParams.defaults.pop.firmsCount + 1))
+    val changed       = new BaselineProvider:
+      val manifest: BaselineManifest = DefaultsProvider.manifest
 
-      def compile(): SimParams = SimParams.defaults
+      def compile(): SimParams = changedParams
 
-    val catalog  = BaselineCatalog.forTesting(ModelContractVersion.LegacySimParamsV1, Vector(tampered))
-    val expected = tampered.manifest.contentDigest
-    val actual   = BaselineCatalog.legacyPayloadDigest(SimParams.defaults)
+    val catalog = BaselineCatalog.forTesting(ModelContractVersion.LegacySimParamsV1, Vector(changed))
+    val actual  = BaselineCatalog.legacyPayloadDigest(changedParams)
 
     catalog.resolve(BaselineRef(BaselineCatalog.LegacyDefaultsId)) shouldBe
-      Left(BaselineLoadError.IntegrityMismatch(BaselineCatalog.LegacyDefaultsId, expected, actual))
+      Left(BaselineLoadError.IntegrityMismatch(BaselineCatalog.LegacyDefaultsId, PinnedLegacyPayloadDigest, actual))
   }
 
   it should "reject a baseline compiled for a different model contract" in {


### PR DESCRIPTION
## Summary

- add an internal catalog with immutable IDs, manifests, qualification status, integrity checks, and model-contract compatibility
- expose the current defaults only as the explicit legacy baseline pl-2026-04-30-legacy-v1
- keep SimParams config-private and document the adapter boundary

## Validation

- sbt scalafmtCheckAll
- sbt model/testOnly BaselineCatalogSpec SimConfigSpec SimParamsSpec ScenarioRegistrySpec
- sbt Test/compile
- python3 scripts/check-docs.py
- bash scripts/check-generated-outputs.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added baseline catalog support for listing and resolving experiment baselines, including strict identifier validation, model-contract compatibility checks, and payload integrity verification.
  * Introduced a legacy “defaults” baseline with pinned metadata and resolved parameter output.
* **Documentation**
  * Updated the research API contract companion with revised audit details and clarified current implementation boundaries for the internal baseline catalog.
* **Tests**
  * Added coverage for successful legacy resolution, unknown/invalid inputs, incompatible model contracts, integrity mismatches, and immutability of resolved parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->