### PR TITLE
Disable CodeRabbit high-level summaries

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ early_access: false
 reviews:
   profile: "assertive"
   request_changes_workflow: true
-  high_level_summary: true
+  high_level_summary: false
   poem: false # Disabling the annoying poem at the end of the PR summary
 
   path_instructions:


### PR DESCRIPTION
Disable CodeRabbit high-level PR summaries while retaining inline review comments and configured review instructions.