### PR TITLE
Make labour margin reconciliation source-universe aware

### DIFF
--- a/docs/rfc/0001-population-and-representation.md
+++ b/docs/rfc/0001-population-and-representation.md
@@ -480,11 +480,12 @@ reconciliation cells; it is not the legacy runtime's seven regional markets.
    providing the bridge that makes person and household totals jointly
    constrain the synthetic population;
 4. labor status by demographic sex and age band, plus regional labor-status
-   totals, using the supported BAEL age universes (15-89 for employed and
-   inactive residents, 15-74 for unemployed residents) plus the explicit 90+
-   residual. Residents aged 90+ map to `non_bael_residual`, participate in
-   demographic and regional reconciliation, and remain excluded from BAEL
-   denominators; and
+   totals, using the supported source universe declared by the selected
+   provider. A labour table whose statistical universe differs from `persons`
+   is a source-specific margin: it is reconciled to compatible labour tables,
+   but is not required to partition all resident persons. BAEL age coverage,
+   exclusions, and residual treatment belong to the economy adapter and must
+   not become source-specific ontology statuses in core; and
 5. employed residents by residence TERYT voivodeship and represented primary
    employment assignments to synthetic workplaces by model production sector.
    Each employed resident has one main assignment. In v1, workplace location is

--- a/docs/rfc/0002-research-api-and-notebook-runtime.md
+++ b/docs/rfc/0002-research-api-and-notebook-runtime.md
@@ -136,7 +136,9 @@ runtime ledger indices, and future primitive columns remain internal.
 4. Amor Fati supplies a managed Almond-based kernel with a release-pinned and
    tested Scala, JVM, Almond, Jupyter, model, baseline-schema, and adapter
    combination. Each selected baseline is verified separately against that
-   compatibility boundary.
+   compatibility boundary. A declared labour margin may use a source-specific
+   statistical universe; it is not implicitly treated as a partition of the
+   full person population unless the manifest declares matching universes.
 5. Researchers launch the managed system environment. Canonical notebooks do
    not resolve Amor Fati through `$ivy`, publish-local conventions, or an
    independently assembled classpath.

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/config/PopulationControlSchema.scala
@@ -479,6 +479,11 @@ object PopulationControlSchema:
       val labourMarginTolerance               = combinedTolerance(bundle.demographicLabour, bundle.regionalLabour)
       val employmentTolerance                 = combinedTolerance(bundle.regionalLabour, bundle.employment)
 
+      val personToDemographicReconciliation =
+        if bundle.demographicLabour.metadata.statisticalUniverse == bundle.persons.metadata.statisticalUniverse then
+          reconcileMaps("person-to-demographic-labour", personBySexAge, demographicLabourBySexAge, personLabourTolerance)
+        else Vector.empty
+
       Vector(
         Reconciliation(
           "private-person-membership",
@@ -488,7 +493,7 @@ object PopulationControlSchema:
         ),
       ) ++
         reconcileMaps("household-member-capacity", householdCapacityByComposition, membershipByComposition, householdMembershipTolerance) ++
-        reconcileMaps("person-to-demographic-labour", personBySexAge, demographicLabourBySexAge, personLabourTolerance) ++
+        personToDemographicReconciliation ++
         reconcileMaps("person-to-regional-labour", personByRegion, regionalLabourByRegion, regionalLabourTolerance) ++
         reconcileMaps("demographic-to-regional-labour", demographicLabourByStatus, regionalLabourByStatus, labourMarginTolerance) ++
         reconcileMaps("employed-residents-to-primary-job-assignments", employedByRegion, primaryAssignmentsByResidenceRegion, employmentTolerance)

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlBundleLoaderSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlBundleLoaderSpec.scala
@@ -84,6 +84,22 @@ class PopulationControlBundleLoaderSpec extends AnyFlatSpec with Matchers:
           detail should include("unknown population scope")
         case other                                         => fail(s"expected invalid population scope, got: $other")
 
+  it should "treat a labour margin with a distinct statistical universe as source-specific" in
+    withCopiedFixture: root =>
+      val metadataPath = root.resolve("tables.tsv")
+      Files.writeString(
+        metadataPath,
+        Files.readString(metadataPath, UTF_8).replace(
+          "demographic_labour\tlabour\tsynthetic resident population",
+          "demographic_labour\tlabour\tBAEL 15+ private usual residents",
+        ),
+        UTF_8,
+      )
+      refreshDigest(root)
+
+      val loaded = PopulationControlBundleLoader.load(root).fold(error => fail(s"unexpected loader failure: $error"), identity)
+      loaded.validation.reconciliations.map(_.id) should not contain "person-to-demographic-labour:(Female,AgeBand(0-14,0,Some(14)))"
+
   it should "reject malformed UTF-8 after its digest has been refreshed" in
     withCopiedFixture: root =>
       val personsPath = root.resolve("persons.tsv")

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlBundleLoaderSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/config/PopulationControlBundleLoaderSpec.scala
@@ -89,10 +89,12 @@ class PopulationControlBundleLoaderSpec extends AnyFlatSpec with Matchers:
       val metadataPath = root.resolve("tables.tsv")
       Files.writeString(
         metadataPath,
-        Files.readString(metadataPath, UTF_8).replace(
-          "demographic_labour\tlabour\tsynthetic resident population",
-          "demographic_labour\tlabour\tBAEL 15+ private usual residents",
-        ),
+        Files
+          .readString(metadataPath, UTF_8)
+          .replace(
+            "demographic_labour\tlabour\tsynthetic resident population",
+            "demographic_labour\tlabour\tBAEL 15+ private usual residents",
+          ),
         UTF_8,
       )
       refreshDigest(root)


### PR DESCRIPTION
## Summary
- reconcile demographic labour margins to persons only when statistical universes match
- preserve source-specific BAEL margins without adding BAEL-specific ontology statuses
- add loader regression coverage and document the contract in RFC-0001/RFC-0002

## Validation
- `sbt testOnly com.boombustgroup.amorfati.config.PopulationControlBundleLoaderSpec` (7 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation checks between person and demographic-labour data now run only when both datasets use the same statistical universe.
  * Prevented misleading validation results when labour data covers a different population scope.

* **Documentation**
  * Clarified that labour margins may use source-specific statistical universes.
  * Updated population-control guidance to keep source-specific coverage details outside the core ontology.

* **Tests**
  * Added coverage confirming incompatible statistical universes do not produce person-to-labour reconciliation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->