### PR TITLE
Add validated population control schema

### DIFF
--- a/docs/rfc/0001-population-and-representation.md
+++ b/docs/rfc/0001-population-and-representation.md
@@ -109,6 +109,7 @@ implement the ontology above.
 | Firms | Sector counts are controlled; size, region, and ownership attributes are then sampled in separate passes, with some ownership probabilities conditional on sector. | The population reflects selected empirical marginals but not a controlled joint distribution of sector, size, region, ownership, and employment. |
 | Banks | A household or firm has one `bankId`; household deposits, mortgages, consumer credit, interest, and most flows use it. | Aggregate multi-bank routing is explicit, but product-level bilateral contracts are not. |
 | Scale | Defaults declare 10,000 firms and use `workersPerFirm` as a population and GDP normalizer. `gdpRatio` scales many macro stocks. | Population representation, firm production, and monetary calibration are coupled. A scale change is not a transparent `1:N` sampling decision. |
+| Population-control inputs | `PopulationControlSchema` defines typed person, household, membership, demographic-labour, regional-labour, and employment controls with source metadata and cross-table reconciliation. Its tests use only a synthetic fixture. | The schema is an executable target-core boundary with no `gdpRatio`; it is not yet a Poland bundle, population compiler, or replacement runtime. |
 | Runtime data layout | Agent state and persistent financial state are primarily `Vector` collections of per-entity case classes. The ledger library executes batches against columnar `Array[Long]` stores, but Amor Fati currently creates an empty execution state for monthly deltas and snapshots the result to a `Map`. | The ledger execution kernel is data-oriented, but the persistent simulation state is not. Population passes still allocate and copy object rows, and the ledger layout is not yet the single persistent layout of financial state. |
 
 Two opening stocks expose the population mismatch directly. Initial
@@ -792,7 +793,9 @@ A practical sequence is:
 
 1. Define the baseline schema, representation weights, compiler manifest,
    population-table schemas, stable-ID policy, and invariants consistently with
