### PR TITLE
Add logical baseline bundle contract

### DIFF
--- a/docs/rfc/0002-research-api-contract.md
+++ b/docs/rfc/0002-research-api-contract.md
@@ -26,9 +26,11 @@ The current configuration surface cannot yet satisfy this contract:
   still describes the existing `2026-04-30` model-start calibration;
 - `BaselineCatalog` now exposes that calibration through the exact legacy ID
   `pl-2026-04-30-legacy-v1`, verifies the compiled payload against a reviewed,
-  pinned digest and required model contract, and keeps `SimParams`
-  config-private; it is not yet a public Research API, persisted bundle loader,
-  or `pl-2026q2-v1` implementation;
+  pinned digest and required model contract, and resolves it into an internal
+  `BaselineBundle`; that legacy bundle contains only the parameter payload,
+  while provenance and validation are references and the population and
+  institutional components remain absent. It is not yet a public Research API,
+  persisted bundle loader, or `pl-2026q2-v1` implementation;
 - the `SimConfigSpec` and `SimConfigPropertySpec` test names refer to
   `SimParams`; there is no separately loadable `SimConfig` baseline contract;
 - `ScenarioRegistry` builds every scenario from a private
@@ -369,9 +371,10 @@ Its ID and manifest must make its migration-only status visible.
 
 The first two boundaries now exist as the internal `BaselineCatalog` kernel.
 It verifies the legacy `SimParams.defaults` payload against a reviewed pinned
-digest and model-contract marker before preparation, but has no public Research
-API facade, filesystem bundle format, or real Q2 baseline. The remaining steps
-above remain required.
+digest and model-contract marker before preparation, then resolves it into a
+logical `BaselineBundle` with explicit component availability. It has no public
+Research API facade, filesystem bundle format, or real Q2 baseline. The
+remaining steps above remain required.
 
 ## Decision Register
 

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
@@ -62,6 +62,35 @@ final case class BaselineManifest(
     description: String,
 )
 
+/** Logical components of an immutable reference-economy baseline.
+  *
+  * Identity, compatibility, and integrity remain manifest metadata. These
+  * components hold the economic input and evidence needed to compile a run.
+  */
+enum BaselineBundleComponentKind:
+  case Parameters
+  case PopulationControls
+  case InstitutionalOpeningState
+  case ExogenousBaselineAssumptions
+  case Provenance
+  case ValidationProfile
+
+/** Whether a component is materially part of the resolved bundle, merely
+  * documented elsewhere, or not available yet.
+  */
+enum BaselineBundleComponentAvailability:
+  case Present
+  case Referenced
+  case Missing
+
+/** One declared logical component of a baseline bundle. */
+final case class BaselineBundleComponent(
+    kind: BaselineBundleComponentKind,
+    availability: BaselineBundleComponentAvailability,
+    detail: String,
+):
+  require(detail.trim.nonEmpty, s"baseline component $kind must describe its availability")
+
 enum BaselineLoadError:
   case InvalidId(input: String, reason: String)
   case UnknownBaseline(requested: BaselineId, available: Vector[BaselineId])
@@ -72,19 +101,35 @@ enum BaselineLoadError:
   )
   case IntegrityMismatch(baseline: BaselineId, expected: BaselineDigest, actual: BaselineDigest)
 
-/** Immutable prepared baseline. Its engine configuration remains
-  * config-private.
+/** Immutable internal baseline bundle prepared for compilation. Its engine
+  * configuration remains config-private, and it does not expose a file format
+  * or a public Research API.
   */
