### PR TITLE
Standardize baseline identifiers

### DIFF
--- a/docs/adr/0008-explicit-reference-population-and-representation-scale.md
+++ b/docs/adr/0008-explicit-reference-population-and-representation-scale.md
@@ -53,7 +53,7 @@ weights, controls, residuals, exceptions, and provenance. Researchers do not
 coordinate independent firm, worker, household, and macro-scaling parameters
 to approximate a population size.
 
-The first reference-economy bundle is `pl-2026q2-v1`, representing Poland at
+The first reference-economy bundle is `PL-2026-Q2-v1`, representing Poland at
 the end of `2026-Q2` with a reference-state boundary at the end of
 `2026-06-30`. This is the Q2 closing boundary in source statistics and the
 opening state for the first simulated month, July 2026. The
@@ -66,7 +66,7 @@ vintage.
 
 The identifier is immutable. Changing source content, a hard control, or a
 transformation creates a new bundle version and digest. A better-reconciled
-compilation of the same quarter is `pl-2026q2-v2`; it does not mutate v1. The
+compilation of the same quarter is `PL-2026-Q2-v2`; it does not mutate v1. The
 existing `2026-04-30` runtime calibration is migration evidence and must be
 recalibrated and validated before it can implement the Q2 v1 bundle.
 

--- a/docs/baselines/pl-2026q2-v1-enterprise-controls.md
+++ b/docs/baselines/pl-2026q2-v1-enterprise-controls.md
@@ -1,9 +1,9 @@
-# pl-2026q2-v1 Enterprise Controls
+# PL-2026-Q2-v1 Enterprise Controls
 
 ## Status
 
 This is the acquisition and acceptance record for the enterprise-control
-component of the retrospective `pl-2026q2-v1` baseline. It is not a baseline
+component of the retrospective `PL-2026-Q2-v1` baseline. It is not a baseline
 bundle, a calibration, or evidence that Amor Fati has compiled Polish
 enterprises. No empirical control rows are committed yet.
 
@@ -23,7 +23,7 @@ they must not be merged into one artificial table.
 
 | Field | Value |
 | --- | --- |
-| Baseline identity | `pl-2026q2-v1` |
+| Baseline identity | `PL-2026-Q2-v1` |
 | Reference-state boundary | End of 2026-06-30: the Q2 closing boundary in source statistics and the opening state for the first simulated month, July 2026. The baseline does not simulate Q2. |
 | Target unit | A register-declared-operating entity is the first control unit and is represented as one modeled enterprise. It is a legal entity or organisational unit, not an establishment or local unit. The REGON universe excludes persons operating only individual agricultural holdings; agriculture therefore needs an explicit supplementary bridge rather than an invented registry count. |
 | Enterprise geography | The 16 voivodeships identified by TERYT codes. Registry enterprise counts use the registered-seat voivodeship. This is not a workplace geography and cannot be silently substituted for the workplace axis of population employment controls. |
@@ -111,7 +111,7 @@ The component can be committed only when all conditions hold:
    heuristic based on size, ownership label, or sector can promote one.
 8. The component digest is computed after final TSV generation. Changing a
    source, classification, crosswalk, bridge, or control value creates a new
-   baseline version rather than editing `pl-2026q2-v1` in place.
+   baseline version rather than editing `PL-2026-Q2-v1` in place.
 
 ## Publication Sequence
 
@@ -132,7 +132,7 @@ The component can be committed only when all conditions hold:
 
 Until this component is accepted, the existing `FirmInit` sampling remains
 legacy migration evidence. It must not be relabelled as a calibrated enterprise
-population for `pl-2026q2-v1`.
+population for `PL-2026-Q2-v1`.
 
 ## Source References
 

--- a/docs/baselines/pl-2026q2-v1-population-controls.md
+++ b/docs/baselines/pl-2026q2-v1-population-controls.md
@@ -1,9 +1,9 @@
-# pl-2026q2-v1 Population Controls
+# PL-2026-Q2-v1 Population Controls
 
 ## Status
 
 This is the acquisition and acceptance record for the population-control
-component of the retrospective `pl-2026q2-v1` baseline. It is not a baseline
+component of the retrospective `PL-2026-Q2-v1` baseline. It is not a baseline
 bundle, a calibration, or evidence that the target population has been
 compiled. No empirical control rows are committed yet.
 