-   the model-wide ontology RFC.
+   the model-wide ontology RFC. `PopulationControlSchema` is the first
+   executable part of this step: it accepts true represented counts and does
+   not admit `gdpRatio` or another economy-wide scale multiplier.
 2. Build the constrained firm and household/person compiler so its native
    output is the target columnar population, then validate it offline against
    the baseline.

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
@@ -1,0 +1,361 @@
+package com.boombustgroup.amorfati.config
+
+import java.time.LocalDate
+
+/** Input contract for the person, household, labour, and employment controls
+  * used by the future population compiler.
+  *
+  * This is deliberately independent of the current agent population and
+  * SimParams. A real reference-economy bundle supplies these controls; this
+  * schema does not itself claim that any particular country or period has been
+  * compiled.
+  */
+object PopulationControlSchema:
+
+  /** A non-negative quantity in the reference population, before sampling or
+    * representation weighting.
+    */
+  final case class RepresentedCount(value: Long):
+    require(value >= 0L, s"represented count must be non-negative: $value")
+
+  enum ControlStrength:
+    /** The compiler must meet the row total within its declared tolerance. */
+    case Hard
+
+    /** The row informs synthesis or calibration, but is not a binding total. */
+    case CalibratedMargin
+
+  enum ControlFamily:
+    case Persons
+    case Households
+    case HouseholdMembership
+    case Labour
+    case Employment
+
+  final case class ClassificationRef(id: String, version: String):
+    require(id.trim.nonEmpty, "classification ID must be non-empty")
+    require(version.trim.nonEmpty, s"classification $id must have a version")
+
+  final case class SourceProvenance(
+      provider: String,
+      sourceLocation: String,
+      observationPeriod: String,
+      release: String,
+      accessedAt: LocalDate,
+      transformation: String,
+  ):
+    require(provider.trim.nonEmpty, "source provider must be non-empty")
+    require(sourceLocation.trim.nonEmpty, s"source location for $provider must be non-empty")
+    require(observationPeriod.trim.nonEmpty, s"observation period for $provider must be non-empty")
+    require(release.trim.nonEmpty, s"release for $provider must be non-empty")
+    require(transformation.trim.nonEmpty, s"transformation for $provider must be non-empty")
+
+  /** Metadata that makes a control table reproducible and its reconciliation
+    * policy explicit.
+    */
+  final case class TableMetadata(
+      family: ControlFamily,
+      statisticalUniverse: String,
+      strength: ControlStrength,
+      absoluteTolerance: Long,
+      classifications: Vector[ClassificationRef],
+      source: SourceProvenance,
+  ):
+    require(statisticalUniverse.trim.nonEmpty, s"${family.toString} statistical universe must be non-empty")
+    require(absoluteTolerance >= 0L, s"${family.toString} absolute tolerance must be non-negative")
+    require(classifications.nonEmpty, s"${family.toString} must declare at least one classification")
+    require(
+      classifications.distinct.size == classifications.size,
+      s"${family.toString} must not repeat a classification reference",
+    )
+
+  final case class ControlTable[A](metadata: TableMetadata, rows: Vector[A]):
+    require(rows.nonEmpty, s"${metadata.family.toString} controls must not be empty")
+
+  final case class RegionCode(value: String):
+    require(value.trim.nonEmpty, "region code must be non-empty")
+
+  final case class ProductionSectorCode(value: String):
+    require(value.trim.nonEmpty, "production sector code must be non-empty")
+
+  /** Closed age interval, or an upper open interval such as 90+. */
+  final case class AgeBand(code: String, minInclusive: Int, maxInclusive: Option[Int]):
+    require(code.trim.nonEmpty, "age-band code must be non-empty")
+    require(minInclusive >= 0, s"age-band minimum must be non-negative: $minInclusive")
+    require(maxInclusive.forall(_ >= minInclusive), s"age-band maximum must be at least $minInclusive")
+
+  enum DemographicSex:
+    case Female
+    case Male
+
+  enum ResidenceType:
+    case PrivateHousehold
+    case CollectiveResidence
+
+  enum HouseholdComposition:
+    case OnePerson
+    case CoupleWithoutDependentChildren
+    case CoupleWithDependentChildren
+    case LoneParent
+    case OtherMultiPerson
+
+  enum HouseholdMemberRole:
+    case Adult
+    case DependentChild
+    case OtherMember
+
+  enum LabourStatus:
+    case Employed
+    case Unemployed
+    case Inactive
+
+    /** Persons younger than the labour-force universe. */
+    case NotApplicable
+
+    /** Declared 90+ residual outside the BAEL labour-status universe. */
+    case NonBaelResidual
+
+  /** Classifications accepted by the controls. The target compiler receives
+    * these axes from a baseline rather than from current runtime enums.
+    */
+  final case class Classifications(
+      region: ClassificationRef,
+      age: ClassificationRef,
+      productionSector: ClassificationRef,
+      regions: Vector[RegionCode],
+      ageBands: Vector[AgeBand],
+      productionSectors: Vector[ProductionSectorCode],
+  ):
+    require(regions.nonEmpty, "population controls require at least one region")
+    require(ageBands.nonEmpty, "population controls require at least one age band")
+    require(productionSectors.nonEmpty, "population controls require at least one production sector")
+    require(regions.distinct.size == regions.size, "population-control regions must be unique")
+    require(ageBands.map(_.code).distinct.size == ageBands.size, "population-control age-band codes must be unique")
+    require(productionSectors.distinct.size == productionSectors.size, "population-control production sectors must be unique")
+    require(nonOverlapping(ageBands), "population-control age bands must not overlap")
+
+  final case class PersonRow(
+      region: RegionCode,
+      sex: DemographicSex,
+      ageBand: AgeBand,
+      residence: ResidenceType,
+      count: RepresentedCount,
+  )
+
+  final case class HouseholdRow(
+      region: RegionCode,
+      size: Int,
+      composition: HouseholdComposition,
+      count: RepresentedCount,
+  ):
+    require(size > 0, s"household size must be positive: $size")
+
+  /** Counts represented member positions, not a count of households. */
+  final case class HouseholdMembershipRow(
+      composition: HouseholdComposition,
+      memberRole: HouseholdMemberRole,
+      ageBand: AgeBand,
+      count: RepresentedCount,
+  )
+
+  final case class DemographicLabourRow(
+      sex: DemographicSex,
+      ageBand: AgeBand,
+      status: LabourStatus,
+      count: RepresentedCount,
+  )
+
+  final case class RegionalLabourRow(
+      region: RegionCode,
+      status: LabourStatus,
+      count: RepresentedCount,
+  )
+
+  /** Filled jobs classified by resident origin, workplace, and production
+    * sector. The residence axis reconciles this table to employed residents.
+    */
+  final case class EmploymentRow(
+      residenceRegion: RegionCode,
+      workplaceRegion: RegionCode,
+      productionSector: ProductionSectorCode,
+      count: RepresentedCount,
+  )
+
+  /** Five logical control families. Labour contains both demographic and
+    * regional margins because both are required to constrain the same status
+    * population.
+    */
+  final case class Bundle(
+      classifications: Classifications,
+      persons: ControlTable[PersonRow],
+      households: ControlTable[HouseholdRow],
+      householdMembership: ControlTable[HouseholdMembershipRow],
+      demographicLabour: ControlTable[DemographicLabourRow],
+      regionalLabour: ControlTable[RegionalLabourRow],
+      employment: ControlTable[EmploymentRow],
+  )
+
+  final case class Reconciliation(
+      id: String,
+      expected: BigInt,
+      actual: BigInt,
+      tolerance: Long,
+  ):
+    def residual: BigInt = actual - expected
+    def passes: Boolean  = residual.abs <= BigInt(tolerance)
+
+  enum ValidationError:
+    case WrongControlFamily(expected: ControlFamily, actual: ControlFamily)
+    case MissingClassification(table: ControlFamily, required: ClassificationRef)
+    case DuplicateRow(table: String, key: String)
+    case UnknownRegion(table: String, region: RegionCode)
+    case UnknownAgeBand(table: String, ageBand: AgeBand)
+    case UnknownProductionSector(table: String, sector: ProductionSectorCode)
+    case InvalidLabourStatusAgeBand(status: LabourStatus, ageBand: AgeBand)
+    case FailedReconciliation(reconciliation: Reconciliation)
+
+  final case class ValidationReport(
+      reconciliations: Vector[Reconciliation],
+      errors: Vector[ValidationError],
+  ):
+    def isValid: Boolean = errors.isEmpty
+
+  object Validator:
+
+    def validate(bundle: Bundle): ValidationReport =
+      val classifications = bundle.classifications
+      val errors          =
+        metadataErrors(bundle, classifications) ++
+          duplicateErrors(bundle) ++
+          axisErrors(bundle, classifications) ++
+          labourAgeErrors(bundle)
+      val reconciliations = reconciliationChecks(bundle)
+      val allErrors       = errors ++ reconciliations.filterNot(_.passes).map(ValidationError.FailedReconciliation.apply)
+      ValidationReport(reconciliations, allErrors)
+
+    private def metadataErrors(bundle: Bundle, classifications: Classifications): Vector[ValidationError] =
+      val expected = Vector(
+        (bundle.persons.metadata, ControlFamily.Persons, Vector(classifications.region, classifications.age)),
+        (bundle.households.metadata, ControlFamily.Households, Vector(classifications.region)),
+        (bundle.householdMembership.metadata, ControlFamily.HouseholdMembership, Vector(classifications.age)),
+        (bundle.demographicLabour.metadata, ControlFamily.Labour, Vector(classifications.age)),
+        (bundle.regionalLabour.metadata, ControlFamily.Labour, Vector(classifications.region)),
+        (bundle.employment.metadata, ControlFamily.Employment, Vector(classifications.region, classifications.productionSector)),
+      )
+      expected.flatMap: (metadata, family, requiredClassifications) =>
+        val familyErrors         = Option.when(metadata.family != family)(ValidationError.WrongControlFamily(family, metadata.family))
+        val classificationErrors = requiredClassifications
+          .filterNot(metadata.classifications.contains)
+          .map(required => ValidationError.MissingClassification(family, required))
+        familyErrors.toVector ++ classificationErrors
+
+    private def duplicateErrors(bundle: Bundle): Vector[ValidationError] =
+      duplicateRows("persons", bundle.persons.rows)(row => s"${row.region.value}|${row.sex}|${row.ageBand.code}|${row.residence}") ++
+        duplicateRows("households", bundle.households.rows)(row => s"${row.region.value}|${row.size}|${row.composition}") ++
+        duplicateRows("household-membership", bundle.householdMembership.rows)(row => s"${row.composition}|${row.memberRole}|${row.ageBand.code}") ++
+        duplicateRows("demographic-labour", bundle.demographicLabour.rows)(row => s"${row.sex}|${row.ageBand.code}|${row.status}") ++
+        duplicateRows("regional-labour", bundle.regionalLabour.rows)(row => s"${row.region.value}|${row.status}") ++
+        duplicateRows("employment", bundle.employment.rows)(row => s"${row.residenceRegion.value}|${row.workplaceRegion.value}|${row.productionSector.value}")
+
+    private def axisErrors(bundle: Bundle, classifications: Classifications): Vector[ValidationError] =
+      val knownRegions = classifications.regions.toSet
+      val knownAges    = classifications.ageBands.toSet
+      val knownSectors = classifications.productionSectors.toSet
+      bundle.persons.rows.flatMap: row =>
+        Vector(
+          Option.when(!knownRegions(row.region))(ValidationError.UnknownRegion("persons", row.region)),
+          Option.when(!knownAges(row.ageBand))(ValidationError.UnknownAgeBand("persons", row.ageBand)),
+        ).flatten
+      ++ bundle.households.rows.flatMap: row =>
+        Vector(Option.when(!knownRegions(row.region))(ValidationError.UnknownRegion("households", row.region))).flatten
+      ++ bundle.householdMembership.rows.flatMap: row =>
+        Vector(Option.when(!knownAges(row.ageBand))(ValidationError.UnknownAgeBand("household-membership", row.ageBand))).flatten
+      ++ bundle.demographicLabour.rows.flatMap: row =>
+        Vector(Option.when(!knownAges(row.ageBand))(ValidationError.UnknownAgeBand("demographic-labour", row.ageBand))).flatten
+      ++ bundle.regionalLabour.rows.flatMap: row =>
+        Vector(Option.when(!knownRegions(row.region))(ValidationError.UnknownRegion("regional-labour", row.region))).flatten
+      ++ bundle.employment.rows.flatMap: row =>
+        Vector(
+          Option.when(!knownRegions(row.residenceRegion))(ValidationError.UnknownRegion("employment residence", row.residenceRegion)),
+          Option.when(!knownRegions(row.workplaceRegion))(ValidationError.UnknownRegion("employment workplace", row.workplaceRegion)),
+          Option.when(!knownSectors(row.productionSector))(ValidationError.UnknownProductionSector("employment", row.productionSector)),
+        ).flatten
+
+    private def labourAgeErrors(bundle: Bundle): Vector[ValidationError] =
+      bundle.demographicLabour.rows.collect:
+        case row if !labourStatusPermitted(row.status, row.ageBand) =>
+          ValidationError.InvalidLabourStatusAgeBand(row.status, row.ageBand)
+
+    private def reconciliationChecks(bundle: Bundle): Vector[Reconciliation] =
+      val membershipByComposition        = totalBy(bundle.householdMembership.rows)(_.composition)(row => BigInt(row.count.value))
+      val householdCapacityByComposition = totalBy(bundle.households.rows)(_.composition)(row => BigInt(row.count.value) * row.size)
+      val personBySexAge                 = totalBy(bundle.persons.rows)(row => row.sex -> row.ageBand)(row => BigInt(row.count.value))
+      val demographicLabourBySexAge      = totalBy(bundle.demographicLabour.rows)(row => row.sex -> row.ageBand)(row => BigInt(row.count.value))
+      val personByRegion                 = totalBy(bundle.persons.rows)(_.region)(row => BigInt(row.count.value))
+      val regionalLabourByRegion         = totalBy(bundle.regionalLabour.rows)(_.region)(row => BigInt(row.count.value))
+      val demographicLabourByStatus      = totalBy(bundle.demographicLabour.rows)(_.status)(row => BigInt(row.count.value))
+      val regionalLabourByStatus         = totalBy(bundle.regionalLabour.rows)(_.status)(row => BigInt(row.count.value))
+      val employedByRegion               = totalBy(bundle.regionalLabour.rows.filter(_.status == LabourStatus.Employed))(_.region)(row => BigInt(row.count.value))
+      val jobsByResidenceRegion          = totalBy(bundle.employment.rows)(_.residenceRegion)(row => BigInt(row.count.value))
+      val personMembershipTolerance      = combinedTolerance(bundle.persons, bundle.householdMembership)
+      val householdMembershipTolerance   = combinedTolerance(bundle.households, bundle.householdMembership)
+      val personLabourTolerance          = combinedTolerance(bundle.persons, bundle.demographicLabour)
+      val regionalLabourTolerance        = combinedTolerance(bundle.persons, bundle.regionalLabour)
+      val labourMarginTolerance          = combinedTolerance(bundle.demographicLabour, bundle.regionalLabour)
+      val employmentTolerance            = combinedTolerance(bundle.regionalLabour, bundle.employment)
+
+      Vector(
+        Reconciliation(
+          "private-person-membership",
+          total(bundle.persons.rows.filter(_.residence == ResidenceType.PrivateHousehold).map(row => BigInt(row.count.value))),
+          total(bundle.householdMembership.rows.map(row => BigInt(row.count.value))),
+          personMembershipTolerance,
+        ),
+      ) ++
+        reconcileMaps("household-member-capacity", householdCapacityByComposition, membershipByComposition, householdMembershipTolerance) ++
+        reconcileMaps("person-to-demographic-labour", personBySexAge, demographicLabourBySexAge, personLabourTolerance) ++
+        reconcileMaps("person-to-regional-labour", personByRegion, regionalLabourByRegion, regionalLabourTolerance) ++
+        reconcileMaps("demographic-to-regional-labour", demographicLabourByStatus, regionalLabourByStatus, labourMarginTolerance) ++
+        reconcileMaps("employed-residents-to-filled-jobs", employedByRegion, jobsByResidenceRegion, employmentTolerance)
+
+    private def duplicateRows[A](table: String, rows: Vector[A])(key: A => String): Vector[ValidationError] =
+      rows
+        .groupBy(key)
+        .collect { case (duplicate, values) if values.size > 1 => ValidationError.DuplicateRow(table, duplicate) }
+        .toVector
+        .sortBy(_.toString)
+
+    private def totalBy[A, K](rows: Vector[A])(key: A => K)(count: A => BigInt): Map[K, BigInt] =
+      rows.groupMapReduce(key)(count)(_ + _)
+
+    private def total(counts: Iterable[BigInt]): BigInt =
+      counts.iterator.foldLeft(BigInt(0))(_ + _)
+
+    private def reconcileMaps[K](id: String, expected: Map[K, BigInt], actual: Map[K, BigInt], tolerance: Long): Vector[Reconciliation] =
+      (expected.keySet ++ actual.keySet).toVector
+        .sortBy(_.toString)
+        .map: key =>
+          Reconciliation(s"$id:$key", expected.getOrElse(key, BigInt(0)), actual.getOrElse(key, BigInt(0)), tolerance)
+
+    private def combinedTolerance[A, B](left: ControlTable[A], right: ControlTable[B]): Long =
+      math.max(left.metadata.absoluteTolerance, right.metadata.absoluteTolerance)
+
+    private def labourStatusPermitted(status: LabourStatus, ageBand: AgeBand): Boolean =
+      status match
+        case LabourStatus.Employed        => containedIn(ageBand, minimum = 15, maximum = 89)
+        case LabourStatus.Unemployed      => containedIn(ageBand, minimum = 15, maximum = 74)
+        case LabourStatus.Inactive        => containedIn(ageBand, minimum = 15, maximum = 89)
+        case LabourStatus.NotApplicable   => ageBand.maxInclusive.exists(_ < 15)
+        case LabourStatus.NonBaelResidual => ageBand.minInclusive >= 90
+
+    private def containedIn(ageBand: AgeBand, minimum: Int, maximum: Int): Boolean =
+      ageBand.minInclusive >= minimum && ageBand.maxInclusive.exists(_ <= maximum)
+
+  private def nonOverlapping(ageBands: Vector[AgeBand]): Boolean =
+    val sorted = ageBands.sortBy(_.minInclusive)
+    sorted
+      .zip(sorted.drop(1))
+      .forall: (left, right) =>
+        left.maxInclusive.exists(_ < right.minInclusive)
+
+end PopulationControlSchema

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
@@ -2,40 +2,80 @@ package com.boombustgroup.amorfati.config
 
 import java.time.LocalDate
 
