### PR TITLE
Add Research API result-bundle manifest

### DIFF
--- a/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResultBundleManifest.scala
+++ b/modules/model/src/main/scala/com/boombustgroup/amorfati/research/ResultBundleManifest.scala
@@ -1,0 +1,61 @@
+package com.boombustgroup.amorfati.research
+
+import com.boombustgroup.amorfati.config.BaselineDigest
+
+/** Immutable provenance contract for one controlled Research API result bundle.
+  */
+final case class ResultBundleManifest(
+    runId: String,
+    apiVersion: String,
+    baselineId: String,
+    baselineDigest: BaselineDigest,
+    scenarioIds: Vector[String],
+    seedStart: Long,
+    seedCount: Int,
+    months: Int,
+    validationStatus: String,
+    reconciliationStatus: String,
+    evidencePolicy: String,
+    resultSchemaVersion: String = "result-bundle-v0",
+):
+  require(runId.matches("[A-Za-z0-9][A-Za-z0-9._-]*"), s"invalid runId: $runId")
+  require(seedStart >= 0L, "seedStart must be non-negative")
+  require(seedCount > 0, "seedCount must be positive")
+  require(months > 0, "months must be positive")
+  require(validationStatus.nonEmpty, "validationStatus must be non-blank")
+  require(reconciliationStatus.nonEmpty, "reconciliationStatus must be non-blank")
+  require(evidencePolicy.nonEmpty, "evidencePolicy must be non-blank")
+
+  /** Stable one-row TSV representation for a result-bundle manifest. */
+  def toTsv: String =
+    val fields = Vector(
+      runId,
+      apiVersion,
+      baselineId,
+      baselineDigest.toString,
+      scenarioIds.mkString(","),
+      seedStart.toString,
+      seedCount.toString,
+      months.toString,
+      validationStatus,
+      reconciliationStatus,
+      evidencePolicy,
+      resultSchemaVersion,
+    )
+    ResultBundleManifest.Header.mkString("\t") + "\n" + fields.mkString("\t") + "\n"
+
+object ResultBundleManifest:
+  val Header: Vector[String] = Vector(
+    "run_id",
+    "api_version",
+    "baseline_id",
+    "baseline_digest",
+    "scenario_ids",
+    "seed_start",
+    "seed_count",
+    "months",
+    "validation_status",
+    "reconciliation_status",
+    "evidence_policy",
+    "result_schema_version",
+  )

--- a/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
+++ b/modules/model/src/test/scala/com/boombustgroup/amorfati/research/ResearchApiSpec.scala
@@ -34,3 +34,25 @@ class ResearchApiSpec extends AnyFlatSpec with Matchers:
       case Left(error)  => error should include("Unknown scenario 'does-not-exist'")
       case Right(value) => fail(s"expected unknown scenario failure, got $value")
   }
+
+  it should "render a deterministic result-bundle manifest" in {
+    val digest   = BaselineCatalog.legacy.list.head.contentDigest
+    val manifest = ResultBundleManifest(
+      runId = "pilot-1",
+      apiVersion = ResearchApi.Version,
+      baselineId = BaselineCatalog.LegacyDefaultsId.value,
+      baselineDigest = digest,
+      scenarioIds = Vector("baseline", "monetary-tightening"),
+      seedStart = 2L,
+      seedCount = 3,
+      months = 12,
+      validationStatus = "passed",
+      reconciliationStatus = "passed",
+      evidencePolicy = "controlled-terminal",
+    )
+
+    manifest.toTsv.linesIterator.toVector shouldBe Vector(
+      ResultBundleManifest.Header.mkString("\t"),
+      s"pilot-1\t${ResearchApi.Version}\tPL-2026-04-30-legacy-v1\t$digest\tbaseline,monetary-tightening\t2\t3\t12\tpassed\tpassed\tcontrolled-terminal\tresult-bundle-v0",
+    )
+  }


### PR DESCRIPTION
## Summary
- add typed result-bundle provenance manifest for Research API runs
- preserve run, API, baseline identity/digest, scenarios, seed policy, horizon, validation and reconciliation status
- provide deterministic TSV rendering

## Validation
- `sbt testOnly com.boombustgroup.amorfati.research.ResearchApiSpec` (3 tests passed)

This remains execution-engine independent; external PL baseline resolution and result artifact writing follow in later work.