@@ -16,11 +16,11 @@ full baseline bundle, not a `Canonical` baseline by itself.
 
 | Field | Value |
 | --- | --- |
-| Baseline identity | `pl-2026q2-v1` |
+| Baseline identity | `PL-2026-Q2-v1` |
 | Territory | Poland, usual residents |
 | Reference-state boundary | End of 2026-06-30. It is the Q2 closing boundary in source statistics and the opening state for the first simulated month, July 2026. The baseline does not simulate Q2. |
 | Compilation mode | Retrospective; source observation periods and release dates may differ from the reference-state boundary and must be recorded per table. |
-| Territorial classification | The 16 voivodeships, identified by TERYT codes. This is the common, stable level for the GUS population, household, labour, and employment extracts, and is the `pl-2026q2-v1` regional axis in the [RFC-0001 minimum control bundle](../rfc/0001-population-and-representation.md#minimum-person-household-control-bundle). It is not the legacy runtime's seven regional markets and is not a proxy for NUTS 2. |
+| Territorial classification | The 16 voivodeships, identified by TERYT codes. This is the common, stable level for the GUS population, household, labour, and employment extracts, and is the `PL-2026-Q2-v1` regional axis in the [RFC-0001 minimum control bundle](../rfc/0001-population-and-representation.md#minimum-person-household-control-bundle). It is not the legacy runtime's seven regional markets and is not a proxy for NUTS 2. |
 | Production classification | PKD 2025 sections or published aggregates, with every aggregation and later mapping to the target production ontology declared explicitly. A Census 2021 or other legacy PKD 2007 input may inform a structural bridge but must not become an undeclared output classification. The six legacy runtime sectors are not control-table codes. |
 | Representation scale | Not a baseline field. The researcher selects it per compilation through `PopulationRepresentation.RepresentationSpec`. |
 
@@ -75,7 +75,7 @@ The component can be committed only when all conditions hold:
    vacancies, and secondary jobs are outside this component.
 7. The component digest is computed after final TSV generation; changing one
    source, bridge, classification, or control value requires a new baseline
-   version rather than editing `pl-2026q2-v1` in place.
+   version rather than editing `PL-2026-Q2-v1` in place.
 
 ## Publication Sequence
 

--- a/docs/enterprise-control-bundle.md
+++ b/docs/enterprise-control-bundle.md
@@ -12,11 +12,11 @@ This is not a full `BaselineBundle`, an XLSX extractor, a firm compiler, a
 public Research API, or a workforce bridge. It does not load `SimParams`,
 execute Scala configuration, initialize runtime firms, or treat a REGON
 expected-workers band as actual employment. The committed `synthetic-v1`
-fixture is a test artifact only; it is not `pl-2026q2-v1` or an empirical
+fixture is a test artifact only; it is not `PL-2026-Q2-v1` or an empirical
 baseline.
 
 The target evidence and remaining enterprise work are defined by the
-[pl-2026q2-v1 enterprise-control acquisition record](baselines/pl-2026q2-v1-enterprise-controls.md)
+[PL-2026-Q2-v1 enterprise-control acquisition record](baselines/pl-2026q2-v1-enterprise-controls.md)
 and [RFC-0001](rfc/0001-population-and-representation.md). The relationship to
 the future full baseline bundle and Research API is defined by
 [RFC-0002's contract](rfc/0002-research-api-contract.md).
@@ -128,6 +128,6 @@ deliberately separate from the legacy `BaselineCatalog` provider over
 
 The next implementation step is a deterministic, separately reviewed source
 extractor that verifies the pinned GUS workbook and emits a candidate
-`pl-2026q2-v1` component. That candidate still needs a reviewed PKD crosswalk,
+`PL-2026-Q2-v1` component. That candidate still needs a reviewed PKD crosswalk,
 remaining enterprise dimensions, and an explicit workforce bridge before it
 can participate in a full baseline compilation.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -195,8 +195,8 @@ sbt "runMain com.boombustgroup.amorfati.Main 1 counterfactual --duration 12 --ru
 For named scenarios, compare the same scenario set across branches:
 
 ```bash
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id baseline-review --out target/scenarios"
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id <short-name>-review --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id baseline-review --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios monetary-tightening --seeds 1 --months 12 --run-id <short-name>-review --out target/scenarios"
 ```
 
 Commit code, tests, and intentionally refreshed docs. Do not commit generated
@@ -426,13 +426,13 @@ are documented in [scenario-registry.md](scenario-registry.md).
 Run a small scenario smoke check:
 
 ```bash
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
 ```
 
 Run every registered scenario with a small seed envelope:
 
 ```bash
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 Robustness scenario sets come from

--- a/docs/population-control-bundle.md
+++ b/docs/population-control-bundle.md
@@ -11,7 +11,7 @@ can consume it.
 This is not a full `BaselineBundle`, a public Research API, or a population
 compiler. It does not load `SimParams`, execute Scala configuration, initialize
 the runtime, or establish a Poland calibration. The committed
-`synthetic-v1` fixture is a test artifact only; it is not `pl-2026q2-v1` or an
+`synthetic-v1` fixture is a test artifact only; it is not `PL-2026-Q2-v1` or an
 empirical baseline.
 
 The target contract and the remaining compiler work are defined by

--- a/docs/rfc/0001-population-and-representation.md
+++ b/docs/rfc/0001-population-and-representation.md
@@ -244,7 +244,7 @@ force. Pension receipt, education, disability, care, retraining, and financial
 distress remain separate dimensions and do not override that classification.
 
 The baseline must record the exact statistical definition and source release
-used for every control. `pl-2026q2-v1` is a retrospectively compiled Q2 baseline,
+used for every control. `PL-2026-Q2-v1` is a retrospectively compiled Q2 baseline,
 not a claim that every control was observable on the reference-state boundary. Later
 source releases are admissible only with explicit observation and release dates.
 
@@ -423,7 +423,7 @@ compilation. It should contain:
 - national-accounts and financial-accounts totals; and
 - migration, births, deaths, pension receipt, and tourism control series.
 
-The first target bundle is `pl-2026q2-v1`. It represents Poland at the end of
+The first target bundle is `PL-2026-Q2-v1`. It represents Poland at the end of
 `2026-Q2`, with a reference-state boundary at the end of `2026-06-30`. This is
 the Q2 closing boundary in source statistics and the opening state for the
 first simulated month, July 2026. A researcher selects that one identity;
@@ -441,12 +441,12 @@ real-time information vintage.
 A baseline identifier is immutable. Changing a source release, transformation,
 classification crosswalk, hard control, or reconciliation policy creates a new
 bundle version and digest. Corrections do not rewrite the meaning or provenance
-of `pl-2026q2-v1`. A better-reconciled compilation of the same represented
-quarter is published as `pl-2026q2-v2`, while a later reference economy receives
+of `PL-2026-Q2-v1`. A better-reconciled compilation of the same represented
+quarter is published as `PL-2026-Q2-v2`, while a later reference economy receives
 its own period identity.
 
 The existing `2026-04-30` Amor Fati calibration is migration evidence for this
-bundle, not an implementation of `pl-2026q2-v1` under a new label. Building v1
+bundle, not an implementation of `PL-2026-Q2-v1` under a new label. Building v1
 requires an explicit Q2 recalibration and validation pass. Aggregate GDP,
 public, banking, external, and financial stocks may be well bridged while the
 joint population of persons, households, and firms remains only partially
@@ -460,7 +460,7 @@ The first compiler does not require one sparse cross-product of every person,
 household, labor, housing, and financial attribute. It requires a versioned set
 of mutually reconciled control tables with shared classifications:
 
-For `pl-2026q2-v1`, the shared regional classification is the 16 TERYT
+For `PL-2026-Q2-v1`, the shared regional classification is the 16 TERYT
 voivodeships recorded in its
 [population-control acquisition record](../baselines/pl-2026q2-v1-population-controls.md).
 This is the same axis for person, household, regional-labour, and employment
@@ -515,7 +515,7 @@ The primary user setting should therefore be residents per agent, not raw agent
 counts:
 
 ```yaml
-baseline: pl-2026q2-v1
+baseline: PL-2026-Q2-v1
 representation:
   residentsPerAgent: 1000
   enterprisePolicy: stratified
@@ -854,7 +854,7 @@ indexes, views, and the data-oriented implementation boundary.
 
 | ID | Decision | First-target resolution | State |
 | --- | --- | --- | --- |
-| P-01 | Baseline identity and vintage | `pl-2026q2-v1`; end-`2026-Q2` reference-state boundary, which is the Q2 close in source statistics and the opening state for July simulation; one researcher-facing identity, immutable version and content digest, and per-source temporal provenance inside the bundle. Better reconciliation of the same quarter becomes v2. | Accepted, 2026-07-20 |
+| P-01 | Baseline identity and vintage | `PL-2026-Q2-v1`; end-`2026-Q2` reference-state boundary, which is the Q2 close in source statistics and the opening state for July simulation; one researcher-facing identity, immutable version and content digest, and per-source temporal provenance inside the bundle. Better reconciliation of the same quarter becomes v2. | Accepted, 2026-07-20 |
 | P-02 | Labor-control convention | All-age usual-resident population; BAEL/EU-LFS labor definitions, with employment ages 15-89, unemployment ages 15-74, under-15 `NotApplicable`, and a declared 90+ non-BAEL residual. | Accepted, 2026-07-20 |
 | P-03 | Minimum person-household controls | Reconciled person, household, membership, labor-status, and region-sector employment tables defined above; no mandatory full cross-product of every attribute. | Accepted, 2026-07-20 |
 | P-04 | Rare and systemic enterprises | Preserve every nonzero hard-control stratum with adaptive weights; preserve a named non-bank enterprise at weight one only by explicit baseline declaration. | Accepted, 2026-07-20 |

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -230,7 +230,7 @@ Conceptually, notebook code should read like:
 
 ```scala
 val experiment = AmorFati.experiment(
-  baseline = Baseline("pl-2026q2-v1"),
+  baseline = Baseline("PL-2026-Q2-v1"),
   representation = Representation.oneTo(1000),
   seed = Seed(42)
 )
@@ -534,7 +534,7 @@ implementation-shaped substitutes.
    between baseline inputs, scenario drivers, and validation outcomes.
 3. Implement a narrow pre-release Research API facade over the current engine,
    using an accurately identified legacy baseline provider until
-   `pl-2026q2-v1` is compiled and validated.
+   `PL-2026-Q2-v1` is compiled and validated.
    Current internal engine types do not enter its public signatures.
 4. Keep the contract explicitly pre-release so notebook evidence can correct it
    before the target state design is fixed.

--- a/docs/rfc/0002-research-api-contract.md
+++ b/docs/rfc/0002-research-api-contract.md
@@ -25,12 +25,12 @@ The current configuration surface cannot yet satisfy this contract:
 - `SimParams.defaults` is the one code-defined production parameterization and
   still describes the existing `2026-04-30` model-start calibration;
 - `BaselineCatalog` now exposes that calibration through the exact legacy ID
-  `pl-2026-04-30-legacy-v1`, verifies the compiled payload against a reviewed,
+  `PL-2026-04-30-legacy-v1`, verifies the compiled payload against a reviewed,
   pinned digest and required model contract, and resolves it into an internal
   `BaselineBundle`; that legacy bundle contains only the parameter payload,
   while provenance and validation are references and the population and
   institutional components remain absent. It is not yet a public Research API,
-  persisted bundle loader, or `pl-2026q2-v1` implementation;
+  persisted bundle loader, or `PL-2026-Q2-v1` implementation;
 - the `SimConfigSpec` and `SimConfigPropertySpec` test names refer to
   `SimParams`; there is no separately loadable `SimConfig` baseline contract;
 - `ScenarioRegistry` now selects typed scenario references and applies a typed
@@ -45,7 +45,7 @@ The current configuration surface cannot yet satisfy this contract:
   was resolved and verified.
 
 The existing defaults and scenarios are useful migration evidence. They must
-not be relabeled as the unimplemented `pl-2026q2-v1` bundle or presented as
+not be relabeled as the unimplemented `PL-2026-Q2-v1` bundle or presented as
 historical replay.
 
 ## Contract Principles
@@ -109,7 +109,7 @@ val experiment = AmorFati.experiment(
 ```
 
 These names and historical asset IDs are illustrative. Except for the accepted
-target identity `pl-2026q2-v1`, they do not claim that a corresponding bundle
+target identity `PL-2026-Q2-v1`, they do not claim that a corresponding bundle
 currently exists. The accepted API must preserve the separation of concepts
 even if its final syntax differs.
 
@@ -150,7 +150,7 @@ not silently select an experimental or legacy baseline.
 
 ## Immutable Baseline Bundle
 
-The first-target `pl-2026q2-v1` bundle is the reference-economy input accepted
+The first-target `PL-2026-Q2-v1` bundle is the reference-economy input accepted
 by RFC-0001. Logically, a bundle contains:
 
 | Component | Required content |
@@ -171,10 +171,10 @@ deterministic integrity rules. The public contract does not require one giant
 configuration file and must not serialize `SimParams` or target-core storage
 objects directly.
 
-The researcher-facing identity remains `pl-2026q2-v1`. Detailed source periods,
+The researcher-facing identity remains `PL-2026-Q2-v1`. Detailed source periods,
 valuation dates, access dates, and transformations remain inside its manifest,
 as required by RFC-0001. Improving a source bridge or reconciliation for the
-same opening quarter produces `pl-2026q2-v2`; it never rewrites v1.
+same opening quarter produces `PL-2026-Q2-v2`; it never rewrites v1.
 
 ## Resolution and Compilation
 
@@ -363,7 +363,7 @@ that historical bundles already exist:
    optional typed scenario patch into an internal `SimParams`;
 4. stop new Research API and notebook code from selecting
    `SimParams.defaults` directly;
-5. replace the legacy provider with the real `pl-2026q2-v1` bundle only after
+5. replace the legacy provider with the real `PL-2026-Q2-v1` bundle only after
    Q2 compilation, calibration, opening reconciliation, and validation exist;
    and
 6. add historical baselines, driver paths, and validation datasets as separate
@@ -392,7 +392,7 @@ baseline. The remaining steps above remain required.
 | R-05 | Historical claims | Distinguish reconstruction, real-time vintage evaluation, and counterfactual analysis in experiment and result metadata. | Proposed for RFC-0002 |
 | R-06 | Validation leakage | Keep observed outcomes separate and record field-level input, calibration, driver, and validation roles. | Proposed for RFC-0002 |
 | R-07 | Compatibility | Direct load, explicit migration, or explicit rejection; never silent baseline reinterpretation. | Proposed for RFC-0002 |
-| R-08 | Pilot baseline | Use an accurately named legacy provider until `pl-2026q2-v1` is genuinely compiled and validated. | Proposed for RFC-0002 |
+| R-08 | Pilot baseline | Use an accurately named legacy provider until `PL-2026-Q2-v1` is genuinely compiled and validated. | Proposed for RFC-0002 |
 | R-09 | Serialization | Choose schema formats and canonical hashing after the logical DTOs and expected control-table sizes are fixed. | Open physical design |
 | R-10 | Distribution | Decide which assets ship with a release and which use a verified artifact cache after size and redistribution constraints are inventoried. | Open operational design |
 | R-11 | Custom researcher baselines | Defer import of non-canonical bundles until canonical loading, validation, trust status, and failure evidence are implemented. | Deferred extension |

--- a/docs/scenario-registry.md
+++ b/docs/scenario-registry.md
@@ -20,19 +20,19 @@ operations index.
 Run the resolved baseline plus two nontrivial scenario patches:
 
 ```bash
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios monetary-tightening,fiscal-expansion --seeds 1 --months 12 --run-id scenario-smoke --out target/scenarios"
 ```
 
 Run every registered scenario:
 
 ```bash
-sbt "scenarioRun --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "scenarioRun --baseline PL-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 Equivalent direct entrypoint:
 
 ```bash
-sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --baseline pl-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
+sbt "runMain com.boombustgroup.amorfati.diagnostics.ScenarioRunExport --baseline PL-2026-04-30-legacy-v1 --scenarios all --seeds 2 --months 24 --run-id local-review --out target/scenarios"
 ```
 
 ## Output Layout
@@ -79,7 +79,7 @@ delta. The allowed `ProvenanceClassification` values are:
 
 The baseline is not a scenario. It is selected by `--baseline`; the current
 registry's patches declare compatibility only with
-`pl-2026-04-30-legacy-v1` until a separately versioned patch set is prepared
+`PL-2026-04-30-legacy-v1` until a separately versioned patch set is prepared
 for another baseline.
 
 | Scenario | Label | Category | Provenance | Source/provider | Vintage | Recommended months | Purpose |

--- a/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
+++ b/modules/cli/src/test/scala/com/boombustgroup/amorfati/diagnostics/NightlyDiagnosticsProfileRunnerSpec.scala
@@ -56,7 +56,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
     )
     steps.find(_.id == "baseline-monte-carlo").value.seeds shouldBe Some(1)
     steps.find(_.id == "baseline-monte-carlo").value.months shouldBe Some(12)
-    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "pl-2026-04-30-legacy-v1")
+    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "PL-2026-04-30-legacy-v1")
     steps.find(_.id == "scenario-run").value.details should contain("scenario_selection" -> "monetary-tightening,fiscal-expansion")
     steps.find(_.id == "robustness-report").value.months shouldBe Some(6)
     steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation
@@ -77,7 +77,7 @@ class NightlyDiagnosticsProfileRunnerSpec extends AnyFlatSpec with Matchers:
       "loan-origination-quality",
     )
     steps.flatMap(_.months).max shouldBe 60
-    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "pl-2026-04-30-legacy-v1")
+    steps.find(_.id == "scenario-run").value.details should contain("baseline_id" -> "PL-2026-04-30-legacy-v1")
     steps.find(_.id == "hh-bank-lead-lag").value.details should contain("lag_max" -> "6")
     steps.find(_.id == "loan-origination-quality").value.details should contain("outcome_window" -> "12")
     steps.map(_.classification) should not contain NightlyDiagnosticsProfileRunner.DiagnosticClass.StressValidation

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/BaselineCatalog.scala
@@ -224,7 +224,7 @@ final class BaselineCatalog private[config] (
           else Right(new BaselineBundle(manifest, provider.components, params))
 
 object BaselineCatalog:
-  val LegacyDefaultsId: BaselineId = BaselineId.from("pl-2026-04-30-legacy-v1").fold(error => throw IllegalStateException(error), identity)
+  val LegacyDefaultsId: BaselineId = BaselineId.from("PL-2026-04-30-legacy-v1").fold(error => throw IllegalStateException(error), identity)
 
   /** Reviewed digest of the complete legacy SimParams.defaults payload. */
   private val LegacyDefaultsPayloadDigest =
@@ -276,7 +276,7 @@ object BaselineCatalog:
         baselineSchemaVersion = 1,
         requiredModelContract = ModelContractVersion.LegacySimParamsV1,
         contentDigest = LegacyDefaultsPayloadDigest,
-        description = "Migration-only provider over SimParams.defaults; not the pl-2026q2-v1 reference-economy bundle.",
+        description = "Migration-only provider over SimParams.defaults; not the PL-2026-Q2-v1 reference-economy bundle.",
       )
 
     def compile(): SimParams = params

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/ScenarioRegistrySpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/ScenarioRegistrySpec.scala
@@ -38,7 +38,7 @@ class ScenarioRegistrySpec extends AnyFlatSpec with Matchers:
 
   it should "reject a scenario for an incompatible baseline" in {
     val resolved       = BaselineCatalog.legacy.resolve(BaselineCatalog.LegacyDefaultsId.value).fold(error => fail(error.toString), identity)
-    val incompatibleId = BaselineId.from("pl-2026q2-v1").fold(error => fail(error), identity)
+    val incompatibleId = BaselineId.from("PL-2026-Q2-v1").fold(error => fail(error), identity)
     val incompatible   = new BaselineBundle(
       resolved.manifest.copy(id = incompatibleId),
       resolved.components,


### PR DESCRIPTION
Adopts `PL-2026-Q2-v1` as the first target baseline identity and `PL-2026-04-30-legacy-v1` for the explicit legacy provider. Updates documentation, CLI examples, catalog metadata, and focused test expectations without renaming documentation paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized baseline identifiers to canonical uppercase, quarter-formatted names across guides, RFCs, ADRs, and bundle documentation.
  * Updated scenario-run examples and added an explicit scenario smoke-check command.

* **Bug Fixes**
  * Corrected the legacy baseline identifier used by the application and related validation expectations.

* **Tests**
  * Updated scenario and diagnostic checks to reflect the canonical baseline identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->