-/** Input contract for the person, household, labour, and employment controls
-  * used by the future population compiler.
+/** Versioned input contract for the person, household, labour, and employment
+  * control tables consumed by the future population compiler.
   *
-  * This is deliberately independent of the current agent population and
-  * SimParams. A real reference-economy bundle supplies these controls; this
-  * schema does not itself claim that any particular country or period has been
-  * compiled.
+  * A control is a count in the reference economy, not an agent count and not a
+  * scaling coefficient. The compiler will turn these controls into a finite
+  * represented population and explicit representation weights. It must not use
+  * this schema to derive an economy-wide monetary multiplier.
+  *
+  * The contract is deliberately independent of the current agent population and
+  * `SimParams`. Supplying a [[Bundle]] says only that a source bundle has been
+  * described and structurally reconciled; it does not claim that a particular
+  * country or period has been empirically qualified or compiled.
   */
 object PopulationControlSchema:
 
-  /** A non-negative quantity in the reference population, before sampling or
-    * representation weighting.
+  /** An integer count in the reference statistical population before any
+    * sampling or representation weighting.
+    *
+    * This type is intentionally distinct from a number of simulated agents: one
+    * simulated person can later represent many of these persons. It is also
+    * intentionally not a monetary quantity or a continuous weight.
     */
   final case class RepresentedCount(value: Long):
     require(value >= 0L, s"represented count must be non-negative: $value")
 
   enum ControlStrength:
-    /** The compiler must meet the row total within its declared tolerance. */
+    /** The compiler must reproduce the row total within the table's declared
+      * absolute tolerance. Hard controls constrain generated populations.
+      */
     case Hard
 
-    /** The row informs synthesis or calibration, but is not a binding total. */
+    /** The row is an empirically useful margin but is not a binding population
+      * total. A compiler may use it for synthesis or calibration while
+      * reporting any resulting residual explicitly.
+      */
     case CalibratedMargin
 
+  /** Broad family of a table. This prevents a table with plausible columns but
+    * the wrong economic meaning from being used in a control slot.
+    */
   enum ControlFamily:
+    /** Resident persons, including persons in collective residences. */
     case Persons
+
+    /** Private households, not the people living in them. */
     case Households
+
+    /** Person positions within private households, not household counts. */
     case HouseholdMembership
+
+    /** Labour-status population margins, by demographic or regional axis. */
     case Labour
+
+    /** Filled jobs, distinguished from employed residents. */
     case Employment
 
+  /** Identity and version of a classification system used by a table, such as a
+    * territorial, age-band, or production-sector classification.
+    *
+    * Values in the rows must be interpreted against this reference; a label
+    * alone is not sufficient for reproducibility when classifications change.
+    */
   final case class ClassificationRef(id: String, version: String):
     require(id.trim.nonEmpty, "classification ID must be non-empty")
     require(version.trim.nonEmpty, s"classification $id must have a version")
 
