### PR TITLE
Refactor scenario composition around explicit baselines

### DIFF
--- a/docs/nightly-diagnostics.md
+++ b/docs/nightly-diagnostics.md
@@ -282,8 +282,8 @@ Recommended steps:
 - baseline Monte Carlo: 1 seed, 12 months, snapshots disabled, decision traces
   disabled
 - SFC matrix evidence: seed 1, 12 months, Markdown output under `target`
-- scenario smoke: `baseline,monetary-tightening,fiscal-expansion`, 1 seed,
-  12 months
+- scenario smoke: resolved baseline plus `monetary-tightening,fiscal-expansion`,
+  1 seed, 12 months
 - robustness smoke: `--scenario-set smoke`, 1 seed, 6 months
 - bank balance-sheet benchmark: 2 seeds
 - household credit-stress calibration: 1 seed, 12 months

--- a/docs/odd-model-documentation.md
+++ b/docs/odd-model-documentation.md
@@ -450,9 +450,9 @@ and one-at-a-time parameter sweeps, producing seed envelopes and sensitivity
 summaries under `target/`.
 
 The reproducible scenario registry is documented in
-`docs/scenario-registry.md`. It defines named baseline, policy, banking,
-external, energy, tourism, and quasi-fiscal experiments with exact parameter
-deltas and an executable `scenarioRun` command path.
+`docs/scenario-registry.md`. It defines named policy, banking, external,
+energy, tourism, and quasi-fiscal patches applied to a selected baseline, with
+exact parameter deltas and an executable `scenarioRun` command path.
 
 ## Accounting And Validation Boundary
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -195,8 +195,8 @@ sbt "runMain com.boombustgroup.amorfati.Main 1 counterfactual --duration 12 --ru
 For named scenarios, compare the same scenario set across branches:
 
 ```bash
-sbt "scenarioRun --scenarios baseline,monetary-tightening --seeds 1 --months 12 --run-id baseline-review --out target/scenarios"
-sbt "scenarioRun --scenarios baseline,monetary-tightening --seeds 1 --months 12 --run-id <short-name>-review --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id baseline-review --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id <short-name>-review --out target/scenarios"
 ```
 
 Commit code, tests, and intentionally refreshed docs. Do not commit generated
@@ -426,13 +426,13 @@ are documented in [scenario-registry.md](scenario-registry.md).
 Run a small scenario smoke check:
 
 ```bash
-sbt "scenarioRun --scenarios baseline,monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
 ```
 
 Run every registered scenario with a small seed envelope:
 
 ```bash
-sbt "scenarioRun --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 Robustness scenario sets come from

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -223,8 +223,8 @@ An experiment specification contains at least:
 
 Population size is not inferred from unrelated firm or worker parameters.
 Baseline and representation semantics come directly from the accepted
-population RFC. `SimParams`, baseline file locations, parsed bundle DTOs, and
-current `ScenarioRegistry.ScenarioSpec.params` do not enter public signatures.
+population RFC. `SimParams`, baseline file locations, and parsed bundle DTOs
+do not enter public signatures.
 
 Conceptually, notebook code should read like:
 

--- a/docs/rfc/0002-research-api-contract.md
+++ b/docs/rfc/0002-research-api-contract.md
@@ -33,9 +33,10 @@ The current configuration surface cannot yet satisfy this contract:
   persisted bundle loader, or `pl-2026q2-v1` implementation;
 - the `SimConfigSpec` and `SimConfigPropertySpec` test names refer to
   `SimParams`; there is no separately loadable `SimConfig` baseline contract;
-- `ScenarioRegistry` builds every scenario from a private
-  `SimParams.defaults` value and stores a fully materialized `SimParams` in each
-  `ScenarioSpec`;
+- `ScenarioRegistry` now selects typed scenario references and applies a typed
+  patch only after resolving a compatible `BaselineBundle`; it currently
+  supports only the legacy baseline and has no persisted scenario manifest,
+  scenario digest, or calendar-indexed driver-path loader;
 - scenario provenance can classify a change as a historical analogue, but the
   current registry does not load a historical opening economy or a complete
   calendar-indexed observed shock path; and
@@ -255,10 +256,12 @@ decision with a future realized driver is a conditional forecast, not a genuine
 out-of-sample evaluation; the manifest and validation report must state that
 classification.
 
-The current `ScenarioRegistry.ScenarioSpec.params: SimParams` is therefore a
-migration shape, not the target contract. The current engine adapter may
-materialize a resolved baseline plus scenario into `SimParams`, but the
-scenario itself remains an independently manifested change set or time path.
+The current registry has removed `ScenarioSpec.params: SimParams`: its typed
+`ScenarioPatch` applies only after a compatible baseline resolves, and the
+unpatched baseline run has no scenario identity. The internal engine adapter
+still materializes that composition into `SimParams`. Persisted scenario
+manifests, independently pinned scenario digests, and driver-path loading
+remain required before this becomes the target contract.
 
 ## Historical Research Modes
 
@@ -356,10 +359,10 @@ that historical bundles already exist:
    boundaries independent of Almond;
 2. expose the existing `2026-04-30` defaults through an accurately named,
    explicitly legacy and non-canonical provider for API ergonomics tests;
-3. adapt the current engine by compiling the resolved provider and scenario
-   into an internal `SimParams`;
+3. adapt the current engine by materializing the resolved provider plus an
+   optional typed scenario patch into an internal `SimParams`;
 4. stop new Research API and notebook code from selecting
-   `SimParams.defaults` or `ScenarioSpec.params` directly;
+   `SimParams.defaults` directly;
 5. replace the legacy provider with the real `pl-2026q2-v1` bundle only after
    Q2 compilation, calibration, opening reconciliation, and validation exist;
    and
@@ -416,7 +419,8 @@ boundary, the design needs:
 - [`BaselineCatalog.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala)
   for the current internal catalog, legacy provider, and preparation checks;
 - [`ScenarioRegistry.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala)
-  for current full-configuration scenario materialization and provenance;
+  for current typed scenario patches, compatible-baseline declarations, and
+  provenance;
 - [`WorldInit.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/init/WorldInit.scala)
   for current initialization inputs and opening-state construction;
 - [`CalibrationProvenance.scala`](../../modules/model/src/main/scala/com/boombustgroup/amorfati/config/CalibrationProvenance.scala)

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -17,22 +17,22 @@ operations index.
 
 ## Command
 
-Run the baseline plus two nontrivial scenarios:
+Run the resolved baseline plus two nontrivial scenario patches:
 
 ```bash
-sbt "scenarioRun --scenarios baseline,monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
 ```
 
 Run every registered scenario:
 
 ```bash
-sbt "scenarioRun --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 Equivalent direct entrypoint:
 
 ```bash
-sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 ## Output Layout
@@ -52,8 +52,10 @@ target/scenarios/local-review/
     local-review_monetary-tightening_24m_seed001.tsv
 ```
 
-Each per-seed TSV uses `McTimeseriesSchema.colNames` as the header, so scenario
-outputs can be compared directly with validation and robustness artifacts.
+Each invocation first writes an unpatched run for the resolved baseline, then
+writes one run for each selected scenario patch. Each per-seed TSV uses
+`McTimeseriesSchema.colNames` as the header, so outputs can be compared
+directly with validation and robustness artifacts.
 
 The generated registry and per-scenario metadata are code-backed by
 `ScenarioRegistry`. `scenario-deltas.tsv` includes the parameter diff plus
@@ -75,9 +77,13 @@ delta. The allowed `ProvenanceClassification` values are:
 
 ## Registered Scenarios
 
+The baseline is not a scenario. It is selected by `--baseline`; the current
+registry's patches declare compatibility only with
+`pl-2026-04-30-legacy-v1` until a separately versioned patch set is prepared
+for another baseline.
+
 | Scenario | Label | Category | Provenance | Source/provider | Vintage | Recommended months | Purpose |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `baseline` | Baseline | baseline | explicit assumption | SimParams.defaults | Poland production baseline 2026-04-30 | 120 | Reference scenario using `SimParams.defaults`. |
 | `monetary-tightening` | Monetary tightening | policy rates | policy counterfactual | Internal policy scenario over the NBP rate channel | 2026-04-30 baseline counterfactual | 60 | Higher NBP policy stance for inflation and credit stress analysis. |
 | `fiscal-expansion` | Fiscal expansion | fiscal policy | policy counterfactual | Internal fiscal policy scenario | 2026-04-30 baseline counterfactual | 60 | Higher government demand and capital share for fiscal multiplier and debt-path comparisons. |
 | `credit-crunch` | Credit crunch | banking stress | historical analogue | Internal banking-stress analogue | post-2008 and pandemic credit-stress analogue | 60 | Tighter credit supply and weaker recovery assumptions for credit and default stress testing. |
@@ -89,14 +95,14 @@ delta. The allowed `ProvenanceClassification` values are:
 
 ## Parameter Deltas
 
-The compact table below records the parameter diff. The generated
+The compact table below records each patch relative to the resolved baseline.
+The generated
 `scenario-deltas.tsv` appends provenance classification, source/provider,
 vintage, and transformation notes from the same `ScenarioRegistry` delta
 objects.
 
 | Scenario | Parameter | Baseline | Scenario value | Note |
 | --- | --- | --- | --- | --- |
-| `baseline` | `SimParams` | `SimParams.defaults` | `SimParams.defaults` | No parameter change. |
 | `monetary-tightening` | `monetary.initialRate` | `0.0375` | `0.075` | Higher starting reference rate. |
 | `monetary-tightening` | `monetary.neutralRate` | `0.04` | `0.05` | Higher neutral-rate anchor. |
 | `monetary-tightening` | `monetary.taylorAlpha` | `1.5` | `1.8` | Stronger inflation response. |

--- a/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.config.RobustnessScenarios.ScenarioSet
-import com.boombustgroup.amorfati.config.{ScenarioRegistry, SimParams}
+import com.boombustgroup.amorfati.config.{ScenarioRef, ScenarioRegistry, SimParams}
 import com.boombustgroup.amorfati.engine.EngineFailure
 import com.boombustgroup.amorfati.montecarlo.core.McRunConfig
 import com.boombustgroup.amorfati.montecarlo.runner.McRunner
@@ -613,7 +613,7 @@ object NightlyDiagnosticsProfileRunner:
           Vector(
             baselineMonteCarlo(seeds = 1, months = 12),
             sfcMatrix(seed = 1L, months = 12),
-            scenarioRun(selection = "baseline,monetary-tightening,fiscal-expansion", seeds = 1, months = 12),
+            scenarioRun(selection = "monetary-tightening,fiscal-expansion", seeds = 1, months = 12),
             robustnessReport(scenarioSet = ScenarioSet.Smoke, seeds = 1, months = 6),
             bankBalanceSheetBenchmark(seeds = 2),
             householdCreditStress(seeds = 1, months = 12),
@@ -904,7 +904,7 @@ object NightlyDiagnosticsProfileRunner:
   private def scenarioClassification(selection: String): DiagnosticClass =
     val includesStress = resolveScenarios(selection).toOption.exists(_.exists(isStressScenario))
     if includesStress then DiagnosticClass.StressValidation
-    else if selection.trim == "baseline" then DiagnosticClass.NormalValidation
+    else if selection.trim == "none" then DiagnosticClass.NormalValidation
     else DiagnosticClass.Exploratory
 
   private def isStressScenario(scenario: ScenarioRegistry.ScenarioSpec): Boolean =
@@ -912,7 +912,8 @@ object NightlyDiagnosticsProfileRunner:
 
   private def resolveScenarios(selection: String): Either[String, Vector[ScenarioRegistry.ScenarioSpec]] =
     selection match
-      case "default" => Right(ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(id).toOption))
+      case "default" =>
+        Right(ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(ScenarioRef(id)).toOption))
       case "all"     => Right(ScenarioRegistry.all)
       case other     => ScenarioRegistry.select(other)
 

--- a/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
+++ b/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunner.scala
@@ -1,7 +1,7 @@
 package com.boombustgroup.amorfati.diagnostics
 
 import com.boombustgroup.amorfati.config.RobustnessScenarios.ScenarioSet
-import com.boombustgroup.amorfati.config.{ScenarioRef, ScenarioRegistry, SimParams}
+import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineRef, ScenarioRef, ScenarioRegistry, SimParams}
 import com.boombustgroup.amorfati.engine.EngineFailure
 import com.boombustgroup.amorfati.montecarlo.core.McRunConfig
 import com.boombustgroup.amorfati.montecarlo.runner.McRunner
@@ -603,6 +603,8 @@ object NightlyDiagnosticsProfileRunner:
 
   // Keep this vector in sync with docs/nightly-diagnostics.md. The 60-month
   // ceiling is deliberate: 120m+ belongs to the future long-horizon profile.
+  private val LegacyScenarioBaseline = BaselineRef(BaselineCatalog.LegacyDefaultsId)
+
   private[diagnostics] val Profiles: Vector[ProfileSpec] =
     Vector(
       ProfileSpec(
@@ -613,7 +615,7 @@ object NightlyDiagnosticsProfileRunner:
           Vector(
             baselineMonteCarlo(seeds = 1, months = 12),
             sfcMatrix(seed = 1L, months = 12),
-            scenarioRun(selection = "monetary-tightening,fiscal-expansion", seeds = 1, months = 12),
+            scenarioRun(selection = "monetary-tightening,fiscal-expansion", baseline = LegacyScenarioBaseline, seeds = 1, months = 12),
             robustnessReport(scenarioSet = ScenarioSet.Smoke, seeds = 1, months = 6),
             bankBalanceSheetBenchmark(seeds = 2),
             householdCreditStress(seeds = 1, months = 12),
@@ -627,7 +629,7 @@ object NightlyDiagnosticsProfileRunner:
           Vector(
             baselineMonteCarlo(seeds = 5, months = 60),
             empiricalValidation(baselineSeeds = 5, baselineMonths = 60),
-            scenarioRun(selection = "default", seeds = 5, months = 60),
+            scenarioRun(selection = "default", baseline = LegacyScenarioBaseline, seeds = 5, months = 60),
             robustnessReport(scenarioSet = ScenarioSet.Core, seeds = 2, months = 24),
             bankBalanceSheetBenchmark(seeds = 10),
             householdCreditStress(seeds = 5, months = 60),
@@ -642,7 +644,7 @@ object NightlyDiagnosticsProfileRunner:
         steps = _ =>
           Vector(
             baselineMonteCarlo(seeds = 10, months = 60),
-            scenarioRun(selection = "extended", seeds = 5, months = 60),
+            scenarioRun(selection = "extended", baseline = LegacyScenarioBaseline, seeds = 5, months = 60),
             robustnessReport(scenarioSet = ScenarioSet.Core, seeds = 5, months = 60),
             bankBalanceSheetBenchmark(seeds = 10),
             householdCreditStress(seeds = 10, months = 60),
@@ -687,7 +689,7 @@ object NightlyDiagnosticsProfileRunner:
           .map(_.paths),
     )
 
-  private def scenarioRun(selection: String, seeds: Int, months: Int): DiagnosticStep =
+  private def scenarioRun(selection: String, baseline: BaselineRef, seeds: Int, months: Int): DiagnosticStep =
     DiagnosticStep(
       id = "scenario-run",
       label = "Scenario Registry Run",
@@ -697,12 +699,13 @@ object NightlyDiagnosticsProfileRunner:
       seeds = Some(seeds),
       months = Some(months),
       outputDir = ctx => ctx.runRoot.resolve("scenario-run").resolve(ctx.runId),
-      details = Vector("scenario_selection" -> selection),
+      details = Vector("baseline_id" -> baseline.id.value, "scenario_selection" -> selection),
       run = ctx =>
         for
           scenarios <- ZIO.fromEither(resolveScenarios(selection))
           result    <- ScenarioRunExport.runZIO(
             ScenarioRunExport.Config(
+              baseline = baseline,
               scenarios = scenarios,
               seedStart = 1L,
               seeds = seeds,

--- a/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
+++ b/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
@@ -65,7 +65,7 @@ object ScenarioRunExport:
       runs          <- ZIO.fromEither(ScenarioRegistry.prepare(baseline, validConfig.scenarios).left.map(_.toString))
       registryPath  <- DiagnosticIo.writeText(validConfig.runRoot.resolve("scenario-registry.md"), renderRegistry(baseline.manifest, validConfig.scenarios))
       deltasPath     = validConfig.runRoot.resolve("scenario-deltas.tsv")
-      deltaRows      = validConfig.scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id.value, delta)))
+      deltaRows      = deltaRowsFor(validConfig.scenarios)
       _             <- McTsvFile.writeAll(deltasPath, deltaRows, DeltasTsvSchema)(DiagnosticIo.outputFailure)
       metadataPaths <- ZIO.foreach(runs): run =>
         DiagnosticIo.writeText(validConfig.runRoot.resolve(run.id).resolve("metadata.md"), renderRunMetadata(validConfig, baseline.manifest, run))
@@ -165,8 +165,10 @@ object ScenarioRunExport:
     lines.mkString("\n") + "\n"
 
   private[diagnostics] def renderDeltas(scenarios: Vector[ScenarioSpec]): String =
-    val rows = scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id.value, delta)))
-    renderTsv(DeltasTsvSchema, rows)
+    renderTsv(DeltasTsvSchema, deltaRowsFor(scenarios))
+
+  private def deltaRowsFor(scenarios: Vector[ScenarioSpec]): Vector[ScenarioDeltaRow] =
+    scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id.value, delta)))
 
   private[diagnostics] def renderRunMetadata(config: Config, baseline: BaselineManifest, run: PreparedScenario): String =
     val scenario    = run.scenario

--- a/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
+++ b/modules/cli/src/main/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExport.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.diagnostics
 
-import com.boombustgroup.amorfati.config.ScenarioRegistry
+import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineId, BaselineManifest, BaselineRef, PreparedScenario, ScenarioRef, ScenarioRegistry}
 import com.boombustgroup.amorfati.config.ScenarioRegistry.{DeltaProvenance, ParameterDelta, ScenarioSpec}
 import com.boombustgroup.amorfati.montecarlo.core.{McSeedMonth, MetricValue}
 import com.boombustgroup.amorfati.montecarlo.core.MetricValue.*
@@ -15,7 +15,8 @@ import scala.util.Try
 object ScenarioRunExport:
 
   final case class Config(
-      scenarios: Vector[ScenarioSpec] = ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(id).toOption),
+      baseline: BaselineRef = BaselineRef(BaselineCatalog.LegacyDefaultsId),
+      scenarios: Vector[ScenarioSpec] = ScenarioRegistry.defaultScenarioIds.flatMap(id => ScenarioRegistry.get(ScenarioRef(id)).toOption),
       seedStart: Long = 1L,
       seeds: Int = 1,
       months: Int = 12,
@@ -60,16 +61,16 @@ object ScenarioRunExport:
   def runZIO(config: Config): ZIO[Any, String, ExportResult] =
     for
       validConfig   <- ZIO.fromEither(validate(config))
-      registryPath  <- DiagnosticIo.writeText(validConfig.runRoot.resolve("scenario-registry.md"), renderRegistry(validConfig.scenarios))
+      baseline      <- ZIO.fromEither(BaselineCatalog.legacy.resolve(validConfig.baseline).left.map(_.toString))
+      runs          <- ZIO.fromEither(ScenarioRegistry.prepare(baseline, validConfig.scenarios).left.map(_.toString))
+      registryPath  <- DiagnosticIo.writeText(validConfig.runRoot.resolve("scenario-registry.md"), renderRegistry(baseline.manifest, validConfig.scenarios))
       deltasPath     = validConfig.runRoot.resolve("scenario-deltas.tsv")
-      deltaRows      = validConfig.scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id, delta)))
+      deltaRows      = validConfig.scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id.value, delta)))
       _             <- McTsvFile.writeAll(deltasPath, deltaRows, DeltasTsvSchema)(DiagnosticIo.outputFailure)
-      metadataPaths <- ZIO.foreach(validConfig.scenarios): scenario =>
-        DiagnosticIo.writeText(validConfig.runRoot.resolve(scenario.id).resolve("metadata.md"), renderScenarioMetadata(validConfig, scenario))
+      metadataPaths <- ZIO.foreach(runs): run =>
+        DiagnosticIo.writeText(validConfig.runRoot.resolve(run.id).resolve("metadata.md"), renderRunMetadata(validConfig, baseline.manifest, run))
       outputs       <- McDiagnosticRunner
-        .runScenarioSeeds(validConfig.scenarios, validConfig.seedRange, validConfig.months, _.id, _.params)((scenario, seed, months) =>
-          runSeed(validConfig, scenario, seed, months),
-        )
+        .runScenarioSeeds(runs, validConfig.seedRange, validConfig.months, _.id, _.params)((run, seed, months) => runSeed(validConfig, run, seed, months))
         .runCollect
         .map(_.toVector)
       paths          = Vector(registryPath, deltasPath) ++ metadataPaths ++ outputs.flatMap(_.paths)
@@ -87,21 +88,23 @@ object ScenarioRunExport:
         case Seq("--help", _*)                      => Left(usage)
         case Seq(flag, tail*) if knownFlag(flag)    =>
           tail match
-            case Seq()                                                              => missingValue(flag)
-            case Seq(value, _*) if value.startsWith("--")                           => missingValue(flag)
-            case Seq(value, next*) if flag == "--scenario" || flag == "--scenarios" =>
+            case Seq()                                       => missingValue(flag)
+            case Seq(value, _*) if value.startsWith("--")    => missingValue(flag)
+            case Seq(value, next*) if flag == "--scenarios"  =>
               ScenarioRegistry.select(value).flatMap(scenarios => loop(next, config.copy(scenarios = scenarios)))
-            case Seq(value, next*) if flag == "--seed-start"                        =>
+            case Seq(value, next*) if flag == "--baseline"   =>
+              BaselineId.from(value).left.map(reason => s"--baseline $reason").flatMap(id => loop(next, config.copy(baseline = BaselineRef(id))))
+            case Seq(value, next*) if flag == "--seed-start" =>
               parseLong(value, flag).flatMap(seedStart => loop(next, config.copy(seedStart = seedStart)))
-            case Seq(value, next*) if flag == "--seeds"                             =>
+            case Seq(value, next*) if flag == "--seeds"      =>
               parseInt(value, flag).flatMap(seeds => loop(next, config.copy(seeds = seeds)))
-            case Seq(value, next*) if flag == "--months"                            =>
+            case Seq(value, next*) if flag == "--months"     =>
               parseInt(value, flag).flatMap(months => loop(next, config.copy(months = months)))
-            case Seq(value, next*) if flag == "--run-id"                            =>
+            case Seq(value, next*) if flag == "--run-id"     =>
               loop(next, config.copy(runId = value))
-            case Seq(value, next*) if flag == "--out"                               =>
+            case Seq(value, next*) if flag == "--out"        =>
               loop(next, config.copy(out = Path.of(value)))
-            case Seq(_, _*)                                                         => Left(s"Unknown argument: $flag")
+            case Seq(_, _*)                                  => Left(s"Unknown argument: $flag")
         case Seq(flag, _*) if flag.startsWith("--") => Left(s"Unknown argument: $flag")
         case Seq(value, _*)                         => Left(s"Unexpected positional argument: $value")
 
@@ -109,34 +112,33 @@ object ScenarioRunExport:
 
   private def validate(config: Config): Either[String, Config] =
     Either
-      .cond(config.scenarios.nonEmpty, config, "--scenarios must contain at least one scenario")
-      .flatMap(valid => Either.cond(valid.seeds > 0, valid, "--seeds must be a positive integer"))
+      .cond(config.seeds > 0, config, "--seeds must be a positive integer")
       .flatMap(valid => Either.cond(valid.months > 0, valid, "--months must be a positive integer"))
       .flatMap(valid => Either.cond(valid.runId.trim.nonEmpty, valid, "--run-id must be non-empty"))
 
   private def runSeed(
       config: Config,
-      scenario: ScenarioSpec,
+      run: PreparedScenario,
       seed: Long,
       months: zio.stream.ZStream[Any, String, McSeedMonth],
   ): ZIO[Any, String, SeedRunOutput] =
-    val tsvPath = config.runRoot.resolve(scenario.id).resolve(f"${config.runId}_${scenario.id}_${config.months}m_seed$seed%03d.tsv")
+    val tsvPath = config.runRoot.resolve(run.id).resolve(f"${config.runId}_${run.id}_${config.months}m_seed$seed%03d.tsv")
     McTsvFile
       .writeStreaming(
         tsvPath,
         months,
         TimeSeriesTsvSchema,
-        s"Scenario ${scenario.id} seed $seed produced no monthly rows",
+        s"Run ${run.id} seed $seed produced no monthly rows",
       )(DiagnosticIo.outputFailure)
       .map: terminal =>
-        val metrics = Metrics.map(metric => TerminalMetric(scenario.id, seed, metric, terminal.row(metric.ordinal)))
+        val metrics = Metrics.map(metric => TerminalMetric(run.id, seed, metric, terminal.row(metric.ordinal)))
         SeedRunOutput(Vector(tsvPath), metrics)
 
-  private[diagnostics] def renderRegistry(scenarios: Vector[ScenarioSpec]): String =
+  private[diagnostics] def renderRegistry(baseline: BaselineManifest, scenarios: Vector[ScenarioSpec]): String =
     val rows = scenarios.map: scenario =>
       markdownRow(
         Vector(
-          scenario.id,
+          scenario.id.value,
           scenario.label,
           scenario.category,
           provenanceClassifications(scenario),
@@ -153,6 +155,9 @@ object ScenarioRunExport:
       "",
       "Generated by `ScenarioRunExport` from `ScenarioRegistry`.",
       "",
+      s"- Resolved baseline: `${baseline.id}`",
+      "- The baseline run has no scenario patch.",
+      "",
       markdownRow(Vector("Scenario", "Label", "Category", "Provenance", "Source / provider", "Vintage", "Recommended months", "Seed policy", "Output folder")),
       markdownRow(Vector("---", "---", "---", "---", "---", "---", "---", "---", "---")),
     ) ++ rows
@@ -160,40 +165,44 @@ object ScenarioRunExport:
     lines.mkString("\n") + "\n"
 
   private[diagnostics] def renderDeltas(scenarios: Vector[ScenarioSpec]): String =
-    val rows = scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id, delta)))
+    val rows = scenarios.flatMap(scenario => scenario.deltas.map(delta => ScenarioDeltaRow(scenario.id.value, delta)))
     renderTsv(DeltasTsvSchema, rows)
 
-  private[diagnostics] def renderScenarioMetadata(config: Config, scenario: ScenarioSpec): String =
-    val channelRows = scenario.expectedChannels.map(channel => s"- `$channel`")
-    val deltaRows   = scenario.deltas.map: delta =>
-      val provenance = delta.provenance
-      markdownRow(
-        Vector(
-          delta.parameter,
-          delta.baseline,
-          delta.scenario,
-          delta.note,
-          provenance.classification.label,
-          provenance.sourceProvider.filter(_.trim.nonEmpty).getOrElse("n/a"),
-          provenance.vintage.filter(_.trim.nonEmpty).getOrElse("n/a"),
-          transformationNotes(provenance),
-        ),
-      )
+  private[diagnostics] def renderRunMetadata(config: Config, baseline: BaselineManifest, run: PreparedScenario): String =
+    val scenario    = run.scenario
+    val channelRows = scenario.toVector.flatMap(_.expectedChannels).map(channel => s"- `$channel`")
+    val deltaRows   = scenario.toVector
+      .flatMap(_.deltas)
+      .map: delta =>
+        val provenance = delta.provenance
+        markdownRow(
+          Vector(
+            delta.parameter,
+            delta.baseline,
+            delta.scenario,
+            delta.note,
+            provenance.classification.label,
+            provenance.sourceProvider.filter(_.trim.nonEmpty).getOrElse("n/a"),
+            provenance.vintage.filter(_.trim.nonEmpty).getOrElse("n/a"),
+            transformationNotes(provenance),
+          ),
+        )
     val lines       =
       Vector(
-        s"# ${scenario.label}",
+        s"# ${run.label}",
         "",
-        s"- Scenario id: `${scenario.id}`",
-        s"- Category: `${scenario.category}`",
-        s"- Purpose: ${scenario.purpose}",
-        s"- Provenance classification: ${provenanceClassifications(scenario)}",
-        s"- Source/provider: ${sourceProviders(scenario)}",
-        s"- Vintage: ${vintages(scenario)}",
+        s"- Baseline id: `${baseline.id}`",
+        s"- Scenario id: `${scenario.map(_.id.value).getOrElse("none")}`",
+        s"- Category: `${scenario.map(_.category).getOrElse("baseline")}`",
+        s"- Purpose: ${scenario.map(_.purpose).getOrElse("Unpatched resolved baseline run.")}",
+        s"- Provenance classification: ${scenario.map(provenanceClassifications).getOrElse("n/a")}",
+        s"- Source/provider: ${scenario.map(sourceProviders).getOrElse("n/a")}",
+        s"- Vintage: ${scenario.map(vintages).getOrElse("n/a")}",
         s"- Run id: `${config.runId}`",
         s"- Months in this run: `${config.months}`",
-        s"- Recommended months: `${scenario.recommendedMonths}`",
-        s"- Seed policy: ${scenario.seedPolicy}",
-        s"- Output folder: `${config.runRoot.resolve(scenario.id)}`",
+        s"- Recommended months: `${scenario.map(_.recommendedMonths).getOrElse(config.months)}`",
+        s"- Seed policy: ${scenario.map(_.seedPolicy).getOrElse("Use the same seed band as every scenario patch.")}",
+        s"- Output folder: `${config.runRoot.resolve(run.id)}`",
         "",
         "## Expected Channels",
         "",
@@ -248,7 +257,7 @@ object ScenarioRunExport:
     (schema.header +: rows.map(schema.render)).mkString("\n") + "\n"
 
   private def knownFlag(flag: String): Boolean =
-    flag == "--scenario" || flag == "--scenarios" || flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
+    flag == "--baseline" || flag == "--scenarios" || flag == "--seed-start" || flag == "--seeds" || flag == "--months" || flag == "--run-id" || flag == "--out"
 
   private def parseLong(value: String, name: String): Either[String, Long] =
     Try(value.toLong).toEither.left.map(_ => s"$name must be a long integer")
@@ -308,6 +317,6 @@ object ScenarioRunExport:
   )
 
   private val usage: String =
-    "Usage: ScenarioRunExport [--scenarios baseline,monetary-tightening|all] [--seed-start <long>] [--seeds <int>] [--months <int>] [--run-id <id>] [--out <path>]"
+    "Usage: ScenarioRunExport [--baseline <id>] [--scenarios monetary-tightening,fiscal-expansion|all|none] [--seed-start <long>] [--seeds <int>] [--months <int>] [--run-id <id>] [--out <path>]"
 
 end ScenarioRunExport

--- a/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -56,6 +56,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     )
     steps.find(_.id == "baseline-monte-carlo").value.seeds shouldBe Some(1)
     steps.find(_.id == "baseline-monte-carlo").value.months shouldBe Some(12)
+    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "pl-2026-04-30-legacy-v1")
     steps.find(_.id == "scenario-run").value.details should contain("scenario_selection" -> "monetary-tightening,fiscal-expansion")
     steps.find(_.id == "robustness-report").value.months shouldBe Some(6)
     steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
@@ -76,6 +77,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "loan-origination-quality",
     )
     steps.flatMap(_.months).max shouldBe 60
+    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "pl-2026-04-30-legacy-v1")
     steps.find(_.id == "hh-bank-lead-lag").value.details should contain("lag_max" -> "6")
     steps.find(_.id == "loan-origination-quality").value.details should contain("outcome_window" -> "12")
     steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation

--- a/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -56,6 +56,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     )
     steps.find(_.id == "baseline-monte-carlo").value.seeds shouldBe Some(1)
     steps.find(_.id == "baseline-monte-carlo").value.months shouldBe Some(12)
+    steps.find(_.id == "scenario-run").value.details should contain("scenario_selection" -> "monetary-tightening,fiscal-expansion")
     steps.find(_.id == "robustness-report").value.months shouldBe Some(6)
     steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
   }
@@ -87,7 +88,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     val scenarioSelection = steps.find(_.id == "scenario-run").value.details.toMap.apply("scenario_selection")
 
     scenarioSelection shouldBe "extended"
-    ScenarioRegistry.select(scenarioSelection).value.map(_.id) should not contain "bank-failure"
+    ScenarioRegistry.select(scenarioSelection).value.map(_.id.value) should not contain "bank-failure"
     steps.find(_.id == "scenario-run").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
     steps.find(_.id == "bank-failure-ablations").value.classification shouldBe NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
     steps.find(_.id == "bank-failure-ablations").value.details should contain("parallelism" -> "2")

--- a/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExportSpec.scala
+++ b/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/ScenarioRunExportSpec.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.diagnostics
 
-import com.boombustgroup.amorfati.config.{OpeningBankProfileScenario, ScenarioRegistry, SimParams}
+import com.boombustgroup.amorfati.config.{BaselineCatalog, OpeningBankProfileScenario, ScenarioRegistry, SimParams}
 import com.boombustgroup.amorfati.types.Multiplier
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -12,18 +12,23 @@ class ScenarioRunExportSpec extends AnyFlatSpec with Matchers:
   private def tsv(fields: String*): String =
     fields.mkString("\t")
 
-  "ScenarioRunExport" should "preserve default scenarios and all-scenario CLI selection" in {
+  "ScenarioRunExport" should "select scenario patches separately from the baseline run" in {
     ScenarioRunExport.Config().scenarios.map(_.id) shouldBe ScenarioRegistry.defaultScenarioIds
     ScenarioRunExport.parseArgs(Vector("--scenarios", "all")).map(_.scenarios.map(_.id)) shouldBe Right(ScenarioRegistry.all.map(_.id))
     ScenarioRunExport.parseArgs(Vector("--scenarios", "extended")).map(_.scenarios.map(_.id)) shouldBe Right(ScenarioRegistry.extendedScenarioIds)
-    ScenarioRegistry.extendedScenarioIds should not contain "bank-failure"
+    ScenarioRunExport.parseArgs(Vector("--scenarios", "none")).map(_.scenarios) shouldBe Right(Vector.empty)
+    ScenarioRunExport.parseArgs(Vector("--scenarios", "baseline")).isLeft shouldBe true
+    ScenarioRegistry.extendedScenarioIds.map(_.value) should not contain "bank-failure"
   }
 
   "ScenarioRunExport" should "export scenario provenance in registry and delta artifacts" in {
     val scenarios = ScenarioRegistry.select("monetary-tightening").fold(err => fail(err), identity)
 
-    val registry = ScenarioRunExport.renderRegistry(scenarios)
+    val baseline = BaselineCatalog.legacy.list.head
+    val registry = ScenarioRunExport.renderRegistry(baseline, scenarios)
     registry should include("Provenance")
+    registry should include(s"Resolved baseline: `${baseline.id}`")
+    registry should include("The baseline run has no scenario patch.")
     registry should include("Source / provider")
     registry should include("policy counterfactual")
     registry should include("Internal policy scenario over the NBP rate channel")
@@ -37,12 +42,16 @@ class ScenarioRunExportSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "export scenario provenance in per-scenario metadata" in {
+    val baseline = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(err => fail(err.toString), identity)
     val scenario = ScenarioRegistry.get("energy-shock").fold(err => fail(err), identity)
-    val metadata = ScenarioRunExport.renderScenarioMetadata(
+    val run      = ScenarioRegistry.prepare(baseline, Vector(scenario)).fold(err => fail(err.toString), identity).last
+    val metadata = ScenarioRunExport.renderRunMetadata(
       ScenarioRunExport.Config(scenarios = Vector(scenario), runId = "provenance-spec", out = Path.of("target/scenarios")),
-      scenario,
+      baseline.manifest,
+      run,
     )
 
+    metadata should include(s"- Baseline id: `${baseline.manifest.id}`")
     metadata should include("- Provenance classification: historical analogue")
     metadata should include("- Source/provider: EU ETS and commodity-price stress analogue")
     metadata should include("| Parameter | Baseline | Scenario | Note | Provenance | Source / provider | Vintage | Transformation notes |")
@@ -51,17 +60,21 @@ class ScenarioRunExportSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "route bank-failure opening capital stress through the bank profile scenario" in {
+    val baseline = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(err => fail(err.toString), identity)
     val scenario = ScenarioRegistry.get("bank-failure").fold(err => fail(err), identity)
+    val run      = ScenarioRegistry.prepare(baseline, Vector(scenario)).fold(err => fail(err.toString), identity).last
 
-    scenario.params.banking.openingBankCapitalAggregateTarget shouldBe SimParams.defaults.banking.openingBankCapitalAggregateTarget
-    scenario.params.banking.openingBankProfileScenario shouldBe OpeningBankProfileScenario.haircutOwnFunds(Multiplier.decimal(55, 2))
+    run.params.banking.openingBankCapitalAggregateTarget shouldBe SimParams.defaults.banking.openingBankCapitalAggregateTarget
+    run.params.banking.openingBankProfileScenario shouldBe OpeningBankProfileScenario.haircutOwnFunds(Multiplier.decimal(55, 2))
     scenario.deltas.map(_.parameter) should contain("banking.openingBankProfileScenario")
   }
 
-  it should "keep scenario runs from overriding the opening bank capital aggregate target directly" in
-    ScenarioRegistry.all
-      .filterNot(_.id == "baseline")
-      .foreach: scenario =>
-        scenario.params.banking.openingBankCapitalAggregateTarget shouldBe SimParams.defaults.banking.openingBankCapitalAggregateTarget
+  it should "keep scenario runs from overriding the opening bank capital aggregate target directly" in {
+    val baseline = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(err => fail(err.toString), identity)
+    val runs     = ScenarioRegistry.prepare(baseline, ScenarioRegistry.all).fold(err => fail(err.toString), identity)
+
+    runs.tail.foreach: run =>
+      run.params.banking.openingBankCapitalAggregateTarget shouldBe SimParams.defaults.banking.openingBankCapitalAggregateTarget
+  }
 
 end ScenarioRunExportSpec

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/ScenarioRegistry.scala
@@ -2,6 +2,141 @@ package com.boombustgroup.amorfati.config
 
 import com.boombustgroup.amorfati.types.*
 
+/** Immutable selector for one registered intervention or driver-path change.
+  *
+  * A baseline run has no ScenarioRef. It is not represented as a no-op
+  * scenario.
+  */
+final case class ScenarioId private (value: String):
+  override def toString: String = value
+
+object ScenarioId:
+  def from(value: String): Either[String, ScenarioId] =
+    val normalized = Option(value).fold("")(_.trim)
+    if normalized.isEmpty then Left("scenario ID must be non-blank")
+    else Right(ScenarioId(normalized))
+
+final case class ScenarioRef(id: ScenarioId)
+
+/** Typed changes applied only after a baseline has been resolved. */
+enum ScenarioPatch:
+  case MonetaryTightening
+  case FiscalExpansion
+  case CreditCrunch
+  case EnergyShock
+  case TourismShock
+  case BankFailure
+  case FxCapitalFlight
+  case QuasiFiscalProgram
+
+  private[config] def applyTo(baseline: SimParams): SimParams =
+    this match
+      case MonetaryTightening =>
+        baseline.copy(
+          monetary = baseline.monetary.copy(
+            initialRate = Rate.decimal(75, 3),
+            neutralRate = Rate.decimal(50, 3),
+            taylorAlpha = Coefficient.decimal(18, 1),
+          ),
+        )
+      case FiscalExpansion    =>
+        baseline.copy(
+          fiscal = baseline.fiscal.copy(
+            govBaseSpending = baseline.fiscal.govBaseSpending * Multiplier.decimal(115, 2),
+            govInvestShare = Share.decimal(30, 2),
+            govAutoStabMult = Coefficient.decimal(35, 1),
+          ),
+        )
+      case CreditCrunch       =>
+        baseline.copy(
+          banking = baseline.banking.copy(
+            baseSpread = Rate.decimal(35, 3),
+            minCar = Multiplier.decimal(10, 2),
+            loanRecovery = Share.decimal(20, 2),
+            eclMigrationSensitivity = Coefficient.decimal(45, 1),
+          ),
+          household = baseline.household.copy(
+            ccMaxDti = Share.decimal(30, 2),
+            ccEligRate = Share.decimal(30, 2),
+          ),
+        )
+      case EnergyShock        =>
+        baseline.copy(
+          climate = baseline.climate.copy(
+            etsBasePrice = Multiplier(120),
+            energyCostShares = Vector(
+              Share.decimal(3, 2),
+              Share.decimal(15, 2),
+              Share.decimal(6, 2),
+              Share.decimal(75, 3),
+              Share.decimal(45, 3),
+              Share.decimal(9, 2),
+            ),
+            greenBudgetShare = Share.decimal(12, 2),
+          ),
+          gvc = baseline.gvc.copy(
+            commodityShockMonth = 6,
+            commodityShockMag = Multiplier.decimal(15, 1),
+          ),
+        )
+      case TourismShock       =>
+        baseline.copy(
+          tourism = baseline.tourism.copy(
+            shockMonth = 6,
+            shockSize = Share.decimal(60, 2),
+            shockRecovery = Rate.decimal(5, 2),
+            inboundShare = Share.decimal(4, 2),
+          ),
+        )
+      case BankFailure        =>
+        baseline.copy(
+          banking = baseline.banking.copy(
+            openingBankProfileScenario = OpeningBankProfileScenario.haircutOwnFunds(Multiplier.decimal(55, 2)),
+            minCar = Multiplier.decimal(12, 2),
+            depositPanicRate = Share.decimal(8, 2),
+            maxDepositSwitchRate = Share.decimal(18, 2),
+          ),
+        )
+      case FxCapitalFlight    =>
+        baseline.copy(
+          forex = baseline.forex.copy(
+            riskOffShockMonth = 6,
+            riskOffMagnitude = Share.decimal(20, 2),
+            riskOffDurationMonths = 9,
+            irpSensitivity = Coefficient.decimal(30, 2),
+            exRateAdjSpeed = Coefficient.decimal(5, 2),
+          ),
+          monetary = baseline.monetary.copy(fxMaxMonthly = Share.decimal(6, 2)),
+        )
+      case QuasiFiscalProgram =>
+        baseline.copy(
+          quasiFiscal = baseline.quasiFiscal.copy(
+            issuanceShare = Share.decimal(65, 2),
+            lendingShare = Share.decimal(70, 2),
+            nbpAbsorptionShare = Share.decimal(85, 2),
+          ),
+          fiscal = baseline.fiscal.copy(govInvestShare = Share.decimal(30, 2)),
+          monetary = baseline.monetary.copy(qeMaxGdpShare = Share.decimal(40, 2)),
+        )
+
+/** Structured reason that a scenario cannot be applied to a resolved bundle. */
+enum ScenarioCompositionError:
+  case IncompatibleBaseline(
+      scenario: ScenarioId,
+      baseline: BaselineId,
+      compatibleBaselines: Vector[BaselineId],
+  )
+
+/** Engine-facing materialization of one selected scenario. This remains inside
+  * the Amor Fati implementation boundary; it is not a Research API result.
+  */
+private[amorfati] final class PreparedScenario private[config] (
+    val id: String,
+    val label: String,
+    val scenario: Option[ScenarioRegistry.ScenarioSpec],
+    private[amorfati] val params: SimParams,
+)
+
 /** Named policy and shock scenarios for reproducible experiment runs.
   *
   * This lives in the config package because scenario composition needs the
@@ -33,7 +168,7 @@ object ScenarioRegistry:
   )
 
   final case class ScenarioSpec(
-      id: String,
+      id: ScenarioId,
       label: String,
       category: String,
       purpose: String,
@@ -41,11 +176,13 @@ object ScenarioRegistry:
       recommendedMonths: Int,
       seedPolicy: String,
       outputFolder: String,
+      compatibleBaselineIds: Vector[BaselineId],
       deltas: Vector[ParameterDelta],
-      params: SimParams,
-  )
+      patch: ScenarioPatch,
+  ):
+    def ref: ScenarioRef = ScenarioRef(id)
 
-  private val Baseline = SimParams.defaults
+    require(compatibleBaselineIds.nonEmpty, s"Scenario $id must declare compatible baselines")
 
   private def provenance(
       classification: ProvenanceClassification,
@@ -59,13 +196,6 @@ object ScenarioRegistry:
       vintage = Some(vintage),
       transformationNotes = Some(transformationNotes),
     )
-
-  private val BaselineProvenance = provenance(
-    ExplicitAssumption,
-    "SimParams.defaults",
-    "Poland production baseline 2026-04-30",
-    "No scenario adjustment; the run uses the configured baseline.",
-  )
 
   private val MonetaryTighteningProvenance = provenance(
     PolicyCounterfactual,
@@ -123,25 +253,18 @@ object ScenarioRegistry:
     "Raises off-budget issuance, subsidized-lending routing, NBP absorption, and QE capacity.",
   )
 
-  val defaultScenarioIds: Vector[String] =
-    Vector("baseline", "monetary-tightening", "fiscal-expansion")
+  private def scenarioId(value: String): ScenarioId =
+    ScenarioId.from(value).fold(error => throw IllegalArgumentException(error), identity)
+
+  private val LegacyCompatibleBaselineIds = Vector(BaselineCatalog.LegacyDefaultsId)
+
+  val defaultScenarioIds: Vector[ScenarioId] =
+    Vector(scenarioId("monetary-tightening"), scenarioId("fiscal-expansion"))
 
   val all: Vector[ScenarioSpec] =
     Vector(
       ScenarioSpec(
-        id = "baseline",
-        label = "Baseline",
-        category = "baseline",
-        purpose = "Reference scenario using SimParams.defaults.",
-        expectedChannels = Vector("all baseline model channels"),
-        recommendedMonths = 120,
-        seedPolicy = "Use fixed seed bands; default smoke command uses seed 1.",
-        outputFolder = "<out>/<run-id>/baseline",
-        deltas = Vector(ParameterDelta("SimParams", "SimParams.defaults", "SimParams.defaults", "No parameter change.", BaselineProvenance)),
-        params = Baseline,
-      ),
-      ScenarioSpec(
-        id = "monetary-tightening",
+        id = scenarioId("monetary-tightening"),
         label = "Monetary tightening",
         category = "policy rates",
         purpose = "Higher NBP policy stance for inflation and credit stress analysis.",
@@ -149,21 +272,16 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline.",
         outputFolder = "<out>/<run-id>/monetary-tightening",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("monetary.initialRate", "0.0375", "0.075", "Higher starting reference rate.", MonetaryTighteningProvenance),
           ParameterDelta("monetary.neutralRate", "0.04", "0.05", "Higher neutral-rate anchor.", MonetaryTighteningProvenance),
           ParameterDelta("monetary.taylorAlpha", "1.5", "1.8", "Stronger inflation response.", MonetaryTighteningProvenance),
         ),
-        params = Baseline.copy(
-          monetary = Baseline.monetary.copy(
-            initialRate = Rate.decimal(75, 3),
-            neutralRate = Rate.decimal(50, 3),
-            taylorAlpha = Coefficient.decimal(18, 1),
-          ),
-        ),
+        patch = ScenarioPatch.MonetaryTightening,
       ),
       ScenarioSpec(
-        id = "fiscal-expansion",
+        id = scenarioId("fiscal-expansion"),
         label = "Fiscal expansion",
         category = "fiscal policy",
         purpose = "Higher government demand and capital share for fiscal multiplier and debt-path comparisons.",
@@ -171,6 +289,7 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline.",
         outputFolder = "<out>/<run-id>/fiscal-expansion",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta(
             "fiscal.govBaseSpending",
@@ -182,16 +301,10 @@ object ScenarioRegistry:
           ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share.", FiscalExpansionProvenance),
           ParameterDelta("fiscal.govAutoStabMult", "3.0", "3.5", "Stronger automatic stabilization.", FiscalExpansionProvenance),
         ),
-        params = Baseline.copy(
-          fiscal = Baseline.fiscal.copy(
-            govBaseSpending = Baseline.fiscal.govBaseSpending * Multiplier.decimal(115, 2),
-            govInvestShare = Share.decimal(30, 2),
-            govAutoStabMult = Coefficient.decimal(35, 1),
-          ),
-        ),
+        patch = ScenarioPatch.FiscalExpansion,
       ),
       ScenarioSpec(
-        id = "credit-crunch",
+        id = scenarioId("credit-crunch"),
         label = "Credit crunch",
         category = "banking stress",
         purpose = "Tighter credit supply and weaker recovery assumptions for credit and default stress testing.",
@@ -199,6 +312,7 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline.",
         outputFolder = "<out>/<run-id>/credit-crunch",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("banking.baseSpread", "0.015", "0.035", "Higher firm-loan spread.", CreditCrunchProvenance),
           ParameterDelta("banking.minCar", "0.08", "0.10", "Higher capital constraint.", CreditCrunchProvenance),
@@ -207,18 +321,10 @@ object ScenarioRegistry:
           ParameterDelta("household.ccMaxDti", "0.40", "0.30", "Tighter household credit affordability cap.", CreditCrunchProvenance),
           ParameterDelta("household.ccEligRate", "0.85", "0.30", "Lower stressed-household access to underwritten consumer credit.", CreditCrunchProvenance),
         ),
-        params = Baseline.copy(
-          banking = Baseline.banking.copy(
-            baseSpread = Rate.decimal(35, 3),
-            minCar = Multiplier.decimal(10, 2),
-            loanRecovery = Share.decimal(20, 2),
-            eclMigrationSensitivity = Coefficient.decimal(45, 1),
-          ),
-          household = Baseline.household.copy(ccMaxDti = Share.decimal(30, 2), ccEligRate = Share.decimal(30, 2)),
-        ),
+        patch = ScenarioPatch.CreditCrunch,
       ),
       ScenarioSpec(
-        id = "energy-shock",
+        id = scenarioId("energy-shock"),
         label = "Energy shock",
         category = "climate and commodity shock",
         purpose = "ETS and commodity-price stress for import costs, inflation, green capital, and sector pressure.",
@@ -226,6 +332,7 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
         outputFolder = "<out>/<run-id>/energy-shock",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("climate.etsBasePrice", "80", "120", "Higher EU ETS starting price.", EnergyShockProvenance),
           ParameterDelta(
@@ -239,27 +346,10 @@ object ScenarioRegistry:
           ParameterDelta("gvc.commodityShockMonth", "0", "6", "Commodity-price shock starts in month 6.", EnergyShockProvenance),
           ParameterDelta("gvc.commodityShockMag", "0.0", "1.5", "One-time commodity-price shock magnitude.", EnergyShockProvenance),
         ),
-        params = Baseline.copy(
-          climate = Baseline.climate.copy(
-            etsBasePrice = Multiplier(120),
-            energyCostShares = Vector(
-              Share.decimal(3, 2),
-              Share.decimal(15, 2),
-              Share.decimal(6, 2),
-              Share.decimal(75, 3),
-              Share.decimal(45, 3),
-              Share.decimal(9, 2),
-            ),
-            greenBudgetShare = Share.decimal(12, 2),
-          ),
-          gvc = Baseline.gvc.copy(
-            commodityShockMonth = 6,
-            commodityShockMag = Multiplier.decimal(15, 1),
-          ),
-        ),
+        patch = ScenarioPatch.EnergyShock,
       ),
       ScenarioSpec(
-        id = "tourism-shock",
+        id = scenarioId("tourism-shock"),
         label = "Tourism shock",
         category = "external demand shock",
         purpose = "Tourism-demand loss for services demand, current account, employment, and FX flows.",
@@ -267,23 +357,17 @@ object ScenarioRegistry:
         recommendedMonths = 36,
         seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
         outputFolder = "<out>/<run-id>/tourism-shock",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("tourism.shockMonth", "0", "6", "Tourism shock starts in month 6.", TourismShockProvenance),
           ParameterDelta("tourism.shockSize", "0.80", "0.60", "60% tourism-demand loss in the named scenario.", TourismShockProvenance),
           ParameterDelta("tourism.shockRecovery", "0.03", "0.05", "Faster monthly recovery than default COVID-style setting.", TourismShockProvenance),
           ParameterDelta("tourism.inboundShare", "0.05", "0.04", "Lower inbound tourism baseline share.", TourismShockProvenance),
         ),
-        params = Baseline.copy(
-          tourism = Baseline.tourism.copy(
-            shockMonth = 6,
-            shockSize = Share.decimal(60, 2),
-            shockRecovery = Rate.decimal(5, 2),
-            inboundShare = Share.decimal(4, 2),
-          ),
-        ),
+        patch = ScenarioPatch.TourismShock,
       ),
       ScenarioSpec(
-        id = "bank-failure",
+        id = scenarioId("bank-failure"),
         label = "Bank failure stress",
         category = "financial stability",
         purpose = "Low bank-capital and deposit-panic stress for failures, liquidity, and resolution channels.",
@@ -291,6 +375,7 @@ object ScenarioRegistry:
         recommendedMonths = 36,
         seedPolicy = "Compare on the same seed band as baseline.",
         outputFolder = "<out>/<run-id>/bank-failure",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta(
             "banking.openingBankProfileScenario",
@@ -303,17 +388,10 @@ object ScenarioRegistry:
           ParameterDelta("banking.depositPanicRate", "0.03", "0.08", "Higher deposit panic migration after failures.", BankFailureProvenance),
           ParameterDelta("banking.maxDepositSwitchRate", "0.10", "0.18", "Higher maximum monthly deposit switching.", BankFailureProvenance),
         ),
-        params = Baseline.copy(
-          banking = Baseline.banking.copy(
-            openingBankProfileScenario = OpeningBankProfileScenario.haircutOwnFunds(Multiplier.decimal(55, 2)),
-            minCar = Multiplier.decimal(12, 2),
-            depositPanicRate = Share.decimal(8, 2),
-            maxDepositSwitchRate = Share.decimal(18, 2),
-          ),
-        ),
+        patch = ScenarioPatch.BankFailure,
       ),
       ScenarioSpec(
-        id = "fx-capital-flight",
+        id = scenarioId("fx-capital-flight"),
         label = "FX and capital-flight stress",
         category = "external financial shock",
         purpose = "Risk-off and carry-unwind stress for exchange rate, reserves, current account, and bond demand.",
@@ -321,6 +399,7 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline; shock starts at month 6.",
         outputFolder = "<out>/<run-id>/fx-capital-flight",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("forex.riskOffShockMonth", "0", "6", "Risk-off shock starts in month 6.", FxCapitalFlightProvenance),
           ParameterDelta("forex.riskOffMagnitude", "0.10", "0.20", "Larger capital outflow shock.", FxCapitalFlightProvenance),
@@ -329,19 +408,10 @@ object ScenarioRegistry:
           ParameterDelta("forex.exRateAdjSpeed", "0.02", "0.05", "Faster exchange-rate adjustment.", FxCapitalFlightProvenance),
           ParameterDelta("monetary.fxMaxMonthly", "0.03", "0.06", "Larger allowed monthly FX intervention.", FxCapitalFlightProvenance),
         ),
-        params = Baseline.copy(
-          forex = Baseline.forex.copy(
-            riskOffShockMonth = 6,
-            riskOffMagnitude = Share.decimal(20, 2),
-            riskOffDurationMonths = 9,
-            irpSensitivity = Coefficient.decimal(30, 2),
-            exRateAdjSpeed = Coefficient.decimal(5, 2),
-          ),
-          monetary = Baseline.monetary.copy(fxMaxMonthly = Share.decimal(6, 2)),
-        ),
+        patch = ScenarioPatch.FxCapitalFlight,
       ),
       ScenarioSpec(
-        id = "quasi-fiscal-program",
+        id = scenarioId("quasi-fiscal-program"),
         label = "Quasi-fiscal program",
         category = "quasi-fiscal policy",
         purpose = "BGK/PFR-style off-budget financing stress for ESA debt, NBP absorption, and subsidized lending.",
@@ -349,6 +419,7 @@ object ScenarioRegistry:
         recommendedMonths = 60,
         seedPolicy = "Compare on the same seed band as baseline.",
         outputFolder = "<out>/<run-id>/quasi-fiscal-program",
+        compatibleBaselineIds = LegacyCompatibleBaselineIds,
         deltas = Vector(
           ParameterDelta("quasiFiscal.issuanceShare", "0.40", "0.65", "Higher BGK/PFR share of capital programs.", QuasiFiscalProgramProvenance),
           ParameterDelta("quasiFiscal.lendingShare", "0.50", "0.70", "More issuance routed to subsidized lending.", QuasiFiscalProgramProvenance),
@@ -356,37 +427,33 @@ object ScenarioRegistry:
           ParameterDelta("fiscal.govInvestShare", "0.20", "0.30", "Higher capital-spending share feeding quasi-fiscal issuance.", QuasiFiscalProgramProvenance),
           ParameterDelta("monetary.qeMaxGdpShare", "0.30", "0.40", "Higher QE stock ceiling.", QuasiFiscalProgramProvenance),
         ),
-        params = Baseline.copy(
-          quasiFiscal = Baseline.quasiFiscal.copy(
-            issuanceShare = Share.decimal(65, 2),
-            lendingShare = Share.decimal(70, 2),
-            nbpAbsorptionShare = Share.decimal(85, 2),
-          ),
-          fiscal = Baseline.fiscal.copy(govInvestShare = Share.decimal(30, 2)),
-          monetary = Baseline.monetary.copy(qeMaxGdpShare = Share.decimal(40, 2)),
-        ),
+        patch = ScenarioPatch.QuasiFiscalProgram,
       ),
     )
 
-  val extendedScenarioIds: Vector[String] =
-    all.map(_.id).filterNot(_ == "bank-failure")
+  val extendedScenarioIds: Vector[ScenarioId] =
+    all.map(_.id).filterNot(_ == scenarioId("bank-failure"))
 
-  private val byId: Map[String, ScenarioSpec] = all.map(scenario => scenario.id -> scenario).toMap
+  private val byId: Map[ScenarioId, ScenarioSpec] = all.map(scenario => scenario.id -> scenario).toMap
 
   all
-    .filterNot(_.id == "baseline")
     .foreach: scenario =>
+      val params = scenario.patch.applyTo(SimParams.defaults)
       require(
-        scenario.params.banking.openingBankCapitalAggregateTarget == Baseline.banking.openingBankCapitalAggregateTarget,
+        params.banking.openingBankCapitalAggregateTarget == SimParams.defaults.banking.openingBankCapitalAggregateTarget,
         s"Scenario ${scenario.id} must use banking.openingBankProfileScenario instead of overriding banking.openingBankCapitalAggregateTarget",
       )
 
-  def get(id: String): Either[String, ScenarioSpec] =
-    byId.get(id).toRight(s"Unknown scenario '$id'. Known scenarios: ${all.map(_.id).mkString(", ")}")
+  def get(ref: ScenarioRef): Either[String, ScenarioSpec] =
+    byId.get(ref.id).toRight(s"Unknown scenario '${ref.id}'. Known scenarios: ${all.map(_.id.value).mkString(", ")}")
+
+  def get(input: String): Either[String, ScenarioSpec] =
+    ScenarioId.from(input).flatMap(id => get(ScenarioRef(id)))
 
   def select(value: String): Either[String, Vector[ScenarioSpec]] =
     val normalized = value.trim
-    if normalized == "all" then Right(all)
+    if normalized == "none" then Right(Vector.empty)
+    else if normalized == "all" then Right(all)
     else if normalized == "extended" then Right(extendedScenarioIds.flatMap(id => byId.get(id)))
     else
       val ids = normalized.split(",").iterator.map(_.trim).filter(_.nonEmpty).toVector
@@ -397,5 +464,36 @@ object ScenarioRegistry:
             selected <- acc
             scenario <- get(id)
           yield selected :+ scenario
+
+  private[amorfati] def prepare(
+      baseline: BaselineBundle,
+      scenarios: Vector[ScenarioSpec],
+  ): Either[ScenarioCompositionError, Vector[PreparedScenario]] =
+    val baselineRun = new PreparedScenario(
+      id = "baseline",
+      label = baseline.manifest.displayName,
+      scenario = None,
+      params = baseline.params,
+    )
+
+    scenarios.foldLeft[Either[ScenarioCompositionError, Vector[PreparedScenario]]](Right(Vector(baselineRun))): (prepared, scenario) =>
+      prepared.flatMap: runs =>
+        if scenario.compatibleBaselineIds.contains(baseline.manifest.id) then
+          Right(
+            runs :+ new PreparedScenario(
+              id = scenario.id.value,
+              label = scenario.label,
+              scenario = Some(scenario),
+              params = scenario.patch.applyTo(baseline.params),
+            ),
+          )
+        else
+          Left(
+            ScenarioCompositionError.IncompatibleBaseline(
+              scenario.id,
+              baseline.manifest.id,
+              scenario.compatibleBaselineIds,
+            ),
+          )
 
 end ScenarioRegistry

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/ScenarioRegistrySpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/ScenarioRegistrySpec.scala
@@ -1,13 +1,13 @@
 package com.boombustgroup.amorfati.config
 
+import com.boombustgroup.amorfati.types.Multiplier
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScenarioRegistrySpec extends AnyFlatSpec with Matchers:
 
-  "ScenarioRegistry" should "record provenance metadata for every non-baseline scenario delta" in
+  "ScenarioRegistry" should "record provenance metadata for every scenario delta" in
     ScenarioRegistry.all
-      .filterNot(_.id == "baseline")
       .foreach: scenario =>
         scenario.deltas should not be empty
         scenario.deltas.foreach: delta =>
@@ -19,9 +19,41 @@ class ScenarioRegistrySpec extends AnyFlatSpec with Matchers:
           }
 
   it should "preserve default scenario selection and all-scenario lookup" in {
-    ScenarioRegistry.defaultScenarioIds shouldBe Vector("baseline", "monetary-tightening", "fiscal-expansion")
+    ScenarioRegistry.defaultScenarioIds.map(_.value) shouldBe Vector("monetary-tightening", "fiscal-expansion")
     ScenarioRegistry.select("all").map(_.map(_.id)) shouldBe Right(ScenarioRegistry.all.map(_.id))
-    ScenarioRegistry.select("baseline, monetary-tightening").map(_.map(_.id)) shouldBe Right(Vector("baseline", "monetary-tightening"))
+    ScenarioRegistry.select("none") shouldBe Right(Vector.empty)
+    ScenarioRegistry.select("baseline").isLeft shouldBe true
+  }
+
+  it should "materialize every selected patch from the resolved compatible baseline" in {
+    val baseline = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
+    val scenario = ScenarioRegistry.get("bank-failure").fold(error => fail(error), identity)
+    val runs     = ScenarioRegistry.prepare(baseline, Vector(scenario)).fold(error => fail(error.toString), identity)
+
+    runs.map(_.id) shouldBe Vector("baseline", "bank-failure")
+    runs.head.params shouldBe SimParams.defaults
+    runs(1).params.banking.openingBankCapitalAggregateTarget shouldBe SimParams.defaults.banking.openingBankCapitalAggregateTarget
+    runs(1).params.banking.openingBankProfileScenario shouldBe OpeningBankProfileScenario.haircutOwnFunds(Multiplier.decimal(55, 2))
+  }
+
+  it should "reject a scenario for an incompatible baseline" in {
+    val resolved       = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
+    val incompatibleId = BaselineId.from("pl-2026q2-v1").fold(error => fail(error), identity)
+    val incompatible   = new BaselineBundle(
+      resolved.manifest.copy(id = incompatibleId),
+      resolved.components,
+      SimParams.defaults,
+    )
+    val scenario       = ScenarioRegistry.get("monetary-tightening").fold(error => fail(error), identity)
+
+    ScenarioRegistry.prepare(incompatible, Vector(scenario)) shouldBe
+      Left(
+        ScenarioCompositionError.IncompatibleBaseline(
+          scenario.id,
+          incompatibleId,
+          Vector(BaselineCatalog.LegacyDefaultsId),
+        ),
+      )
   }
 
 end ScenarioRegistrySpec


### PR DESCRIPTION
## Summary
- remove the baseline pseudo-scenario and deprecated --scenario alias
- resolve a BaselineRef before applying typed, compatibility-checked ScenarioPatch values
- always export an unpatched baseline run plus selected patches, with baseline identity in metadata
- update nightly profiles, docs, and Research API contract notes

## Breaking change
ScenarioRunExport now uses --baseline <id> and --scenarios <patches|all|none>. baseline is no longer a valid scenario selector; use --scenarios none for an unpatched baseline-only export.

## Validation
- sbt scalafmtCheckAll
- sbt Test/compile
- model ScenarioRegistrySpec and BaselineCatalogSpec (11 tests)
- cli ScenarioRunExportSpec and NightlyDiagnosticsProfileRunnerSpec (19 tests)
- python3 scripts/check-docs.py
- bash scripts/check-generated-outputs.sh
- scenarioRun smoke: legacy baseline plus monetary-tightening, 1 seed, 1 month

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit baseline selection for scenario exports via the `--baseline` option.
  * Scenario exports now run an unpatched baseline first, then output one run per selected scenario patch.
  * Improved scenario selection behavior, including support for “none”, and clearer separation between baselines and scenario patches in outputs.
* **Documentation**
  * Updated operations and scenario registry guidance and examples to use `--baseline` and align scenario/delta/metadata output layout.
  * Refined the research API and notebook/runtime contract language around what’s included in public signatures.
* **Tests**
  * Expanded coverage for baseline-aware selections and output metadata/provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->