-final class ResolvedBaseline private[config] (
+final class BaselineBundle private[config] (
     val manifest: BaselineManifest,
+    val components: Vector[BaselineBundleComponent],
     private[config] val params: SimParams,
-)
+):
+  private val componentKinds = components.map(_.kind)
+
+  require(
+    componentKinds.toSet == BaselineBundleComponentKind.values.toSet && componentKinds.distinct.size == componentKinds.size,
+    "baseline bundle must declare every logical component exactly once",
+  )
+  require(
+    manifest.qualification != BaselineQualification.Canonical || components.forall(_.availability == BaselineBundleComponentAvailability.Present),
+    "a canonical baseline bundle must contain every logical component",
+  )
+
+  def component(kind: BaselineBundleComponentKind): BaselineBundleComponent =
+    components.find(_.kind == kind).getOrElse(throw IllegalStateException(s"missing declared baseline component: $kind"))
 
 /** Internal source of a baseline payload. Disk-backed bundles replace this seam
   * later.
   */
 private[config] trait BaselineProvider:
   def manifest: BaselineManifest
+  def components: Vector[BaselineBundleComponent]
   def compile(): SimParams
 
 /** Exact baseline resolution and verification for the current model contract.
@@ -102,10 +147,10 @@ final class BaselineCatalog private[config] (
 
   def list: Vector[BaselineManifest] = providers.map(_.manifest)
 
-  def resolve(input: String): Either[BaselineLoadError, ResolvedBaseline] =
+  def resolve(input: String): Either[BaselineLoadError, BaselineBundle] =
     BaselineId.from(input).left.map(reason => BaselineLoadError.InvalidId(input, reason)).flatMap(id => resolve(BaselineRef(id)))
 
-  def resolve(ref: BaselineRef): Either[BaselineLoadError, ResolvedBaseline] =
+  def resolve(ref: BaselineRef): Either[BaselineLoadError, BaselineBundle] =
     providersById
       .get(ref.id)
       .toRight(BaselineLoadError.UnknownBaseline(ref.id, list.map(_.id)))
@@ -116,7 +161,7 @@ final class BaselineCatalog private[config] (
           val params = provider.compile()
           val actual = BaselineCatalog.legacyPayloadDigest(params)
           if actual != manifest.contentDigest then Left(BaselineLoadError.IntegrityMismatch(ref.id, manifest.contentDigest, actual))
-          else Right(ResolvedBaseline(manifest, params))
+          else Right(new BaselineBundle(manifest, provider.components, params))
 
 object BaselineCatalog:
   val LegacyDefaultsId: BaselineId = BaselineId.from("pl-2026-04-30-legacy-v1").fold(error => throw IllegalStateException(error), identity)
@@ -127,6 +172,40 @@ object BaselineCatalog:
 
   private object LegacyDefaultsProvider extends BaselineProvider:
     private val params = SimParams.defaults
+
+    val components: Vector[BaselineBundleComponent] =
+      Vector(
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.Parameters,
+          BaselineBundleComponentAvailability.Present,
+          "Pinned in-memory SimParams.defaults payload.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.PopulationControls,
+          BaselineBundleComponentAvailability.Missing,
+          "Legacy defaults do not contain versioned population control tables.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.InstitutionalOpeningState,
+          BaselineBundleComponentAvailability.Missing,
+          "WorldInit derives opening state from legacy parameters rather than a reconciled institutional component.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.ExogenousBaselineAssumptions,
+          BaselineBundleComponentAvailability.Missing,
+          "Legacy defaults do not separate baseline driver assumptions from model parameters.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.Provenance,
+          BaselineBundleComponentAvailability.Referenced,
+          "CalibrationProvenance.Baseline documents provenance but is not an immutable bundle artifact.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.ValidationProfile,
+          BaselineBundleComponentAvailability.Referenced,
+          "Existing validation evidence is not yet attached as a baseline-specific profile.",
+        ),
+      )
 
     val manifest: BaselineManifest =
       BaselineManifest(

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
@@ -34,9 +34,26 @@ object BaselineDigest:
 
 /** Qualification status shown by the baseline catalog. */
 enum BaselineQualification:
+  /** Scientifically released for its stated scope after required reconciliation
+    * and validation evidence. This is the only status suitable for canonical
+    * research workflows.
+    */
   case Canonical
