### PR TITLE
Add typed Research API experiment preparation

### DIFF
--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResearchApi.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResearchApi.scala
@@ -1,6 +1,6 @@
 package com.boombustgroup.amorfati.research
 
-import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineRef, PreparedScenario, ScenarioRef, ScenarioRegistry}
+import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineRef, ScenarioRef, ScenarioRegistry}
 
 /** Pre-release, typed boundary for researcher experiment construction.
   *
@@ -28,12 +28,14 @@ object ResearchApi:
   final case class PreparedExperiment(
       apiVersion: String,
       baseline: com.boombustgroup.amorfati.config.BaselineManifest,
-      scenarios: Vector[PreparedScenario],
+      scenarios: Vector[PreparedScenarioView],
       seedStart: Long,
       seeds: Int,
       months: Int,
       runId: String,
   )
+
+  final case class PreparedScenarioView(id: String, label: String, scenarioId: Option[String])
 
   def prepare(spec: ExperimentSpec, catalog: BaselineCatalog): Either[String, PreparedExperiment] =
     for
@@ -41,4 +43,12 @@ object ResearchApi:
       scenarioSpecs  <- spec.scenarios.foldLeft[Either[String, Vector[com.boombustgroup.amorfati.config.ScenarioRegistry.ScenarioSpec]]](Right(Vector.empty)):
         (acc, ref) => acc.flatMap(selected => ScenarioRegistry.get(ref.id.value).map(selected :+ _))
       scenarios      <- ScenarioRegistry.prepare(baselineBundle, scenarioSpecs).left.map(_.toString)
-    yield PreparedExperiment(Version, baselineBundle.manifest, scenarios, spec.seedStart, spec.seeds, spec.months, spec.runId)
+    yield PreparedExperiment(
+      Version,
+      baselineBundle.manifest,
+      scenarios.map(run => PreparedScenarioView(run.id, run.label, run.scenario.map(_.id.value))),
+      spec.seedStart,
+      spec.seeds,
+      spec.months,
+      spec.runId,
+    )

--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResearchApi.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResearchApi.scala
@@ -1,0 +1,44 @@
+package com.boombustgroup.amorfati.research
+
+import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineRef, PreparedScenario, ScenarioRef, ScenarioRegistry}
+
+/** Pre-release, typed boundary for researcher experiment construction.
+  *
+  * This facade deliberately prepares an experiment without exposing SimParams,
+  * agent collections, or the future data-oriented storage layout. Execution
+  * adapters may consume the prepared value while the public vocabulary remains
+  * stable during the controlled core replacement.
+  */
+object ResearchApi:
+  val Version = "research-api-v0"
+
+  final case class ExperimentSpec(
+      baseline: BaselineRef,
+      scenarios: Vector[ScenarioRef],
+      seedStart: Long = 1L,
+      seeds: Int = 1,
+      months: Int = 1,
+      runId: String = "research-run",
+  ):
+    require(seedStart >= 0L, "seedStart must be non-negative")
+    require(seeds > 0, "seeds must be positive")
+    require(months > 0, "months must be positive")
+    require(runId.matches("[A-Za-z0-9][A-Za-z0-9._-]*"), s"invalid runId: $runId")
+
+  final case class PreparedExperiment(
+      apiVersion: String,
+      baseline: com.boombustgroup.amorfati.config.BaselineManifest,
+      scenarios: Vector[PreparedScenario],
+      seedStart: Long,
+      seeds: Int,
+      months: Int,
+      runId: String,
+  )
+
+  def prepare(spec: ExperimentSpec, catalog: BaselineCatalog): Either[String, PreparedExperiment] =
+    for
+      baselineBundle <- catalog.resolve(spec.baseline).left.map(_.toString)
+      scenarioSpecs  <- spec.scenarios.foldLeft[Either[String, Vector[com.boombustgroup.amorfati.config.ScenarioRegistry.ScenarioSpec]]](Right(Vector.empty)):
+        (acc, ref) => acc.flatMap(selected => ScenarioRegistry.get(ref.id.value).map(selected :+ _))
+      scenarios      <- ScenarioRegistry.prepare(baselineBundle, scenarioSpecs).left.map(_.toString)
+    yield PreparedExperiment(Version, baselineBundle.manifest, scenarios, spec.seedStart, spec.seeds, spec.months, spec.runId)

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
@@ -16,6 +16,11 @@ class ResearchApiSpec extends AnyFlatSpec with Matchers:
     val prepared = ResearchApi.prepare(spec, BaselineCatalog.legacy).fold(error => fail(error), identity)
     prepared.apiVersion shouldBe ResearchApi.Version
     prepared.baseline.id shouldBe BaselineCatalog.LegacyDefaultsId
+    prepared.baseline.contentDigest shouldBe BaselineCatalog.legacy.list.head.contentDigest
+    prepared.seedStart shouldBe spec.seedStart
+    prepared.seeds shouldBe spec.seeds
+    prepared.months shouldBe spec.months
+    prepared.runId shouldBe spec.runId
     prepared.scenarios.map(_.id) should contain("monetary-tightening")
   }
 

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
@@ -1,0 +1,31 @@
+package com.boombustgroup.amorfati.research
+
+import com.boombustgroup.amorfati.config.{BaselineCatalog, BaselineId, BaselineRef, ScenarioId, ScenarioRef}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ResearchApiSpec extends AnyFlatSpec with Matchers:
+  "ResearchApi" should "prepare a typed experiment through the catalog" in {
+    val spec = ResearchApi.ExperimentSpec(
+      baseline = BaselineRef(BaselineCatalog.LegacyDefaultsId),
+      scenarios = Vector(ScenarioRef(ScenarioId.from("monetary-tightening").toOption.get)),
+      months = 12,
+      runId = "pilot-1",
+    )
+
+    val prepared = ResearchApi.prepare(spec, BaselineCatalog.legacy).fold(error => fail(error), identity)
+    prepared.apiVersion shouldBe ResearchApi.Version
+    prepared.baseline.id shouldBe BaselineCatalog.LegacyDefaultsId
+    prepared.scenarios.map(_.id) should contain("monetary-tightening")
+  }
+
+  it should "reject an unknown scenario before execution" in {
+    val spec = ResearchApi.ExperimentSpec(
+      baseline = BaselineRef(BaselineCatalog.LegacyDefaultsId),
+      scenarios = Vector(ScenarioRef(ScenarioId.from("does-not-exist").toOption.get)),
+    )
+
+    ResearchApi.prepare(spec, BaselineCatalog.legacy) match
+      case Left(error)  => error should include("Unknown scenario 'does-not-exist'")
+      case Right(value) => fail(s"expected unknown scenario failure, got $value")
+  }


### PR DESCRIPTION
## Summary
- add a pre-release typed Research API facade for experiment construction
- resolve immutable baselines through BaselineCatalog before scenario preparation
- validate registered scenario IDs and preserve baseline manifest identity
- keep SimParams and runtime storage internal

## Validation
- `sbt testOnly com.boombustgroup.amorfati.research.ResearchApiSpec` (2 tests passed)

This is the pilot contract only; execution adapters, external PL bundle resolution, result manifests, and Almond integration follow separately.