+  /** Provenance of a source table after any transformation required to make it
+    * a population control.
+    *
+    * `observationPeriod` is when the measured population applies, `release`
+    * identifies the published vintage, and `accessedAt` records when Amor Fati
+    * retrieved it. `transformation` must explain operations such as category
+    * aggregation, interpolation, or an adjustment of statistical universes.
+    */
   final case class SourceProvenance(
       provider: String,
       sourceLocation: String,
@@ -50,8 +90,14 @@ object PopulationControlSchema:
     require(release.trim.nonEmpty, s"release for $provider must be non-empty")
     require(transformation.trim.nonEmpty, s"transformation for $provider must be non-empty")
 
-  /** Metadata that makes a control table reproducible and its reconciliation
-    * policy explicit.
+  /** Metadata that defines a table's statistical meaning and makes its use
+    * reproducible.
+    *
+    * `statisticalUniverse` names the population actually counted, for example
+    * resident persons or private households. `absoluteTolerance` is expressed
+    * in [[RepresentedCount]] units and applies only to reconciliations that use
+    * this table; it is not a generic percentage error or a licence to rescale
+    * the economy.
     */
   final case class TableMetadata(
       family: ControlFamily,
@@ -69,29 +115,58 @@ object PopulationControlSchema:
       s"${family.toString} must not repeat a classification reference",
     )
 
+  /** One non-empty control table. The row type fixes its dimensions while the
+    * metadata fixes its universe, source, classifications, and strength.
+    */
   final case class ControlTable[A](metadata: TableMetadata, rows: Vector[A]):
     require(rows.nonEmpty, s"${metadata.family.toString} controls must not be empty")
 
+  /** Stable code from the bundle's declared territorial classification, not a
+    * `Region` enum from the current simulation runtime.
+    */
   final case class RegionCode(value: String):
     require(value.trim.nonEmpty, "region code must be non-empty")
 
+  /** Stable code from the bundle's declared production classification. It
+    * constrains jobs and firms, rather than being a current runtime sector ID.
+    */
   final case class ProductionSectorCode(value: String):
     require(value.trim.nonEmpty, "production sector code must be non-empty")
 
-  /** Closed age interval, or an upper open interval such as 90+. */
+  /** A closed age interval, or an upper-open interval such as `90+`.
+    *
+    * Bands are values rather than bare labels so the validator can reject
+    * overlapping classifications and enforce labour-statistics age universes.
+    */
   final case class AgeBand(code: String, minInclusive: Int, maxInclusive: Option[Int]):
     require(code.trim.nonEmpty, "age-band code must be non-empty")
     require(minInclusive >= 0, s"age-band minimum must be non-negative: $minInclusive")
     require(maxInclusive.forall(_ >= minInclusive), s"age-band maximum must be at least $minInclusive")
 
   enum DemographicSex:
+    /** Female category in the baseline's declared demographic classification.
+      */
     case Female
+
+    /** Male category in the baseline's declared demographic classification. */
     case Male
 
+  /** Residence perimeter for person controls. Only private-household persons
+    * reconcile to household-membership positions.
+    */
   enum ResidenceType:
+    /** Person resides in a private household represented by household controls.
+      */
     case PrivateHousehold
+
+    /** Person resides outside private households, for example in an
+      * institutional or other collective residence.
+      */
     case CollectiveResidence
 
+  /** Household composition used for both household counts and member-position
+    * controls. Their shared value permits the capacity reconciliation.
+    */
   enum HouseholdComposition:
     case OnePerson
     case CoupleWithoutDependentChildren
@@ -99,24 +174,48 @@ object PopulationControlSchema:
     case LoneParent
     case OtherMultiPerson
 
+  /** Role of a represented member position within a household-composition
+    * margin. These roles are not legal relationships or runtime agent classes.
+    */
   enum HouseholdMemberRole:
     case Adult
     case DependentChild
     case OtherMember
 
+  /** Labour-force status used to partition demographic and regional population
+    * margins. The permitted age bands follow the stated BAEL convention; a
+    * baseline that uses another convention must make that change explicit.
+    */
   enum LabourStatus:
+    /** In work within the employment age universe. */
     case Employed
+
+    /** In the labour force without work, within the unemployment age universe.
+      */
     case Unemployed
+
+    /** Outside the labour force, but within the inactive-population age
+      * universe.
+      */
     case Inactive
 
-    /** Persons younger than the labour-force universe. */
+    /** Persons younger than the labour-force universe. They still reconcile to
+      * the resident population but are neither employed, unemployed, nor
+      * inactive.
+      */
     case NotApplicable
 
-    /** Declared 90+ residual outside the BAEL labour-status universe. */
+    /** Explicit 90+ residual outside the BAEL labour-status universe. This
+      * prevents an open-ended person band from being silently classified as
+      * inactive.
+      */
     case NonBaelResidual
 
-  /** Classifications accepted by the controls. The target compiler receives
-    * these axes from a baseline rather than from current runtime enums.
+  /** Closed vocabularies accepted by this bundle's rows.
+    *
+    * The compiler receives these axes from a baseline rather than current
+    * runtime enums. Rows using an undeclared code or band are invalid even when
+    * their labels look familiar.
     */
   final case class Classifications(
       region: ClassificationRef,
@@ -134,6 +233,11 @@ object PopulationControlSchema:
     require(productionSectors.distinct.size == productionSectors.size, "population-control production sectors must be unique")
     require(nonOverlapping(ageBands), "population-control age bands must not overlap")
 
+  /** Resident-person count by territory, demographic sex, age band, and
+    * residence perimeter. Counts from `PrivateHousehold` rows must reconcile to
+    * household-member positions; collective-residence rows remain part of the
+    * total person population but have no household membership counterpart.
+    */
   final case class PersonRow(
       region: RegionCode,
       sex: DemographicSex,
@@ -142,6 +246,10 @@ object PopulationControlSchema:
       count: RepresentedCount,
   )
 
+  /** Private-household count by region, observed size, and composition. The
+    * product of `size` and `count` is the household capacity used to reconcile
+    * against [[HouseholdMembershipRow]] controls.
+    */
   final case class HouseholdRow(
       region: RegionCode,
       size: Int,
@@ -150,7 +258,10 @@ object PopulationControlSchema:
   ):
     require(size > 0, s"household size must be positive: $size")
 
-  /** Counts represented member positions, not a count of households. */
+  /** Count of represented person positions in private households, not a count
+    * of households. A composition's rows must sum to the capacity implied by
+    * corresponding [[HouseholdRow]] controls.
+    */
   final case class HouseholdMembershipRow(
       composition: HouseholdComposition,
       memberRole: HouseholdMemberRole,
@@ -158,6 +269,10 @@ object PopulationControlSchema:
       count: RepresentedCount,
   )
 
+  /** Labour-status population margin by demographic sex and age. Together, its
+    * statuses must partition the corresponding person count and reconcile to
+    * the independent regional labour margin.
+    */
   final case class DemographicLabourRow(
       sex: DemographicSex,
       ageBand: AgeBand,
@@ -165,14 +280,19 @@ object PopulationControlSchema:
       count: RepresentedCount,
   )
 
+  /** Labour-status population margin by residence region. Its employed total
+    * reconciles to filled jobs by workers' residence, not necessarily by
+    * workplace because commuters are represented explicitly.
+    */
   final case class RegionalLabourRow(
       region: RegionCode,
       status: LabourStatus,
       count: RepresentedCount,
   )
 
-  /** Filled jobs classified by resident origin, workplace, and production
-    * sector. The residence axis reconciles this table to employed residents.
+  /** Filled jobs classified by worker residence, workplace, and production
+    * sector. The residence axis reconciles this table to employed residents;
+    * the workplace axis preserves commuting without treating jobs as residents.
     */
   final case class EmploymentRow(
       residenceRegion: RegionCode,
@@ -181,9 +301,11 @@ object PopulationControlSchema:
       count: RepresentedCount,
   )
 
-  /** Five logical control families. Labour contains both demographic and
-    * regional margins because both are required to constrain the same status
-    * population.
+  /** Coherent set of the five logical control families for one baseline.
+    *
+    * Labour has two physical tables because demographic and regional margins
+    * independently constrain the same status population. They are both
+    * required: neither is derived from the other by this schema.
     */
   final case class Bundle(
       classifications: Classifications,
@@ -195,6 +317,11 @@ object PopulationControlSchema:
       employment: ControlTable[EmploymentRow],
   )
 
+  /** Evidence for one accounting-style count reconciliation. `expected` is the
+    * authoritative side named by the reconciliation, `actual` is the compared
+    * side, and `residual` is actual minus expected. `BigInt` avoids overflow
+    * when aggregating national counts.
+    */
   final case class Reconciliation(
       id: String,
       expected: BigInt,
@@ -204,6 +331,10 @@ object PopulationControlSchema:
     def residual: BigInt = actual - expected
     def passes: Boolean  = residual.abs <= BigInt(tolerance)
 
+  /** Structural or reconciliation failure in a [[Bundle]]. These errors say
+    * that a bundle cannot safely enter a population compiler; they do not judge
+    * the empirical credibility of its source or calibration.
+    */
   enum ValidationError:
     case WrongControlFamily(expected: ControlFamily, actual: ControlFamily)
     case MissingClassification(table: ControlFamily, required: ClassificationRef)
@@ -214,6 +345,9 @@ object PopulationControlSchema:
     case InvalidLabourStatusAgeBand(status: LabourStatus, ageBand: AgeBand)
     case FailedReconciliation(reconciliation: Reconciliation)
 
+  /** Complete structural-validation evidence. Reconciliations are retained even
+    * when they pass so a baseline manifest can report the residuals.
+    */
   final case class ValidationReport(
       reconciliations: Vector[Reconciliation],
       errors: Vector[ValidationError],
@@ -222,6 +356,13 @@ object PopulationControlSchema:
 
   object Validator:
 
+    /** Validate a bundle's declared classification axes, duplicate cells,
+      * labour-age convention, and cross-table count identities.
+      *
+      * This is a pre-compilation gate. It does not synthesize agents, estimate
+      * missing margins, validate source methodology, or qualify a baseline for
+      * scientific use.
+      */
     def validate(bundle: Bundle): ValidationReport =
       val classifications = bundle.classifications
       val errors          =

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlSchemaSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlSchemaSpec.scala
@@ -170,14 +170,69 @@ class PopulationControlSchemaSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "reject an undeclared axis value and duplicate control cell" in {
-    val unknownRegion  = RegionCode("undeclared")
-    val invalidPersons = validBundle.persons.copy(
-      rows = validBundle.persons.rows :+
+    val unknownRegion             = RegionCode("undeclared")
+    val unknownPersonAge          = AgeBand("undeclared-person-age", 75, Some(80))
+    val unknownHouseholdRegion    = RegionCode("undeclared-household-region")
+    val unknownMembershipAge      = AgeBand("undeclared-membership-age", 75, Some(80))
+    val unknownDemographicAge     = AgeBand("undeclared-demographic-age", 75, Some(80))
+    val unknownRegionalLabourArea = RegionCode("undeclared-regional-labour-area")
+    val unknownEmploymentHome     = RegionCode("undeclared-employment-home")
+    val unknownEmploymentWork     = RegionCode("undeclared-employment-work")
+    val unknownEmploymentSector   = ProductionSectorCode("undeclared-employment-sector")
+    val invalidPersons            = validBundle.persons.copy(
+      rows = validBundle.persons.rows ++ Vector(
         PersonRow(unknownRegion, DemographicSex.Female, Child, ResidenceType.PrivateHousehold, RepresentedCount(1)),
+        PersonRow(North, DemographicSex.Female, unknownPersonAge, ResidenceType.PrivateHousehold, RepresentedCount(1)),
+      ),
     )
-    val report         = Validator.validate(validBundle.copy(persons = invalidPersons))
+    val invalidBundle             = validBundle.copy(
+      persons = invalidPersons,
+      households = validBundle.households.copy(
+        rows = validBundle.households.rows :+ HouseholdRow(unknownHouseholdRegion, 1, HouseholdComposition.OnePerson, RepresentedCount(1)),
+      ),
+      householdMembership = validBundle.householdMembership.copy(
+        rows = validBundle.householdMembership.rows :+ HouseholdMembershipRow(
+          HouseholdComposition.OnePerson,
+          HouseholdMemberRole.Adult,
+          unknownMembershipAge,
+          RepresentedCount(1),
+        ),
+      ),
+      demographicLabour = validBundle.demographicLabour.copy(
+        rows = validBundle.demographicLabour.rows :+ DemographicLabourRow(
+          DemographicSex.Female,
+          unknownDemographicAge,
+          LabourStatus.Inactive,
+          RepresentedCount(1),
+        ),
+      ),
+      regionalLabour = validBundle.regionalLabour.copy(
+        rows = validBundle.regionalLabour.rows :+ RegionalLabourRow(
+          unknownRegionalLabourArea,
+          LabourStatus.Inactive,
+          RepresentedCount(1),
+        ),
+      ),
+      employment = validBundle.employment.copy(
+        rows = validBundle.employment.rows :+ EmploymentRow(
+          unknownEmploymentHome,
+          unknownEmploymentWork,
+          unknownEmploymentSector,
+          RepresentedCount(1),
+        ),
+      ),
+    )
+    val report                    = Validator.validate(invalidBundle)
 
     report.errors should contain(ValidationError.UnknownRegion("persons", unknownRegion))
+    report.errors should contain(ValidationError.UnknownAgeBand("persons", unknownPersonAge))
+    report.errors should contain(ValidationError.UnknownRegion("households", unknownHouseholdRegion))
+    report.errors should contain(ValidationError.UnknownAgeBand("household-membership", unknownMembershipAge))
+    report.errors should contain(ValidationError.UnknownAgeBand("demographic-labour", unknownDemographicAge))
+    report.errors should contain(ValidationError.UnknownRegion("regional-labour", unknownRegionalLabourArea))
+    report.errors should contain(ValidationError.UnknownRegion("employment residence", unknownEmploymentHome))
+    report.errors should contain(ValidationError.UnknownRegion("employment workplace", unknownEmploymentWork))
+    report.errors should contain(ValidationError.UnknownProductionSector("employment", unknownEmploymentSector))
 
     val duplicatePersons = validBundle.persons.copy(rows = validBundle.persons.rows :+ validBundle.persons.rows.head)
     Validator.validate(validBundle.copy(persons = duplicatePersons)).errors.exists {

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlSchemaSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlSchemaSpec.scala
@@ -1,0 +1,213 @@
+package com.boombustgroup.amorfati.config
+
+import com.boombustgroup.amorfati.config.PopulationControlSchema.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDate
+
+class PopulationControlSchemaSpec extends AnyFlatSpec with Matchers:
+
+  private val RegionClassification = ClassificationRef("fixture-region", "v1")
+  private val AgeClassification    = ClassificationRef("fixture-age", "v1")
+  private val SectorClassification = ClassificationRef("fixture-sector", "v1")
+
+  private val North    = RegionCode("north")
+  private val South    = RegionCode("south")
+  private val Child    = AgeBand("0-14", 0, Some(14))
+  private val Adult    = AgeBand("15-74", 15, Some(74))
+  private val Goods    = ProductionSectorCode("goods")
+  private val Services = ProductionSectorCode("services")
+
+  private val classifications = Classifications(
+    region = RegionClassification,
+    age = AgeClassification,
+    productionSector = SectorClassification,
+    regions = Vector(North, South),
+    ageBands = Vector(Child, Adult),
+    productionSectors = Vector(Goods, Services),
+  )
+
+  private val source = SourceProvenance(
+    provider = "synthetic-fixture",
+    sourceLocation = "test://population-controls",
+    observationPeriod = "fixture-period",
+    release = "fixture-release",
+    accessedAt = LocalDate.of(2026, 1, 1),
+    transformation = "hand-constructed reconciliation fixture",
+  )
+
+  private def metadata(family: ControlFamily, classifications: Vector[ClassificationRef]): TableMetadata =
+    TableMetadata(
+      family = family,
+      statisticalUniverse = "synthetic resident population",
+      strength = ControlStrength.Hard,
+      absoluteTolerance = 0L,
+      classifications = classifications,
+      source = source,
+    )
+
+  private val validBundle = Bundle(
+    classifications = classifications,
+    persons = ControlTable(
+      metadata(ControlFamily.Persons, Vector(RegionClassification, AgeClassification)),
+      Vector(
+        PersonRow(North, DemographicSex.Female, Child, ResidenceType.PrivateHousehold, RepresentedCount(10)),
+        PersonRow(North, DemographicSex.Male, Child, ResidenceType.PrivateHousehold, RepresentedCount(10)),
+        PersonRow(North, DemographicSex.Female, Adult, ResidenceType.PrivateHousehold, RepresentedCount(30)),
+        PersonRow(North, DemographicSex.Male, Adult, ResidenceType.PrivateHousehold, RepresentedCount(30)),
+        PersonRow(North, DemographicSex.Male, Adult, ResidenceType.CollectiveResidence, RepresentedCount(2)),
+        PersonRow(South, DemographicSex.Female, Child, ResidenceType.PrivateHousehold, RepresentedCount(8)),
+        PersonRow(South, DemographicSex.Male, Child, ResidenceType.PrivateHousehold, RepresentedCount(8)),
+        PersonRow(South, DemographicSex.Female, Adult, ResidenceType.PrivateHousehold, RepresentedCount(20)),
+        PersonRow(South, DemographicSex.Male, Adult, ResidenceType.PrivateHousehold, RepresentedCount(20)),
+      ),
+    ),
+    households = ControlTable(
+      metadata(ControlFamily.Households, Vector(RegionClassification)),
+      Vector(
+        HouseholdRow(North, 1, HouseholdComposition.OnePerson, RepresentedCount(20)),
+        HouseholdRow(North, 2, HouseholdComposition.CoupleWithoutDependentChildren, RepresentedCount(10)),
+        HouseholdRow(North, 4, HouseholdComposition.CoupleWithDependentChildren, RepresentedCount(5)),
+        HouseholdRow(North, 3, HouseholdComposition.LoneParent, RepresentedCount(4)),
+        HouseholdRow(North, 4, HouseholdComposition.OtherMultiPerson, RepresentedCount(2)),
+        HouseholdRow(South, 1, HouseholdComposition.OnePerson, RepresentedCount(16)),
+        HouseholdRow(South, 2, HouseholdComposition.CoupleWithoutDependentChildren, RepresentedCount(5)),
+        HouseholdRow(South, 4, HouseholdComposition.CoupleWithDependentChildren, RepresentedCount(5)),
+        HouseholdRow(South, 3, HouseholdComposition.LoneParent, RepresentedCount(2)),
+        HouseholdRow(South, 4, HouseholdComposition.OtherMultiPerson, RepresentedCount(1)),
+      ),
+    ),
+    householdMembership = ControlTable(
+      metadata(ControlFamily.HouseholdMembership, Vector(AgeClassification)),
+      Vector(
+        HouseholdMembershipRow(HouseholdComposition.OnePerson, HouseholdMemberRole.Adult, Adult, RepresentedCount(36)),
+        HouseholdMembershipRow(HouseholdComposition.CoupleWithoutDependentChildren, HouseholdMemberRole.Adult, Adult, RepresentedCount(30)),
+        HouseholdMembershipRow(HouseholdComposition.CoupleWithDependentChildren, HouseholdMemberRole.Adult, Adult, RepresentedCount(20)),
+        HouseholdMembershipRow(HouseholdComposition.CoupleWithDependentChildren, HouseholdMemberRole.DependentChild, Child, RepresentedCount(20)),
+        HouseholdMembershipRow(HouseholdComposition.LoneParent, HouseholdMemberRole.Adult, Adult, RepresentedCount(6)),
+        HouseholdMembershipRow(HouseholdComposition.LoneParent, HouseholdMemberRole.DependentChild, Child, RepresentedCount(12)),
+        HouseholdMembershipRow(HouseholdComposition.OtherMultiPerson, HouseholdMemberRole.Adult, Adult, RepresentedCount(8)),
+        HouseholdMembershipRow(HouseholdComposition.OtherMultiPerson, HouseholdMemberRole.DependentChild, Child, RepresentedCount(4)),
+      ),
+    ),
+    demographicLabour = ControlTable(
+      metadata(ControlFamily.Labour, Vector(AgeClassification)),
+      Vector(
+        DemographicLabourRow(DemographicSex.Female, Child, LabourStatus.NotApplicable, RepresentedCount(18)),
+        DemographicLabourRow(DemographicSex.Male, Child, LabourStatus.NotApplicable, RepresentedCount(18)),
+        DemographicLabourRow(DemographicSex.Female, Adult, LabourStatus.Employed, RepresentedCount(40)),
+        DemographicLabourRow(DemographicSex.Female, Adult, LabourStatus.Unemployed, RepresentedCount(5)),
+        DemographicLabourRow(DemographicSex.Female, Adult, LabourStatus.Inactive, RepresentedCount(5)),
+        DemographicLabourRow(DemographicSex.Male, Adult, LabourStatus.Employed, RepresentedCount(42)),
+        DemographicLabourRow(DemographicSex.Male, Adult, LabourStatus.Unemployed, RepresentedCount(5)),
+        DemographicLabourRow(DemographicSex.Male, Adult, LabourStatus.Inactive, RepresentedCount(5)),
+      ),
+    ),
+    regionalLabour = ControlTable(
+      metadata(ControlFamily.Labour, Vector(RegionClassification)),
+      Vector(
+        RegionalLabourRow(North, LabourStatus.Employed, RepresentedCount(50)),
+        RegionalLabourRow(North, LabourStatus.Unemployed, RepresentedCount(6)),
+        RegionalLabourRow(North, LabourStatus.Inactive, RepresentedCount(6)),
+        RegionalLabourRow(North, LabourStatus.NotApplicable, RepresentedCount(20)),
+        RegionalLabourRow(South, LabourStatus.Employed, RepresentedCount(32)),
+        RegionalLabourRow(South, LabourStatus.Unemployed, RepresentedCount(4)),
+        RegionalLabourRow(South, LabourStatus.Inactive, RepresentedCount(4)),
+        RegionalLabourRow(South, LabourStatus.NotApplicable, RepresentedCount(16)),
+      ),
+    ),
+    employment = ControlTable(
+      metadata(ControlFamily.Employment, Vector(RegionClassification, SectorClassification)),
+      Vector(
+        EmploymentRow(North, North, Goods, RepresentedCount(30)),
+        EmploymentRow(North, South, Services, RepresentedCount(20)),
+        EmploymentRow(South, North, Goods, RepresentedCount(12)),
+        EmploymentRow(South, South, Services, RepresentedCount(20)),
+      ),
+    ),
+  )
+
+  "PopulationControlSchema.Validator" should "accept a reconciled synthetic bundle without an economic scale multiplier" in {
+    val report = Validator.validate(validBundle)
+
+    withClue(s"Validation errors: ${report.errors.mkString(", ")}") {
+      report.isValid shouldBe true
+    }
+    report.reconciliations.map(_.id) should contain("private-person-membership")
+    report.reconciliations.foreach(_.passes shouldBe true)
+  }
+
+  it should "reject a filled-job total that differs from employed residents" in {
+    val invalidEmployment = validBundle.employment.copy(
+      rows = validBundle.employment.rows.updated(3, EmploymentRow(South, South, Services, RepresentedCount(19))),
+    )
+    val report            = Validator.validate(validBundle.copy(employment = invalidEmployment))
+
+    report.isValid shouldBe false
+    report.errors.collect { case ValidationError.FailedReconciliation(reconciliation) => reconciliation.id } should contain(
+      "employed-residents-to-filled-jobs:RegionCode(south)",
+    )
+  }
+
+  it should "apply a reconciliation tolerance only to its participating tables" in {
+    val tolerantEmployment       = validBundle.employment.copy(
+      metadata = validBundle.employment.metadata.copy(absoluteTolerance = 1L),
+    )
+    val invalidDemographicLabour = validBundle.demographicLabour.copy(
+      rows = validBundle.demographicLabour.rows.updated(
+        2,
+        DemographicLabourRow(DemographicSex.Female, Adult, LabourStatus.Employed, RepresentedCount(39)),
+      ),
+    )
+    val report                   = Validator.validate(
+      validBundle.copy(employment = tolerantEmployment, demographicLabour = invalidDemographicLabour),
+    )
+
+    report.errors.collect { case ValidationError.FailedReconciliation(reconciliation) => reconciliation.id } should contain(
+      "person-to-demographic-labour:(Female,AgeBand(15-74,15,Some(74)))",
+    )
+  }
+
+  it should "reject an undeclared axis value and duplicate control cell" in {
+    val unknownRegion  = RegionCode("undeclared")
+    val invalidPersons = validBundle.persons.copy(
+      rows = validBundle.persons.rows :+
+        PersonRow(unknownRegion, DemographicSex.Female, Child, ResidenceType.PrivateHousehold, RepresentedCount(1)),
+    )
+    val report         = Validator.validate(validBundle.copy(persons = invalidPersons))
+
+    report.errors should contain(ValidationError.UnknownRegion("persons", unknownRegion))
+
+    val duplicatePersons = validBundle.persons.copy(rows = validBundle.persons.rows :+ validBundle.persons.rows.head)
+    Validator.validate(validBundle.copy(persons = duplicatePersons)).errors.exists {
+      case ValidationError.DuplicateRow("persons", _) => true
+      case _                                          => false
+    } shouldBe true
+  }
+
+  it should "require each table to declare the classifications it uses" in {
+    val incompleteMetadata = validBundle.employment.metadata.copy(classifications = Vector(RegionClassification))
+    val report             = Validator.validate(validBundle.copy(employment = validBundle.employment.copy(metadata = incompleteMetadata)))
+
+    report.errors should contain(ValidationError.MissingClassification(ControlFamily.Employment, SectorClassification))
+  }
+
+  it should "enforce the declared labour-status age convention" in {
+    val invalidLabour = validBundle.demographicLabour.copy(
+      rows = validBundle.demographicLabour.rows.updated(
+        0,
+        DemographicLabourRow(DemographicSex.Female, Child, LabourStatus.Employed, RepresentedCount(18)),
+      ),
+    )
+    val report        = Validator.validate(validBundle.copy(demographicLabour = invalidLabour))
+
+    report.errors should contain(ValidationError.InvalidLabourStatusAgeBand(LabourStatus.Employed, Child))
+  }
+
+  it should "reject overlapping age-band classifications before a bundle is built" in {
+    an[IllegalArgumentException] should be thrownBy
+      classifications.copy(ageBands = Vector(AgeBand("0-20", 0, Some(20)), AgeBand("15+", 15, None)))
+  }
+
+end PopulationControlSchemaSpec


### PR DESCRIPTION
## Summary
- add a typed, runtime-independent control schema for person, household, membership, labour, regional-labour, and employment inputs
- require source provenance, versioned classifications, declared reconciliation tolerances, and cross-table demographic and employment reconciliation
- document this as the first executable RFC-0001 boundary, explicitly without gdpRatio or a whole-economy scale multiplier

## Deliberate scope
- no Poland baseline bundle or population compiler
- no migration of the current runtime or SimParams
- test data is synthetic and makes no calibration claim

## Validation
- sbt "model/testOnly com.boombustgroup.amorfati.config.PopulationControlSchemaSpec com.boombustgroup.amorfati.config.BaselineCatalogSpec"
- sbt Test/compile
- sbt scalafmtCheckAll
- python3 scripts/check-docs.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a typed population-control schema covering persons, households, household membership, labour (demographic/regional), and employment, with structured provenance and classification axes.
  * Added deterministic validation: checks control-table metadata, axis/classification consistency, duplicate rows, labour-status eligibility by age bands, and emits cross-table reconciliation results with per-table tolerance.
  * Reconciliation validation is scoped to the participating tables and does not rely on economy-wide scale multipliers.
* **Tests**
  * Added synthetic-fixture coverage for valid bundles and targeted validation failure cases.
* **Documentation**
  * Updated the RFC to position this schema as the first executable population-control boundary and clarify its scope/constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->