+
+  /** Structurally loadable but not yet qualified for canonical scientific
+    * claims. It remains visible for controlled development and review.
+    */
   case Experimental
+
+  /** Compatibility adapter over an older or incomplete configuration surface.
+    * It may reproduce legacy work, but must not be presented as a canonical
+    * reference economy.
+    */
   case Legacy
+
+  /** Immutable former canonical release retained solely so prior experiments
+    * remain reproducible after a later baseline succeeds it.
+    */
   case Superseded
 
 /** Version of the model-side contract required to compile a baseline. */
@@ -68,19 +85,53 @@ final case class BaselineManifest(
   * components hold the economic input and evidence needed to compile a run.
   */
 enum BaselineBundleComponentKind:
+  /** Typed calibrated model parameters, including units, domains, and their
+    * parameter-level provenance references.
+    */
   case Parameters
+
+  /** Reconciled controls for persons, households, labor, firms, migration, and
+    * other represented populations used by the population compiler.
+    */
   case PopulationControls
+
+  /** Named institutions, opening balance-sheet controls, financial-account
+    * totals, and classification crosswalks needed to initialize the economy.
+    */
   case InstitutionalOpeningState
+
+  /** Declared no-shock or expected paths that belong to the reference economy,
+    * rather than an intervention selected by a research scenario.
+    */
   case ExogenousBaselineAssumptions
+
+  /** Per-source observation periods, releases, access dates, transformations,
+    * reconciliation rules, and redistribution constraints.
+    */
   case Provenance
+
+  /** Compilation invariants, opening reconciliations, empirical targets, known
+    * gaps, and the evidence supporting the qualification status.
+    */
   case ValidationProfile
 
 /** Whether a component is materially part of the resolved bundle, merely
   * documented elsewhere, or not available yet.
   */
 enum BaselineBundleComponentAvailability:
+  /** The component is material input to this bundle and must be covered by its
+    * integrity contract when persisted bundle artifacts are introduced.
+    */
   case Present
+
+  /** Related evidence exists elsewhere, but is not yet a versioned and
+    * integrity-pinned component of this baseline bundle.
+    */
   case Referenced
+
+  /** The bundle has no representation of this component. A canonical bundle may
+    * not use this availability.
+    */
   case Missing
 
 /** One declared logical component of a baseline bundle. */
@@ -92,13 +143,22 @@ final case class BaselineBundleComponent(
   require(detail.trim.nonEmpty, s"baseline component $kind must describe its availability")
 
 enum BaselineLoadError:
+  /** The supplied textual selector cannot become a valid immutable ID. */
   case InvalidId(input: String, reason: String)
+
+  /** The selector is syntactically valid but no installed provider has it. */
   case UnknownBaseline(requested: BaselineId, available: Vector[BaselineId])
+
+  /** The provider was built for a different model-side compilation contract. */
   case IncompatibleModel(
       baseline: BaselineId,
       required: ModelContractVersion,
       current: ModelContractVersion,
   )
+
+  /** The compiled payload differs from the reviewed digest pinned in the
+    * provider manifest.
+    */
   case IntegrityMismatch(baseline: BaselineId, expected: BaselineDigest, actual: BaselineDigest)
 
 /** Immutable internal baseline bundle prepared for compilation. Its engine

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/BaselineCatalogSpec.scala
@@ -13,6 +13,40 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
   private object DefaultsProvider extends BaselineProvider:
     private val params = SimParams.defaults
 
+    val components: Vector[BaselineBundleComponent] =
+      Vector(
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.Parameters,
+          BaselineBundleComponentAvailability.Present,
+          "Test parameter payload.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.PopulationControls,
+          BaselineBundleComponentAvailability.Missing,
+          "Test population controls.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.InstitutionalOpeningState,
+          BaselineBundleComponentAvailability.Missing,
+          "Test institutional opening state.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.ExogenousBaselineAssumptions,
+          BaselineBundleComponentAvailability.Missing,
+          "Test baseline assumptions.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.Provenance,
+          BaselineBundleComponentAvailability.Referenced,
+          "Test provenance.",
+        ),
+        BaselineBundleComponent(
+          BaselineBundleComponentKind.ValidationProfile,
+          BaselineBundleComponentAvailability.Referenced,
+          "Test validation profile.",
+        ),
+      )
+
     val manifest: BaselineManifest =
       BaselineManifest(
         id = BaselineCatalog.LegacyDefaultsId,
@@ -36,6 +70,10 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
     resolved.manifest.id shouldBe BaselineCatalog.LegacyDefaultsId
     resolved.manifest.qualification shouldBe BaselineQualification.Legacy
     resolved.manifest.contentDigest shouldBe PinnedLegacyPayloadDigest
+    resolved.components should have size BaselineBundleComponentKind.values.length
+    resolved.component(BaselineBundleComponentKind.Parameters).availability shouldBe BaselineBundleComponentAvailability.Present
+    resolved.component(BaselineBundleComponentKind.PopulationControls).availability shouldBe BaselineBundleComponentAvailability.Missing
+    resolved.component(BaselineBundleComponentKind.Provenance).availability shouldBe BaselineBundleComponentAvailability.Referenced
     resolved.params shouldBe SimParams.defaults
   }
 
@@ -54,7 +92,8 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
   it should "reject a changed legacy payload against the pinned digest" in {
     val changedParams = SimParams.defaults.copy(pop = SimParams.defaults.pop.copy(firmsCount = SimParams.defaults.pop.firmsCount + 1))
     val changed       = new BaselineProvider:
-      val manifest: BaselineManifest = DefaultsProvider.manifest
+      val manifest: BaselineManifest                  = DefaultsProvider.manifest
+      val components: Vector[BaselineBundleComponent] = DefaultsProvider.components
 
       def compile(): SimParams = changedParams
 
@@ -68,7 +107,8 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
   it should "reject a baseline compiled for a different model contract" in {
     val incompatibleContract = ModelContractVersion.from("target-core-v1")
     val incompatible         = new BaselineProvider:
-      val manifest: BaselineManifest = DefaultsProvider.manifest.copy(requiredModelContract = incompatibleContract)
+      val manifest: BaselineManifest                  = DefaultsProvider.manifest.copy(requiredModelContract = incompatibleContract)
+      val components: Vector[BaselineBundleComponent] = DefaultsProvider.components
 
       def compile(): SimParams = SimParams.defaults
 
@@ -91,4 +131,11 @@ class BaselineCatalogSpec extends AnyFlatSpec with Matchers:
 
     changed.pop.firmsCount shouldBe first.params.pop.firmsCount + 1
     second.params.pop.firmsCount shouldBe first.params.pop.firmsCount
+  }
+
+  it should "reject a canonical bundle with unresolved logical components" in {
+    val canonicalManifest = DefaultsProvider.manifest.copy(qualification = BaselineQualification.Canonical)
+
+    an[IllegalArgumentException] should be thrownBy
+      new BaselineBundle(canonicalManifest, DefaultsProvider.components, SimParams.defaults)
   }


### PR DESCRIPTION
## Summary
- introduce the internal BaselineBundle contract and six RFC-defined component kinds
- make legacy component availability explicit without claiming a Q2 bundle exists
- prevent canonical bundles from resolving with incomplete logical components

## Validation
- sbt "model/testOnly com.boombustgroup.amorfati.config.BaselineCatalogSpec"
- sbt scalafmtCheckAll
- sbt Test/compile
- python3 scripts/check-docs.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Baseline resolution now provides a structured bundle that includes an explicit inventory of component kinds and their availability (available, referenced, or missing).
  * Legacy baseline metadata more precisely highlights supported inputs and notes which components are not currently available.
* **Documentation**
  * Updated the research API RFC to reflect the clarified baseline component resolution behavior and current implementation boundaries.
* **Tests**
  * Added/expanded tests to validate component availability propagation and to ensure invalid bundle construction for unresolved component kinds is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->